### PR TITLE
Enable build cache for all builds

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -71,11 +71,11 @@ if (useScansGradleCom) {
       }
     }
   }
+}
 
-  buildCache {
-    remote(gradleEnterprise.buildCache) {
-      isPush = isCI && geAccessKey.isNotEmpty()
-    }
+buildCache {
+  remote(gradleEnterprise.buildCache) {
+    isPush = isCI && geAccessKey.isNotEmpty()
   }
 }
 


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10953 I moved the `buildCache` block so it would be enabled only when scans are published to `ge.opentelemetry.io`. Apparently even if you don't authenticate to our develocity you can still read the build cache, moving back the `buildCache` block so that PR builds could also benefit from it.