### PR TITLE
AWS Lambda Runtime legacy internal handlers need to be ignored from being instrumented and so traced …

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -39,6 +39,8 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
   public ElementMatcher<TypeDescription> typeMatcher() {
     return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestHandler"))
         .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")))
+        // In Java 8 and Java 11 runtimes, AWS Lambda runtime is packaged under `lambdainternal` package
+        // (it is `com.amazonaws.services.lambda.runtime.api.client` for new runtime likes Java 17 and Java 21)
         .and(not(nameStartsWith("lambdainternal")));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -38,7 +38,8 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestHandler"))
-        .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")));
+        .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")))
+        .and(not(nameStartsWith("lambdainternal")));
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -39,8 +39,10 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
   public ElementMatcher<TypeDescription> typeMatcher() {
     return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestHandler"))
         .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")))
-        // In Java 8 and Java 11 runtimes, AWS Lambda runtime is packaged under `lambdainternal` package
-        // (it is `com.amazonaws.services.lambda.runtime.api.client` for new runtime likes Java 17 and Java 21)
+        // In Java 8 and Java 11 runtimes,
+        // AWS Lambda runtime is packaged under `lambdainternal` package.
+        // But it is `com.amazonaws.services.lambda.runtime.api.client`
+        // for new runtime likes Java 17 and Java 21.
         .and(not(nameStartsWith("lambdainternal")));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/lambdainternal/AwsLambdaLegacyInternalRequestHandler.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/lambdainternal/AwsLambdaLegacyInternalRequestHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package lambdainternal;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class AwsLambdaLegacyInternalRequestHandler implements RequestHandler<String, String> {
+
+  private final RequestHandler<String, String> requestHandler;
+
+  public AwsLambdaLegacyInternalRequestHandler(RequestHandler<String, String> requestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  @Override
+  public String handleRequest(String input, Context context) {
+    return requestHandler.handleRequest(input, context);
+  }
+}


### PR DESCRIPTION
... Otherwise, there might be double root spans.

Fixes #10931 

In Java 8 and Java 11 runtimes, AWS Lambda runtime is packaged under `lambdainternal` package (it is `com.amazonaws.services.lambda.runtime.api.client` for new runtime likes Java 17 and Java 21)

I have 
- zipped `/var/runtime/` folder in the AWS Lambda environment for Java 8 and Java 11 runtimes, 
- uploaded it to S3, 
- downloaded it to my local 
- and then unzipped

Here are the existing files:
<img width="1364" alt="Screenshot 2024-03-23 at 17 01 27" src="https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/3143425/ecc09160-2049-49e4-8158-456acf704df5">

Then I have decompiled classes from `LambdaSandboxJava-byol.jar` and `LambdaJavaRTEntry-byol.jar`.

And as you can see below, AWS Lambda runtime internal classes are packaged under `lambdainternal` package and the internal handler (`lambdainternal.EventHandlerLoader`) we need to ignore is there.

<img width="425" alt="Screenshot 2024-03-23 at 16 41 03" src="https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/3143425/f95335cc-5f4e-4f4b-93c0-23be10147fc8">
