### PR TITLE
Support Pulsar producer and consumer metrics

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/README.md
+++ b/instrumentation/pulsar/pulsar-2.8/README.md
@@ -1,5 +1,28 @@
 # Settings for the Apache Pulsar instrumentation
 
 | System property                                            | Type    | Default | Description                                         |
-| ---------------------------------------------------------- | ------- | ------- | --------------------------------------------------- |
+|------------------------------------------------------------|---------|---------|-----------------------------------------------------|
 | `otel.instrumentation.pulsar.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
+| `otel.instrumentation.pulsar-clients-metrics.enable`       | Boolean | `true`  | Enable the Pulsar producer and consumer metrics.    |
+
+# Pulsar Client Metrics
+
+The following table shows the full set of metrics exposed by the OpenTelemetry Pulsar client
+instrumentation.
+
+## Producer Metrics
+
+| Metric Name                                    | Attribute Keys                            | Unit     | Metric Description                 | Metric Type               |
+|------------------------------------------------|-------------------------------------------|----------|------------------------------------|---------------------------|
+| `pulsar.client.producer.message.sent.size`     | `topic` `producer.name`                   | bytes    | Counts the size of sent messages   | `LONG_OBSERVABLE_GAUGE`   |
+| `pulsar.client.producer.message.sent.count`    | `topic` `producer.name` `response.status` | messages | Counts the number of sent messages | `LONG_OBSERVABLE_GAUGE`   |
+| `pulsar.client.producer.message.sent.duration` | `topic` `producer.name` `quantile`        | ms       | The duration of sent messages      | `DOUBLE_OBSERVABLE_GAUGE` |
+
+## Consumer Metrics
+
+| Metric Name                                     | Attribute Keys                                           | Unit     | Metric Description                                 | Metric Type             |
+|-------------------------------------------------|----------------------------------------------------------|----------|----------------------------------------------------|-------------------------|
+| `pulsar.client.consumer.message.received.size`  | `topic` `subscription` `consumer.name`                   | bytes    | Counts the size of received messages               | `LONG_OBSERVABLE_GAUGE` |
+| `pulsar.client.consumer.message.received.count` | `topic` `subscription` `consumer.name` `response.status` | messages | Counts the number of received messages             | `LONG_OBSERVABLE_GAUGE` |
+| `pulsar.client.consumer.acks.sent.count`        | `topic` `subscription` `consumer.name` `response.status` | acks     | Counts the number of sent message acknowledgements | `LONG_OBSERVABLE_GAUGE` |
+| `pulsar.client.consumer.receiver.queue.usage`   | `topic` `subscription` `consumer.name`                   | messages | Number of the messages in the receiver queue       | `LONG_OBSERVABLE_GAUGE` |

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/ProducerImplInstrumentation.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/ProducerImplInstrumentation.java
@@ -51,6 +51,12 @@ public class ProducerImplInstrumentation implements TypeInstrumentation {
             .and(named("sendAsync"))
             .and(takesArgument(1, named("org.apache.pulsar.client.impl.SendCallback"))),
         ProducerImplInstrumentation.class.getName() + "$ProducerSendAsyncMethodAdvice");
+
+    transformer.applyAdviceToMethod(
+        isMethod()
+            .and(isPublic())
+            .and(named("closeAsync")),
+        ProducerImplInstrumentation.class.getName() + "$ProducerCloseAsyncMethodAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -63,6 +69,7 @@ public class ProducerImplInstrumentation implements TypeInstrumentation {
       String brokerUrl = pulsarClient.getLookup().getServiceUrl();
       String topic = producer.getTopic();
       VirtualFieldStore.inject(producer, brokerUrl, topic);
+      PulsarMetricsUtil.getMetricsRegistry().registerProducer(producer);
     }
   }
 
@@ -83,6 +90,14 @@ public class ProducerImplInstrumentation implements TypeInstrumentation {
 
       Context context = producerInstrumenter().start(parent, request);
       callback = new SendCallbackWrapper(context, request, callback);
+    }
+  }
+
+  public static class ProducerCloseAsyncMethodAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void before(
+        @Advice.This ProducerImpl<?> producer) {
+      PulsarMetricsUtil.getMetricsRegistry().deleteProducer(producer);
     }
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarConfigs.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarConfigs.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
+
+public class PulsarConfigs {
+
+  public static final String METRICS_CONFIG_NAME = "otel.instrumentation.pulsar-clients-metrics.enabled";
+  public static final String EXPERIMENTAL_SPAN_ATTRIBUTES_NAME = "otel.instrumentation.pulsar.experimental-span-attributes";
+
+  private PulsarConfigs() {
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarMetricsRegistry.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarMetricsRegistry.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
+
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_CONSUMER_NAME;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_PRODUCER_NAME;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_QUANTILE;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_RESPONSE_STATUS;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_SUBSCRIPTION;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.ATTRIBUTE_TOPIC;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.CONSUMER_METRICS_PREFIX;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.PRODUCER_METRICS_PREFIX;
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarMetricsUtil.SCOPE_NAME;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.client.impl.ProducerImpl;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class PulsarMetricsRegistry {
+
+  private final Set<ProducerImpl<?>> producers = Collections.synchronizedSet(
+      new HashSet<>());
+  private final Set<ConsumerImpl<?>> consumers = Collections.synchronizedSet(
+      new HashSet<>());
+  private final Meter meter = GlobalOpenTelemetry.getMeterProvider()
+      .meterBuilder(SCOPE_NAME)
+      .build();
+
+  public void init() {
+
+    /* =========================== Producer Metrics =========================== */
+
+    // pulsar.client.producer.message.sent.size
+    meter.gaugeBuilder(PRODUCER_METRICS_PREFIX + "message.sent.size")
+        .setUnit("bytes")
+        .setDescription("Counts the size of sent messages")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ProducerImpl<?> producer : PulsarMetricsRegistry.this.producers) {
+            measurement.record(producer.getStats().getTotalBytesSent(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName()));
+          }
+        });
+
+    // pulsar.client.producer.message.sent.count
+    meter.gaugeBuilder(PRODUCER_METRICS_PREFIX + "message.sent.count")
+        .setUnit("messages")
+        .setDescription("Counts the number of sent messages")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ProducerImpl<?> producer : PulsarMetricsRegistry.this.producers) {
+            measurement.record(producer.getStats().getTotalMsgsSent(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "success"));
+            measurement.record(producer.getStats().getTotalSendFailed(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "failure"));
+          }
+        });
+
+    // pulsar.client.producer.message.sent.duration
+    meter.gaugeBuilder(PRODUCER_METRICS_PREFIX + "message.sent.duration")
+        .setUnit("ms")
+        .setDescription("The duration of sent messages")
+        .buildWithCallback(measurement -> {
+          for (ProducerImpl<?> producer : PulsarMetricsRegistry.this.producers) {
+            measurement.record(producer.getStats().getSendLatencyMillis50pct(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "0.5"));
+            measurement.record(producer.getStats().getSendLatencyMillis75pct(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "0.75"));
+            measurement.record(producer.getStats().getSendLatencyMillis95pct(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "0.95"));
+            measurement.record(producer.getStats().getSendLatencyMillis99pct(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "0.99"));
+            measurement.record(producer.getStats().getSendLatencyMillis999pct(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "0.999"));
+            measurement.record(producer.getStats().getSendLatencyMillisMax(),
+                Attributes.of(ATTRIBUTE_TOPIC, producer.getTopic(),
+                    ATTRIBUTE_PRODUCER_NAME, producer.getProducerName(),
+                    ATTRIBUTE_QUANTILE, "max"));
+          }
+        });
+
+    /* =========================== Consumer Metrics =========================== */
+
+    // pulsar.client.consumer.message.received.size
+    meter.gaugeBuilder(CONSUMER_METRICS_PREFIX + "message.received.size")
+        .setUnit("bytes")
+        .setDescription("Counts the size of received messages")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ConsumerImpl<?> consumer : PulsarMetricsRegistry.this.consumers) {
+            measurement.record(consumer.getStats().getTotalBytesReceived(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName()));
+          }
+        });
+
+    // pulsar.client.consumer.message.received.count
+    meter.gaugeBuilder(CONSUMER_METRICS_PREFIX + "message.received.count")
+        .setUnit("messages")
+        .setDescription("Counts the number of received messages")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ConsumerImpl<?> consumer : PulsarMetricsRegistry.this.consumers) {
+            measurement.record(consumer.getStats().getTotalMsgsReceived(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "success"));
+            measurement.record(consumer.getStats().getTotalReceivedFailed(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "failure"));
+          }
+        });
+
+    // pulsar.client.consumer.acks.sent.count
+    meter.gaugeBuilder(CONSUMER_METRICS_PREFIX + "acks.sent.count")
+        .setUnit("acks")
+        .setDescription("Counts the number of sent message acknowledgements")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ConsumerImpl<?> consumer : PulsarMetricsRegistry.this.consumers) {
+            measurement.record(consumer.getStats().getTotalAcksSent(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "success"));
+            measurement.record(consumer.getStats().getTotalAcksFailed(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName(),
+                    ATTRIBUTE_RESPONSE_STATUS, "failure"));
+          }
+        });
+
+    // pulsar.client.consumer.receiver.queue.usage
+    meter.gaugeBuilder(CONSUMER_METRICS_PREFIX + "receiver.queue.usage")
+        .setUnit("messages")
+        .setDescription("Number of the messages in the receiver queue")
+        .ofLongs()
+        .buildWithCallback(measurement -> {
+          for (ConsumerImpl<?> consumer : PulsarMetricsRegistry.this.consumers) {
+            measurement.record(consumer.getTotalIncomingMessages(),
+                Attributes.of(ATTRIBUTE_TOPIC, consumer.getTopic(),
+                    ATTRIBUTE_SUBSCRIPTION, consumer.getSubscription(),
+                    ATTRIBUTE_CONSUMER_NAME, consumer.getConsumerName()));
+          }
+        });
+
+    // TODO Add receiver queue limit metrics after the value is exposed by Pulsar Client.
+  }
+
+  public void registerProducer(ProducerImpl<?> producer) {
+    producers.add(producer);
+  }
+
+  public void registerConsumer(ConsumerImpl<?> consumer) {
+    consumers.add(consumer);
+  }
+
+  public void deleteProducer(ProducerImpl<?> producer) {
+    producers.remove(producer);
+  }
+
+  public void deleteConsumer(ConsumerImpl<?> consumer) {
+    consumers.remove(consumer);
+  }
+
+  public int getProducerSize() {
+    return producers.size();
+  }
+
+  public int getConsumerSize() {
+    return consumers.size();
+  }
+
+  public static class PulsarMetricsRegistryDisabled extends PulsarMetricsRegistry {
+
+    public static final PulsarMetricsRegistry INSTANCE = new PulsarMetricsRegistryDisabled();
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void registerProducer(ProducerImpl<?> producer) {
+    }
+
+    @Override
+    public void registerConsumer(ConsumerImpl<?> consumer) {
+    }
+
+    @Override
+    public void deleteProducer(ProducerImpl<?> producer) {
+    }
+
+    @Override
+    public void deleteConsumer(ConsumerImpl<?> consumer) {
+    }
+
+    @Override
+    public int getProducerSize() {
+      return 0;
+    }
+
+    @Override
+    public int getConsumerSize() {
+      return 0;
+    }
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarMetricsUtil.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarMetricsUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
+
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarConfigs.METRICS_CONFIG_NAME;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+
+public class PulsarMetricsUtil {
+
+  public static final String SCOPE_NAME = "io.opentelemetry.pulsar-clients-java-2.8";
+  public static final String PULSAR_CLIENT_PREFIX = "pulsar.client.";
+  public static final String PRODUCER_METRICS_PREFIX = PULSAR_CLIENT_PREFIX + "producer.";
+  public static final String CONSUMER_METRICS_PREFIX = PULSAR_CLIENT_PREFIX + "consumer.";
+  public static final AttributeKey<String> ATTRIBUTE_TOPIC = AttributeKey.stringKey("topic");
+  public static final AttributeKey<String> ATTRIBUTE_SUBSCRIPTION = AttributeKey.stringKey(
+      "subscription");
+  public static final AttributeKey<String> ATTRIBUTE_PRODUCER_NAME = AttributeKey.stringKey(
+      "producer.name");
+  public static final AttributeKey<String> ATTRIBUTE_CONSUMER_NAME = AttributeKey.stringKey(
+      "consumer.name");
+  public static final AttributeKey<String> ATTRIBUTE_QUANTILE = AttributeKey.stringKey("quantile");
+  public static final AttributeKey<String> ATTRIBUTE_RESPONSE_STATUS = AttributeKey.stringKey(
+      "response.status");
+
+  private static volatile PulsarMetricsRegistry metricsRegistry;
+
+  public static synchronized PulsarMetricsRegistry getMetricsRegistry() {
+    if (metricsRegistry == null) {
+      synchronized (PulsarMetricsUtil.class) {
+        if (metricsRegistry == null) {
+          if (InstrumentationConfig.get().getBoolean(METRICS_CONFIG_NAME, true)) {
+            metricsRegistry = new PulsarMetricsRegistry();
+            metricsRegistry.init();
+          } else {
+            metricsRegistry = PulsarMetricsRegistry.PulsarMetricsRegistryDisabled.INSTANCE;
+          }
+        }
+      }
+    }
+    return metricsRegistry;
+  }
+
+  private PulsarMetricsUtil() {
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
+import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarConfigs.EXPERIMENTAL_SPAN_ATTRIBUTES_NAME;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
@@ -122,7 +124,7 @@ public final class PulsarSingletons {
                 ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()));
 
     if (InstrumentationConfig.get()
-        .getBoolean("otel.instrumentation.pulsar.experimental-span-attributes", false)) {
+        .getBoolean(EXPERIMENTAL_SPAN_ATTRIBUTES_NAME, false)) {
       builder.addAttributesExtractor(ExperimentalProducerAttributesExtractor.INSTANCE);
     }
 


### PR DESCRIPTION
### Background

The Apache Pulsar community will directly support [OpenTelemetry metrics](https://github.com/apache/pulsar/pull/22178) in the Pulsar client by adding the OpenTelemetry API dependency. However, it will require users to upgrade to upcoming releases (3.3.0). Users who want to stay on the old version also need a solution to expose Pulsar Client metrics via OpenTelemetry.

### Motivation

This change will expose basic metrics of the Pulsar producers and consumers by default, and users can turn off the Metrics using JVM Args `-Dotel.instrumentation.pulsar-clients-metrics.enabled=false`. So that users can apply the Java Agent to their application to get Pulsar Client metrics from an old version of Pulsar Client (at least from 2.8.0 to 3.2.0). 

The following metrics will be added to the Pulsar client instrumentation.

#### Producer Metrics

| Metric Name                                    | Attribute Keys                            | Unit     | Metric Description                 | Metric Type               |
|------------------------------------------------|-------------------------------------------|----------|------------------------------------|---------------------------|
| `pulsar.client.producer.message.sent.size`     | `topic` `producer.name`                   | bytes    | Counts the size of sent messages   | `LONG_OBSERVABLE_GAUGE`   |
| `pulsar.client.producer.message.sent.count`    | `topic` `producer.name` `response.status` | messages | Counts the number of sent messages | `LONG_OBSERVABLE_GAUGE`   |
| `pulsar.client.producer.message.sent.duration` | `topic` `producer.name` `quantile`        | ms       | The duration of sent messages      | `DOUBLE_OBSERVABLE_GAUGE` |

#### Consumer Metrics

| Metric Name                                     | Attribute Keys                                           | Unit     | Metric Description                                 | Metric Type             |
|-------------------------------------------------|----------------------------------------------------------|----------|----------------------------------------------------|-------------------------|
| `pulsar.client.consumer.message.received.size`  | `topic` `subscription` `consumer.name`                   | bytes    | Counts the size of received messages               | `LONG_OBSERVABLE_GAUGE` |
| `pulsar.client.consumer.message.received.count` | `topic` `subscription` `consumer.name` `response.status` | messages | Counts the number of received messages             | `LONG_OBSERVABLE_GAUGE` |
| `pulsar.client.consumer.acks.sent.count`        | `topic` `subscription` `consumer.name` `response.status` | acks     | Counts the number of sent message acknowledgements | `LONG_OBSERVABLE_GAUGE` |
| `pulsar.client.consumer.receiver.queue.usage`   | `topic` `subscription` `consumer.name`                   | messages | Number of the messages in the receiver queue       | `LONG_OBSERVABLE_GAUGE` |

### Implementation

This PR will introduced a new PulsarMetricsRegistry. The newly created producers and consumers will register to the metrics register and the metrics registry will collect the metrics from the producers and consumer by using Pulsar's public API `producer.getStats()` and `consumer.getStats()`, which exposed the basic metrics of the producer and consumer.

However, the exposed the metrics by the `producer.getStats()` and `consumer.getStats()` do not conformed to the OpenTelemetry metric types. For example, the `getSendLatencyMillis50pct();` method will return the P50 publish latency directly which I can't build a real Summary or even Histogram. So I finally use Gauge for all the metrics exposed by Pulsar Client.