### PR TITLE
Fix muzzle failure in quarkus-resteasy-reactive

### DIFF
--- a/instrumentation/quarkus-resteasy-reactive/javaagent/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/javaagent/build.gradle.kts
@@ -6,7 +6,8 @@ muzzle {
   pass {
     group.set("io.quarkus")
     module.set("quarkus-resteasy-reactive")
-    versions.set("(,)")
+    // renamed to quarkus-rest in 3.9.0
+    versions.set("(,3.9.0)")
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10909

`3.9.0` pom uses `relocation` to point to new coordinates which muzzle doesn't seem to like. I didn't add the new artifact to muzzle because I'm not sure whether it would actually work, latest dep version is already capped for `quarkus-resteasy-reactive` (probably because the test stopped working in newer versions, idk whether instrumentation works).