### PR TITLE
Set source version for javadoc task

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -99,6 +99,11 @@ afterEvaluate {
     sourceCompatibility = otelJava.minJavaVersionSupported.get().majorVersion
     targetCompatibility = otelJava.minJavaVersionSupported.get().majorVersion
   }
+  tasks.withType<Javadoc>().configureEach {
+    with(options) {
+      source = otelJava.minJavaVersionSupported.get().majorVersion
+    }
+  }
 }
 
 evaluationDependsOn(":dependencyManagement")

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -60,6 +60,11 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }
 
+tasks.withType<Javadoc>().configureEach {
+  // using com.sun.tools.javac.api.JavacTrees breaks javadoc generation
+  enabled = false
+}
+
 // Our conventions apply this project as a dependency in the errorprone configuration, which would cause
 // a circular dependency if trying to compile this project with that still there. So we filter this
 // project out.


### PR DESCRIPTION
```
/home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation/instrumentation/spring/spring-boot-autoconfigure-3/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/web/RestClientBeanPostProcessor.java:25: error: pattern matching in instanceof is not supported in -source 8

    if (bean instanceof RestClient restClient) {
                                   ^
  (use -source 16 or higher to enable pattern matching in instanceof)
1 error
> Task :instrumentation:spring:spring-boot-autoconfigure-3:javadoc FAILED
```