### PR TITLE
Reduce iterator allocations on hot paths

### DIFF
--- a/docs/contributing/style-guideline.md
+++ b/docs/contributing/style-guideline.md
@@ -137,7 +137,14 @@ It is ok to use `Optional` in places where it does not leak into public API sign
 Also, avoid `Optional` usage on the hot path (instrumentation code), unless the instrumented library
 itself uses it.
 
-## `java.util.stream.Stream` usage
+## Hot path constraints
 
-Avoid streams on the hot path (instrumentation code), unless the instrumented library itself uses
-them.
+Avoid allocations whenever possible on the hot path (instrumentation code).
+This includes `Iterator` allocations from collections; note that
+`for(SomeType t : plainJavaArray)` does not allocate an iterator object.
+Non-allocating stream api usage on the hot path is acceptable but may not
+fit the surrounding code style; this is a judgement call.  Note that
+some stream apis make it much more difficult to allocate efficiently
+(e.g., `collect` with presized sink data structures involves
+convoluted `Supplier` code, or lambdas passed to `forEach` might be
+capturing/allocating lambdas).

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -170,21 +170,19 @@ public class Instrumenter<REQUEST, RESPONSE> {
     }
 
     SpanLinksBuilder spanLinksBuilder = new SpanLinksBuilderImpl(spanBuilder);
-    for (SpanLinksExtractor<? super REQUEST> spanLinksExtractor : spanLinksExtractors) {
-      spanLinksExtractor.extract(spanLinksBuilder, parentContext, request);
-    }
+    spanLinksExtractors.forEach(
+        spanLinksExtractor -> spanLinksExtractor.extract(spanLinksBuilder, parentContext, request));
 
     UnsafeAttributes attributes = new UnsafeAttributes();
-    for (AttributesExtractor<? super REQUEST, ? super RESPONSE> extractor : attributesExtractors) {
-      extractor.onStart(attributes, parentContext, request);
-    }
+    attributesExtractors.forEach(
+        extractor -> extractor.onStart(attributes, parentContext, request));
 
     Context context = parentContext;
 
     // context customizers run before span start, so that they can have access to the parent span
     // context, and so that their additions to the context will be visible to span processors
-    for (ContextCustomizer<? super REQUEST> contextCustomizer : contextCustomizers) {
-      context = contextCustomizer.onStart(context, request, attributes);
+    for (int i = 0; i < contextCustomizers.size(); i++) {
+      context = contextCustomizers.get(i).onStart(context, request, attributes);
     }
 
     boolean localRoot = LocalRootSpan.isLocalRoot(context);
@@ -197,8 +195,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
       // operation listeners run after span start, so that they have access to the current span
       // for capturing exemplars
       long startNanos = getNanos(startTime);
-      for (OperationListener operationListener : operationListeners) {
-        context = operationListener.onStart(context, attributes, startNanos);
+      for (int i = 0; i < operationListeners.size(); i++) {
+        context = operationListeners.get(i).onStart(context, attributes, startNanos);
       }
     }
 
@@ -226,8 +224,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
     }
 
     UnsafeAttributes attributes = new UnsafeAttributes();
