### PR TITLE
Fix rocketmq test

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/build.gradle.kts
@@ -31,4 +31,7 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+
+  // with default settings tests will fail when disk is 90% full
+  jvmArgs("-Drocketmq.broker.diskSpaceWarningLevelRatio=1.0")
 }

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/build.gradle.kts
@@ -19,4 +19,6 @@ tasks.withType<Test>().configureEach {
   jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+  // with default settings tests will fail when disk is 90% full
+  jvmArgs("-Drocketmq.broker.diskSpaceWarningLevelRatio=1.0")
 }

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
@@ -284,8 +284,7 @@ abstract class AbstractRocketMqClientTest {
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
                               equalTo(SemanticAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                              equalTo(
-                                  SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
+                              equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
                               equalTo(SemanticAttributes.MESSAGING_OPERATION, "publish"),
                               satisfies(
                                   SemanticAttributes.MESSAGING_MESSAGE_ID,
@@ -320,8 +319,7 @@ abstract class AbstractRocketMqClientTest {
                             .hasLinksSatisfying(links(producerSpanContext.get()))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(SemanticAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
                                 equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
                                 satisfies(
                                     SemanticAttributes.MESSAGING_MESSAGE_BODY_SIZE,
@@ -329,8 +327,7 @@ abstract class AbstractRocketMqClientTest {
                                 satisfies(
                                     SemanticAttributes.MESSAGING_MESSAGE_ID,
                                     val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    SemanticAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
+                                equalTo(SemanticAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isNotEmpty()),
@@ -347,8 +344,7 @@ abstract class AbstractRocketMqClientTest {
                             .hasLinksSatisfying(links(producerSpanContext.get()))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(SemanticAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, sharedTopic),
                                 equalTo(SemanticAttributes.MESSAGING_OPERATION, "process"),
                                 satisfies(
                                     SemanticAttributes.MESSAGING_MESSAGE_BODY_SIZE,
@@ -356,8 +352,7 @@ abstract class AbstractRocketMqClientTest {
                                 satisfies(
                                     SemanticAttributes.MESSAGING_MESSAGE_ID,
                                     val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    SemanticAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagB"),
+                                equalTo(SemanticAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagB"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isNotEmpty()),


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P90D&search.tags=CI&search.timeZoneId=Europe%2FTallinn&tests.container=io.opentelemetry.instrumentation.rocketmqclient.v4_8.RocketMqClientTest&tests.sortField=FLAKY&tests.unstableOnly=true
Conversion from groovy to java made test significantly more flaky, this PR aims to correct the issues introduced with the conversion.