### PR TITLE
Fix flaky vert.x sql concurrency test

### DIFF
--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
@@ -373,23 +373,22 @@ class VertxSqlClientTest {
     for (CompletableFuture<Object> future : futureList) {
       executorService.submit(
           () -> {
-            testing
-                .runWithSpan(
-                    "parent",
-                    () ->
-                        pool.withConnection(
+            testing.runWithSpan(
+                "parent",
+                () ->
+                    pool.withConnection(
                             conn ->
                                 conn.preparedQuery("select * from test where id = $1")
-                                    .execute(Tuple.of(1))))
-                .onComplete(
-                    rowSetAsyncResult -> {
-                      if (rowSetAsyncResult.succeeded()) {
-                        future.complete(rowSetAsyncResult.result());
-                      } else {
-                        future.completeExceptionally(rowSetAsyncResult.cause());
-                      }
-                      latch.countDown();
-                    });
+                                    .execute(Tuple.of(1)))
+                        .onComplete(
+                            rowSetAsyncResult -> {
+                              if (rowSetAsyncResult.succeeded()) {
+                                future.complete(rowSetAsyncResult.result());
+                              } else {
+                                future.completeExceptionally(rowSetAsyncResult.cause());
+                              }
+                              latch.countDown();
+                            }));
           });
     }
     latch.await(30, TimeUnit.SECONDS);


### PR DESCRIPTION
https://ge.opentelemetry.io/s/dt6kbljxdypqq/tests/task/:instrumentation:vertx:vertx-sql-client-4.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientTest/testConcurrency()

The context used in completable future callbacks is either the context where the future was completed in or when the future is already completed the context where the callback is added. Moving adding the `onComplete` callback inside `testing.runWithSpan("parent", ...)` seems to fix test failure when the query has already completed before `onComplete`  is called.
