### PR TITLE
Prevent renovate updating alpha artifacts to snapshot version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,8 @@
       // major.minor.patch, under the assumption that you would want to update to the stable version
       // of that release instead of the unstable version for a future release
       // (TODO remove once the artifacts above release stable versions)
-      "ignoreUnstable": false
+      "ignoreUnstable": false,
+      "allowedVersions": "!/\\-SNAPSHOT$/"
     },
     {
       "matchPackagePrefixes": ["ch.qos.logback:"],


### PR DESCRIPTION
An alternative to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10761