### PR TITLE
fix grpc set metadata multi-value

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/MetadataSetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/MetadataSetter.java
@@ -13,6 +13,7 @@ enum MetadataSetter implements TextMapSetter<Metadata> {
 
   @Override
   public void set(Metadata carrier, String key, String value) {
+    carrier.removeAll(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
     carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11237
`removeAll` key before `put` in grpc `MetadataSetter`