-    for (AttributesExtractor<? super REQUEST, ? super RESPONSE> extractor : attributesExtractors) {
-      extractor.onEnd(attributes, context, request, response, error);
+    for (int i = 0; i < attributesExtractors.size(); i++) {
+      attributesExtractors.get(i).onEnd(attributes, context, request, response, error);
     }
     span.setAllAttributes(attributes);
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
@@ -63,24 +63,24 @@ final class SpanSuppressors {
 
   static final class BySpanKey implements SpanSuppressor {
 
-    private final Set<SpanKey> spanKeys;
+    private final SpanKey[] spanKeys;
 
     BySpanKey(Set<SpanKey> spanKeys) {
-      this.spanKeys = spanKeys;
+      this.spanKeys = spanKeys.toArray(new SpanKey[spanKeys.size()]);
     }
 
     @Override
     public Context storeInContext(Context context, SpanKind spanKind, Span span) {
-      for (SpanKey spanKey : spanKeys) {
-        context = spanKey.storeInContext(context, span);
+      for (int i = 0; i < spanKeys.length; i++) {
+        context = spanKeys[i].storeInContext(context, span);
       }
       return context;
     }
 
     @Override
     public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
-      for (SpanKey spanKey : spanKeys) {
-        if (spanKey.fromContextOrNull(parentContext) == null) {
+      for (int i = 0; i < spanKeys.length; i++) {
+        if (spanKeys[i].fromContextOrNull(parentContext) == null) {
           return false;
         }
       }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
@@ -71,16 +71,16 @@ final class SpanSuppressors {
 
     @Override
     public Context storeInContext(Context context, SpanKind spanKind, Span span) {
-      for (int i = 0; i < spanKeys.length; i++) {
-        context = spanKeys[i].storeInContext(context, span);
+      for (SpanKey spanKey : spanKeys) {
+        context = spanKey.storeInContext(context, span);
       }
       return context;
     }
 
     @Override
     public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
-      for (int i = 0; i < spanKeys.length; i++) {
-        if (spanKeys[i].fromContextOrNull(parentContext) == null) {
+      for (SpanKey spanKey : spanKeys) {
+        if (spanKey.fromContextOrNull(parentContext) == null) {
           return false;
         }
       }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressors.java
@@ -66,7 +66,7 @@ final class SpanSuppressors {
     private final SpanKey[] spanKeys;
 
     BySpanKey(Set<SpanKey> spanKeys) {
-      this.spanKeys = spanKeys.toArray(new SpanKey[spanKeys.size()]);
+      this.spanKeys = spanKeys.toArray(new SpanKey[0]);
     }
 
     @Override

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/CapturedHttpHeadersUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/CapturedHttpHeadersUtil.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.semconv.http;
 
-import static java.util.Collections.unmodifiableList;
-
 import io.opentelemetry.api.common.AttributeKey;
 import java.util.List;
 import java.util.Locale;
@@ -24,9 +22,11 @@ final class CapturedHttpHeadersUtil {
   private static final ConcurrentMap<String, AttributeKey<List<String>>> responseKeysCache =
       new ConcurrentHashMap<>();
 
-  static List<String> lowercase(List<String> names) {
-    return unmodifiableList(
-        names.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList()));
+  static String[] lowercase(List<String> names) {
+    return names.stream()
+        .map(s -> s.toLowerCase(Locale.ROOT))
+        .collect(Collectors.toList())
+        .toArray(new String[0]);
   }
 
   static AttributeKey<List<String>> requestAttributeKey(String headerName) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesExtractor.java
@@ -37,8 +37,8 @@ abstract class HttpCommonAttributesExtractor<
 
   final GETTER getter;
   private final HttpStatusCodeConverter statusCodeConverter;
-  private final List<String> capturedRequestHeaders;
-  private final List<String> capturedResponseHeaders;
+  private final String[] capturedRequestHeaders;
+  private final String[] capturedResponseHeaders;
   private final Set<String> knownMethods;
 
   HttpCommonAttributesExtractor(
@@ -64,13 +64,12 @@ abstract class HttpCommonAttributesExtractor<
       internalSet(attributes, SemanticAttributes.HTTP_REQUEST_METHOD_ORIGINAL, method);
     }
 
-    capturedRequestHeaders.forEach(
-        name -> {
-          List<String> values = getter.getHttpRequestHeader(request, name);
-          if (!values.isEmpty()) {
-            internalSet(attributes, requestAttributeKey(name), values);
-          }
-        });
+    for (String name : capturedRequestHeaders) {
+      List<String> values = getter.getHttpRequestHeader(request, name);
+      if (!values.isEmpty()) {
+        internalSet(attributes, requestAttributeKey(name), values);
+      }
+    }
   }
 
   @Override
@@ -88,13 +87,12 @@ abstract class HttpCommonAttributesExtractor<
         internalSet(attributes, SemanticAttributes.HTTP_RESPONSE_STATUS_CODE, (long) statusCode);
       }
 
-      capturedResponseHeaders.forEach(
-          name -> {
-            List<String> values = getter.getHttpResponseHeader(request, response, name);
-            if (!values.isEmpty()) {
-              internalSet(attributes, responseAttributeKey(name), values);
-            }
-          });
+      for (String name : capturedResponseHeaders) {
+        List<String> values = getter.getHttpResponseHeader(request, response, name);
+        if (!values.isEmpty()) {
+          internalSet(attributes, responseAttributeKey(name), values);
+        }
+      }
     }
 
     String errorType = null;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesExtractor.java
@@ -64,12 +64,13 @@ abstract class HttpCommonAttributesExtractor<
       internalSet(attributes, SemanticAttributes.HTTP_REQUEST_METHOD_ORIGINAL, method);
     }
 
-    for (String name : capturedRequestHeaders) {
-      List<String> values = getter.getHttpRequestHeader(request, name);
-      if (!values.isEmpty()) {
-        internalSet(attributes, requestAttributeKey(name), values);
-      }
-    }
+    capturedRequestHeaders.forEach(
+        name -> {
+          List<String> values = getter.getHttpRequestHeader(request, name);
+          if (!values.isEmpty()) {
+            internalSet(attributes, requestAttributeKey(name), values);
+          }
+        });
   }
 
   @Override
@@ -87,12 +88,13 @@ abstract class HttpCommonAttributesExtractor<
         internalSet(attributes, SemanticAttributes.HTTP_RESPONSE_STATUS_CODE, (long) statusCode);
       }
 
-      for (String name : capturedResponseHeaders) {
-        List<String> values = getter.getHttpResponseHeader(request, response, name);
-        if (!values.isEmpty()) {
-          internalSet(attributes, responseAttributeKey(name), values);
-        }
-      }
+      capturedResponseHeaders.forEach(
+          name -> {
+            List<String> values = getter.getHttpResponseHeader(request, response, name);
+            if (!values.isEmpty()) {
+              internalSet(attributes, responseAttributeKey(name), values);
+            }
+          });
     }
 
     String errorType = null;


### PR DESCRIPTION
Allocating iterators on hot paths adds unnecessary overhead.  Prefer `forEach` or `int i=0` iteration for these locations.  This is a straightforward optimization that doesn't add additional code complexity.

I looked for static analysis tools to do this across the code base, and did not find anything particularly great.  Intellij's `Loop can be collapsed with stream api` suggestions came the closest, but sometimes produced uglier code than the original or sometimes was questionable if it impacted performance or not.

This is not an exhaustive exploration of this topic, but just a first and easy cut at it.
