### PR TITLE
feat(spring-mvc): Fallback to name Span including requestURI

### DIFF
--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/HttpRouteSupport.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/HttpRouteSupport.java
@@ -113,6 +113,8 @@ final class HttpRouteSupport {
         if (bestMatchingPattern != null) {
           return prependContextPath(request, bestMatchingPattern.toString());
         }
+      } else {
+        return request.getRequestURI();
       }
     } finally {
       // mimic spring DispatcherServlet and restore the previous value of PATH_ATTRIBUTE

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/WebMvcTelemetryProducingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/WebMvcTelemetryProducingFilter.java
@@ -60,9 +60,7 @@ final class WebMvcTelemetryProducingFilter extends OncePerRequestFilter implemen
       error = t;
       throw t;
     } finally {
-      if (httpRouteSupport.hasMappings()) {
-        HttpServerRoute.update(context, CONTROLLER, httpRouteSupport::getHttpRoute, request);
-      }
+      HttpServerRoute.update(context, CONTROLLER, httpRouteSupport::getHttpRoute, request);
       instrumenter.end(context, request, response, error);
     }
   }


### PR DESCRIPTION
Adding `opentelemetry-spring-boot-starter` defaults to create an instance of `WebMvcTelemetryProducingFilter` for  Spring WebMvc Applications . This filter applies to all requests.

However, you only get "beautiful span names" for  mappings of type `RequestMappingHandlerMapping`. I understand this is most likely related to the desire to group path patterns under a common span name.

For other, non `RequestMappingHandlerMapping` based requests, you get the bare HTTP method - e.g. `GET` for the span name.

Sure, the name `WebMvc` hints at Spring WebMvc, but the filter creates spans already. Besides, the code around it already does most of the wiring you want in more bare situations (e.g. Servlet).

Wouldn't it be reasonable to fallback to `requestURI` based paths, so we get `GET /not-request-mapping-handler-mapping` instead of `GET` span names when the request is not `RequestMappingHandlerMapping` based?

The attached patch does the trick for me.


