### PR TITLE
Name build artifact with the javaagent jar

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -178,7 +178,9 @@ jobs:
       - name: Upload agent jar
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
+          name: opentelemetry-javaagent
           path: javaagent/build/libs/opentelemetry-javaagent-*-SNAPSHOT.jar
+          if-no-files-found: ignore
 
   test:
     name: test${{ matrix.test-partition }} (${{ matrix.test-java-version }}, ${{ matrix.vm }})


### PR DESCRIPTION
Name the artifact (zip file) that contains the javaagent jar to `opentelemetry-javaagent`, the default name is `artifact`.