### PR TITLE
Add extension functions for Ktor plugins 

### DIFF
--- a/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/HttpClientInstrumentation.java
+++ b/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/HttpClientInstrumentation.java
@@ -56,9 +56,9 @@ public class HttpClientInstrumentation implements TypeInstrumentation {
     public Unit invoke(KtorClientTracingBuilder builder) {
       OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
       builder.setOpenTelemetry(openTelemetry);
-      builder.setCapturedRequestHeaders(CommonConfig.get().getClientRequestHeaders());
-      builder.setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders());
-      builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods());
+      builder.capturedRequestHeaders(CommonConfig.get().getClientRequestHeaders());
+      builder.capturedResponseHeaders(CommonConfig.get().getClientResponseHeaders());
+      builder.knownMethods(CommonConfig.get().getKnownHttpRequestMethods());
 
       return kotlin.Unit.INSTANCE;
     }

--- a/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/ServerInstrumentation.java
+++ b/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/ServerInstrumentation.java
@@ -50,9 +50,9 @@ public class ServerInstrumentation implements TypeInstrumentation {
     public Unit invoke(KtorServerTracing.Configuration configuration) {
       OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
       configuration.setOpenTelemetry(openTelemetry);
-      configuration.setCapturedRequestHeaders(CommonConfig.get().getServerRequestHeaders());
-      configuration.setCapturedResponseHeaders(CommonConfig.get().getServerResponseHeaders());
-      configuration.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods());
+      configuration.capturedRequestHeaders(CommonConfig.get().getServerRequestHeaders());
+      configuration.capturedResponseHeaders(CommonConfig.get().getServerResponseHeaders());
+      configuration.knownMethods(CommonConfig.get().getKnownHttpRequestMethods());
 
       return kotlin.Unit.INSTANCE;
     }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracingBuilder.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracingBuilder.kt
@@ -90,27 +90,15 @@ class KtorClientTracingBuilder {
     additionalExtractors += extractors
   }
 
