### PR TITLE
Avoid virtual thread deadlock by not using inline expunction on virtual fields

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -47,8 +47,10 @@ public final class RuntimeVirtualFieldSupplier {
 
   private static final class CacheBasedVirtualFieldSupplier implements VirtualFieldSupplier {
 
+    // We use a cache without inline expunction here to prevent deadlocks on virtual threads
+    // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10747
     private final Cache<Class<?>, Cache<Class<?>, VirtualField<?, ?>>>
-        ownerToFieldToImplementationMap = Cache.weak();
+        ownerToFieldToImplementationMap = Cache.weakWithoutInlineExpunction();
 
     @Override
     @SuppressWarnings("unchecked")

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -62,7 +62,10 @@ public final class RuntimeVirtualFieldSupplier {
   }
 
   private static final class CacheBasedVirtualField<T, F> extends VirtualField<T, F> {
-    private final Cache<T, F> cache = Cache.weak();
+
+    // We use a cache without inline expunction here to prevent deadlocks on virtual threads
+    // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10747
+    private final Cache<T, F> cache = Cache.weakWithoutInlineExpunction();
 
     @Override
     @Nullable

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/Cache.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/Cache.java
@@ -24,7 +24,15 @@ public interface Cache<K, V> {
    * Object#equals(Object)}.
    */
   static <K, V> Cache<K, V> weak() {
-    return new WeakLockFreeCache<>();
+    return new WeakLockFreeCache<>(true);
+  }
+
+  /**
+   * Same as {@link #weak()}, but the provided cache doesn't do inline cleanup of GCed keys.
+   * Instead, those are cleaned up by a background thread.
+   */
+  static <K, V> Cache<K, V> weakWithoutInlineExpunction() {
+    return new WeakLockFreeCache<>(false);
   }
 
   /**

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/WeakLockFreeCache.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/WeakLockFreeCache.java
@@ -12,8 +12,12 @@ final class WeakLockFreeCache<K, V> implements Cache<K, V> {
 
   private final WeakConcurrentMap<K, V> delegate;
 
-  WeakLockFreeCache() {
-    this.delegate = new WeakConcurrentMap.WithInlinedExpunction<>();
+  WeakLockFreeCache(boolean inlineExpunction) {
+    if (inlineExpunction) {
+      this.delegate = new WeakConcurrentMap.WithInlinedExpunction<>();
+    } else {
+      this.delegate = new WeakConcurrentMap<>();
+    }
   }
 
   @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -266,8 +266,11 @@ final class VirtualFieldImplementationsGenerator {
   // Called from generated code
   @SuppressWarnings({"UnusedMethod", "UnusedVariable", "MethodCanBeStatic"})
   static final class VirtualFieldImplementationTemplate extends VirtualField<Object, Object> {
+
+    // We use a cache without inline expunction here to prevent deadlocks on virtual threads
+    // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10747
     private static final VirtualFieldImplementationTemplate INSTANCE =
-        new VirtualFieldImplementationTemplate(Cache.weak());
+        new VirtualFieldImplementationTemplate(Cache.weakWithoutInlineExpunction());
 
     private final Cache<Object, Object> map;
 


### PR DESCRIPTION
Attempt to fix #10747.

Unfortunately I wasn't able to reproduce the original issue and add a test case, because it is unclear under which conditions `Continuation.yield` may throw exceptions. These exceptions are required to reproduce the issue.