### PR TITLE
Fix jmx-metrics on wildfly

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
+++ b/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
@@ -33,23 +33,22 @@ public class JmxMetricInsightInstaller implements AgentListener {
 
     if (config.getBoolean("otel.jmx.enabled", true)) {
       JmxMetricInsight service =
-          JmxMetricInsight.createService(GlobalOpenTelemetry.get(), beanDiscoveryDelay(config));
+          JmxMetricInsight.createService(
+              GlobalOpenTelemetry.get(), beanDiscoveryDelay(config).toMillis());
       MetricConfiguration conf = buildMetricConfiguration(config);
       service.start(conf);
     }
   }
 
-  private static long beanDiscoveryDelay(ConfigProperties configProperties) {
-    Long discoveryDelay = configProperties.getLong("otel.jmx.discovery.delay");
+  private static Duration beanDiscoveryDelay(ConfigProperties configProperties) {
+    Duration discoveryDelay = configProperties.getDuration("otel.jmx.discovery.delay");
     if (discoveryDelay != null) {
       return discoveryDelay;
     }
 
     // If discovery delay has not been configured, have a peek at the metric export interval.
     // It makes sense for both of these values to be similar.
-    return configProperties
-        .getDuration("otel.metric.export.interval", Duration.ofMinutes(1))
-        .toMillis();
+    return configProperties.getDuration("otel.metric.export.interval", Duration.ofMinutes(1));
   }
 
   private static String resourceFor(String platform) {

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
@@ -39,12 +39,18 @@ class BeanFinder {
   void discoverBeans(MetricConfiguration conf) {
     this.conf = conf;
 
-    if (!conf.isEmpty()) {
-      // Issue 9336: Corner case: PlatformMBeanServer will remain unitialized until a direct
-      // reference to it is made. This call makes sure that the PlatformMBeanServer will be in
-      // the set of MBeanServers reported by MBeanServerFactory.
-      ManagementFactory.getPlatformMBeanServer();
-    }
+    exec.schedule(
+        () -> {
+          // Issue 9336: Corner case: PlatformMBeanServer will remain unitialized until a direct
+          // reference to it is made. This call makes sure that the PlatformMBeanServer will be in
+          // the set of MBeanServers reported by MBeanServerFactory.
+          // Issue 11143: This call initializes java.util.logging.LogManager. We should not call it
+          // before application has had a chance to configure custom log manager. This is needed for
+          // wildfly.
+          ManagementFactory.getPlatformMBeanServer();
+        },
+        discoveryDelay,
+        TimeUnit.MILLISECONDS);
 
     exec.schedule(
         new Runnable() {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11143
Calling `ManagementFactory.getPlatformMBeanServer()` initializes `java.util.logging.LogManager`. This prevents wildfly from starting because it wants to use a custom LogManager implementation, but can't replace it because java.util.logging is already initialized. This PR adds a delay to calling `ManagementFactory.getPlatformMBeanServer()` which should allow wildfly to set up its logging before this call happens.