-  fun attributeExtractor(
-    extractorBuilder: ExtractorBuilder.() -> Unit = {}
-  ) {
+  fun attributeExtractor(extractorBuilder: ExtractorBuilder.() -> Unit = {}) {
     val builder = ExtractorBuilder().apply(extractorBuilder).build()
     addAttributesExtractors(
       object : AttributesExtractor<HttpRequestData, HttpResponse> {
-        override fun onStart(
-          attributes: AttributesBuilder,
-          parentContext: Context,
-          request: HttpRequestData
-        ) {
+        override fun onStart(attributes: AttributesBuilder, parentContext: Context, request: HttpRequestData) {
           builder.onStart(OnStartData(attributes, parentContext, request))
         }
 
-        override fun onEnd(
-          attributes: AttributesBuilder,
-          context: Context,
-          request: HttpRequestData,
-          response: HttpResponse?,
-          error: Throwable?
-        ) {
+        override fun onEnd(attributes: AttributesBuilder, context: Context, request: HttpRequestData, response: HttpResponse?, error: Throwable?) {
           builder.onEnd(OnEndData(attributes, context, request, response, error))
         }
       }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracingBuilder.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracingBuilder.kt
@@ -34,65 +34,78 @@ class KtorClientTracingBuilder {
     this.openTelemetry = openTelemetry
   }
 
-  fun setCapturedRequestHeaders(vararg headers: String) = setCapturedRequestHeaders(headers.asList())
+  @Deprecated(
+    "Please use method `capturedRequestHeaders`",
+    ReplaceWith("capturedRequestHeaders(headers.asIterable())")
+  )
+  fun setCapturedRequestHeaders(vararg headers: String) = capturedRequestHeaders(headers.asIterable())
 
-  fun setCapturedRequestHeaders(headers: List<String>) {
-    httpAttributesExtractorBuilder.setCapturedRequestHeaders(headers)
-  }
+  @Deprecated(
+    "Please use method `capturedRequestHeaders`",
+    ReplaceWith("capturedRequestHeaders(headers)")
+  )
+  fun setCapturedRequestHeaders(headers: List<String>) = capturedRequestHeaders(headers)
 
-  fun capturedRequestHeaders(vararg headers: String) {
-    capturedRequestHeaders(headers.asIterable())
-  }
+  fun capturedRequestHeaders(vararg headers: String) = capturedRequestHeaders(headers.asIterable())
 
   fun capturedRequestHeaders(headers: Iterable<String>) {
-    setCapturedRequestHeaders(headers.toList())
+    httpAttributesExtractorBuilder.setCapturedRequestHeaders(headers.toList())
   }
 
-  fun setCapturedResponseHeaders(vararg headers: String) = setCapturedResponseHeaders(headers.asList())
+  @Deprecated(
+    "Please use method `capturedResponseHeaders`",
+    ReplaceWith("capturedResponseHeaders(headers.asIterable())")
+  )
+  fun setCapturedResponseHeaders(vararg headers: String) = capturedResponseHeaders(headers.asIterable())
 
-  fun setCapturedResponseHeaders(headers: List<String>) {
-    httpAttributesExtractorBuilder.setCapturedResponseHeaders(headers)
-  }
+  @Deprecated(
+    "Please use method `capturedResponseHeaders`",
+    ReplaceWith("capturedResponseHeaders(headers)")
+  )
+  fun setCapturedResponseHeaders(headers: List<String>) = capturedResponseHeaders(headers)
 
-  fun capturedResponseHeaders(vararg headers: String) {
-    capturedResponseHeaders(headers.asIterable())
-  }
+  fun capturedResponseHeaders(vararg headers: String) = capturedResponseHeaders(headers.asIterable())
 
   fun capturedResponseHeaders(headers: Iterable<String>) {
-    setCapturedResponseHeaders(headers.toList())
+    httpAttributesExtractorBuilder.setCapturedResponseHeaders(headers.toList())
   }
 
-  fun setKnownMethods(knownMethods: Set<String>) {
-    httpAttributesExtractorBuilder.setKnownMethods(knownMethods)
-    httpSpanNameExtractorBuilder.setKnownMethods(knownMethods)
-  }
+  @Deprecated(
+    "Please use method `knownMethods`",
+    ReplaceWith("knownMethods(knownMethods)")
+  )
+  fun setKnownMethods(knownMethods: Set<String>) = knownMethods(knownMethods)
 
-  fun knownMethods(vararg methods: String) {
-    setKnownMethods(methods.toSet())
-  }
+  fun knownMethods(vararg methods: String) = knownMethods(methods.asIterable())
 
-  fun knownMethods(methods: Iterable<String>) {
-    setKnownMethods(methods.toSet())
-  }
-
-  fun knownMethods(vararg methods: HttpMethod) {
-    knownMethods(methods.asIterable())
-  }
+  fun knownMethods(vararg methods: HttpMethod) = knownMethods(methods.asIterable())
 
   @JvmName("knownMethodsJvm")
-  fun knownMethods(methods: Iterable<HttpMethod>) {
-    setKnownMethods(methods.map { it.value }.toSet())
+  fun knownMethods(methods: Iterable<HttpMethod>) = knownMethods(methods.map { it.value })
+
+  fun knownMethods(methods: Iterable<String>) {
+    methods.toSet().apply {
+      httpAttributesExtractorBuilder.setKnownMethods(this)
+      httpSpanNameExtractorBuilder.setKnownMethods(this)
+    }
   }
 
+  @Deprecated("Please use method `attributeExtractor`")
   fun addAttributesExtractors(vararg extractors: AttributesExtractor<in HttpRequestData, in HttpResponse>) = addAttributesExtractors(extractors.asList())
 
+  @Deprecated("Please use method `attributeExtractor`")
   fun addAttributesExtractors(extractors: Iterable<AttributesExtractor<in HttpRequestData, in HttpResponse>>) {
-    additionalExtractors += extractors
+    extractors.forEach {
+      attributeExtractor {
+        onStart { it.onStart(attributes, parentContext, request) }
+        onEnd { it.onEnd(attributes, parentContext, request, response, error) }
+      }
+    }
   }
 
   fun attributeExtractor(extractorBuilder: ExtractorBuilder.() -> Unit = {}) {
     val builder = ExtractorBuilder().apply(extractorBuilder).build()
-    addAttributesExtractors(
+    additionalExtractors.add(
       object : AttributesExtractor<HttpRequestData, HttpResponse> {
         override fun onStart(attributes: AttributesBuilder, parentContext: Context, request: HttpRequestData) {
           builder.onStart(OnStartData(attributes, parentContext, request))
@@ -143,12 +156,15 @@ class KtorClientTracingBuilder {
    *
    * @param emitExperimentalHttpClientMetrics `true` if the experimental HTTP client metrics are to be emitted.
    */
+  @Deprecated("Please use method `emitExperimentalHttpClientMetrics`")
   fun setEmitExperimentalHttpClientMetrics(emitExperimentalHttpClientMetrics: Boolean) {
-    this.emitExperimentalHttpClientMetrics = emitExperimentalHttpClientMetrics
+    if (emitExperimentalHttpClientMetrics) {
+      emitExperimentalHttpClientMetrics()
+    }
   }
 
   fun emitExperimentalHttpClientMetrics() {
-    setEmitExperimentalHttpClientMetrics(true)
+    emitExperimentalHttpClientMetrics = true
   }
 
   internal fun build(): KtorClientTracing {

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
@@ -97,9 +97,7 @@ class KtorServerTracing private constructor(
       additionalExtractors.add(extractor)
     }
 
-    fun attributeExtractor(
-      extractorBuilder: ExtractorBuilder.() -> Unit = {}
-    ) {
+    fun attributeExtractor(extractorBuilder: ExtractorBuilder.() -> Unit = {}) {
       val builder = ExtractorBuilder().apply(extractorBuilder).build()
       addAttributeExtractor(
         object : AttributesExtractor<ApplicationRequest, ApplicationResponse> {
@@ -107,13 +105,7 @@ class KtorServerTracing private constructor(
             builder.onStart(OnStartData(attributes, parentContext, request))
           }
 
-          override fun onEnd(
-            attributes: AttributesBuilder,
-            context: Context,
-            request: ApplicationRequest,
-            response: ApplicationResponse?,
-            error: Throwable?
-          ) {
+          override fun onEnd(attributes: AttributesBuilder, context: Context, request: ApplicationRequest, response: ApplicationResponse?, error: Throwable?) {
             builder.onEnd(OnEndData(attributes, context, request, response, error))
           }
         }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
@@ -57,6 +57,7 @@ class KtorServerTracing private constructor(
       this.openTelemetry = openTelemetry
     }
 
+    @Deprecated("Please use method `spanStatusExtractor`")
     fun setStatusExtractor(
       extractor: (SpanStatusExtractor<ApplicationRequest, ApplicationResponse>) -> SpanStatusExtractor<in ApplicationRequest, in ApplicationResponse>
     ) {
@@ -83,6 +84,7 @@ class KtorServerTracing private constructor(
       val error: Throwable?
     )
 
+    @Deprecated("Please use method `spanKindExtractor`")
     fun setSpanKindExtractor(extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<ApplicationRequest>) {
       spanKindExtractor { prevSpanKindExtractor ->
         extractor(prevSpanKindExtractor).extract(this)
@@ -97,6 +99,7 @@ class KtorServerTracing private constructor(
       }
     }
 
+    @Deprecated("Please use method `attributeExtractor`")
     fun addAttributeExtractor(extractor: AttributesExtractor<in ApplicationRequest, in ApplicationResponse>) {
       attributeExtractor {
         onStart {
@@ -156,51 +159,49 @@ class KtorServerTracing private constructor(
       val error: Throwable?
     )
 
-    fun setCapturedRequestHeaders(requestHeaders: List<String>) {
-      httpAttributesExtractorBuilder.setCapturedRequestHeaders(requestHeaders)
-    }
+    @Deprecated(
+      "Please use method `capturedRequestHeaders`",
+      ReplaceWith("capturedRequestHeaders(headers)")
+    )
+    fun setCapturedRequestHeaders(headers: List<String>) = capturedRequestHeaders(headers)
+
+    fun capturedRequestHeaders(vararg headers: String) = capturedRequestHeaders(headers.asIterable())
 
     fun capturedRequestHeaders(headers: Iterable<String>) {
-      setCapturedRequestHeaders(headers.toList())
+      httpAttributesExtractorBuilder.setCapturedRequestHeaders(headers.toList())
     }
 
-    fun capturedRequestHeaders(vararg headers: String) {
-      capturedRequestHeaders(headers.asIterable())
-    }
+    @Deprecated(
+      "Please use method `capturedResponseHeaders`",
+      ReplaceWith("capturedResponseHeaders(headers)")
+    )
+    fun setCapturedResponseHeaders(headers: List<String>) = capturedResponseHeaders(headers)
 
-    fun setCapturedResponseHeaders(responseHeaders: List<String>) {
-      httpAttributesExtractorBuilder.setCapturedResponseHeaders(responseHeaders)
-    }
+    fun capturedResponseHeaders(vararg headers: String) = capturedResponseHeaders(headers.asIterable())
 
     fun capturedResponseHeaders(headers: Iterable<String>) {
-      setCapturedResponseHeaders(headers.toList())
+      httpAttributesExtractorBuilder.setCapturedResponseHeaders(headers.toList())
     }
 
-    fun capturedResponseHeaders(vararg headers: String) {
-      capturedResponseHeaders(headers.asIterable())
-    }
+    @Deprecated(
+      "Please use method `knownMethods`",
+      ReplaceWith("knownMethods(knownMethods)")
+    )
+    fun setKnownMethods(knownMethods: Set<String>) = knownMethods(knownMethods)
 
-    fun setKnownMethods(knownMethods: Set<String>) {
-      httpAttributesExtractorBuilder.setKnownMethods(knownMethods)
-      httpSpanNameExtractorBuilder.setKnownMethods(knownMethods)
-      httpServerRouteBuilder.setKnownMethods(knownMethods)
-    }
+    fun knownMethods(vararg methods: String) = knownMethods(methods.asIterable())
 
-    fun knownMethods(vararg methods: String) {
-      setKnownMethods(methods.toSet())
-    }
-
-    fun knownMethods(methods: Iterable<String>) {
-      setKnownMethods(methods.toSet())
-    }
+    fun knownMethods(vararg methods: HttpMethod) = knownMethods(methods.asIterable())
 
     @JvmName("knownMethodsJvm")
-    fun knownMethods(methods: Iterable<HttpMethod>) {
-      knownMethods(methods.map { it.value })
-    }
+    fun knownMethods(methods: Iterable<HttpMethod>) = knownMethods(methods.map { it.value })
 
-    fun knownMethods(vararg methods: HttpMethod) {
-      knownMethods(methods.map { it.value })
+    fun knownMethods(methods: Iterable<String>) {
+      methods.toSet().apply {
+        httpAttributesExtractorBuilder.setKnownMethods(this)
+        httpSpanNameExtractorBuilder.setKnownMethods(this)
+        httpServerRouteBuilder.setKnownMethods(this)
+      }
     }
 
     internal fun isOpenTelemetryInitialized(): Boolean = this::openTelemetry.isInitialized

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientTest.kt
@@ -20,8 +20,8 @@ class KtorHttpClientTest : AbstractKtorHttpClientTest() {
   override fun HttpClientConfig<*>.installTracing() {
     install(KtorClientTracing) {
       setOpenTelemetry(TESTING.openTelemetry)
-      setCapturedRequestHeaders(listOf(TEST_REQUEST_HEADER))
-      setCapturedResponseHeaders(listOf(TEST_RESPONSE_HEADER))
+      capturedRequestHeaders(TEST_REQUEST_HEADER)
+      capturedResponseHeaders(TEST_RESPONSE_HEADER)
     }
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerSpanKindExtractorTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerSpanKindExtractorTest.kt
@@ -13,7 +13,6 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
@@ -60,13 +59,11 @@ class KtorServerSpanKindExtractorTest : AbstractHttpServerUsingTest<ApplicationE
     return embeddedServer(Netty, port = port) {
       install(KtorServerTracing) {
         setOpenTelemetry(testing.openTelemetry)
-        setSpanKindExtractor {
-          SpanKindExtractor { req ->
-            if (req.uri.startsWith("/from-pubsub/")) {
-              SpanKind.CONSUMER
-            } else {
-              SpanKind.SERVER
-            }
+        spanKindExtractor {
+          if (uri.startsWith("/from-pubsub/")) {
+            SpanKind.CONSUMER
+          } else {
+            SpanKind.SERVER
           }
         }
       }

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorTestUtil.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorTestUtil.kt
@@ -14,8 +14,8 @@ class KtorTestUtil {
     fun installOpenTelemetry(application: Application, openTelemetry: OpenTelemetry) {
       application.install(KtorServerTracing) {
         setOpenTelemetry(openTelemetry)
-        setCapturedRequestHeaders(listOf(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-        setCapturedResponseHeaders(listOf(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
+        capturedRequestHeaders(AbstractHttpServerTest.TEST_REQUEST_HEADER)
+        capturedResponseHeaders(AbstractHttpServerTest.TEST_RESPONSE_HEADER)
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10617
Earlier, an [issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10617) about adding extension functions for plugins that allow writing existing code in the Ktor DSL style was opened. 
In this PR, such new functions were added.
These new functions we used in [the example](https://github.com/ktorio/ktor-samples/tree/main/opentelemetry) where also can be found examples of usages new functions for [server](https://github.com/ktorio/ktor-samples/blob/main/opentelemetry/server/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupServerTelemetry.kt) and [client](https://github.com/ktorio/ktor-samples/blob/main/opentelemetry/client/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupClientTelemetry.kt)