### PR TITLE
Fix spring kafka context leak when batch listener is retried

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -69,6 +69,7 @@ tasks {
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
 
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
   }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/AbstractMessageListenerContainerInstrumentation.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/AbstractMessageListenerContainerInstrumentation.java
@@ -16,7 +16,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.springframework.kafka.listener.BatchInterceptor;
 import org.springframework.kafka.listener.RecordInterceptor;
 
 public class AbstractMessageListenerContainerInstrumentation implements TypeInstrumentation {
@@ -28,40 +27,17 @@ public class AbstractMessageListenerContainerInstrumentation implements TypeInst
 
   @Override
   public void transform(TypeTransformer transformer) {
-    // getBatchInterceptor() is called internally by AbstractMessageListenerContainer
-    // implementations
-    transformer.applyAdviceToMethod(
-        named("getBatchInterceptor")
-            .and(isProtected())
-            .and(takesArguments(0))
-            .and(returns(named("org.springframework.kafka.listener.BatchInterceptor"))),
-        this.getClass().getName() + "$GetBatchInterceptorAdvice");
     // getRecordInterceptor() is called internally by AbstractMessageListenerContainer
     // implementations
+    // for batch listeners we don't instrument getBatchInterceptor() here but instead instrument
+    // KafkaMessageListenerContainer$ListenerConsumer because spring doesn't always call the success
+    // and failure methods on a batch interceptor
     transformer.applyAdviceToMethod(
         named("getRecordInterceptor")
             .and(isProtected())
             .and(takesArguments(0))
             .and(returns(named("org.springframework.kafka.listener.RecordInterceptor"))),
         this.getClass().getName() + "$GetRecordInterceptorAdvice");
-  }
-
-  @SuppressWarnings("unused")
-  public static class GetBatchInterceptorAdvice {
-
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static <K, V> void onExit(
-        @Advice.Return(readOnly = false) BatchInterceptor<K, V> interceptor) {
-
-      if (interceptor == null
-          || !interceptor
-              .getClass()
-              .getName()
-              .equals(
-                  "io.opentelemetry.instrumentation.spring.kafka.v2_7.InstrumentedBatchInterceptor")) {
-        interceptor = telemetry().createBatchInterceptor(interceptor);
-      }
-    }
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
@@ -6,23 +6,47 @@
 package io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.kafka.internal.KafkaInstrumenterFactory;
+import io.opentelemetry.instrumentation.kafka.internal.KafkaReceiveRequest;
 import io.opentelemetry.instrumentation.spring.kafka.v2_7.SpringKafkaTelemetry;
+import io.opentelemetry.instrumentation.spring.kafka.v2_7.internal.SpringKafkaErrorCauseExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 
 public final class SpringKafkaSingletons {
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-kafka-2.7";
 
   private static final SpringKafkaTelemetry TELEMETRY =
       SpringKafkaTelemetry.builder(GlobalOpenTelemetry.get())
+          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               InstrumentationConfig.get()
                   .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
           .setMessagingReceiveInstrumentationEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
           .build();
+  private static final Instrumenter<KafkaReceiveRequest, Void> BATCH_PROCESS_INSTRUMENTER;
+
+  static {
+    KafkaInstrumenterFactory factory =
+        new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
+            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureExperimentalSpanAttributes(
+                InstrumentationConfig.get()
+                    .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
+            .setMessagingReceiveInstrumentationEnabled(
+                ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
+            .setErrorCauseExtractor(SpringKafkaErrorCauseExtractor.INSTANCE);
+    BATCH_PROCESS_INSTRUMENTER = factory.createBatchProcessInstrumenter();
+  }
 
   public static SpringKafkaTelemetry telemetry() {
     return TELEMETRY;
+  }
+
+  public static Instrumenter<KafkaReceiveRequest, Void> batchProcessInstrumenter() {
+    return BATCH_PROCESS_INSTRUMENTER;
   }
 
   private SpringKafkaSingletons() {}

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -14,15 +14,21 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.SemanticAttributes;
 import io.opentelemetry.testing.AbstractSpringKafkaTest;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -144,8 +150,42 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               });
         });
 
-    AtomicReference<SpanData> producer = new AtomicReference<>();
+    Consumer<SpanDataAssert> receiveSpanAssert =
+        span ->
+            span.hasName("testSingleTopic receive")
+                .hasKind(SpanKind.CONSUMER)
+                .hasNoParent()
+                .hasAttributesSatisfyingExactly(
+                    equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
+                    equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                    equalTo(SemanticAttributes.MESSAGING_OPERATION, "receive"),
+                    equalTo(
+                        SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
+                    satisfies(
+                        SemanticAttributes.MESSAGING_CLIENT_ID,
+                        stringAssert -> stringAssert.startsWith("consumer")),
+                    equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+    List<AttributeAssertion> processAttributes =
+        Arrays.asList(
+            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
+            equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+            equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
+            satisfies(
+                SemanticAttributes.MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
+            satisfies(
+                SemanticAttributes.MESSAGING_KAFKA_DESTINATION_PARTITION,
+                AbstractLongAssert::isNotNegative),
+            satisfies(
+                SemanticAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                AbstractLongAssert::isNotNegative),
+            equalTo(SemanticAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+            equalTo(SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
+            satisfies(
+                SemanticAttributes.MESSAGING_CLIENT_ID,
+                stringAssert -> stringAssert.startsWith("consumer")),
+            satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
 
+    AtomicReference<SpanData> producer = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
         orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
         trace -> {
@@ -174,22 +214,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         },
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName("testSingleTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(SemanticAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testSingleListener"),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)),
+                receiveSpanAssert,
                 span ->
                     span.hasName("testSingleTopic process")
                         .hasKind(SpanKind.CONSUMER)
@@ -197,30 +222,29 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                         .hasLinks(LinkData.create(producer.get().getSpanContext()))
                         .hasStatus(StatusData.error())
                         .hasException(new IllegalArgumentException("boom"))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                AbstractLongAssert::isNotNegative),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_KAFKA_DESTINATION_PARTITION,
-                                AbstractLongAssert::isNotNegative),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(SemanticAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testSingleListener"),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
-                            satisfies(
-                                longKey("kafka.record.queue_time_ms"),
-                                AbstractLongAssert::isNotNegative)),
+                        .hasAttributesSatisfyingExactly(processAttributes),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                receiveSpanAssert,
+                span ->
+                    span.hasName("testSingleTopic process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                        .hasStatus(StatusData.error())
+                        .hasException(new IllegalArgumentException("boom"))
+                        .hasAttributesSatisfyingExactly(processAttributes),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                receiveSpanAssert,
+                span ->
+                    span.hasName("testSingleTopic process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(processAttributes),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -331,10 +355,35 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               });
         });
 
+    Consumer<SpanDataAssert> receiveSpanAssert =
+        span ->
+            span.hasName("testBatchTopic receive")
+                .hasKind(SpanKind.CONSUMER)
+                .hasNoParent()
+                .hasAttributesSatisfyingExactly(
+                    equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
+                    equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                    equalTo(SemanticAttributes.MESSAGING_OPERATION, "receive"),
+                    equalTo(SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
+                    satisfies(
+                        SemanticAttributes.MESSAGING_CLIENT_ID,
+                        stringAssert -> stringAssert.startsWith("consumer")),
+                    equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+    List<AttributeAssertion> processAttributes =
+        Arrays.asList(
+            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
+            equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+            equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
+            equalTo(SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
+            satisfies(
+                SemanticAttributes.MESSAGING_CLIENT_ID,
+                stringAssert -> stringAssert.startsWith("consumer")),
+            equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
-    testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+    List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+    assertions.add(
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
@@ -358,44 +407,79 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                               stringAssert -> stringAssert.startsWith("producer"))));
 
           producer.set(trace.getSpan(1));
-        },
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName("testBatchTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(SemanticAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testBatchListener"),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)),
-                span ->
-                    span.hasName("testBatchTopic process")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(0))
-                        .hasLinks(LinkData.create(producer.get().getSpanContext()))
-                        .hasStatus(StatusData.error())
-                        .hasException(new IllegalArgumentException("boom"))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(SemanticAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testBatchListener"),
-                            satisfies(
-                                SemanticAttributes.MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(SemanticAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)),
-                span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
+        });
+
+    if (Boolean.getBoolean("testLatestDeps")) {
+      // latest dep tests call receive once and only retry the failed process step
+      assertions.add(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  receiveSpanAssert,
+                  span ->
+                      span.hasName("testBatchTopic process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                          .hasStatus(StatusData.error())
+                          .hasException(new IllegalArgumentException("boom"))
+                          .hasAttributesSatisfyingExactly(processAttributes),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(1)),
+                  span ->
+                      span.hasName("testBatchTopic process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                          .hasStatus(StatusData.error())
+                          .hasException(new IllegalArgumentException("boom"))
+                          .hasAttributesSatisfyingExactly(processAttributes),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(3)),
+                  span ->
+                      span.hasName("testBatchTopic process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(processAttributes),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(5))));
+    } else {
+      assertions.addAll(
+          Arrays.asList(
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      receiveSpanAssert,
+                      span ->
+                          span.hasName("testBatchTopic process")
+                              .hasKind(SpanKind.CONSUMER)
+                              .hasParent(trace.getSpan(0))
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasStatus(StatusData.error())
+                              .hasException(new IllegalArgumentException("boom"))
+                              .hasAttributesSatisfyingExactly(processAttributes),
+                      span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      receiveSpanAssert,
+                      span ->
+                          span.hasName("testBatchTopic process")
+                              .hasKind(SpanKind.CONSUMER)
+                              .hasParent(trace.getSpan(0))
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasStatus(StatusData.error())
+                              .hasException(new IllegalArgumentException("boom"))
+                              .hasAttributesSatisfyingExactly(processAttributes),
+                      span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      receiveSpanAssert,
+                      span ->
+                          span.hasName("testBatchTopic process")
+                              .hasKind(SpanKind.CONSUMER)
+                              .hasParent(trace.getSpan(0))
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasAttributesSatisfyingExactly(processAttributes),
+                      span -> span.hasName("consumer").hasParent(trace.getSpan(1)))));
+    }
+
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER), assertions);
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaConsumerContext;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaReceiveRequest;
+import java.lang.ref.WeakReference;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -21,6 +22,8 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
 
   private static final VirtualField<ConsumerRecords<?, ?>, State<KafkaReceiveRequest>> stateField =
       VirtualField.find(ConsumerRecords.class, State.class);
