### PR TITLE
Remove emeriti maintainer company affiliations

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Maintainers ([@open-telemetry/java-instrumentation-maintainers](https://github.c
 Emeritus maintainers:
 
 - [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek)
-- [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Splunk
+- [Nikita Salnikov-Tarnovski](https://github.com/iNikem)
 - [Tyler Benson](https://github.com/tylerbenson)
 
 Learn more about roles in


### PR DESCRIPTION
since they easily become outdated and probably not too relevant anyways