### PR TITLE
Allow excluding all methods of a class

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/MethodsConfigurationParser.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/MethodsConfigurationParser.java
@@ -18,18 +18,10 @@ public final class MethodsConfigurationParser {
 
   private static final Logger logger = Logger.getLogger(MethodsConfigurationParser.class.getName());
 
-  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.$]+";
-  private static final String METHOD_LIST_REGEX = "\\s*(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?)\\s*";
+  private static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.$]+";
+  private static final String METHOD_LIST_REGEX = "(?:\\s*\\w+\\s*,)*+(?:\\s*\\w+)?\\s*";
   private static final String CONFIG_FORMAT =
-      "(?:\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\["
-          + METHOD_LIST_REGEX
-          + "]\\s*;)*\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\["
-          + METHOD_LIST_REGEX
-          + "]";
+      PACKAGE_CLASS_NAME_REGEX + "(?:\\[" + METHOD_LIST_REGEX + "])?";
 
   /**
    * This method takes a string in a form of {@code
@@ -52,6 +44,10 @@ public final class MethodsConfigurationParser {
       String[] classMethods = configString.split(";", -1);
       for (String classMethod : classMethods) {
         if (classMethod.trim().isEmpty()) {
+          continue;
+        }
+        if (!classMethod.contains("[")) {
+          toTrace.put(classMethod.trim(), Collections.emptySet());
           continue;
         }
         String[] splitClassMethod = classMethod.split("\\[", -1);

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/MethodsConfigurationParserTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/MethodsConfigurationParserTest.groovy
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.tooling.config
 
 import spock.lang.Specification
 
+import static java.util.Collections.emptySet
+
 class MethodsConfigurationParserTest extends Specification {
 
   def "test configuration #value"() {
@@ -18,7 +20,7 @@ class MethodsConfigurationParserTest extends Specification {
     value                                                           | expected
     null                                                            | [:]
     " "                                                             | [:]
-    "some.package.ClassName"                                        | [:]
+    "some.package.ClassName"                                        | ["some.package.ClassName":emptySet()]
     "some.package.ClassName[ , ]"                                   | [:]
     "some.package.ClassName[ , method]"                             | [:]
     "some.package.Class\$Name[ method , ]"                          | ["some.package.Class\$Name": ["method"].toSet()]


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10722
Currently we require configuration options such as `OTEL_INSTRUMENTATION_OPENTELEMETRY_INSTRUMENTATION_ANNOTATIONS_EXCLUDE_METHODS` to list all methods they wish to exclude. This PR lets users specify just the class name which will be interpreted as exclude all methods from that class.