### PR TITLE
OpenTelemetry agent adaption for GraalVM native image

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,261 @@
 Comparing source compatibility of  against 
-No changes.
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.internal.SpanKeyProvider
+	---! REMOVED SUPERCLASS: io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesExtractor
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder<REQUEST,RESPONSE> builder(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<REQUEST,RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<REQUEST,RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.internal.SpanKey internalGetSpanKey()
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor<REQUEST,RESPONSE> build()
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder<REQUEST,RESPONSE> setCapturedRequestHeaders(java.util.List<java.lang.String>)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder<REQUEST,RESPONSE> setCapturedResponseHeaders(java.util.List<java.lang.String>)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder<REQUEST,RESPONSE> setKnownMethods(java.util.Set<java.lang.String>)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getServerAddress(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.Integer getServerPort(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getUrlFull(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.OperationListener
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics get()
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.context.Context, io.opentelemetry.api.common.Attributes, long)
+	---  REMOVED METHOD: PUBLIC(-) io.opentelemetry.context.Context onStart(io.opentelemetry.context.Context, io.opentelemetry.api.common.Attributes, long)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpClientRequestResendCount  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) int get(io.opentelemetry.context.Context)
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.context.Context initialize(io.opentelemetry.context.Context)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getErrorType(java.lang.Object, java.lang.Object, java.lang.Throwable)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.util.List<java.lang.String> getHttpRequestHeader(java.lang.Object, java.lang.String)
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getHttpRequestMethod(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.util.List<java.lang.String> getHttpResponseHeader(java.lang.Object, java.lang.Object, java.lang.String)
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.Integer getHttpResponseStatusCode(java.lang.Object, java.lang.Object, java.lang.Throwable)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.internal.SpanKeyProvider
+	---! REMOVED SUPERCLASS: io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesExtractor
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder<REQUEST,RESPONSE> builder(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.internal.SpanKey internalGetSpanKey()
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor<REQUEST,RESPONSE> build()
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder<REQUEST,RESPONSE> setCapturedRequestHeaders(java.util.List<java.lang.String>)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder<REQUEST,RESPONSE> setCapturedResponseHeaders(java.util.List<java.lang.String>)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder<REQUEST,RESPONSE> setKnownMethods(java.util.Set<java.lang.String>)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.semconv.network.ClientAttributesGetter
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getHttpRoute(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getUrlPath(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getUrlQuery(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getUrlScheme(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerMetrics  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.OperationListener
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics get()
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.context.Context, io.opentelemetry.api.common.Attributes, long)
+	---  REMOVED METHOD: PUBLIC(-) io.opentelemetry.context.Context onStart(io.opentelemetry.context.Context, io.opentelemetry.api.common.Attributes, long)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteBuilder<REQUEST> builder(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer<REQUEST> create(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) void update(io.opentelemetry.context.Context, io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource, java.lang.String)
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) void update(io.opentelemetry.context.Context, io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource, io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteGetter<T>, java.lang.Object)
+		GENERIC TEMPLATES: --- T:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) void update(io.opentelemetry.context.Context, io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource, io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteBiGetter<T,U>, java.lang.Object, java.lang.Object)
+		GENERIC TEMPLATES: --- T:java.lang.Object, --- U:java.lang.Object
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteBiGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- T:java.lang.Object, --- U:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String get(io.opentelemetry.context.Context, java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED ANNOTATION: java.lang.FunctionalInterface
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteBuilder  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer<REQUEST> build()
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteBuilder<REQUEST> setKnownMethods(java.util.Set<java.lang.String>)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- T:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String get(io.opentelemetry.context.Context, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---  REMOVED ANNOTATION: java.lang.FunctionalInterface
+---! REMOVED ENUM: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource  (class removed)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED INTERFACE: java.lang.constant.Constable
+	---! REMOVED INTERFACE: java.lang.Comparable
+	---! REMOVED INTERFACE: java.io.Serializable
+	---! REMOVED SUPERCLASS: java.lang.Enum
+	---! REMOVED FIELD: PUBLIC(-) STATIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource SERVER_FILTER
+	---! REMOVED FIELD: PUBLIC(-) STATIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource CONTROLLER
+	---! REMOVED FIELD: PUBLIC(-) STATIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource SERVER
+	---! REMOVED FIELD: PUBLIC(-) STATIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource NESTED_CONTROLLER
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource valueOf(java.lang.String)
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource[] values()
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder<REQUEST> builder(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder<REQUEST> builder(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor<REQUEST> create(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor<REQUEST> create(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,?>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED CONSTRUCTOR: PUBLIC(-) HttpSpanNameExtractorBuilder(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<REQUEST,?>, io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<REQUEST,?>)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor<REQUEST> build()
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder<REQUEST> setKnownMethods(java.util.Set<java.lang.String>)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter<? super REQUEST,? super RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter<? super REQUEST,? super RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) void extract(io.opentelemetry.instrumentation.api.instrumenter.SpanStatusBuilder, java.lang.Object, java.lang.Object, java.lang.Throwable)
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.network.ClientAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.network.ClientAttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.network.ClientAttributesGetter<REQUEST>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.network.ClientAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getClientAddress(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.Integer getClientPort(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter<REQUEST,RESPONSE>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkLocalAddress(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.net.InetSocketAddress getNetworkLocalInetSocketAddress(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.Integer getNetworkLocalPort(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkPeerAddress(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.net.InetSocketAddress getNetworkPeerInetSocketAddress(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.Integer getNetworkPeerPort(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkProtocolName(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkProtocolVersion(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkTransport(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getNetworkType(java.lang.Object, java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter<REQUEST>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getServerAddress(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.Integer getServerPort(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesExtractor  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---! REMOVED INTERFACE: io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) STATIC(-) io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesExtractor<REQUEST,RESPONSE> create(io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter<REQUEST>)
+		GENERIC TEMPLATES: --- REQUEST:java.lang.Object, --- RESPONSE:java.lang.Object
+	---  REMOVED METHOD: PUBLIC(-) void onEnd(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object, java.lang.Object, java.lang.Throwable)
+	---  REMOVED METHOD: PUBLIC(-) void onStart(io.opentelemetry.api.common.AttributesBuilder, io.opentelemetry.context.Context, java.lang.Object)
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter  (not serializable)
+	---  CLASS FILE FORMAT VERSION: n.a. <- 52.0
+	GENERIC TEMPLATES: --- REQUEST:java.lang.Object
+	---! REMOVED SUPERCLASS: java.lang.Object
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getUrlPath(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getUrlQuery(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable
+	---! REMOVED METHOD: PUBLIC(-) java.lang.String getUrlScheme(java.lang.Object)
+		---  REMOVED ANNOTATION: javax.annotation.Nullable

--- a/instrumentation-native-support/build.gradle.kts
+++ b/instrumentation-native-support/build.gradle.kts
@@ -1,0 +1,36 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+  id("otel.javaagent-instrumentation")
+  id("io.opentelemetry.instrumentation.javaagent-shadowing")
+}
+
+dependencies {
+  compileOnly(project(":javaagent-bootstrap"))
+  compileOnly(project(":javaagent-tooling"))
+  compileOnly(project(":javaagent-extension-api"))
+  compileOnly(project(":instrumentation-api"))
+  compileOnly(project(":instrumentation-annotations-support"))
+  compileOnly(project(":instrumentation:internal:internal-reflection:javaagent"))
+  compileOnly(project(":instrumentation:executors:bootstrap"))
+  compileOnly(project(":instrumentation:java-util-logging:javaagent"))
+  compileOnly(project(":instrumentation:java-util-logging:shaded-stub-for-instrumenting"))
+
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  // Dependent on the modifications in https://github.com/oracle/graal/pull/8077. Use a developing snapshot for now
+  compileOnly("org.graalvm.sdk:graal-sdk:23.0.2-instru")
+}
+
+otelJava {
+  minJavaVersionSupported.set(JavaVersion.VERSION_17)
+}
+
+tasks {
+  val shadowJar by existing(ShadowJar::class) {
+    archiveFileName.set("${project.name}-${project.version}.jar")
+  }
+
+  assemble {
+    dependsOn(shadowJar)
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/CallableAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/CallableAspect.java
@@ -1,0 +1,39 @@
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import io.opentelemetry.javaagent.bootstrap.executors.TaskAdviceHelper;
+import java.util.concurrent.Callable;
+
+/**
+ * Match classes implement {@link Callable}.
+ * This is the native image version of {@code io.opentelemetry.javaagent.instrumentation.executors.CallableInstrumentation}.
+ */
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+@Aspect(implementInterface = "java.util.concurrent.Callable", onlyWith = Aspect.JDKClassOnly.class)
+public class CallableAspect {
+  @Advice.Before("call")
+  public static Scope beforeCall(@Advice.This Callable<?> task) {
+    try {
+      VirtualField<Callable<?>, PropagatedContext> virtualField =
+          VirtualField.find(Callable.class, PropagatedContext.class);
+      return TaskAdviceHelper.makePropagatedContextCurrent(virtualField, task);
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = "call", onThrowable = Throwable.class)
+  public static void afterCall(@Advice.BeforeResult Scope scope) {
+    try {
+      if (scope != null) {
+        scope.close();
+      }
+    } catch (Throwable t) {
+      //do nothing
+    }
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/ExecutorsAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/ExecutorsAspect.java
@@ -1,0 +1,230 @@
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.bootstrap.executors.ContextPropagatingRunnable;
+import io.opentelemetry.javaagent.bootstrap.executors.ExecutorAdviceHelper;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
+
+/**
+ * This is the native image version of
+ * {@code io.opentelemetry.javaagent.instrumentation.executors.JavaExecutorInstrumentation}
+ * and
+ * {@code io.opentelemetry.javaagent.instrumentation.executors.ExecutorMatchers}.
+ */
+@SuppressWarnings({"OtelPrivateConstructorForUtilityClass", "EmptyCatch"})
+@Aspect(matchers = {
+    "java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor",
+    "java.util.concurrent.Executors$DelegatedExecutorService",
+    "java.util.concurrent.Executors$FinalizableDelegatedExecutorService",
+    "java.util.concurrent.ForkJoinPool",
+    "java.util.concurrent.ScheduledThreadPoolExecutor",
+    "java.util.concurrent.ThreadPoolExecutor",
+    "java.util.concurrent.ThreadPerTaskExecutor"})
+public class ExecutorsAspect {
+
+  @Advice.ResultWrapper
+  public static class ResultWrapper {
+    @Advice.BeforeResult
+    public PropagatedContext ret;
+    public Optional<Runnable> newTask;
+  }
+
+  @Advice.Before(value = {"execute", "addTask"}, notFoundAction = Advice.NotFoundAction.ignore)
+  public static ResultWrapper beforeExecute(@Advice.Rewrite(field = "newTask") Runnable task) {
+    try {
+      ResultWrapper resultWrapper = new ResultWrapper();
+      Context context = Java8BytecodeBridge.currentContext();
+      if (!ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        return resultWrapper;
+      }
+      if (ContextPropagatingRunnable.shouldDecorateRunnable(task)) {
+        resultWrapper.newTask = Optional
+            .of(ContextPropagatingRunnable.propagateContext(task, context));
+        return resultWrapper;
+      }
+      VirtualField<Runnable, PropagatedContext> virtualField = VirtualField.find(Runnable.class,
+          PropagatedContext.class);
+      resultWrapper.ret = ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+      return resultWrapper;
+    } catch (Throwable t) {
+      ResultWrapper resultWrapper = new ResultWrapper();
+      resultWrapper.newTask = null;
+      resultWrapper.ret = null;
+      return resultWrapper;
+    }
+  }
+
+  @Advice.After(value = {"execute", "addTask"},
+      onThrowable = Throwable.class, notFoundAction = Advice.NotFoundAction.ignore)
+  public static void afterExecute(
+      @Advice.BeforeResult ResultWrapper resultWrapper,
+      @Advice.Thrown Throwable throwable) {
+    try {
+      ExecutorAdviceHelper.cleanUpAfterSubmit(resultWrapper.ret, throwable);
+    } catch (Throwable t) {
+    }
+
+  }
+
+  @Advice.Before(value = {"execute", "submit", "invoke"},
+      notFoundAction = Advice.NotFoundAction.ignore)
+  public static PropagatedContext enterJobSubmit(ForkJoinTask<?> task) {
+    try {
+      Context context = Java8BytecodeBridge.currentContext();
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        VirtualField<ForkJoinTask<?>, PropagatedContext> virtualField = VirtualField
+            .find(ForkJoinTask.class,
+                PropagatedContext.class);
+        return ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+      }
+      return null;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = {"execute", "submit", "invoke"}, onThrowable = Throwable.class,
+      notFoundAction = Advice.NotFoundAction.ignore)
+  public static void exitJobSubmit(
+      @Advice.BeforeResult PropagatedContext propagatedContext,
+      @Advice.Thrown Throwable throwable) {
+    try {
+      ExecutorAdviceHelper.cleanUpAfterSubmit(propagatedContext, throwable);
+    } catch (Throwable t) {
+
+    }
+  }
+
+  @Advice.Before(value = {"submit", "schedule"}, notFoundAction = Advice.NotFoundAction.ignore,
+      onlyWithReturnType = SubClassOfFuture.class)
+  public static PropagatedContext enterSubmitRunnable(Runnable task) {
+    try {
+      Context context = Java8BytecodeBridge.currentContext();
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        VirtualField<Runnable, PropagatedContext> virtualField = VirtualField.find(Runnable.class,
+            PropagatedContext.class);
+        return ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+      }
+      return null;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = {"submit", "schedule"}, onThrowable = Throwable.class,
+      notFoundAction = Advice.NotFoundAction.ignore, onlyWithReturnType = SubClassOfFuture.class)
+  public static void exitSubmitRunnable(Runnable task,
+      @Advice.BeforeResult PropagatedContext propagatedContext,
+      @Advice.Thrown Throwable throwable,
+      @Advice.Return Future<?> future) {
+    try {
+      if (propagatedContext != null && future != null) {
+        VirtualField<Future<?>, PropagatedContext> virtualField = VirtualField.find(Future.class,
+            PropagatedContext.class);
+        virtualField.set(future, propagatedContext);
+      }
+      ExecutorAdviceHelper.cleanUpAfterSubmit(propagatedContext, throwable);
+    } catch (Throwable t) {
+
+    }
+  }
+
+  @Advice.Before(value = {"submit", "schedule"}, notFoundAction = Advice.NotFoundAction.ignore,
+      onlyWithReturnType = SubClassOfFuture.class)
+  public static PropagatedContext enterSubmitCallable(Callable<?> task) {
+    try {
+      Context context = Java8BytecodeBridge.currentContext();
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        VirtualField<Callable<?>, PropagatedContext> virtualField = VirtualField
+            .find(Callable.class,
+                PropagatedContext.class);
+        return ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+      }
+      return null;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = {"submit", "schedule"}, onThrowable = Throwable.class,
+      notFoundAction = Advice.NotFoundAction.ignore, onlyWithReturnType = SubClassOfFuture.class)
+  public static void exitSubmitCallable(
+      Callable<?> task,
+      @Advice.BeforeResult PropagatedContext propagatedContext,
+      @Advice.Thrown Throwable throwable,
+      @Advice.Return Future<?> future) {
+    try {
+      if (propagatedContext != null && future != null) {
+        VirtualField<Future<?>, PropagatedContext> virtualField = VirtualField.find(Future.class,
+            PropagatedContext.class);
+        virtualField.set(future, propagatedContext);
+      }
+      ExecutorAdviceHelper.cleanUpAfterSubmit(propagatedContext, throwable);
+    } catch (Throwable t) {
+
+    }
+  }
+
+  @Advice.Before(value = {"invokeAny", "invokeAll"}, notFoundAction = Advice.NotFoundAction.ignore)
+  public static Collection<?> submitEnter(
+      Collection<? extends Callable<?>> tasks) {
+    try {
+      if (tasks == null) {
+        return Collections.emptyList();
+      }
+
+      Context context = Java8BytecodeBridge.currentContext();
+      for (Callable<?> task : tasks) {
+        if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+          VirtualField<Callable<?>, PropagatedContext> virtualField = VirtualField
+              .find(Callable.class,
+                  PropagatedContext.class);
+          ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+        }
+      }
+      return tasks;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = {"invokeAny", "invokeAll"}, onThrowable = Throwable.class,
+      notFoundAction = Advice.NotFoundAction.ignore)
+  public static void submitExit(Collection<? extends Callable<?>> originalTasks,
+      @Advice.BeforeResult Collection<? extends Callable<?>> tasks,
+      @Advice.Thrown Throwable throwable) {
+    try {
+      if (throwable != null) {
+        for (Callable<?> task : tasks) {
+          if (task != null) {
+            VirtualField<Callable<?>, PropagatedContext> virtualField = VirtualField
+                .find(Callable.class,
+                    PropagatedContext.class);
+            PropagatedContext propagatedContext = virtualField.get(task);
+            ExecutorAdviceHelper.cleanUpAfterSubmit(propagatedContext, throwable);
+          }
+        }
+      }
+    } catch (Throwable t) {
+
+    }
+  }
+
+  static class SubClassOfFuture implements Predicate<Class<?>> {
+    @Override
+    public boolean test(Class<?> clazz) {
+      return Advice.isInterfaceOf(Future.class, clazz);
+    }
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/ForkJoinTaskAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/ForkJoinTaskAspect.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.bootstrap.executors.ExecutorAdviceHelper;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import io.opentelemetry.javaagent.bootstrap.executors.TaskAdviceHelper;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinTask;
+
+/**
+ * Match subclasses of {@link ForkJoinTask} provided by JDK.
+ * This is the native image version of {@code io.opentelemetry.javaagent.instrumentation.executors.JavaForkJoinTaskInstrumentation}.
+ */
+@SuppressWarnings({"OtelPrivateConstructorForUtilityClass", "EmptyCatch"})
+@Aspect(subClassOf = "java.util.concurrent.ForkJoinTask", onlyWith = Aspect.JDKClassOnly.class)
+public class ForkJoinTaskAspect {
+  @Advice.Before
+  public static Scope exec(@Advice.This ForkJoinTask<?> thisRef) {
+    try {
+      VirtualField<ForkJoinTask<?>, PropagatedContext> virtualField = VirtualField
+          .find(ForkJoinTask.class,
+              PropagatedContext.class);
+      Scope scope = TaskAdviceHelper.makePropagatedContextCurrent(virtualField, thisRef);
+      if (thisRef instanceof Runnable) {
+        VirtualField<Runnable, PropagatedContext> runnableVirtualField = VirtualField
+            .find(Runnable.class,
+                PropagatedContext.class);
+        Scope newScope = TaskAdviceHelper
+            .makePropagatedContextCurrent(runnableVirtualField, (Runnable) thisRef);
+        if (null != newScope) {
+          if (null != scope) {
+            newScope.close();
+          } else {
+            scope = newScope;
+          }
+        }
+      }
+      if (thisRef instanceof Callable) {
+        VirtualField<Callable<?>, PropagatedContext> callableVirtualField = VirtualField
+            .find(Callable.class,
+                PropagatedContext.class);
+        Scope newScope = TaskAdviceHelper.makePropagatedContextCurrent(
+            callableVirtualField, (Callable<?>) thisRef);
+        if (null != newScope) {
+          if (null != scope) {
+            newScope.close();
+          } else {
+            scope = newScope;
+          }
+        }
+      }
+      return scope;
+    } catch (Throwable t) {
+      // suppress exception
+      return null;
+    }
+  }
+
+  @Advice.After(value = "exec", onThrowable = Throwable.class)
+  public static void afterExec(@Advice.BeforeResult Scope scope) {
+    try {
+      if (scope != null) {
+        scope.close();
+      }
+    } catch (Throwable t) {
+
+    }
+
+  }
+
+  @Advice.Before("fork")
+  public static PropagatedContext beforeFork(@Advice.This ForkJoinTask<?> task) {
+    try {
+      Context context = Java8BytecodeBridge.currentContext();
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        VirtualField<ForkJoinTask<?>, PropagatedContext> virtualField = VirtualField
+            .find(ForkJoinTask.class,
+                PropagatedContext.class);
+        return ExecutorAdviceHelper.attachContextToTask(context, virtualField, task);
+      }
+      return null;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @Advice.After(value = "fork", onThrowable = Throwable.class)
+  public static void afterFork(
+      @Advice.BeforeResult PropagatedContext propagatedContext,
+      @Advice.Thrown Throwable throwable) {
+    ExecutorAdviceHelper.cleanUpAfterSubmit(propagatedContext, throwable);
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/FutureAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/FutureAspect.java
@@ -1,0 +1,45 @@
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.bootstrap.executors.ExecutorAdviceHelper;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
+
+/**
+ * This is the native image version of
+ * {@code io.opentelemetry.javaagent.instrumentation.executors.FutureInstrumentation}.
+ */
+@SuppressWarnings({"OtelPrivateConstructorForUtilityClass", "EmptyCatch"})
+@Aspect(matchers = {
+    "java.util.concurrent.CompletableFuture$BiRelay",
+    "java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor",
+    "java.util.concurrent.ForkJoinTask",
+    "java.util.concurrent.ForkJoinTask$AdaptedCallable",
+    "java.util.concurrent.FutureTask",
+    "java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask",
+})
+public class FutureAspect {
+
+  @Advice.After(onlyWithReturnType = IsBoolean.class, notFoundAction = Advice.NotFoundAction.info)
+  public static void cancel(boolean mayInterruptIfRunning, @Advice.This Future<?> future) {
+    try {
+      VirtualField<Future<?>, PropagatedContext> virtualField = VirtualField.find(Future.class,
+          PropagatedContext.class);
+      ExecutorAdviceHelper.cleanPropagatedContext(virtualField, future);
+    } catch (Throwable t) {
+
+    }
+
+  }
+
+  static class IsBoolean implements Predicate<Class<?>> {
+
+    @Override
+    public boolean test(Class<?> clazz) {
+      return clazz.equals(boolean.class);
+    }
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/LoggerAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/LoggerAspect.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import com.oracle.svm.core.annotate.Aspect.JDKClassOnly;
+
+import io.opentelemetry.javaagent.bootstrap.CallDepth;
+import io.opentelemetry.javaagent.instrumentation.jul.JavaUtilLoggingHelper;
+import io.opentelemetry.api.logs.LoggerProvider;
+
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Match all subclasses of java.util.logging.Logger.
+ * This is the native image version of {@link io.opentelemetry.javaagent.instrumentation.jul.JavaUtilLoggingInstrumentationModule}.
+ */
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+@Aspect(subClassOf = "java.util.logging.Logger", onlyWith = JDKClassOnly.class)
+final public class LoggerAspect {
+  @SuppressWarnings("EmptyCatch")
+  @Advice.Before("log")
+  public static CallDepth beforeLog(LogRecord logRecord, @Advice.This Logger logger) {
+    CallDepth otelCallDepth = null;
+    try {
+      otelCallDepth = CallDepth.forClass(LoggerProvider.class);
+      if (otelCallDepth.getAndIncrement() == 0) {
+        JavaUtilLoggingHelper.capture(logger, logRecord);
+      }
+    } catch (Throwable throwable) {
+
+    }
+    return otelCallDepth;
+  }
+
+  @SuppressWarnings("EmptyCatch")
+  @Advice.After(value = "log", onThrowable = Throwable.class)
+  public static void afterLog(LogRecord logRecord, @Advice.BeforeResult CallDepth otelCallDepth) {
+    try {
+      otelCallDepth.decrementAndGet();
+    } catch (Throwable t) {
+
+    }
+  }
+
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/OTFeature.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/OTFeature.java
@@ -1,0 +1,49 @@
+package io.opentelemetry.javaagent.nativesupport;
+
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldNamesDelegate;
+import org.graalvm.collections.Pair;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+
+/**
+ * Register reflections used in OT code like:
+ * <pre>
+ *      VirtualField&lt;Callable&lt;?&gt;, PropagatedContext&gt; virtualField = VirtualField.find(Callable.class, PropagatedContext.class);
+ * </pre>
+ * The {@code find} method uses reflection. But it can be replaced to reflection result by OT Gradle build plugin at jar build time.
+ */
+@SuppressWarnings({"NotJavadoc", "UnescapedEntity", "rawtypes", "unchecked"})
+public class OTFeature implements Feature {
+
+  private static final Pair<Class<?>, Class<?>>[] virtualFieldClassPairs = new Pair[] {
+      /** from {@link ExecutorsAspect} */
+      Pair.create(Runnable.class, PropagatedContext.class),
+      Pair.create(ForkJoinTask.class, PropagatedContext.class),
+      Pair.create(Future.class, PropagatedContext.class),
+      Pair.create(Callable.class, PropagatedContext.class)
+  };
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess a) {
+    for (Pair<Class<?>, Class<?>> virtualFieldClassPair : virtualFieldClassPairs) {
+      String virtualFieldClassName = GeneratedVirtualFieldNamesDelegate
+          .getVirtualFieldImplementationClassName(virtualFieldClassPair.getLeft().getTypeName(),
+              virtualFieldClassPair.getRight().getTypeName());
+      try {
+        Class<?> c = a.findClassByName(virtualFieldClassName);
+        RuntimeReflection.register(c);
+        Method m = c.getDeclaredMethod("getVirtualField", Class.class, Class.class);
+        RuntimeReflection.register(m);
+      } catch (ReflectiveOperationException e) {
+        System.out.println("Warning: Can't find " + virtualFieldClassName
+            + "#getVirtualField(Class,Class) method");
+      }
+    }
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/RunnableAspect.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/RunnableAspect.java
@@ -1,0 +1,41 @@
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Advice;
+import com.oracle.svm.core.annotate.Aspect;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import io.opentelemetry.javaagent.bootstrap.executors.TaskAdviceHelper;
+
+/**
+ * This is the native image version of
+ * {@code io.opentelemetry.javaagent.instrumentation.executors.RunnableInstrumentation}.
+ */
+@SuppressWarnings({"OtelPrivateConstructorForUtilityClass", "EmptyCatch"})
+@Aspect(implementInterface = "java.lang.Runnable", onlyWith = Aspect.JDKClassOnly.class)
+public class RunnableAspect {
+
+  @Advice.Before("run")
+  public static Scope beforeRun(@Advice.This Runnable thiz) {
+    try {
+      VirtualField<Runnable, PropagatedContext> virtualField = VirtualField.find(Runnable.class,
+          PropagatedContext.class);
+      return TaskAdviceHelper.makePropagatedContextCurrent(virtualField, thiz);
+    } catch (Throwable t) {
+      return null;
+    }
+
+  }
+
+  @Advice.After(value = "run", onThrowable = Throwable.class)
+  public static void afterRun(@Advice.BeforeResult Scope scope) {
+    try {
+      if (scope != null) {
+        scope.close();
+      }
+    } catch (Throwable t) {
+
+    }
+
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_OpenTelemetryAgent.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_OpenTelemetryAgent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.opentelemetry.javaagent.OpenTelemetryAgent;
+import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
+
+import java.lang.instrument.Instrumentation;
+
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+@TargetClass(OpenTelemetryAgent.class)
+public final class Target_io_opentelemetry_javaagent_OpenTelemetryAgent {
+
+  @SuppressWarnings("UnusedMethod")
+  @Substitute
+  private static void startAgent(Instrumentation inst, boolean fromPremain) {
+    try {
+      AgentInitializer.initialize(inst, null, fromPremain);
+    } catch (Throwable ex) {
+      // Don't rethrow.  We don't have a log manager here, so just print.
+      System.err.println("ERROR " + OpenTelemetryAgent.class.getName());
+      ex.printStackTrace();
+    }
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_bootstrap_AgentInitializer.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_bootstrap_AgentInitializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
+import io.opentelemetry.javaagent.bootstrap.AgentStarter;
+
+import java.io.File;
+import java.lang.instrument.Instrumentation;
+
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+@TargetClass(AgentInitializer.class)
+public final class Target_io_opentelemetry_javaagent_bootstrap_AgentInitializer {
+  @Alias private static ClassLoader agentClassLoader;
+
+  @Alias private static AgentStarter agentStarter;
+
+  @SuppressWarnings("Unused")
+  @Substitute
+  public static void initialize(Instrumentation inst, File javaagentFile, boolean fromPremain) {
+    if (agentClassLoader != null) {
+      return;
+    }
+    agentClassLoader = ClassLoader.getSystemClassLoader();
+    agentStarter = createAgentStarter(agentClassLoader, inst, javaagentFile);
+    agentStarter.start();
+  }
+
+  @Alias(noSubstitution = true)
+  private static native AgentStarter createAgentStarter(
+      ClassLoader agentClassLoader, Instrumentation instrumentation, File javaagentFile);
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_tooling_AgentInstaller.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_tooling_AgentInstaller.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.opentelemetry.javaagent.bootstrap.InstrumentedTaskClasses;
+import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+import io.opentelemetry.javaagent.tooling.AgentExtension;
+import io.opentelemetry.javaagent.tooling.AgentInstaller;
+import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
+import io.opentelemetry.javaagent.tooling.asyncannotationsupport.WeakRefAsyncOperationEndStrategies;
+import io.opentelemetry.javaagent.tooling.config.ConfigPropertiesBridge;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
+import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
+import io.opentelemetry.javaagent.tooling.util.Trie;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+import java.lang.instrument.Instrumentation;
+import java.util.List;
+
+import static io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installOpenTelemetrySdk;
+import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.loadOrdered;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.SEVERE;
+
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+@TargetClass(AgentInstaller.class)
+public final class Target_io_opentelemetry_javaagent_tooling_AgentInstaller {
+  @SuppressWarnings("ConstantField")
+  @Alias
+  static String JAVAAGENT_ENABLED_CONFIG;
+
+  @Alias private static io.opentelemetry.javaagent.bootstrap.PatchLogger logger;
+
+  @Substitute
+  public static void installBytebuddyAgent(
+      Instrumentation inst, ClassLoader extensionClassLoader, EarlyInitAgentConfig earlyConfig) {
+    logVersionInfo();
+    if (earlyConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
+      List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
+      installBytebuddyAgent(inst, extensionClassLoader, agentListeners);
+    } else {
+      logger.fine("Tracing is disabled, not installing instrumentations.");
+    }
+  }
+
+  @Substitute
+  private static void installBytebuddyAgent(
+      Instrumentation inst,
+      ClassLoader extensionClassLoader,
+      Iterable<AgentListener> agentListeners) {
+    WeakRefAsyncOperationEndStrategies.initialize();
+
+    // If noop OpenTelemetry is enabled, autoConfiguredSdk will be null and AgentListeners are not
+    // called
+    AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
+        installOpenTelemetrySdk(extensionClassLoader);
+
+    ConfigProperties sdkConfig = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    InstrumentationConfig.internalInitializeConfig(new ConfigPropertiesBridge(sdkConfig));
+    copyNecessaryConfigToSystemProperties(sdkConfig);
+
+    setBootstrapPackages(sdkConfig, extensionClassLoader);
+    /*ConfiguredResourceAttributesHolder.initialize(
+    SdkAutoconfigureAccess.getResourceAttributes(autoConfiguredSdk));*/
+
+    for (BeforeAgentListener agentListener :
+        loadOrdered(BeforeAgentListener.class, extensionClassLoader)) {
+      agentListener.beforeAgent(autoConfiguredSdk);
+    }
+
+    int numberOfLoadedExtensions = 0;
+    for (AgentExtension agentExtension : loadOrdered(AgentExtension.class, extensionClassLoader)) {
+      if (logger.isLoggable(FINE)) {
+        logger.log(
+            FINE,
+            "Loading extension {0} [class {1}]",
+            new Object[] {agentExtension.extensionName(), agentExtension.getClass().getName()});
+      }
+      try {
+        numberOfLoadedExtensions++;
+      } catch (Exception | LinkageError e) {
+        logger.log(
+            SEVERE,
+            "Unable to load extension "
+                + agentExtension.extensionName()
+                + " [class "
+                + agentExtension.getClass().getName()
+                + "]",
+            e);
+      }
+    }
+    logger.log(FINE, "Installed {0} extension(s)", numberOfLoadedExtensions);
+    // configureIgnoredTypes here
+    IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
+    for (IgnoredTypesConfigurer configurer :
+        loadOrdered(IgnoredTypesConfigurer.class, extensionClassLoader)) {
+      configurer.configure(builder, sdkConfig);
+    }
+
+    Trie<Boolean> ignoredTasksTrie = builder.buildIgnoredTasksTrie();
+    InstrumentedTaskClasses.setIgnoredTaskClassesPredicate(ignoredTasksTrie::contains);
+    // configureIgnoredTypes
+    addHttpServerResponseCustomizers(extensionClassLoader);
+
+    runAfterAgentListeners(agentListeners, autoConfiguredSdk);
+  }
+
+  @Alias
+  private static native void logVersionInfo();
+
+  @Alias
+  private static native void copyNecessaryConfigToSystemProperties(ConfigProperties config);
+
+  @Alias
+  private static native void setBootstrapPackages(
+      ConfigProperties config, ClassLoader extensionClassLoader);
+
+  @Alias
+  private static native void addHttpServerResponseCustomizers(ClassLoader extensionClassLoader);
+
+  @Alias
+  private static native void runAfterAgentListeners(
+      Iterable<AgentListener> agentListeners, AutoConfiguredOpenTelemetrySdk autoConfiguredSdk);
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_tooling_AgentStarterImpl.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_io_opentelemetry_javaagent_tooling_AgentStarterImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import io.opentelemetry.javaagent.tooling.AgentStarterImpl;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
+
+@TargetClass(AgentStarterImpl.class)
+public final class Target_io_opentelemetry_javaagent_tooling_AgentStarterImpl {
+
+  @SuppressWarnings({"MethodCanBeStatic", "UnusedVariable", "Unused"})
+  @Substitute
+  private ClassLoader createExtensionClassLoader(
+      ClassLoader agentClassLoader, EarlyInitAgentConfig earlyConfig) {
+    return ClassLoader.getSystemClassLoader();
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_java_lang_Class.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/nativesupport/Target_java_lang_Class.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.nativesupport;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.annotate.TargetElement;
+import io.opentelemetry.javaagent.instrumentation.internal.reflection.ReflectionHelper;
+
+/**
+ * This class is the native support version of {@link
+ * io.opentelemetry.javaagent.instrumentation.internal.reflection.ClassInstrumentation}. <br>
+ * The {@code ClassInstrumentation} class transforms {@link Class} at Java program
+ * <b>runtime</b>. This class do the same transform at native image <b>build time</b>.
+ */
+@TargetClass(Class.class)
+public final class Target_java_lang_Class {
+
+  @Alias(noSubstitution = true)
+  @TargetElement(name = "getInterfaces")
+  private native Class<?>[] originalGetInterfaces(boolean clone);
+
+  /**
+   * This substituted method filters the result of original method. <br>
+   * {@code (Class<?>)(Object)this} makes javac happy. At javac compile time, {@code this} is {@code
+   * Target_java_lang_Class}. At runtime, {@code this} is the original class, i.e. {@code
+   * java.lang.Class}.
+   */
+  @Substitute
+  private Class<?>[] getInterfaces(boolean clone) {
+    return ReflectionHelper.filterInterfaces(
+        originalGetInterfaces(clone), (Class<?>) (Object) this);
+  }
+}

--- a/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNamesDelegate.java
+++ b/instrumentation-native-support/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNamesDelegate.java
@@ -1,0 +1,8 @@
+package io.opentelemetry.javaagent.tooling.field;
+
+@SuppressWarnings("OtelPrivateConstructorForUtilityClass")
+public class GeneratedVirtualFieldNamesDelegate {
+    public static String getVirtualFieldImplementationClassName(String typeName, String fieldTypeName){
+        return GeneratedVirtualFieldNames.getVirtualFieldImplementationClassName(typeName,fieldTypeName);
+    }
+}

--- a/instrumentation-native-support/src/main/resources/META-INF/native-image/native-image.properties
+++ b/instrumentation-native-support/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,0 +1,2 @@
+Args=\
+  --features=io.opentelemetry.javaagent.nativesupport.OTFeature

--- a/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
+++ b/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
@@ -37,6 +37,20 @@ public final class JavaUtilLoggingHelper {
     }
 
     String instrumentationName = logger.getName();
+    capture(instrumentationName,logRecord);
+  }
+
+  public static void capture(java.util.logging.Logger logger, LogRecord logRecord){
+    if (!logger.isLoggable(logRecord.getLevel())) {
+      // this is already checked in most cases, except if Logger.log(LogRecord) was called directly
+      return;
+    }
+
+    String instrumentationName = logger.getName();
+    capture(instrumentationName,logRecord);
+  }
+
+  private static void capture(String instrumentationName, LogRecord logRecord){
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       instrumentationName = "ROOT";
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,6 +84,8 @@ include(":custom-checks")
 include(":muzzle")
 
 // agent projects
+include(":instrumentation-native-support")
+
 include(":opentelemetry-api-shaded-for-instrumenting")
 include(":opentelemetry-ext-annotations-shaded-for-instrumenting")
 include(":opentelemetry-instrumentation-annotations-shaded-for-instrumenting")
@@ -579,3 +581,6 @@ include(":instrumentation:zio:zio-2.0:javaagent")
 // benchmark
 include(":benchmark-overhead-jmh")
 include(":benchmark-jfr-analyzer")
+
+// graalvm native image support
+include(":instrumentation-native-support:main")


### PR DESCRIPTION
## Introduction
GraalVM native image can improve Java applications's startup performance and runtime memory footprint significantly. But as everything is compiled in advance and no bytecode is left at runtime, agent instrumentation at runtime is not possible for native image.
The [agent support PR](https://github.com/oracle/graal/pull/8077) from GraalVM community proposes an approach to address such scenario. It detects the transformed classes and compiles them into the native image. But still a few things need to do at the agent side:

- premain initializations: Original `premain` initializations in agent can't be simply applied to the native image, because it may do something unnecessary and incompatible with native image. For example, OTel installs bytebuddy during premain phase, but it is unnecessary in native image.
- JDK class transformations: GraalVM cann't take the instrumented JDK classes at build time for two major reasons: 1). GraalVM is a Java application as well. Modified JDK classes may lead to unexpected behaviors at build time. 2). GraalVM modified JDK classes too, conflicts are unacceptable. Therefore, agent side should rewrite the JDK class transformations with GraalVM's API.

This PR worked on the above two sides. Together with the [agent support PR](https://github.com/oracle/graal/pull/8077), the spring boot demo application can work with OTel agent now (see the next section for details). 

But this PR only made a minimal adaption to get a few demo applications work. We hope this PR is the start point for OTel agent native adaption. More people in the community can join to complete the adaption.

## Run the Spring Boot Demo Application
Demo project: 
[spring-boot.zip](https://github.com/open-telemetry/opentelemetry-java-instrumentation/files/14916623/spring-boot.zip)


### Prequisite

 - Build the [agent support PR](https://github.com/oracle/graal/pull/8077) to get the GraalVM JDK.
 - Or download the [dev version [binary](https://github.com/ziyilin/ziyi-forked-graal/releases/tag/static-instrument) for the experiment only.
 - Make sure your `GRAALVM_HOME` system variable refers to one of the above GraalVM binaries.

### Steps
1. Build this PR
   1.1  Install graal-sdk-instru.jar. The graal sdk jar can be compiled from the [agent support PR](https://github.com/oracle/graal/pull/8077). A precompiled graal-sdk-23.0.2-instru.jar is enclosed in the demo project zip file. Run ` mvn install:install-file -Dfile=path/to/graal-sdk-23.0.2-instru.jar -Dpackaging=jar -DgroupId=org.graalvm.sdk -DartifactId=graal-sdk -Dversion=23.0.2-instru` to install it for later usage. 
   1.2  `./gradlew publishToMavenLocal`.  Build and install jars to local maven repository.
   1.3  `mvn install:install-file -Dfile=./instrumentation-native-support/build/libs/instrumentation-native-support-2.3.0-alpha-SNAPSHOT.jar -Dpackaging=jar -DgroupId=io.opentelemetry.javaagent -DartifactId=instrumentation-native-support -Dversion=2.3.0-alpha-SNAPSHOT`. Add the native support jar to your local maven repository for later usage. **Note**: the version can be changed. Please modify it according to your actual value.

2. Cd to the root of unzipped demo project
3. `mvn package`: Build the jar package of this project
4. `./run.sh --jvm --collect --log`: Execute the project in JVM mode, enabling OpenTelemetry agent to log monitoring data. Meanwhile, native-image-agent is enabled to collect transformation classes and other dynamic data. When this step ends, data is dumped to `native-configs` directory.
5. `./build.sh`: Build the native image.
6. `./run.sh --svm --log`: Run the native image application. 
7. `curl localhost:2327`: Send a request to the application.

## Limitations
GraalVM native image only has one classloader at runtime, so it cannot support classloader based class isolation which is used in the OTel agent. For example, the `inst/**/*.classdata` files are renamed back to `class` and loaded in the classpath at GraalVM build time for now. One solution is to shade them to new packages, but we are not sure about its impact. It is welcomed for discussion.
