### PR TITLE
package cloud resource in javaagent - but keep them disabled by default

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,9 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "io.opentelemetry.contrib:opentelemetry-aws-resources",
         "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator",
+        "io.opentelemetry.contrib:opentelemetry-gcp-resources",
         "io.opentelemetry.proto:opentelemetry-proto",
         "io.opentelemetry.semconv:opentelemetry-semconv"
       ],

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -96,8 +96,10 @@ val DEPENDENCIES = listOf(
   "commons-logging:commons-logging:1.3.0",
   "commons-validator:commons-validator:1.8.0",
   "io.netty:netty:3.10.6.Final",
+  "io.opentelemetry.contrib:opentelemetry-aws-resources:1.33.0-alpha",
   "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator:1.33.0-alpha",
   "io.opentelemetry.proto:opentelemetry-proto:1.1.0-alpha",
+  "io.opentelemetry.contrib:opentelemetry-gcp-resources:1.33.0-alpha",
   "io.opentelemetry:opentelemetry-extension-annotations:1.18.0", // deprecated, no longer part of bom
   "org.assertj:assertj-core:3.25.3",
   "org.awaitility:awaitility:4.2.0",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -9,6 +9,7 @@ rootProject.extra["versions"] = dependencyVersions
 
 // this line is managed by .github/scripts/update-sdk-version.sh
 val otelSdkVersion = "1.36.0"
+val otelContribVersion = "1.33.0-alpha"
 val otelSdkAlphaVersion = otelSdkVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 
 // Need both BOM and groovy jars
@@ -39,7 +40,7 @@ val DEPENDENCY_BOMS = listOf(
 
 val autoServiceVersion = "1.1.1"
 val autoValueVersion = "1.10.4"
-val errorProneVersion = "2.26.0"
+val errorProneVersion = "2.25.0"
 val byteBuddyVersion = "1.14.12"
 val asmVersion = "9.6"
 val jmhVersion = "1.37"
@@ -96,10 +97,10 @@ val DEPENDENCIES = listOf(
   "commons-logging:commons-logging:1.3.0",
   "commons-validator:commons-validator:1.8.0",
   "io.netty:netty:3.10.6.Final",
-  "io.opentelemetry.contrib:opentelemetry-aws-resources:1.33.0-alpha",
-  "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator:1.33.0-alpha",
+  "io.opentelemetry.contrib:opentelemetry-aws-resources:${otelContribVersion}",
+  "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator:${otelContribVersion}",
+  "io.opentelemetry.contrib:opentelemetry-gcp-resources:${otelContribVersion}",
   "io.opentelemetry.proto:opentelemetry-proto:1.1.0-alpha",
-  "io.opentelemetry.contrib:opentelemetry-gcp-resources:1.33.0-alpha",
   "io.opentelemetry:opentelemetry-extension-annotations:1.18.0", // deprecated, no longer part of bom
   "org.assertj:assertj-core:3.25.3",
   "org.awaitility:awaitility:4.2.0",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,7 +40,7 @@ val DEPENDENCY_BOMS = listOf(
 
 val autoServiceVersion = "1.1.1"
 val autoValueVersion = "1.10.4"
-val errorProneVersion = "2.25.0"
+val errorProneVersion = "2.26.0"
 val byteBuddyVersion = "1.14.12"
 val asmVersion = "9.6"
 val jmhVersion = "1.37"

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -37,17 +37,8 @@ dependencies {
 
   implementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
 
-  implementation("io.opentelemetry.contrib:opentelemetry-aws-resources") {
-    exclude("io.opentelemetry", "opentelemetry-api")
-    exclude("io.opentelemetry", "opentelemetry-sdk")
-    exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
-  }
-
-  implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources") {
-    exclude("io.opentelemetry", "opentelemetry-api")
-    exclude("io.opentelemetry", "opentelemetry-sdk")
-    exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
-  }
+  implementation("io.opentelemetry.contrib:opentelemetry-aws-resources")
+  implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources")
 
   api("net.bytebuddy:byte-buddy-dep")
   implementation("org.ow2.asm:asm-tree")

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -37,6 +37,18 @@ dependencies {
 
   implementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
 
+  implementation("io.opentelemetry.contrib:opentelemetry-aws-resources") {
+    exclude("io.opentelemetry", "opentelemetry-api")
+    exclude("io.opentelemetry", "opentelemetry-sdk")
+    exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
+  }
+
+  implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources") {
+    exclude("io.opentelemetry", "opentelemetry-api")
+    exclude("io.opentelemetry", "opentelemetry-sdk")
+    exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
+  }
+
   api("net.bytebuddy:byte-buddy-dep")
   implementation("org.ow2.asm:asm-tree")
   implementation("org.ow2.asm:asm-util")

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
@@ -35,7 +35,7 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
     DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
         "io.opentelemetry.contrib.aws.resource.LambdaResourceProvider", "aws");
     DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
-        "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider", "aws");
+        "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider", "gcp");
     // for testing
     DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
         "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider",
@@ -62,7 +62,8 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
       String providerName = providerEntry.getKey();
       String providerGroup = providerEntry.getValue();
       Boolean explictEnabled =
-          config.getBoolean(String.format("otel.instrumentation.%s.enabled", providerGroup));
+          config.getBoolean(
+              String.format("otel.instrumentation.resource-provider.%s.enabled", providerGroup));
 
       if (isEnabled(providerName, enabledProviders, explictEnabled)) {
         enabled.add(providerName);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.config;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+@AutoService(AutoConfigurationCustomizerProvider.class)
+public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCustomizerProvider {
+
+  private static final Set<String> DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS =
+      new HashSet<>(
+          Arrays.asList(
+              "io.opentelemetry.contrib.aws.resource.BeanstalkResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.EcsResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.EksResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.LambdaResourceProvider",
+              "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider",
+              // for testing
+              "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider"));
+  static final String DISABLED_KEY = "otel.java.disabled.resource.providers";
+  static final String ENABLED_KEY = "otel.java.enabled.resource.providers";
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfigurationCustomizer) {
+    autoConfigurationCustomizer.addPropertiesCustomizer(this::customize);
+  }
+
+  // VisibleForTesting
+  Map<String, String> customize(ConfigProperties config) {
+    Set<String> enabledProviders = new HashSet<>(config.getList(ENABLED_KEY));
+
+    List<String> enabled = new ArrayList<>();
+    List<String> disabled = new ArrayList<>();
+
+    for (String providerName : DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS) {
+      Boolean explictEnabled =
+          config.getBoolean(String.format("otel.instrumentation.%s.enabled", providerName));
+
+      if (isEnabled(providerName, enabledProviders, explictEnabled)) {
+        enabled.add(providerName);
+      } else {
+        disabled.add(providerName);
+      }
+    }
+
+    if (!enabledProviders.isEmpty()) {
+      // users has requested specific providers to be enabled only
+      enabled.addAll(enabledProviders);
+      return Collections.singletonMap(ENABLED_KEY, String.join(",", enabled));
+    }
+
+    if (disabled.isEmpty()) {
+      // all providers that are disabled by default are enabled, no need to set any properties
+      return Collections.emptyMap();
+    }
+
+    disabled.addAll(config.getList(DISABLED_KEY));
+    return Collections.singletonMap(DISABLED_KEY, String.join(",", disabled));
+  }
+
+  private static boolean isEnabled(
+      String className, Set<String> enabledProviders, @Nullable Boolean explicitEnabled) {
+    if (explicitEnabled != null) {
+      return explicitEnabled;
+    }
+    return !enabledProviders.isEmpty() && enabledProviders.contains(className);
+  }
+
+  @Override
+  public int order() {
+    // make sure it runs AFTER all the user-provided customizers
+    return Integer.MAX_VALUE;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
@@ -10,8 +10,8 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -21,17 +21,27 @@ import javax.annotation.Nullable;
 @AutoService(AutoConfigurationCustomizerProvider.class)
 public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCustomizerProvider {
 
-  private static final Set<String> DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS =
-      new HashSet<>(
-          Arrays.asList(
-              "io.opentelemetry.contrib.aws.resource.BeanstalkResourceProvider",
-              "io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider",
-              "io.opentelemetry.contrib.aws.resource.EcsResourceProvider",
-              "io.opentelemetry.contrib.aws.resource.EksResourceProvider",
-              "io.opentelemetry.contrib.aws.resource.LambdaResourceProvider",
-              "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider",
-              // for testing
-              "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider"));
+  private static final Map<String, String> DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS = new HashMap<>();
+
+  static {
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.aws.resource.BeanstalkResourceProvider", "aws");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider", "aws");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.aws.resource.EcsResourceProvider", "aws");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.aws.resource.EksResourceProvider", "aws");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.aws.resource.LambdaResourceProvider", "aws");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider", "aws");
+    // for testing
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider",
+        "test");
+  }
+
   static final String DISABLED_KEY = "otel.java.disabled.resource.providers";
   static final String ENABLED_KEY = "otel.java.enabled.resource.providers";
 
