### PR TITLE
Use agent version of the hasSuperType matcher

### DIFF
--- a/instrumentation/xxl-job/xxl-job-1.9.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v1_9_2/SimpleJobHandlerInstrumentation.java
+++ b/instrumentation/xxl-job/xxl-job-1.9.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v1_9_2/SimpleJobHandlerInstrumentation.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.xxljob.v1_9_2;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_GLUE_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_METHOD_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_SCRIPT_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.v1_9_2.XxlJobSingletons.helper;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;

--- a/instrumentation/xxl-job/xxl-job-2.1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v2_1_2/SimpleJobHandlerInstrumentation.java
+++ b/instrumentation/xxl-job/xxl-job-2.1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v2_1_2/SimpleJobHandlerInstrumentation.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.xxljob.v2_1_2;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_GLUE_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_METHOD_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_SCRIPT_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.v2_1_2.XxlJobSingletons.helper;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v2_3_0/SimpleJobHandlerInstrumentation.java
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/v2_3_0/SimpleJobHandlerInstrumentation.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.xxljob.v2_3_0;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_GLUE_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_METHOD_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.common.XxlJobConstants.XXL_SCRIPT_JOB_HANDLER;
 import static io.opentelemetry.javaagent.instrumentation.xxljob.v2_3_0.XxlJobSingletons.helper;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;

--- a/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
+++ b/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
@@ -24,6 +24,7 @@ import net.bytebuddy.agent.builder.AgentBuilder.Default.Transformation;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ErasureMatcher;
 import net.bytebuddy.matcher.HasSuperClassMatcher;
+import net.bytebuddy.matcher.HasSuperTypeMatcher;
 import net.bytebuddy.matcher.NameMatcher;
 import net.bytebuddy.matcher.StringMatcher;
 import net.bytebuddy.matcher.StringSetMatcher;
@@ -42,6 +43,8 @@ public class AgentBuilderUtil {
   private static final Field nameMatcherField = getField(NameMatcher.class, "matcher");
   private static final Field hasSuperClassMatcherField =
       getField(HasSuperClassMatcher.class, "matcher");
+  private static final Field hasSuperTypeMatcherField =
+      getField(HasSuperTypeMatcher.class, "matcher");
   private static final Field erasureMatcherField = getField(ErasureMatcher.class, "matcher");
   private static final Field conjunctionMatchersField =
       getField(ElementMatcher.Junction.Conjunction.class, "matchers");
@@ -160,6 +163,8 @@ public class AgentBuilderUtil {
       return result;
     } else if (matcher instanceof HasSuperClassMatcher) {
       return Result.subtype(inspect(getDelegateMatcher((HasSuperClassMatcher<?>) matcher)));
+    } else if (matcher instanceof HasSuperTypeMatcher) {
+      return Result.subtype(inspect(getDelegateMatcher((HasSuperTypeMatcher<?>) matcher)));
     } else if (matcher instanceof ErasureMatcher) {
       return inspect(getDelegateMatcher((ErasureMatcher<?>) matcher));
     } else if (matcher instanceof NameMatcher) {
@@ -255,6 +260,11 @@ public class AgentBuilderUtil {
   private static ElementMatcher<?> getDelegateMatcher(HasSuperClassMatcher<?> matcher)
       throws Exception {
     return (ElementMatcher<?>) hasSuperClassMatcherField.get(matcher);
+  }
+
+  private static ElementMatcher<?> getDelegateMatcher(HasSuperTypeMatcher<?> matcher)
+      throws Exception {
+    return (ElementMatcher<?>) hasSuperTypeMatcherField.get(matcher);
   }
 
   private static ElementMatcher<?> getDelegateMatcher(ErasureMatcher<?> matcher) throws Exception {


### PR DESCRIPTION
Also implement support for decomposing the byte buddy version of the hasSuperType matcher so that we could skip this matcher when we know that it is not going to match the currently transformed class.