### PR TITLE
Override xray trace header insteand of appending

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/RequestHeaderSetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/RequestHeaderSetter.java
@@ -13,6 +13,6 @@ enum RequestHeaderSetter implements TextMapSetter<SdkHttpRequest.Builder> {
 
   @Override
   public void set(SdkHttpRequest.Builder builder, String name, String value) {
-    builder.appendHeader(name, value);
+    builder.putHeader(name, value);
   }
 }


### PR DESCRIPTION
### Bug description
It is a bug fix that OTel propagator should always call `putHeader()` method to override the trace header in AWS request instead of appending a trace header on existing http header values. The method `appendMethod()` worked before because AWS java SDK only keeps the last value in http header value list. 
But recently [AWS Java SDK fixed the http header values chunked problem](https://github.com/aws/aws-sdk-java-v2/pull/4897), now all the values in http header are retained, it causes AWS service may receive 2 trace header values for a trace header key, then breaks trace context propagation.
<img width="770" alt="Screenshot 2024-03-05 at 4 05 50 PM" src="https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/66336933/cf8079a5-9e86-416e-85da-1eff2ab3529b">

#### Details regarding AWS request may have trace header not from OpenTelemetry
case 1:
it is an AWS design that in AWS Lambda environment, the AWS SDK will automatically inject a trace header to outgoing requests without OTel SDK needed. If customer instruments his Lambda function by OTel, OTel should override the trace header from AWS SDK one.

case 2:
User makes mistake that he instruments the application by 2 different SDKs

### Solution
override existing trace header instead of appending value on it.