@@ -47,9 +57,12 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
     List<String> enabled = new ArrayList<>();
     List<String> disabled = new ArrayList<>();
 
-    for (String providerName : DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS) {
+    for (Map.Entry<String, String> providerEntry :
+        DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.entrySet()) {
+      String providerName = providerEntry.getKey();
+      String providerGroup = providerEntry.getValue();
       Boolean explictEnabled =
-          config.getBoolean(String.format("otel.instrumentation.%s.enabled", providerName));
+          config.getBoolean(String.format("otel.instrumentation.%s.enabled", providerGroup));
 
       if (isEnabled(providerName, enabledProviders, explictEnabled)) {
         enabled.add(providerName);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
@@ -63,7 +63,7 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
       String providerGroup = providerEntry.getValue();
       Boolean explictEnabled =
           config.getBoolean(
-              String.format("otel.instrumentation.resource-provider.%s.enabled", providerGroup));
+              String.format("otel.resource.providers.%s.enabled", providerGroup));
 
       if (isEnabled(providerName, enabledProviders, explictEnabled)) {
         enabled.add(providerName);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizer.java
@@ -62,8 +62,7 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
       String providerName = providerEntry.getKey();
       String providerGroup = providerEntry.getValue();
       Boolean explictEnabled =
-          config.getBoolean(
-              String.format("otel.resource.providers.%s.enabled", providerGroup));
+          config.getBoolean(String.format("otel.resource.providers.%s.enabled", providerGroup));
 
       if (isEnabled(providerName, enabledProviders, explictEnabled)) {
         enabled.add(providerName);

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
@@ -59,7 +59,6 @@ public class ResourceProviderPropertiesCustomizerTest {
   Stream<DynamicTest> enabledTestCases() {
     String className =
         "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider";
-
     return Stream.of(
             new EnabledTestCase(
                 "explicitEnabled", true, Collections.emptySet(), Collections.emptySet(), true),
@@ -116,7 +115,7 @@ public class ResourceProviderPropertiesCustomizerTest {
 
                       if (tc.explicitEnabled != null) {
                         props.put(
-                            "otel.instrumentation." + className + ".enabled",
+                            "otel.instrumentation.test.enabled",
                             Boolean.toString(tc.explicitEnabled));
                       }
 
@@ -126,22 +125,12 @@ public class ResourceProviderPropertiesCustomizerTest {
                                   .addPropertiesSupplier(() -> props)
                                   .build());
 
-                      //                      ConfigProperties config =
-                      // DefaultConfigProperties.createFromMap(props);
-                      //                      Map<String, String> customize = new
-                      // ResourceProviderPropertiesCustomizer().customize(
-                      //                          config);
-
                       if (tc.result) {
                         assertThat(attributes.get(AttributeKey.stringKey("key")))
                             .isEqualTo("value");
                       } else {
                         assertThat(attributes.get(AttributeKey.stringKey("key"))).isNull();
                       }
-                      //
-                      //                      assertThat(
-                      //                          customize)
-                      //                          .isEqualTo(tc.result);
                     }));
   }
 }

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
@@ -115,7 +115,7 @@ public class ResourceProviderPropertiesCustomizerTest {
 
                       if (tc.explicitEnabled != null) {
                         props.put(
-                            "otel.instrumentation.resource-provider.test.enabled",
+                            "otel.resource.providers.test.enabled",
                             Boolean.toString(tc.explicitEnabled));
                       }
 

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.assertj.core.util.Strings;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+public class ResourceProviderPropertiesCustomizerTest {
+
+  public static final class Provider
+      implements io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider {
+    @Override
+    public Resource createResource(ConfigProperties config) {
+      return Resource.create(Attributes.of(AttributeKey.stringKey("key"), "value"));
+    }
+  }
+
+  private static class EnabledTestCase {
+    private final String name;
+    private final boolean result;
+    private final Set<String> enabledProviders;
+    private final Set<String> disabledProviders;
+    private final Boolean explicitEnabled;
+
+    private EnabledTestCase(
+        String name,
+        boolean result,
+        Set<String> enabledProviders,
+        Set<String> disabledProviders,
+        @Nullable Boolean explicitEnabled) {
+      this.name = name;
+      this.result = result;
+      this.enabledProviders = enabledProviders;
+      this.disabledProviders = disabledProviders;
+      this.explicitEnabled = explicitEnabled;
+    }
+  }
+
+  @SuppressWarnings("BooleanParameter")
+  @TestFactory
+  Stream<DynamicTest> enabledTestCases() {
+    String className =
+        "io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider";
+
+    return Stream.of(
+            new EnabledTestCase(
+                "explicitEnabled", true, Collections.emptySet(), Collections.emptySet(), true),
+            new EnabledTestCase(
+                "explicitEnabledFalse",
+                false,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                false),
+            new EnabledTestCase(
+                "enabledProvidersEmpty",
+                false,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                null),
+            new EnabledTestCase(
+                "enabledProvidersContains",
+                true,
+                Collections.singleton(className),
+                Collections.emptySet(),
+                null),
+            new EnabledTestCase(
+                "enabledProvidersNotContains",
+                false,
+                Collections.singleton("otherClassName"),
+                Collections.emptySet(),
+                null),
+            new EnabledTestCase(
+                "disabledProvidersContains",
+                false,
+                Collections.emptySet(),
+                Collections.singleton(className),
+                null),
+            new EnabledTestCase(
+                "disabledProvidersNotContains",
+                false,
+                Collections.emptySet(),
+                Collections.singleton("otherClassName"),
+                null),
+            new EnabledTestCase(
+                "defaultEnabledFalse", false, Collections.emptySet(), Collections.emptySet(), null))
+        .map(
+            tc ->
+                DynamicTest.dynamicTest(
+                    tc.name,
+                    () -> {
+                      Map<String, String> props = new HashMap<>();
+                      props.put(
+                          ResourceProviderPropertiesCustomizer.ENABLED_KEY,
+                          Strings.join(tc.enabledProviders).with(","));
+                      props.put(
+                          ResourceProviderPropertiesCustomizer.DISABLED_KEY,
+                          Strings.join(tc.disabledProviders).with(","));
+
+                      if (tc.explicitEnabled != null) {
+                        props.put(
+                            "otel.instrumentation." + className + ".enabled",
+                            Boolean.toString(tc.explicitEnabled));
+                      }
+
+                      Attributes attributes =
+                          SdkAutoconfigureAccess.getResourceAttributes(
+                              AutoConfiguredOpenTelemetrySdk.builder()
+                                  .addPropertiesSupplier(() -> props)
+                                  .build());
+
+                      //                      ConfigProperties config =
+                      // DefaultConfigProperties.createFromMap(props);
+                      //                      Map<String, String> customize = new
+                      // ResourceProviderPropertiesCustomizer().customize(
+                      //                          config);
+
+                      if (tc.result) {
+                        assertThat(attributes.get(AttributeKey.stringKey("key")))
+                            .isEqualTo("value");
+                      } else {
+                        assertThat(attributes.get(AttributeKey.stringKey("key"))).isNull();
+                      }
+                      //
+                      //                      assertThat(
+                      //                          customize)
+                      //                          .isEqualTo(tc.result);
+                    }));
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ResourceProviderPropertiesCustomizerTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,8 +26,7 @@ import org.junit.jupiter.api.TestFactory;
 
 public class ResourceProviderPropertiesCustomizerTest {
 
-  public static final class Provider
-      implements io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider {
+  public static final class Provider implements ResourceProvider {
     @Override
     public Resource createResource(ConfigProperties config) {
       return Resource.create(Attributes.of(AttributeKey.stringKey("key"), "value"));
@@ -115,7 +115,7 @@ public class ResourceProviderPropertiesCustomizerTest {
 
                       if (tc.explicitEnabled != null) {
                         props.put(
-                            "otel.instrumentation.test.enabled",
+                            "otel.instrumentation.resource-provider.test.enabled",
                             Boolean.toString(tc.explicitEnabled));
                       }
 

--- a/javaagent-tooling/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/javaagent-tooling/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.javaagent.tooling.config.ResourceProviderPropertiesCustomizerTest$Provider

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/ResourceProviderTest.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/ResourceProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+public class ResourceProviderTest {
+
+  @Test
+  void resourceProviderOrder() throws Exception {
+    boolean containerProviderFound = false;
+    boolean awsProviderFound = false;
+    // verify that aws resource provider is found after the regular container provider
+    // provider that is found later can overrider values from previous providers
+    Class<?> resourceProviderClass =
+        Class.forName(
+            "io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider",
+            false,
+            IntegrationTestUtils.getAgentClassLoader());
+    for (Object resourceProvider :
+        ServiceLoader.load(resourceProviderClass, IntegrationTestUtils.getAgentClassLoader())) {
+      Class<?> clazz = resourceProvider.getClass();
+      if (clazz
+          .getName()
+          .equals("io.opentelemetry.instrumentation.resources.ContainerResourceProvider")) {
+        containerProviderFound = true;
+        assertFalse(awsProviderFound);
+      } else if (clazz.getName().startsWith("io.opentelemetry.contrib.aws.resource.")) {
+        awsProviderFound = true;
+        assertTrue(containerProviderFound);
+      }
+    }
+    assertTrue(containerProviderFound);
+    assertTrue(awsProviderFound);
+  }
+}

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -37,270 +37,282 @@ _2024-03-11 16:28:36 PDT_
 > - **Embedded license files**: [jackson-dataformat-yaml-2.16.2.jar/META-INF/LICENSE](jackson-dataformat-yaml-2.16.2.jar/META-INF/LICENSE)
     - [jackson-dataformat-yaml-2.16.2.jar/META-INF/NOTICE](jackson-dataformat-yaml-2.16.2.jar/META-INF/NOTICE)
 
-**6** **Group:** `com.googlecode.concurrentlinkedhashmap` **Name:** `concurrentlinkedhashmap-lru` **Version:** `1.4.2`
+**6** **Group:** `com.google.cloud.opentelemetry` **Name:** `detector-resources-support` **Version:** `0.27.0`
+> - **POM Project URL**: [https://github.com/GoogleCloudPlatform/opentelemetry-operations-java](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**7** **Group:** `com.googlecode.concurrentlinkedhashmap` **Name:** `concurrentlinkedhashmap-lru` **Version:** `1.4.2`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [http://code.google.com/p/concurrentlinkedhashmap](http://code.google.com/p/concurrentlinkedhashmap)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**7** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.12.0`
+**8** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.12.0`
 > - **POM Project URL**: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [okhttp-4.12.0.jar/okhttp3/internal/publicsuffix/NOTICE](okhttp-4.12.0.jar/okhttp3/internal/publicsuffix/NOTICE)
 
-**8** **Group:** `com.squareup.okio` **Name:** `okio-jvm` **Version:** `3.8.0`
+**9** **Group:** `com.squareup.okio` **Name:** `okio-jvm` **Version:** `3.8.0`
 > - **POM Project URL**: [https://github.com/square/okio/](https://github.com/square/okio/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**9** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api` **Version:** `1.36.0`
+**10** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**10** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api-events` **Version:** `1.36.0-alpha`
+**11** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api-events` **Version:** `1.36.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**11** **Group:** `io.opentelemetry` **Name:** `opentelemetry-context` **Version:** `1.36.0`
+**12** **Group:** `io.opentelemetry` **Name:** `opentelemetry-context` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**12** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-common` **Version:** `1.36.0`
+**13** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-common` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**13** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-logging` **Version:** `1.36.0`
+**14** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-logging` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**14** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-logging-otlp` **Version:** `1.36.0`
+**15** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-logging-otlp` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**15** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-otlp` **Version:** `1.36.0`
+**16** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-otlp` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**16** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-otlp-common` **Version:** `1.36.0`
+**17** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-otlp-common` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**17** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-prometheus` **Version:** `1.36.0-alpha`
+**18** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-prometheus` **Version:** `1.36.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**18** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-sender-okhttp` **Version:** `1.36.0`
+**19** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-sender-okhttp` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**19** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-zipkin` **Version:** `1.36.0`
+**20** **Group:** `io.opentelemetry` **Name:** `opentelemetry-exporter-zipkin` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**20** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-incubator` **Version:** `1.36.0-alpha`
+**21** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-incubator` **Version:** `1.36.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**21** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-kotlin` **Version:** `1.36.0`
+**22** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-kotlin` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**22** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-trace-propagators` **Version:** `1.36.0`
+**23** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-trace-propagators` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**23** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk` **Version:** `1.36.0`
+**24** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**24** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-common` **Version:** `1.36.0`
+**25** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-common` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**25** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-autoconfigure` **Version:** `1.36.0`
+**26** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-autoconfigure` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**26** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-autoconfigure-spi` **Version:** `1.36.0`
+**27** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-autoconfigure-spi` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**27** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-incubator` **Version:** `1.36.0-alpha`
+**28** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-incubator` **Version:** `1.36.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**28** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-jaeger-remote-sampler` **Version:** `1.36.0`
+**29** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-extension-jaeger-remote-sampler` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**29** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-logs` **Version:** `1.36.0`
+**30** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-logs` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**30** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-metrics` **Version:** `1.36.0`
+**31** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-metrics` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**31** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-trace` **Version:** `1.36.0`
+**32** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-trace` **Version:** `1.36.0`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**32** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray-propagator` **Version:** `1.33.0-alpha`
+**33** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-resources` **Version:** `1.33.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**33** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.23.1-alpha`
+**34** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray-propagator` **Version:** `1.28.0-alpha`
+> - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**35** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-gcp-resources` **Version:** `1.33.0-alpha`
+> - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**36** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.23.1-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/semantic-conventions-java](https://github.com/open-telemetry/semantic-conventions-java)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**34** **Group:** `io.prometheus` **Name:** `prometheus-metrics-config` **Version:** `1.1.0`
+**37** **Group:** `io.prometheus` **Name:** `prometheus-metrics-config` **Version:** `1.1.0`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**35** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exporter-common` **Version:** `1.1.0`
+**38** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exporter-common` **Version:** `1.1.0`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**36** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exporter-httpserver` **Version:** `1.1.0`
+**39** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exporter-httpserver` **Version:** `1.1.0`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**37** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exposition-formats` **Version:** `1.1.0`
+**40** **Group:** `io.prometheus` **Name:** `prometheus-metrics-exposition-formats` **Version:** `1.1.0`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**38** **Group:** `io.prometheus` **Name:** `prometheus-metrics-model` **Version:** `1.1.0`
+**41** **Group:** `io.prometheus` **Name:** `prometheus-metrics-model` **Version:** `1.1.0`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**39** **Group:** `io.prometheus` **Name:** `prometheus-metrics-shaded-protobuf` **Version:** `1.1.0`
+**42** **Group:** `io.prometheus` **Name:** `prometheus-metrics-shaded-protobuf` **Version:** `1.1.0`
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**40** **Group:** `io.zipkin.reporter2` **Name:** `zipkin-reporter` **Version:** `3.3.0`
+**43** **Group:** `io.zipkin.reporter2` **Name:** `zipkin-reporter` **Version:** `3.3.0`
 > - **Manifest Project URL**: [https://zipkin.io/](https://zipkin.io/)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [zipkin-reporter-3.3.0.jar/META-INF/LICENSE](zipkin-reporter-3.3.0.jar/META-INF/LICENSE)
 
-**41** **Group:** `io.zipkin.reporter2` **Name:** `zipkin-sender-okhttp3` **Version:** `3.3.0`
+**44** **Group:** `io.zipkin.reporter2` **Name:** `zipkin-sender-okhttp3` **Version:** `3.3.0`
 > - **Manifest Project URL**: [https://zipkin.io/](https://zipkin.io/)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [zipkin-sender-okhttp3-3.3.0.jar/META-INF/LICENSE](zipkin-sender-okhttp3-3.3.0.jar/META-INF/LICENSE)
 
-**42** **Group:** `io.zipkin.zipkin2` **Name:** `zipkin` **Version:** `2.27.1`
+**45** **Group:** `io.zipkin.zipkin2` **Name:** `zipkin` **Version:** `2.27.1`
 > - **Manifest Project URL**: [http://zipkin.io/](http://zipkin.io/)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [zipkin-2.27.1.jar/META-INF/LICENSE](zipkin-2.27.1.jar/META-INF/LICENSE)
 
-**43** **Group:** `net.bytebuddy` **Name:** `byte-buddy-dep` **Version:** `1.14.12`
+**46** **Group:** `net.bytebuddy` **Name:** `byte-buddy-dep` **Version:** `1.14.12`
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [byte-buddy-dep-1.14.12.jar/META-INF/LICENSE](byte-buddy-dep-1.14.12.jar/META-INF/LICENSE)
     - [byte-buddy-dep-1.14.12.jar/META-INF/NOTICE](byte-buddy-dep-1.14.12.jar/META-INF/NOTICE)
 
-**44** **Group:** `org.jetbrains` **Name:** `annotations` **Version:** `13.0`
+**47** **Group:** `org.jetbrains` **Name:** `annotations` **Version:** `13.0`
 > - **POM Project URL**: [http://www.jetbrains.org](http://www.jetbrains.org)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**45** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `1.9.23`
+**48** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `1.9.23`
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**46** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.9.23`
+**49** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.9.23`
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**47** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.9.23`
+**50** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.9.23`
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**48** **Group:** `org.ow2.asm` **Name:** `asm` **Version:** `9.6`
+**51** **Group:** `org.ow2.asm` **Name:** `asm` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**49** **Group:** `org.ow2.asm` **Name:** `asm-analysis` **Version:** `9.6`
+**52** **Group:** `org.ow2.asm` **Name:** `asm-analysis` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**50** **Group:** `org.ow2.asm` **Name:** `asm-commons` **Version:** `9.6`
+**53** **Group:** `org.ow2.asm` **Name:** `asm-commons` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**51** **Group:** `org.ow2.asm` **Name:** `asm-tree` **Version:** `9.6`
+**54** **Group:** `org.ow2.asm` **Name:** `asm-tree` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**52** **Group:** `org.ow2.asm` **Name:** `asm-util` **Version:** `9.6`
+**55** **Group:** `org.ow2.asm` **Name:** `asm-util` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**53** **Group:** `org.snakeyaml` **Name:** `snakeyaml-engine` **Version:** `2.7`
+**56** **Group:** `org.snakeyaml` **Name:** `snakeyaml-engine` **Version:** `2.7`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**54** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `2.2`
+**57** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `2.2`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## MIT License
 
-**55** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.12`
+**58** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.12`
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [slf4j-api-2.0.12.jar/META-INF/LICENSE.txt](slf4j-api-2.0.12.jar/META-INF/LICENSE.txt)
 
-**56** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.12`
+**59** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.12`
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [slf4j-simple-2.0.12.jar/META-INF/LICENSE.txt](slf4j-simple-2.0.12.jar/META-INF/LICENSE.txt)
 
 ## The 3-Clause BSD License
 
-**57** **Group:** `org.ow2.asm` **Name:** `asm` **Version:** `9.6`
+**60** **Group:** `org.ow2.asm` **Name:** `asm` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**58** **Group:** `org.ow2.asm` **Name:** `asm-analysis` **Version:** `9.6`
+**61** **Group:** `org.ow2.asm` **Name:** `asm-analysis` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**59** **Group:** `org.ow2.asm` **Name:** `asm-commons` **Version:** `9.6`
+**62** **Group:** `org.ow2.asm` **Name:** `asm-commons` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**60** **Group:** `org.ow2.asm` **Name:** `asm-tree` **Version:** `9.6`
+**63** **Group:** `org.ow2.asm` **Name:** `asm-tree` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**61** **Group:** `org.ow2.asm` **Name:** `asm-util` **Version:** `9.6`
+**64** **Group:** `org.ow2.asm` **Name:** `asm-util` **Version:** `9.6`
 > - **Manifest Project URL**: [http://asm.ow2.org](http://asm.ow2.org)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [http://asm.ow2.io/](http://asm.ow2.io/)
@@ -309,4 +321,4 @@ _2024-03-11 16:28:36 PDT_
 
 ## Unknown
 
-**62** **Group:** `com.squareup.okio` **Name:** `okio` **Version:** `3.8.0`
+**65** **Group:** `com.squareup.okio` **Name:** `okio` **Version:** `3.8.0`

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -151,7 +151,7 @@ _2024-03-11 16:28:36 PDT_
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**34** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray-propagator` **Version:** `1.28.0-alpha`
+**34** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray-propagator` **Version:** `1.33.0-alpha`
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 


### PR DESCRIPTION
plugins can be enabled or disabled using `otel.resource.providers.<>.enabled`, e.g. `otel.resource.providers.aws.enabled`

Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10447