### PR TITLE
Remove unneeded relocation rules

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -28,9 +28,7 @@ tasks.withType<ShadowJar>().configureEach {
     // relocate(OpenTelemetry API) since these classes live in the bootstrap class loader
     relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
     relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
-    relocate("io.opentelemetry.semconv.incubating", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv.incubating")
     relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
-    relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
   }
 
   // relocate(the OpenTelemetry extensions that are used by instrumentation modules)

--- a/examples/distro/gradle/shadow.gradle
+++ b/examples/distro/gradle/shadow.gradle
@@ -12,9 +12,7 @@ ext.relocatePackages = { shadowJar ->
   // relocate(OpenTelemetry API) since these classes live in the bootstrap class loader
   shadowJar.relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
   shadowJar.relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
-  shadowJar.relocate("io.opentelemetry.semconv.incubating", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv.incubating")
   shadowJar.relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
-  shadowJar.relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -97,7 +97,6 @@ tasks.withType<ShadowJar>().configureEach {
     relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
     relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
     relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
-    relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
   }
 
   // relocate(the OpenTelemetry extensions that are used by instrumentation modules)

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
@@ -36,12 +36,6 @@ public class RemappingUrlConnection extends URLConnection {
               "#io.opentelemetry.semconv",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"),
           rule(
-              "#io.opentelemetry.semconv.incubating",
-              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv.incubating"),
-          rule(
-              "#io.opentelemetry.extension.incubator",
-              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator"),
-          rule(
               "#io.opentelemetry.contrib.awsxray",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray"),
           rule(


### PR DESCRIPTION
`io.opentelemetry.semconv.incubating` -> `io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv.incubating` isn't needed because there already is `io.opentelemetry.semconv` -> `io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv`
`io.opentelemetry.extension.incubator` relocation shouldn't be needed because these classes aren't packaged to bootstrap any more