### PR TITLE
Increase heap size for owasp scan

### DIFF
--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -24,6 +24,10 @@ jobs:
           distribution: temurin
           java-version: 17.0.6
 
+      - name: Increase gradle daemon heap size
+        run: |
+          sed -i "s/org.gradle.jvmargs=/org.gradle.jvmargs=-Xmx3g /" gradle.properties
+
       - uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3.1.0
         with:
           arguments: ":javaagent:dependencyCheckAnalyze"


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/8368425160/job/22920730104
has `OutOfMemoryError`, could be related to `NVD API request failures are occurring; retrying request for the 5 time`