### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: gradle/wrapper-validation-action@5188e9b5527a0a094cee21e2fe9a8ca44b4629af # v3.3.1
+      - uses: gradle/actions/wrapper-validation@750cdda3edd6d51b7fdfc069d2e2818cf3c44f4c # v3.3.1
 
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`gradle/wrapper-validation-action` is deprecated