### PR TITLE
Fix printing build scan url when tests failed

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -268,7 +268,7 @@ jobs:
           gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Build scan
-        if: ${{ hashFiles('build-scan.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('build-scan.txt') != '' }}
         run: cat build-scan.txt
 
       - name: Upload deadlock detector artifacts if any

--- a/.github/workflows/reusable-test-indy.yml
+++ b/.github/workflows/reusable-test-indy.yml
@@ -87,5 +87,5 @@ jobs:
           gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Build scan
-        if: ${{ hashFiles('build-scan.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('build-scan.txt') != '' }}
         run: cat build-scan.txt

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -84,7 +84,7 @@ jobs:
           gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Build scan
-        if: ${{ hashFiles('build-scan.txt') != '' }}
+        if: ${{ !cancelled() && hashFiles('build-scan.txt') != '' }}
         run: cat build-scan.txt
 
       - name: Upload deadlock detector artifacts if any


### PR DESCRIPTION
As described in https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions by default `success()` check is added to the condition. Checking for not cancelled should make the job run even when the previous step failed https://docs.github.com/en/actions/learn-github-actions/expressions#always