### PR TITLE
Fix openj9 tests in 1.33.x branch

### DIFF
--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractorTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.AddressAndPort;
@@ -91,9 +92,10 @@ class ForwardedForAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(ForwardedForArgs.class)
+  @SuppressWarnings("MockitoDoSetup")
   void shouldParseForwardedFor(List<String> headers, @Nullable String expectedAddress) {
-    when(getter.getHttpRequestHeader("request", "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader("request", "x-forwarded-for")).thenReturn(headers);
+    doReturn(emptyList()).when(getter).getHttpRequestHeader("request", "forwarded");
+    doReturn(headers).when(getter).getHttpRequestHeader("request", "x-forwarded-for");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, "request");

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.AddressAndPort;
@@ -82,10 +83,11 @@ class ForwardedHostAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(HostArgs.class)
+  @SuppressWarnings("MockitoDoSetup")
   void shouldParseForwardedHost(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "x-forwarded-host")).thenReturn(headers);
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, REQUEST);
@@ -96,11 +98,12 @@ class ForwardedHostAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(HostArgs.class)
+  @SuppressWarnings("MockitoDoSetup")
   void shouldParsePseudoAuthority(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "x-forwarded-host")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, ":authority")).thenReturn(headers);
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, ":authority");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, REQUEST);
@@ -111,12 +114,13 @@ class ForwardedHostAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(HostArgs.class)
+  @SuppressWarnings("MockitoDoSetup")
   void shouldParseHost(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "x-forwarded-host")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, ":authority")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "host")).thenReturn(headers);
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, ":authority");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, "host");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, REQUEST);

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedUrlSchemeProviderTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedUrlSchemeProviderTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -73,10 +74,10 @@ class ForwardedUrlSchemeProviderTest {
 
   @ParameterizedTest
   @ArgumentsSource(ForwardedProtoHeaderValues.class)
+  @SuppressWarnings("MockitoDoSetup")
   void parseForwardedProtoHeader(List<String> values, String expectedScheme) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "x-forwarded-proto")).thenReturn(values);
-    ;
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(values).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-proto");
     assertThat(underTest.apply(REQUEST)).isEqualTo(expectedScheme);
   }
 


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11239 I changed some mockito tests as suggested by errorprone. Unfortunately this makes tests fail on openj9 11 and 17. This PR reverts these changes and adds @@SuppressWarnings("MockitoDoSetup") instead.