+  private static final ThreadLocal<WeakReference<ConsumerRecords<?, ?>>> lastProcessed =
+      new ThreadLocal<>();
 
   private final Instrumenter<KafkaReceiveRequest, Void> batchProcessInstrumenter;
   @Nullable private final BatchInterceptor<K, V> decorated;
@@ -37,13 +40,24 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
     Context parentContext = getParentContext(records);
 
     KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
-    if (batchProcessInstrumenter.shouldStart(parentContext, request)) {
+    if (batchProcessInstrumenter.shouldStart(parentContext, request) && !skipProcessing(records)) {
       Context context = batchProcessInstrumenter.start(parentContext, request);
       Scope scope = context.makeCurrent();
       stateField.set(records, State.create(request, context, scope));
     }
 
     return decorated == null ? records : decorated.intercept(records, consumer);
+  }
+
+  private static boolean skipProcessing(ConsumerRecords<?, ?> records) {
+    // When retrying failed listener interceptors work as expected only in the earlier versions that
+    // we test (e.g spring-kafka:2.7.1). In later versions interceptor isn't called at all during
+    // the retry, which results in missing process span, or worse, the intercept method is called,
+    // but neither success nor failure is called, which results in a context leak. Here we attempt
+    // to prevent the context leak by observing whether intercept is called with the same
+    // ConsumerRecords as on previous call, and if it is, we skip creating the process span.
+    WeakReference<ConsumerRecords<?, ?>> reference = lastProcessed.get();
+    return reference != null && reference.get() == records;
   }
 
   private static Context getParentContext(ConsumerRecords<?, ?> records) {
@@ -77,6 +91,7 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
       KafkaReceiveRequest request = state.request();
       state.scope().close();
       batchProcessInstrumenter.end(state.context(), request, null, error);
+      lastProcessed.set(new WeakReference<>(records));
     }
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaInstrumenterFactory;
+import io.opentelemetry.instrumentation.spring.kafka.v2_7.internal.SpringKafkaErrorCauseExtractor;
 import java.util.List;
 
 /** A builder of {@link SpringKafkaTelemetry}. */

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/internal/SpringKafkaErrorCauseExtractor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/internal/SpringKafkaErrorCauseExtractor.java
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.spring.kafka.v2_7;
+package io.opentelemetry.instrumentation.spring.kafka.v2_7.internal;
 
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 
-enum SpringKafkaErrorCauseExtractor implements ErrorCauseExtractor {
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public enum SpringKafkaErrorCauseExtractor implements ErrorCauseExtractor {
   INSTANCE;
 
   @Override

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/BatchRecordListener.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/BatchRecordListener.java
@@ -18,6 +18,7 @@ public class BatchRecordListener {
 
   private static final AtomicInteger lastBatchSize = new AtomicInteger();
   private static volatile CountDownLatch messageReceived = new CountDownLatch(2);
+  private int failureCount;
 
   @KafkaListener(
       id = "testBatchListener",
@@ -30,7 +31,8 @@ public class BatchRecordListener {
     GlobalTraceUtil.runWithSpan("consumer", () -> {});
     records.forEach(
         record -> {
-          if (record.value().equals("error")) {
+          if (record.value().equals("error") && failureCount < 2) {
+            failureCount++;
             throw new IllegalArgumentException("boom");
           }
         });

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/SingleRecordListener.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/SingleRecordListener.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 
 public class SingleRecordListener {
+  private int failureCount;
 
   @KafkaListener(
       id = "testSingleListener",
@@ -17,7 +18,8 @@ public class SingleRecordListener {
       containerFactory = "singleFactory")
   public void listener(ConsumerRecord<String, String> record) {
     GlobalTraceUtil.runWithSpan("consumer", () -> {});
-    if (record.value().equals("error")) {
+    if (record.value().equals("error") && failureCount < 2) {
+      failureCount++;
       throw new IllegalArgumentException("boom");
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10698
In later versions of spring kafka `BatchInterceptor` does not work correctly for retries. On retry only the `intercept` method is called that starts the span, but `success` and `failure` that end it are not called. This results in a context leak. This PR implements javaagent instrumentation for batch listeners without using `BatchInterceptor` and modifies the `BatchInterceptor` in library instrumentation to ignore retries. Tests are altered to also test retries.