### PR TITLE
Remove incubating semconv dependency from library instrumentation

### DIFF
--- a/conventions/src/main/kotlin/otel.javaagent-instrumentation.gradle.kts
+++ b/conventions/src/main/kotlin/otel.javaagent-instrumentation.gradle.kts
@@ -22,3 +22,7 @@ configurations {
     extendsFrom(bootstrap)
   }
 }
+
+dependencies {
+  api("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
+}

--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -12,7 +12,6 @@ group = "io.opentelemetry.instrumentation"
 
 dependencies {
   api("io.opentelemetry.semconv:opentelemetry-semconv")
-  api("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
   api(project(":instrumentation-api"))
   implementation("io.opentelemetry:opentelemetry-api-incubator")
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/code/CodeAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/code/CodeAttributesExtractor.java
@@ -7,10 +7,10 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.code;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import javax.annotation.Nullable;
 
 /**
@@ -20,6 +20,11 @@ import javax.annotation.Nullable;
  */
 public final class CodeAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  // copied from CodeIncubatingAttributes
+  private static final AttributeKey<String> CODE_FUNCTION = AttributeKey.stringKey("code.function");
+  private static final AttributeKey<String> CODE_NAMESPACE =
+      AttributeKey.stringKey("code.namespace");
 
   /** Creates the code attributes extractor. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -37,9 +42,9 @@ public final class CodeAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     Class<?> cls = getter.getCodeClass(request);
     if (cls != null) {
-      internalSet(attributes, CodeIncubatingAttributes.CODE_NAMESPACE, cls.getName());
+      internalSet(attributes, CODE_NAMESPACE, cls.getName());
     }
-    internalSet(attributes, CodeIncubatingAttributes.CODE_FUNCTION, getter.getMethodName(request));
+    internalSet(attributes, CODE_FUNCTION, getter.getMethodName(request));
   }
 
   @Override

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -7,10 +7,10 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 
 /**
  * Extractor of <a
@@ -23,6 +23,10 @@ import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
     extends DbClientCommonAttributesExtractor<
         REQUEST, RESPONSE, DbClientAttributesGetter<REQUEST>> {
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_STATEMENT = AttributeKey.stringKey("db.statement");
+  private static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
 
   /** Creates the database client attributes extractor with default configuration. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -38,7 +42,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    internalSet(attributes, DbIncubatingAttributes.DB_STATEMENT, getter.getStatement(request));
-    internalSet(attributes, DbIncubatingAttributes.DB_OPERATION, getter.getOperation(request));
+    internalSet(attributes, DB_STATEMENT, getter.getStatement(request));
+    internalSet(attributes, DB_OPERATION, getter.getOperation(request));
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesExtractor.java
@@ -7,17 +7,22 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import javax.annotation.Nullable;
 
 abstract class DbClientCommonAttributesExtractor<
         REQUEST, RESPONSE, GETTER extends DbClientCommonAttributesGetter<REQUEST>>
     implements AttributesExtractor<REQUEST, RESPONSE>, SpanKeyProvider {
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
+  private static final AttributeKey<String> DB_SYSTEM = AttributeKey.stringKey("db.system");
+  private static final AttributeKey<String> DB_USER = AttributeKey.stringKey("db.user");
 
   final GETTER getter;
 
@@ -27,9 +32,9 @@ abstract class DbClientCommonAttributesExtractor<
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, DbIncubatingAttributes.DB_SYSTEM, getter.getSystem(request));
-    internalSet(attributes, DbIncubatingAttributes.DB_USER, getter.getUser(request));
-    internalSet(attributes, DbIncubatingAttributes.DB_NAME, getter.getName(request));
+    internalSet(attributes, DB_SYSTEM, getter.getSystem(request));
+    internalSet(attributes, DB_USER, getter.getUser(request));
+    internalSet(attributes, DB_NAME, getter.getName(request));
   }
 
   @Override

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -11,7 +11,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 
 /**
  * Extractor of <a
@@ -19,13 +18,17 @@ import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
  * attributes</a>. This class is designed with SQL (or SQL-like) database clients in mind.
  *
  * <p>It sets the same set of attributes as {@link DbClientAttributesExtractor} plus an additional
- * <code>{@link DbIncubatingAttributes#DB_SQL_TABLE}</code> attribute. The raw SQL statements
- * returned by the {@link SqlClientAttributesGetter#getRawStatement(Object)} method are sanitized
- * before use, all statement parameters are removed.
+ * <code>db.sql.table</code> attribute. The raw SQL statements returned by the {@link
+ * SqlClientAttributesGetter#getRawStatement(Object)} method are sanitized before use, all statement
+ * parameters are removed.
  */
 public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     extends DbClientCommonAttributesExtractor<
         REQUEST, RESPONSE, SqlClientAttributesGetter<REQUEST>> {
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
+  private static final AttributeKey<String> DB_STATEMENT = AttributeKey.stringKey("db.statement");
 
   /** Creates the SQL client attributes extractor with default configuration. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -62,9 +65,8 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
 
     SqlStatementInfo sanitizedStatement = sanitizer.sanitize(getter.getRawStatement(request));
     String operation = sanitizedStatement.getOperation();
-    internalSet(
-        attributes, DbIncubatingAttributes.DB_STATEMENT, sanitizedStatement.getFullStatement());
-    internalSet(attributes, DbIncubatingAttributes.DB_OPERATION, operation);
+    internalSet(attributes, DB_STATEMENT, sanitizedStatement.getFullStatement());
+    internalSet(attributes, DB_OPERATION, operation);
     if (!SQL_CALL.equals(operation)) {
       internalSet(attributes, dbTableAttribute, sanitizedStatement.getMainIdentifier());
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
@@ -10,13 +10,15 @@ import static java.util.Objects.requireNonNull;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 
 /** A builder of {@link SqlClientAttributesExtractor}. */
 public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_SQL_TABLE = AttributeKey.stringKey("db.sql.table");
+
   final SqlClientAttributesGetter<REQUEST> getter;
-  AttributeKey<String> dbTableAttribute = DbIncubatingAttributes.DB_SQL_TABLE;
+  AttributeKey<String> dbTableAttribute = DB_SQL_TABLE;
   boolean statementSanitizationEnabled = true;
 
   SqlClientAttributesExtractorBuilder(SqlClientAttributesGetter<REQUEST> getter) {
@@ -26,7 +28,7 @@ public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
   /**
    * Configures the extractor to set the table value extracted by the {@link
    * SqlClientAttributesExtractor} under the {@code dbTableAttribute} key. By default, the <code>
-   * {@link DbIncubatingAttributes#DB_SQL_TABLE}</code> attribute is used.
+   * db.sql.table</code> attribute is used.
    *
    * @param dbTableAttribute The {@link AttributeKey} under which the table extracted by the {@link
    *     SqlClientAttributesExtractor} will be stored.

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractor.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -22,6 +22,9 @@ import javax.annotation.Nullable;
  */
 public final class HttpClientPeerServiceAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  // copied from PeerIncubatingAttributes
+  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final HttpClientAttributesGetter<REQUEST, RESPONSE> attributesGetter;
   private final PeerServiceResolver peerServiceResolver;
@@ -67,7 +70,7 @@ public final class HttpClientPeerServiceAttributesExtractor<REQUEST, RESPONSE>
     Supplier<String> pathSupplier = () -> getUrlPath(attributesGetter, request);
     String peerService = mapToPeerService(serverAddress, serverPort, pathSupplier);
     if (peerService != null) {
-      attributes.put(PeerIncubatingAttributes.PEER_SERVICE, peerService);
+      attributes.put(PEER_SERVICE, peerService);
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractor.java
@@ -7,18 +7,24 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 
 public final class HttpExperimentalAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  // copied from HttpIncubatingAttributes
+  static final AttributeKey<Long> HTTP_REQUEST_BODY_SIZE =
+      AttributeKey.longKey("http.request.body.size");
+  static final AttributeKey<Long> HTTP_RESPONSE_BODY_SIZE =
+      AttributeKey.longKey("http.response.body.size");
 
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpClientAttributesGetter<REQUEST, RESPONSE> getter) {
@@ -49,11 +55,11 @@ public final class HttpExperimentalAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
 
     Long requestBodySize = requestBodySize(request);
-    internalSet(attributes, HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, requestBodySize);
+    internalSet(attributes, HTTP_REQUEST_BODY_SIZE, requestBodySize);
 
     if (response != null) {
       Long responseBodySize = responseBodySize(request, response);
-      internalSet(attributes, HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, responseBodySize);
+      internalSet(attributes, HTTP_RESPONSE_BODY_SIZE, responseBodySize);
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpMessageBodySizeUtil.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpMessageBodySizeUtil.java
@@ -7,19 +7,19 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import javax.annotation.Nullable;
 
 final class HttpMessageBodySizeUtil {
 
   @Nullable
   static Long getHttpRequestBodySize(Attributes... attributesList) {
-    return getAttribute(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, attributesList);
+    return getAttribute(HttpExperimentalAttributesExtractor.HTTP_REQUEST_BODY_SIZE, attributesList);
   }
 
   @Nullable
   static Long getHttpResponseBodySize(Attributes... attributesList) {
-    return getAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, attributesList);
+    return getAttribute(
+        HttpExperimentalAttributesExtractor.HTTP_RESPONSE_BODY_SIZE, attributesList);
   }
 
   @Nullable

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -7,12 +7,12 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -26,6 +26,32 @@ import javax.annotation.Nullable;
  */
 public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE>, SpanKeyProvider {
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+      AttributeKey.stringKey("messaging.client_id");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
+      AttributeKey.booleanKey("messaging.destination.anonymous");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+      AttributeKey.stringKey("messaging.destination.name");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
+      AttributeKey.stringKey("messaging.destination.template");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
+      AttributeKey.booleanKey("messaging.destination.temporary");
+  private static final AttributeKey<Long> MESSAGING_MESSAGE_BODY_SIZE =
+      AttributeKey.longKey("messaging.message.body.size");
+  private static final AttributeKey<String> MESSAGING_MESSAGE_CONVERSATION_ID =
+      AttributeKey.stringKey("messaging.message.conversation_id");
+  private static final AttributeKey<Long> MESSAGING_MESSAGE_ENVELOPE_SIZE =
+      AttributeKey.longKey("messaging.message.envelope.size");
+  private static final AttributeKey<String> MESSAGING_MESSAGE_ID =
+      AttributeKey.stringKey("messaging.message.id");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_SYSTEM =
+      AttributeKey.stringKey("messaging.system");
 
   static final String TEMP_DESTINATION_NAME = "(temporary)";
 
@@ -62,46 +88,27 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(
-        attributes, MessagingIncubatingAttributes.MESSAGING_SYSTEM, getter.getSystem(request));
+    internalSet(attributes, MESSAGING_SYSTEM, getter.getSystem(request));
     boolean isTemporaryDestination = getter.isTemporaryDestination(request);
     if (isTemporaryDestination) {
-      internalSet(attributes, MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true);
-      internalSet(
-          attributes,
-          MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-          TEMP_DESTINATION_NAME);
+      internalSet(attributes, MESSAGING_DESTINATION_TEMPORARY, true);
+      internalSet(attributes, MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
     } else {
+      internalSet(attributes, MESSAGING_DESTINATION_NAME, getter.getDestination(request));
       internalSet(
-          attributes,
-          MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-          getter.getDestination(request));
-      internalSet(
-          attributes,
-          MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE,
-          getter.getDestinationTemplate(request));
+          attributes, MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
     }
     boolean isAnonymousDestination = getter.isAnonymousDestination(request);
     if (isAnonymousDestination) {
-      internalSet(attributes, MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS, true);
+      internalSet(attributes, MESSAGING_DESTINATION_ANONYMOUS, true);
     }
+    internalSet(attributes, MESSAGING_MESSAGE_CONVERSATION_ID, getter.getConversationId(request));
+    internalSet(attributes, MESSAGING_MESSAGE_BODY_SIZE, getter.getMessageBodySize(request));
     internalSet(
-        attributes,
-        MessagingIncubatingAttributes.MESSAGING_MESSAGE_CONVERSATION_ID,
-        getter.getConversationId(request));
-    internalSet(
-        attributes,
-        MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-        getter.getMessageBodySize(request));
-    internalSet(
-        attributes,
-        MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE,
-        getter.getMessageEnvelopeSize(request));
-    internalSet(
-        attributes, MessagingIncubatingAttributes.MESSAGING_CLIENT_ID, getter.getClientId(request));
+        attributes, MESSAGING_MESSAGE_ENVELOPE_SIZE, getter.getMessageEnvelopeSize(request));
+    internalSet(attributes, MESSAGING_CLIENT_ID, getter.getClientId(request));
     if (operation != null) {
-      internalSet(
-          attributes, MessagingIncubatingAttributes.MESSAGING_OPERATION, operation.operationName());
+      internalSet(attributes, MESSAGING_OPERATION, operation.operationName());
     }
   }
 
@@ -112,14 +119,9 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
+    internalSet(attributes, MESSAGING_MESSAGE_ID, getter.getMessageId(request, response));
     internalSet(
-        attributes,
-        MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-        getter.getMessageId(request, response));
-    internalSet(
-        attributes,
-        MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-        getter.getBatchMessageCount(request, response));
+        attributes, MESSAGING_BATCH_MESSAGE_COUNT, getter.getBatchMessageCount(request, response));
 
     for (String name : capturedHeaders) {
       List<String> values = getter.getMessageHeader(request, name);

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractor.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.net;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import javax.annotation.Nullable;
 
 /**
@@ -19,6 +19,9 @@ import javax.annotation.Nullable;
  */
 public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  // copied from PeerIncubatingAttributes
+  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final ServerAttributesGetter<REQUEST> attributesGetter;
   private final PeerServiceResolver peerServiceResolver;
@@ -60,7 +63,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
     Integer serverPort = attributesGetter.getServerPort(request);
     String peerService = mapToPeerService(serverAddress, serverPort);
     if (peerService != null) {
-      attributes.put(PeerIncubatingAttributes.PEER_SERVICE, peerService);
+      attributes.put(PEER_SERVICE, peerService);
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
@@ -7,14 +7,19 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import javax.annotation.Nullable;
 
 abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  // copied from RpcIncubatingAttributes
+  static final AttributeKey<String> RPC_METHOD = AttributeKey.stringKey("rpc.method");
+  static final AttributeKey<String> RPC_SERVICE = AttributeKey.stringKey("rpc.service");
+  static final AttributeKey<String> RPC_SYSTEM = AttributeKey.stringKey("rpc.system");
 
   private final RpcAttributesGetter<REQUEST> getter;
 
@@ -24,9 +29,9 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   public final void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, RpcIncubatingAttributes.RPC_SYSTEM, getter.getSystem(request));
-    internalSet(attributes, RpcIncubatingAttributes.RPC_SERVICE, getter.getService(request));
-    internalSet(attributes, RpcIncubatingAttributes.RPC_METHOD, getter.getMethod(request));
+    internalSet(attributes, RPC_SYSTEM, getter.getSystem(request));
+    internalSet(attributes, RPC_SERVICE, getter.getService(request));
+    internalSet(attributes, RPC_METHOD, getter.getMethod(request));
   }
 
   @Override

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.Arrays;
 
 final class RpcMetricsAdvice {
+
+  // copied from RpcIncubatingAttributes
+  private static final AttributeKey<Long> RPC_GRPC_STATUS_CODE =
+      AttributeKey.longKey("rpc.grpc.status_code");
 
   static void applyClientDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
@@ -23,10 +27,10 @@ final class RpcMetricsAdvice {
     ((ExtendedDoubleHistogramBuilder) builder)
         .setAttributesAdvice(
             Arrays.asList(
-                RpcIncubatingAttributes.RPC_SYSTEM,
-                RpcIncubatingAttributes.RPC_SERVICE,
-                RpcIncubatingAttributes.RPC_METHOD,
-                RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
+                RpcCommonAttributesExtractor.RPC_SYSTEM,
+                RpcCommonAttributesExtractor.RPC_SERVICE,
+                RpcCommonAttributesExtractor.RPC_METHOD,
+                RPC_GRPC_STATUS_CODE,
                 NetworkAttributes.NETWORK_TYPE,
                 NetworkAttributes.NETWORK_TRANSPORT,
                 ServerAttributes.SERVER_ADDRESS,
@@ -42,10 +46,10 @@ final class RpcMetricsAdvice {
     ((ExtendedDoubleHistogramBuilder) builder)
         .setAttributesAdvice(
             Arrays.asList(
-                RpcIncubatingAttributes.RPC_SYSTEM,
-                RpcIncubatingAttributes.RPC_SERVICE,
-                RpcIncubatingAttributes.RPC_METHOD,
-                RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
+                RpcCommonAttributesExtractor.RPC_SYSTEM,
+                RpcCommonAttributesExtractor.RPC_SERVICE,
+                RpcCommonAttributesExtractor.RPC_METHOD,
+                RPC_GRPC_STATUS_CODE,
                 NetworkAttributes.NETWORK_TYPE,
                 NetworkAttributes.NETWORK_TRANSPORT,
                 ServerAttributes.SERVER_ADDRESS,

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
   api("io.opentelemetry:opentelemetry-api")
   implementation("io.opentelemetry:opentelemetry-api-incubator")
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
-  implementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboClientNetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
@@ -17,7 +18,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -27,6 +27,9 @@ import org.apache.dubbo.rpc.Result;
 public final class DubboTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.apache-dubbo-2.7";
+
+  // copied from PeerIncubatingAttributes
+  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final OpenTelemetry openTelemetry;
   @Nullable private String peerService;
@@ -82,7 +85,7 @@ public final class DubboTelemetryBuilder {
 
     if (peerService != null) {
       clientInstrumenterBuilder.addAttributesExtractor(
-          AttributesExtractor.constant(PeerIncubatingAttributes.PEER_SERVICE, peerService));
+          AttributesExtractor.constant(PEER_SERVICE, peerService));
     }
 
     return new DubboTelemetry(

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientExperimentalMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimentalAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpServerExperimentalMetrics;
@@ -30,7 +31,6 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.armeria.v1_3.internal.ArmeriaHttpClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +41,8 @@ import javax.annotation.Nullable;
 public final class ArmeriaTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.armeria-1.3";
+  // copied from PeerIncubatingAttributes
+  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final OpenTelemetry openTelemetry;
   @Nullable private String peerService;
@@ -243,7 +245,7 @@ public final class ArmeriaTelemetryBuilder {
 
     if (peerService != null) {
       clientInstrumenterBuilder.addAttributesExtractor(
-          AttributesExtractor.constant(PeerIncubatingAttributes.PEER_SERVICE, peerService));
+          AttributesExtractor.constant(PEER_SERVICE, peerService));
     }
     if (emitExperimentalHttpClientMetrics) {
       clientInstrumenterBuilder

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionAttributesExtractor.java
@@ -6,11 +6,10 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0.internal;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -22,6 +21,15 @@ import javax.annotation.Nullable;
  */
 public final class AwsLambdaFunctionAttributesExtractor
     implements AttributesExtractor<AwsLambdaRequest, Object> {
+
+  // copied from FaasIncubatingAttributes
+  private static final AttributeKey<String> FAAS_INVOCATION_ID =
+      AttributeKey.stringKey("faas.invocation_id");
+  // copied from CloudIncubatingAttributes
+  private static final AttributeKey<String> CLOUD_ACCOUNT_ID =
+      AttributeKey.stringKey("cloud.account.id");
+  private static final AttributeKey<String> CLOUD_RESOURCE_ID =
+      AttributeKey.stringKey("cloud.resource_id");
 
   @Nullable private static final MethodHandle GET_FUNCTION_ARN;
 
@@ -47,11 +55,11 @@ public final class AwsLambdaFunctionAttributesExtractor
       io.opentelemetry.context.Context parentContext,
       AwsLambdaRequest request) {
     Context awsContext = request.getAwsContext();
-    attributes.put(FaasIncubatingAttributes.FAAS_INVOCATION_ID, awsContext.getAwsRequestId());
+    attributes.put(FAAS_INVOCATION_ID, awsContext.getAwsRequestId());
     String arn = getFunctionArn(awsContext);
     if (arn != null) {
-      attributes.put(CloudIncubatingAttributes.CLOUD_RESOURCE_ID, arn);
-      attributes.put(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, getAccountId(arn));
+      attributes.put(CLOUD_RESOURCE_ID, arn);
+      attributes.put(CLOUD_ACCOUNT_ID, getAccountId(arn));
     }
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
@@ -14,13 +14,13 @@ import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -30,6 +30,11 @@ import javax.annotation.Nullable;
 
 final class ApiGatewayProxyAttributesExtractor
     implements AttributesExtractor<AwsLambdaRequest, Object> {
+
+  // copied from FaasIncubatingAttributes
+  private static final AttributeKey<String> FAAS_TRIGGER = AttributeKey.stringKey("faas.trigger");
+  // copied from FaasIncubatingAttributes.FaasTriggerValues
+  private static final String HTTP = "http";
 
   private final Set<String> knownMethods;
 
@@ -41,8 +46,7 @@ final class ApiGatewayProxyAttributesExtractor
   public void onStart(
       AttributesBuilder attributes, Context parentContext, AwsLambdaRequest request) {
     if (request.getInput() instanceof APIGatewayProxyRequestEvent) {
-      attributes.put(
-          FaasIncubatingAttributes.FAAS_TRIGGER, FaasIncubatingAttributes.FaasTriggerValues.HTTP);
+      attributes.put(FAAS_TRIGGER, HTTP);
       onRequest(attributes, (APIGatewayProxyRequestEvent) request.getInput());
     }
   }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/SqsEventAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/SqsEventAttributesExtractor.java
@@ -6,17 +6,26 @@
 package io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.annotation.Nullable;
 
 class SqsEventAttributesExtractor implements AttributesExtractor<SQSEvent, Void> {
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_SYSTEM =
+      AttributeKey.stringKey("messaging.system");
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, SQSEvent event) {
-    attributes.put(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS");
-    attributes.put(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process");
+    attributes.put(MESSAGING_SYSTEM, AWS_SQS);
+    attributes.put(MESSAGING_OPERATION, "process");
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/SqsMessageAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/SqsMessageAttributesExtractor.java
@@ -6,20 +6,32 @@
 package io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.annotation.Nullable;
 
 class SqsMessageAttributesExtractor implements AttributesExtractor<SQSMessage, Void> {
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+      AttributeKey.stringKey("messaging.destination.name");
+  private static final AttributeKey<String> MESSAGING_MESSAGE_ID =
+      AttributeKey.stringKey("messaging.message.id");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_SYSTEM =
+      AttributeKey.stringKey("messaging.system");
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, SQSMessage message) {
-    attributes.put(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS");
-    attributes.put(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process");
-    attributes.put(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, message.getMessageId());
-    attributes.put(
-        MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, message.getEventSource());
+    attributes.put(MESSAGING_SYSTEM, AWS_SQS);
+    attributes.put(MESSAGING_OPERATION, "process");
+    attributes.put(MESSAGING_MESSAGE_ID, message.getMessageId());
+    attributes.put(MESSAGING_DESTINATION_NAME, message.getEventSource());
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
@@ -84,7 +84,9 @@ public class AwsLambdaSqsEventWrapperTest {
                     span.hasName("otel process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                            equalTo(
+                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                             equalTo(
                                 MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))));
   }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
@@ -86,7 +86,9 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(0).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                            equalTo(
+                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                             equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
                         .hasLinks(
                             LinkData.create(
@@ -106,7 +108,9 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                            equalTo(
+                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                             equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
                             equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "message1"),
                             equalTo(
@@ -123,7 +127,9 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                            equalTo(
+                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                             equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
                             equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "message2"),
                             equalTo(

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
@@ -81,7 +81,8 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(
@@ -129,7 +130,8 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
@@ -197,7 +197,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "$UrlAttributes.URL_FULL" { it.startsWith("http://") }
             "$ServerAttributes.SERVER_ADDRESS" String
             "$ServerAttributes.SERVER_PORT" { it == null || Number }
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "s3ToSqsTestQueue"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
             "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
@@ -533,7 +533,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "$UrlAttributes.URL_FULL" { it.startsWith("http://") }
             "$ServerAttributes.SERVER_ADDRESS" String
             "$ServerAttributes.SERVER_PORT" { it == null || Number }
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "s3ToSnsToSqsTestQueue"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
             "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
@@ -188,7 +188,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "$UrlAttributes.URL_FULL" String
             "$ServerAttributes.SERVER_ADDRESS" String
             "$ServerAttributes.SERVER_PORT" { it == null || Number }
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "snsToSqsTestQueue"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
             "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SnsAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SnsAttributesExtractor.java
@@ -8,19 +8,23 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.annotation.Nullable;
 
 public class SnsAttributesExtractor implements AttributesExtractor<Request<?>, Response<?>> {
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+      AttributeKey.stringKey("messaging.destination.name");
+
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
     String destination = findMessageDestination(request.getOriginalRequest());
-    AttributesExtractorUtil.internalSet(
-        attributes, MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, destination);
+    AttributesExtractorUtil.internalSet(attributes, MESSAGING_DESTINATION_NAME, destination);
   }
 
   /*

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsAttributesGetter.java
@@ -15,9 +15,12 @@ import javax.annotation.Nullable;
 enum SqsAttributesGetter implements MessagingAttributesGetter<Request<?>, Response<?>> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(Request<?> request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsProcessRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsProcessRequestAttributesGetter.java
@@ -15,9 +15,12 @@ enum SqsProcessRequestAttributesGetter
     implements MessagingAttributesGetter<SqsProcessRequest, Response<?>> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(SqsProcessRequest request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsReceiveRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsReceiveRequestAttributesGetter.java
@@ -16,9 +16,12 @@ enum SqsReceiveRequestAttributesGetter
     implements MessagingAttributesGetter<SqsReceiveRequest, Response<?>> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(SqsReceiveRequest request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
@@ -127,7 +127,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                 equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                     "testSdkSqs"),
@@ -156,7 +157,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                 equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                     "testSdkSqs"),
@@ -234,7 +236,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                 equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                     "testSdkSqs"),
@@ -263,7 +266,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                 equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                     "testSdkSqs"),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -159,7 +159,8 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                   equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                   equalTo(
                                       MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                       "testSdkSqs"),
@@ -202,7 +203,8 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                   equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                   equalTo(
                                       MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                       "testSdkSqs"),
@@ -243,7 +245,8 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                   equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                   equalTo(
                                       MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                       "testSdkSqs"),
@@ -333,7 +336,8 @@ public abstract class AbstractSqsTracingTest {
                                 equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                 equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                 equalTo(
                                     MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                     "testSdkSqs"),
@@ -401,7 +405,8 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                          "AmazonSQS"),
+                                          MessagingIncubatingAttributes.MessagingSystemValues
+                                              .AWS_SQS),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                           "testSdkSqs"),
@@ -437,7 +442,8 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                          "AmazonSQS"),
+                                          MessagingIncubatingAttributes.MessagingSystemValues
+                                              .AWS_SQS),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                           "testSdkSqs"),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.request;
 
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
+import io.opentelemetry.api.common.AttributeKey;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +21,8 @@ enum AwsSdkRequestType {
       /*
        * Only one of TopicArn and TargetArn are permitted on an SNS request.
        */
-      request(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME.getKey(), "TargetArn"),
-      request(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn"));
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TargetArn"),
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn"));
 
   // Wrapping in unmodifiableMap
   @SuppressWarnings("ImmutableEnumChecker")
@@ -34,5 +34,11 @@ enum AwsSdkRequestType {
 
   List<FieldMapping> fields(FieldMapping.Type type) {
     return fields.get(type);
+  }
+
+  private static class AttributeKeys {
+    // copied from MessagingIncubatingAttributes
+    static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+        AttributeKey.stringKey("messaging.destination.name");
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsAttributesGetter.java
@@ -16,9 +16,12 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 enum SqsAttributesGetter implements MessagingAttributesGetter<ExecutionAttributes, Response> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(ExecutionAttributes request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsProcessRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsProcessRequestAttributesGetter.java
@@ -15,9 +15,12 @@ enum SqsProcessRequestAttributesGetter
     implements MessagingAttributesGetter<SqsProcessRequest, Response> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(SqsProcessRequest request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsReceiveRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/SqsReceiveRequestAttributesGetter.java
@@ -16,9 +16,12 @@ enum SqsReceiveRequestAttributesGetter
     implements MessagingAttributesGetter<SqsReceiveRequest, Response> {
   INSTANCE;
 
+  // copied from MessagingIncubatingAttributes.MessagingSystemValues
+  private static final String AWS_SQS = "aws_sqs";
+
   @Override
   public String getSystem(SqsReceiveRequest request) {
-    return "AmazonSQS";
+    return AWS_SQS;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -18,7 +18,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -43,6 +42,12 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 
 /** AWS request execution interceptor. */
 final class TracingExecutionInterceptor implements ExecutionInterceptor {
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
+  private static final AttributeKey<String> DB_SYSTEM = AttributeKey.stringKey("db.system");
+  // copied from DbIncubatingAttributes.DbSystemValues
+  private static final String DB_SYSTEM_DYNAMODB = "dynamodb";
 
   // the class name is part of the attribute name, so that it will be shaded when used in javaagent
   // instrumentation, and won't conflict with usage outside javaagent instrumentation
@@ -312,10 +317,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
     fieldMapper.mapToAttributes(sdkRequest, awsSdkRequest, span);
 
     if (awsSdkRequest.type() == DYNAMODB) {
-      span.setAttribute(DbIncubatingAttributes.DB_SYSTEM, "dynamodb");
+      span.setAttribute(DB_SYSTEM, DB_SYSTEM_DYNAMODB);
       String operation = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
       if (operation != null) {
-        span.setAttribute(DbIncubatingAttributes.DB_OPERATION, operation);
+        span.setAttribute(DB_OPERATION, operation);
       }
     }
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -145,7 +145,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
               "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "somequeue"
               "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "publish"
               "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
-              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             } else if (service == "Kinesis") {
               "aws.stream.name" "somestream"
             } else if (service == "Sns") {
@@ -305,7 +305,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
               "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "somequeue"
               "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "publish"
               "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
-              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             } else if (service == "Kinesis") {
               "aws.stream.name" "somestream"
             } else if (service == "Sns") {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.groovy
@@ -157,7 +157,7 @@ abstract class AbstractAws2SqsSuppressReceiveSpansTest extends InstrumentationSp
             "$UrlAttributes.URL_FULL" { it.startsWith("http://localhost:$sqsPort") }
             "$ServerAttributes.SERVER_ADDRESS" "localhost"
             "$ServerAttributes.SERVER_PORT" sqsPort
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "testSdkSqs"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "publish"
             "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
@@ -178,7 +178,7 @@ abstract class AbstractAws2SqsSuppressReceiveSpansTest extends InstrumentationSp
             "$UrlAttributes.URL_FULL" { it.startsWith("http://localhost:$sqsPort") }
             "$ServerAttributes.SERVER_ADDRESS" "localhost"
             "$ServerAttributes.SERVER_PORT" sqsPort
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "testSdkSqs"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
             "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
@@ -329,7 +329,7 @@ abstract class AbstractAws2SqsSuppressReceiveSpansTest extends InstrumentationSp
             "$UrlAttributes.URL_FULL" { it.startsWith("http://localhost:$sqsPort") }
             "$ServerAttributes.SERVER_ADDRESS" "localhost"
             "$ServerAttributes.SERVER_PORT" sqsPort
-            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+            "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
             "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "testSdkSqs"
             "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "publish"
           }
@@ -351,7 +351,7 @@ abstract class AbstractAws2SqsSuppressReceiveSpansTest extends InstrumentationSp
               "$UrlAttributes.URL_FULL" { it.startsWith("http://localhost:$sqsPort") }
               "$ServerAttributes.SERVER_ADDRESS" "localhost"
               "$ServerAttributes.SERVER_PORT" sqsPort
-              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
               "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "testSdkSqs"
               "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
               "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String
@@ -379,7 +379,7 @@ abstract class AbstractAws2SqsSuppressReceiveSpansTest extends InstrumentationSp
               "$UrlAttributes.URL_FULL" { it.startsWith("http://localhost:$sqsPort") }
               "$ServerAttributes.SERVER_ADDRESS" "localhost"
               "$ServerAttributes.SERVER_PORT" sqsPort
-              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" "AmazonSQS"
+              "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS
               "$MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME" "testSdkSqs"
               "$MessagingIncubatingAttributes.MESSAGING_OPERATION" "process"
               "$MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID" String

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -215,7 +215,8 @@ public abstract class AbstractAws2SqsTracingTest {
                                   equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                                   equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                                   equalTo(
                                       MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                       "testSdkSqs"),
@@ -298,7 +299,8 @@ public abstract class AbstractAws2SqsTracingTest {
                                     equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                     equalTo(
                                         MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                        "AmazonSQS"),
+                                        MessagingIncubatingAttributes.MessagingSystemValues
+                                            .AWS_SQS),
                                     equalTo(
                                         MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                         "testSdkSqs"),
@@ -344,7 +346,8 @@ public abstract class AbstractAws2SqsTracingTest {
                                     equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                     equalTo(
                                         MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                        "AmazonSQS"),
+                                        MessagingIncubatingAttributes.MessagingSystemValues
+                                            .AWS_SQS),
                                     equalTo(
                                         MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                         "testSdkSqs"),
@@ -522,7 +525,9 @@ public abstract class AbstractAws2SqsTracingTest {
                                   v -> v.startsWith("http://localhost:" + sqsPort)),
                               equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                               equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                              equalTo(
+                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                               equalTo(
                                   MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                   "testSdkSqs"),
@@ -549,7 +554,9 @@ public abstract class AbstractAws2SqsTracingTest {
                                   v -> v.startsWith("http://localhost:" + sqsPort)),
                               equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
                               equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS"),
+                              equalTo(
+                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS),
                               equalTo(
                                   MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                   "testSdkSqs"),
@@ -596,7 +603,8 @@ public abstract class AbstractAws2SqsTracingTest {
                                       equalTo(ServerAttributes.SERVER_PORT, sqsPort),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                          "AmazonSQS"),
+                                          MessagingIncubatingAttributes.MessagingSystemValues
+                                              .AWS_SQS),
                                       equalTo(
                                           MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
                                           "testSdkSqs"),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
@@ -95,7 +95,9 @@ class AwsSpanAssertions {
       attributeAssertions.addAll(
           Arrays.asList(
               equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, queueName),
-              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "AmazonSQS")));
+              equalTo(
+                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                  MessagingIncubatingAttributes.MessagingSystemValues.AWS_SQS)));
       if (spanName.endsWith("receive")) {
         attributeAssertions.add(
             equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"));

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
@@ -7,14 +7,15 @@ package io.opentelemetry.instrumentation.cassandra.v4_4;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import javax.annotation.Nullable;
 
 final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<CassandraRequest> {
+  // copied from DbIncubatingAttributes.DbSystemValues
+  private static final String CASSANDRA = "cassandra";
 
   @Override
   public String getSystem(CassandraRequest request) {
-    return DbIncubatingAttributes.DbSystemValues.CASSANDRA;
+    return CASSANDRA;
   }
 
   @Override

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
@@ -8,17 +8,20 @@ package io.opentelemetry.instrumentation.cassandra.v4_4;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 
 /** A builder of {@link CassandraTelemetry}. */
 public class CassandraTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.cassandra-4.4";
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_CASSANDRA_TABLE =
+      AttributeKey.stringKey("db.cassandra.table");
 
   private final OpenTelemetry openTelemetry;
 
@@ -55,7 +58,7 @@ public class CassandraTelemetryBuilder {
             openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(attributesGetter))
         .addAttributesExtractor(
             SqlClientAttributesExtractor.builder(attributesGetter)
-                .setTableAttribute(DbIncubatingAttributes.DB_CASSANDRA_TABLE)
+                .setTableAttribute(DB_CASSANDRA_TABLE)
                 .setStatementSanitizationEnabled(statementSanitizationEnabled)
                 .build())
         .addAttributesExtractor(

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/internal/ElasticsearchDbAttributesGetter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.elasticsearch.rest.internal;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -28,6 +27,9 @@ final class ElasticsearchDbAttributesGetter
   private static final Logger logger =
       Logger.getLogger(ElasticsearchDbAttributesGetter.class.getName());
 
+  // copied from DbIncubatingAttributes.DbSystemValues
+  private static final String ELASTICSEARCH = "elasticsearch";
+
   private final boolean captureSearchQuery;
 
   ElasticsearchDbAttributesGetter(boolean captureSearchQuery) {
@@ -36,7 +38,7 @@ final class ElasticsearchDbAttributesGetter
 
   @Override
   public String getSystem(ElasticsearchRestRequest request) {
-    return DbIncubatingAttributes.DbSystemValues.ELASTICSEARCH;
+    return ELASTICSEARCH;
   }
 
   @Override

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
@@ -9,14 +9,19 @@ import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUti
 import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.requestAttributeKey;
 
 import io.grpc.Status;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 
 final class GrpcAttributesExtractor implements AttributesExtractor<GrpcRequest, Status> {
+
+  // copied from RpcIncubatingAttributes
+  private static final AttributeKey<Long> RPC_GRPC_STATUS_CODE =
+      AttributeKey.longKey("rpc.grpc.status_code");
+
   private final GrpcRpcAttributesGetter getter;
   private final List<String> capturedRequestMetadata;
 
@@ -39,7 +44,7 @@ final class GrpcAttributesExtractor implements AttributesExtractor<GrpcRequest, 
       @Nullable Status status,
       @Nullable Throwable error) {
     if (status != null) {
-      attributes.put(RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE, status.getCode().value());
+      attributes.put(RPC_GRPC_STATUS_CODE, status.getCode().value());
     }
     for (String key : capturedRequestMetadata) {
       List<String> value = getter.metadataValue(request, key);

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.grpc.v1_6;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
@@ -20,7 +21,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcClientNetworkAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 public final class GrpcTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.grpc-1.6";
+  // copied from PeerIncubatingAttributes
+  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final OpenTelemetry openTelemetry;
   @Nullable private String peerService;
@@ -197,7 +199,7 @@ public final class GrpcTelemetryBuilder {
 
     if (peerService != null) {
       clientInstrumenterBuilder.addAttributesExtractor(
-          AttributesExtractor.constant(PeerIncubatingAttributes.PEER_SERVICE, peerService));
+          AttributesExtractor.constant(PEER_SERVICE, peerService));
     }
 
     return new GrpcTelemetry(

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -14,15 +14,22 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 final class TracingServerInterceptor implements ServerInterceptor {
+
+  // copied from MessageIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGE_ID = AttributeKey.longKey("message.id");
+  private static final AttributeKey<String> MESSAGE_TYPE = AttributeKey.stringKey("message.type");
+  // copied from MessageIncubatingAttributes.MessageTypeValues
+  private static final String SENT = "SENT";
+  private static final String RECEIVED = "RECEIVED";
 
   @SuppressWarnings("rawtypes")
   private static final AtomicLongFieldUpdater<TracingServerCall> MESSAGE_ID_UPDATER =
@@ -92,11 +99,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
       }
       Span span = Span.fromContext(context);
       Attributes attributes =
-          Attributes.of(
-              MessageIncubatingAttributes.MESSAGE_TYPE,
-              MessageIncubatingAttributes.MessageTypeValues.SENT,
-              MessageIncubatingAttributes.MESSAGE_ID,
-              MESSAGE_ID_UPDATER.incrementAndGet(this));
+          Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, MESSAGE_ID_UPDATER.incrementAndGet(this));
       span.addEvent("message", attributes);
     }
 
@@ -126,9 +129,9 @@ final class TracingServerInterceptor implements ServerInterceptor {
       public void onMessage(REQUEST message) {
         Attributes attributes =
             Attributes.of(
-                MessageIncubatingAttributes.MESSAGE_TYPE,
-                MessageIncubatingAttributes.MessageTypeValues.RECEIVED,
-                MessageIncubatingAttributes.MESSAGE_ID,
+                MESSAGE_TYPE,
+                RECEIVED,
+                MESSAGE_ID,
                 MESSAGE_ID_UPDATER.incrementAndGet(TracingServerCall.this));
         Span.fromContext(context).addEvent("message", attributes);
         delegate().onMessage(message);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceDbAttributesExtractor.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceDbAttributesExtractor.java
@@ -7,16 +7,21 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 enum DataSourceDbAttributesExtractor implements AttributesExtractor<DataSource, DbInfo> {
   INSTANCE;
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
+  private static final AttributeKey<String> DB_SYSTEM = AttributeKey.stringKey("db.system");
+  private static final AttributeKey<String> DB_USER = AttributeKey.stringKey("db.user");
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, DataSource dataSource) {}
@@ -31,9 +36,9 @@ enum DataSourceDbAttributesExtractor implements AttributesExtractor<DataSource, 
     if (dbInfo == null) {
       return;
     }
-    internalSet(attributes, DbIncubatingAttributes.DB_SYSTEM, dbInfo.getSystem());
-    internalSet(attributes, DbIncubatingAttributes.DB_USER, dbInfo.getUser());
-    internalSet(attributes, DbIncubatingAttributes.DB_NAME, getName(dbInfo));
+    internalSet(attributes, DB_SYSTEM, dbInfo.getSystem());
+    internalSet(attributes, DB_USER, dbInfo.getUser());
+    internalSet(attributes, DB_NAME, getName(dbInfo));
   }
 
   private static String getName(DbInfo dbInfo) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -11,7 +11,6 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -819,15 +818,15 @@ public enum JdbcConnectionUrlParser {
       builder.subtype(subtype);
 
       if (subtype.equals("sqlserver")) {
-        builder.system(DbIncubatingAttributes.DbSystemValues.MSSQL);
+        builder.system(DbSystemValues.MSSQL);
       } else if (subtype.equals("oracle")) {
-        builder.system(DbIncubatingAttributes.DbSystemValues.ORACLE);
+        builder.system(DbSystemValues.ORACLE);
       } else if (subtype.equals("mysql")) {
-        builder.system(DbIncubatingAttributes.DbSystemValues.MYSQL);
+        builder.system(DbSystemValues.MYSQL);
       } else if (subtype.equals("postgresql")) {
-        builder.system(DbIncubatingAttributes.DbSystemValues.POSTGRESQL);
+        builder.system(DbSystemValues.POSTGRESQL);
       } else if (subtype.equals("db2")) {
-        builder.system(DbIncubatingAttributes.DbSystemValues.DB2);
+        builder.system(DbSystemValues.DB2);
       }
 
       return MODIFIED_URL_LIKE.doParse(jdbcUrl, builder);
@@ -971,29 +970,45 @@ public enum JdbcConnectionUrlParser {
     switch (type) {
       case "as400": // IBM AS400 Database
       case "db2": // IBM Db2
-        return DbIncubatingAttributes.DbSystemValues.DB2;
+        return DbSystemValues.DB2;
       case "derby": // Apache Derby
-        return DbIncubatingAttributes.DbSystemValues.DERBY;
+        return DbSystemValues.DERBY;
       case "h2": // H2 Database
-        return DbIncubatingAttributes.DbSystemValues.H2;
+        return DbSystemValues.H2;
       case "hsqldb": // Hyper SQL Database
         return "hsqldb";
       case "mariadb": // MariaDB
-        return DbIncubatingAttributes.DbSystemValues.MARIADB;
+        return DbSystemValues.MARIADB;
       case "mysql": // MySQL
-        return DbIncubatingAttributes.DbSystemValues.MYSQL;
+        return DbSystemValues.MYSQL;
       case "oracle": // Oracle Database
-        return DbIncubatingAttributes.DbSystemValues.ORACLE;
+        return DbSystemValues.ORACLE;
       case "postgresql": // PostgreSQL
-        return DbIncubatingAttributes.DbSystemValues.POSTGRESQL;
+        return DbSystemValues.POSTGRESQL;
       case "jtds": // jTDS - the pure Java JDBC 3.0 driver for Microsoft SQL Server
       case "microsoft":
       case "sqlserver": // Microsoft SQL Server
-        return DbIncubatingAttributes.DbSystemValues.MSSQL;
+        return DbSystemValues.MSSQL;
       case "sap": // SAP Hana
-        return DbIncubatingAttributes.DbSystemValues.HANADB;
+        return DbSystemValues.HANADB;
       default:
-        return DbIncubatingAttributes.DbSystemValues.OTHER_SQL; // Unknown DBMS
+        return DbSystemValues.OTHER_SQL; // Unknown DBMS
     }
+  }
+
+  // copied from DbIncubatingAttributes
+  private static final class DbSystemValues {
+    static final String OTHER_SQL = "other_sql";
+    static final String MSSQL = "mssql";
+    static final String MYSQL = "mysql";
+    static final String ORACLE = "oracle";
+    static final String DB2 = "db2";
+    static final String POSTGRESQL = "postgresql";
+    static final String HANADB = "hanadb";
+    static final String DERBY = "derby";
+    static final String MARIADB = "mariadb";
+    static final String H2 = "h2";
+
+    private DbSystemValues() {}
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesExtractor.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.instrumentation.kafka.internal;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.annotation.Nullable;
 
 enum KafkaReceiveAttributesExtractor implements AttributesExtractor<KafkaReceiveRequest, Void> {
   INSTANCE;
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
+      AttributeKey.stringKey("messaging.kafka.consumer.group");
 
   @Override
   public void onStart(
@@ -20,7 +24,7 @@ enum KafkaReceiveAttributesExtractor implements AttributesExtractor<KafkaReceive
 
     String consumerGroup = request.getConsumerGroup();
     if (consumerGroup != null) {
-      attributes.put(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, consumerGroup);
+      attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, consumerGroup);
     }
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.semconv.ExceptionAttributes;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
@@ -29,6 +28,10 @@ import org.apache.logging.log4j.message.Message;
  * any time.
  */
 public final class LogEventMapper<T> {
+
+  // copied from ThreadIncubatingAttributes
+  private static final AttributeKey<Long> THREAD_ID = AttributeKey.longKey("thread.id");
+  private static final AttributeKey<String> THREAD_NAME = AttributeKey.stringKey("thread.name");
 
   private static final String SPECIAL_MAP_MESSAGE_ATTRIBUTE = "message";
 
@@ -108,8 +111,8 @@ public final class LogEventMapper<T> {
     captureContextDataAttributes(attributes, contextData);
 
     if (captureExperimentalAttributes) {
-      attributes.put(ThreadIncubatingAttributes.THREAD_NAME, threadName);
-      attributes.put(ThreadIncubatingAttributes.THREAD_ID, threadId);
+      attributes.put(THREAD_NAME, threadName);
+      attributes.put(THREAD_ID, threadId);
     }
 
     builder.setAllAttributes(attributes.build());

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
@@ -21,8 +21,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
 import io.opentelemetry.semconv.ExceptionAttributes;
-import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -37,6 +35,15 @@ import org.slf4j.event.KeyValuePair;
  * any time.
  */
 public final class LoggingEventMapper {
+  // copied from CodeIncubatingAttributes
+  private static final AttributeKey<String> CODE_FILEPATH = AttributeKey.stringKey("code.filepath");
+  private static final AttributeKey<String> CODE_FUNCTION = AttributeKey.stringKey("code.function");
+  private static final AttributeKey<Long> CODE_LINENO = AttributeKey.longKey("code.lineno");
+  private static final AttributeKey<String> CODE_NAMESPACE =
+      AttributeKey.stringKey("code.namespace");
+  // copied from
+  private static final AttributeKey<Long> THREAD_ID = AttributeKey.longKey("thread.id");
+  private static final AttributeKey<String> THREAD_NAME = AttributeKey.stringKey("thread.name");
 
   private static final boolean supportsKeyValuePairs = supportsKeyValuePairs();
   private static final boolean supportsMultipleMarkers = supportsMultipleMarkers();
@@ -126,9 +133,9 @@ public final class LoggingEventMapper {
     captureMdcAttributes(attributes, loggingEvent.getMDCPropertyMap());
 
     if (captureExperimentalAttributes) {
-      attributes.put(ThreadIncubatingAttributes.THREAD_NAME, loggingEvent.getThreadName());
+      attributes.put(THREAD_NAME, loggingEvent.getThreadName());
       if (threadId != -1) {
-        attributes.put(ThreadIncubatingAttributes.THREAD_ID, threadId);
+        attributes.put(THREAD_ID, threadId);
       }
     }
 
@@ -138,13 +145,13 @@ public final class LoggingEventMapper {
         StackTraceElement firstStackElement = callerData[0];
         String fileName = firstStackElement.getFileName();
         if (fileName != null) {
-          attributes.put(CodeIncubatingAttributes.CODE_FILEPATH, fileName);
+          attributes.put(CODE_FILEPATH, fileName);
         }
-        attributes.put(CodeIncubatingAttributes.CODE_NAMESPACE, firstStackElement.getClassName());
-        attributes.put(CodeIncubatingAttributes.CODE_FUNCTION, firstStackElement.getMethodName());
+        attributes.put(CODE_NAMESPACE, firstStackElement.getClassName());
+        attributes.put(CODE_FUNCTION, firstStackElement.getMethodName());
         int lineNumber = firstStackElement.getLineNumber();
         if (lineNumber > 0) {
-          attributes.put(CodeIncubatingAttributes.CODE_LINENO, lineNumber);
+          attributes.put(CODE_LINENO, lineNumber);
         }
       }
     }

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoAttributesExtractor.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoAttributesExtractor.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.instrumentation.mongo.v3_1;
 
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_MONGODB_COLLECTION;
 import static java.util.Arrays.asList;
 
 import com.mongodb.event.CommandStartedEvent;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -18,6 +18,10 @@ import javax.annotation.Nullable;
 import org.bson.BsonValue;
 
 class MongoAttributesExtractor implements AttributesExtractor<CommandStartedEvent, Void> {
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_MONGODB_COLLECTION =
+      AttributeKey.stringKey("db.mongodb.collection");
+
   @Override
   public void onStart(
       AttributesBuilder attributes, Context parentContext, CommandStartedEvent event) {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.mongo.v3_1;
 
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -23,6 +22,9 @@ import org.bson.json.JsonWriter;
 import org.bson.json.JsonWriterSettings;
 
 class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStartedEvent> {
+
+  // copied from DbIncubatingAttributes.DbSystemValues
+  private static final String MONGODB = "mongodb";
 
   @Nullable private static final Method IS_TRUNCATED_METHOD;
   private static final String HIDDEN_CHAR = "?";
@@ -47,7 +49,7 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
 
   @Override
   public String getSystem(CommandStartedEvent event) {
-    return DbIncubatingAttributes.DbSystemValues.MONGODB;
+    return MONGODB;
   }
 
   @Override

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -11,7 +11,6 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
@@ -24,6 +23,9 @@ import java.util.stream.Collectors;
  * any time.
  */
 public final class DbExecution {
+  // copied from DbIncubatingAttributes.DbSystemValues
+  private static final String OTHER_SQL = "other_sql";
+
   private final String system;
   private final String user;
   private final String name;
@@ -42,7 +44,7 @@ public final class DbExecution {
                 .getDatabaseProductName()
                 .toLowerCase(Locale.ROOT)
                 .split(" ")[0]
-            : DbIncubatingAttributes.DbSystemValues.OTHER_SQL;
+            : OTHER_SQL;
     this.user = factoryOptions.hasOption(USER) ? (String) factoryOptions.getValue(USER) : null;
     this.name =
         factoryOptions.hasOption(DATABASE)

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ContainerResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ContainerResource.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.instrumentation.resources;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +22,9 @@ import java.util.stream.Stream;
  * v2 runtimes.
  */
 public final class ContainerResource {
+
+  // copied from ContainerIncubatingAttributes
+  private static final AttributeKey<String> CONTAINER_ID = AttributeKey.stringKey("container.id");
 
   static final Filesystem FILESYSTEM_INSTANCE = new Filesystem();
   private static final Resource INSTANCE = buildSingleton();
@@ -48,7 +51,7 @@ public final class ContainerResource {
   // Visible for testing
   Resource buildResource() {
     return getContainerId()
-        .map(id -> Resource.create(Attributes.of(ContainerIncubatingAttributes.CONTAINER_ID, id)))
+        .map(id -> Resource.create(Attributes.of(CONTAINER_ID, id)))
         .orElseGet(Resource::empty);
   }
 

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostResource.java
@@ -5,16 +5,20 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 /** Factory for a {@link Resource} which provides information about the host info. */
 public final class HostResource {
+
+  // copied from HostIncubatingAttributes
+  public static final AttributeKey<String> HOST_ARCH = AttributeKey.stringKey("host.arch");
+  public static final AttributeKey<String> HOST_NAME = AttributeKey.stringKey("host.name");
 
   private static final Resource INSTANCE = buildResource();
 
@@ -27,7 +31,7 @@ public final class HostResource {
   static Resource buildResource() {
     AttributesBuilder attributes = Attributes.builder();
     try {
-      attributes.put(HostIncubatingAttributes.HOST_NAME, InetAddress.getLocalHost().getHostName());
+      attributes.put(HOST_NAME, InetAddress.getLocalHost().getHostName());
     } catch (UnknownHostException e) {
       // Ignore
     }
@@ -38,7 +42,7 @@ public final class HostResource {
       // Ignore
     }
     if (hostArch != null) {
-      attributes.put(HostIncubatingAttributes.HOST_ARCH, hostArch);
+      attributes.put(HOST_ARCH, hostArch);
     }
 
     return Resource.create(attributes.build(), SchemaUrls.V1_24_0);

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/OsResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/OsResource.java
@@ -5,16 +5,21 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes;
 import java.util.Locale;
 import javax.annotation.Nullable;
 
 /** Factory of a {@link Resource} which provides information about the current operating system. */
 public final class OsResource {
+
+  // copied from OsIncubatingAttributes
+  private static final AttributeKey<String> OS_DESCRIPTION =
+      AttributeKey.stringKey("os.description");
+  private static final AttributeKey<String> OS_TYPE = AttributeKey.stringKey("os.type");
 
   private static final Resource INSTANCE = buildResource();
 
@@ -45,7 +50,7 @@ public final class OsResource {
 
     String osName = getOs(os);
     if (osName != null) {
-      attributes.put(OsIncubatingAttributes.OS_TYPE, osName);
+      attributes.put(OS_TYPE, osName);
     }
 
     String version = null;
@@ -55,7 +60,7 @@ public final class OsResource {
       // Ignore
     }
     String osDescription = version != null ? os + ' ' + version : os;
-    attributes.put(OsIncubatingAttributes.OS_DESCRIPTION, osDescription);
+    attributes.put(OS_DESCRIPTION, osDescription);
 
     return Resource.create(attributes.build(), SchemaUrls.V1_24_0);
   }
@@ -64,30 +69,47 @@ public final class OsResource {
   private static String getOs(String os) {
     os = os.toLowerCase(Locale.ROOT);
     if (os.startsWith("windows")) {
-      return OsIncubatingAttributes.OsTypeValues.WINDOWS;
+      return OsTypeValues.WINDOWS;
     } else if (os.startsWith("linux")) {
-      return OsIncubatingAttributes.OsTypeValues.LINUX;
+      return OsTypeValues.LINUX;
     } else if (os.startsWith("mac")) {
-      return OsIncubatingAttributes.OsTypeValues.DARWIN;
+      return OsTypeValues.DARWIN;
     } else if (os.startsWith("freebsd")) {
-      return OsIncubatingAttributes.OsTypeValues.FREEBSD;
+      return OsTypeValues.FREEBSD;
     } else if (os.startsWith("netbsd")) {
-      return OsIncubatingAttributes.OsTypeValues.NETBSD;
+      return OsTypeValues.NETBSD;
     } else if (os.startsWith("openbsd")) {
-      return OsIncubatingAttributes.OsTypeValues.OPENBSD;
+      return OsTypeValues.OPENBSD;
     } else if (os.startsWith("dragonflybsd")) {
-      return OsIncubatingAttributes.OsTypeValues.DRAGONFLYBSD;
+      return OsTypeValues.DRAGONFLYBSD;
     } else if (os.startsWith("hp-ux")) {
-      return OsIncubatingAttributes.OsTypeValues.HPUX;
+      return OsTypeValues.HPUX;
     } else if (os.startsWith("aix")) {
-      return OsIncubatingAttributes.OsTypeValues.AIX;
+      return OsTypeValues.AIX;
     } else if (os.startsWith("solaris")) {
-      return OsIncubatingAttributes.OsTypeValues.SOLARIS;
+      return OsTypeValues.SOLARIS;
     } else if (os.startsWith("z/os")) {
-      return OsIncubatingAttributes.OsTypeValues.Z_OS;
+      return OsTypeValues.Z_OS;
     }
     return null;
   }
 
   private OsResource() {}
+
+  // copied from OsIncubatingAttributes
+  private static final class OsTypeValues {
+    static final String WINDOWS = "windows";
+    static final String LINUX = "linux";
+    static final String DARWIN = "darwin";
+    static final String FREEBSD = "freebsd";
+    static final String NETBSD = "netbsd";
+    static final String OPENBSD = "openbsd";
+    static final String DRAGONFLYBSD = "dragonflybsd";
+    static final String HPUX = "hpux";
+    static final String AIX = "aix";
+    static final String SOLARIS = "solaris";
+    static final String Z_OS = "z_os";
+
+    private OsTypeValues() {}
+  }
 }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -21,6 +21,15 @@ import java.util.regex.Pattern;
 
 /** Factory of a {@link Resource} which provides information about the current running process. */
 public final class ProcessResource {
+
+  // copied from ProcessIncubatingAttributes
+  private static final AttributeKey<List<String>> PROCESS_COMMAND_ARGS =
+      AttributeKey.stringArrayKey("process.command_args");
+  private static final AttributeKey<String> PROCESS_COMMAND_LINE =
+      AttributeKey.stringKey("process.command_line");
+  private static final AttributeKey<String> PROCESS_EXECUTABLE_PATH =
+      AttributeKey.stringKey("process.executable.path");
+  private static final AttributeKey<Long> PROCESS_PID = AttributeKey.longKey("process.pid");
 
   // Note: This pattern doesn't support file paths with spaces in them.
   // Important: This is statically used in buildResource, so must be declared/initialized first.
@@ -56,7 +65,7 @@ public final class ProcessResource {
     long pid = ProcessPid.getPid();
 
     if (pid >= 0) {
-      attributes.put(ProcessIncubatingAttributes.PROCESS_PID, pid);
+      attributes.put(PROCESS_PID, pid);
     }
 
     String javaHome = null;
@@ -78,8 +87,7 @@ public final class ProcessResource {
         executablePath.append(".exe");
       }
 
-      attributes.put(
-          ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH, executablePath.toString());
+      attributes.put(PROCESS_EXECUTABLE_PATH, executablePath.toString());
 
       String[] args = ProcessArguments.getProcessArguments();
       // This will only work with Java 9+ but provides everything except the executablePath.
@@ -87,7 +95,7 @@ public final class ProcessResource {
         List<String> commandArgs = new ArrayList<>(args.length + 1);
         commandArgs.add(executablePath.toString());
         commandArgs.addAll(Arrays.asList(args));
-        attributes.put(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS, commandArgs);
+        attributes.put(PROCESS_COMMAND_ARGS, commandArgs);
       } else { // Java 8
         StringBuilder commandLine = new StringBuilder(executablePath);
         for (String arg : runtime.getInputArguments()) {
@@ -103,7 +111,7 @@ public final class ProcessResource {
           }
           commandLine.append(' ').append(javaCommand);
         }
-        attributes.put(ProcessIncubatingAttributes.PROCESS_COMMAND_LINE, commandLine.toString());
+        attributes.put(PROCESS_COMMAND_LINE, commandLine.toString());
       }
     }
 

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessRuntimeResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessRuntimeResource.java
@@ -5,13 +5,21 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 
 /** Factory of a {@link Resource} which provides information about the Java runtime. */
 public final class ProcessRuntimeResource {
+
+  // copied from ProcessIncubatingAttributes
+  private static final AttributeKey<String> PROCESS_RUNTIME_DESCRIPTION =
+      AttributeKey.stringKey("process.runtime.description");
+  private static final AttributeKey<String> PROCESS_RUNTIME_NAME =
+      AttributeKey.stringKey("process.runtime.name");
+  private static final AttributeKey<String> PROCESS_RUNTIME_VERSION =
+      AttributeKey.stringKey("process.runtime.version");
 
   private static final Resource INSTANCE = buildResource();
 
@@ -34,11 +42,11 @@ public final class ProcessRuntimeResource {
 
       return Resource.create(
           Attributes.of(
-              ProcessIncubatingAttributes.PROCESS_RUNTIME_NAME,
+              PROCESS_RUNTIME_NAME,
               name,
-              ProcessIncubatingAttributes.PROCESS_RUNTIME_VERSION,
+              PROCESS_RUNTIME_VERSION,
               version,
-              ProcessIncubatingAttributes.PROCESS_RUNTIME_DESCRIPTION,
+              PROCESS_RUNTIME_DESCRIPTION,
               description),
           SchemaUrls.V1_24_0);
     } catch (SecurityException ignored) {

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerExperimentalAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerExperimentalAttributeExtractor.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -17,6 +16,10 @@ import org.apache.rocketmq.common.message.MessageExt;
 enum RocketMqConsumerExperimentalAttributeExtractor
     implements AttributesExtractor<MessageExt, Void> {
   INSTANCE;
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TAG =
+      AttributeKey.stringKey("messaging.rocketmq.message.tag");
 
   private static final AttributeKey<Long> MESSAGING_ROCKETMQ_QUEUE_ID =
       AttributeKey.longKey("messaging.rocketmq.queue_id");
@@ -29,7 +32,7 @@ enum RocketMqConsumerExperimentalAttributeExtractor
   public void onStart(AttributesBuilder attributes, Context parentContext, MessageExt msg) {
     String tags = msg.getTags();
     if (tags != null) {
-      attributes.put(MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, tags);
+      attributes.put(MESSAGING_ROCKETMQ_MESSAGE_TAG, tags);
     }
     attributes.put(MESSAGING_ROCKETMQ_QUEUE_ID, msg.getQueueId());
     attributes.put(MESSAGING_ROCKETMQ_QUEUE_OFFSET, msg.getQueueOffset());

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -6,10 +6,9 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
@@ -27,6 +26,12 @@ import org.apache.rocketmq.common.message.MessageExt;
 class RocketMqInstrumenterFactory {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rocketmq-client-4.8";
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_SYSTEM =
+      AttributeKey.stringKey("messaging.system");
 
   static Instrumenter<SendMessageContext, Void> createProducerInstrumenter(
       OpenTelemetry openTelemetry,

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerExperimentalAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerExperimentalAttributeExtractor.java
@@ -9,13 +9,16 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.client.hook.SendMessageContext;
 
 enum RocketMqProducerExperimentalAttributeExtractor
     implements AttributesExtractor<SendMessageContext, Void> {
   INSTANCE;
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TAG =
+      AttributeKey.stringKey("messaging.rocketmq.message.tag");
 
   private static final AttributeKey<String> MESSAGING_ROCKETMQ_BROKER_ADDRESS =
       AttributeKey.stringKey("messaging.rocketmq.broker_address");
@@ -28,7 +31,7 @@ enum RocketMqProducerExperimentalAttributeExtractor
     if (request.getMessage() != null) {
       String tags = request.getMessage().getTags();
       if (tags != null) {
-        attributes.put(MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG, tags);
+        attributes.put(MESSAGING_ROCKETMQ_MESSAGE_TAG, tags);
       }
     }
     String brokerAddr = request.getBrokerAddr();

--- a/instrumentation/spring/spring-security-config-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/EnduserAttributesCapturer.java
+++ b/instrumentation/spring/spring-security-config-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/EnduserAttributesCapturer.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.instrumentation.spring.security.config.v6_0;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
-import io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes;
 import java.util.Objects;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,6 +20,11 @@ import org.springframework.security.core.GrantedAuthority;
  * the appropriate {@code setEnduser*Enabled(true)} method.
  */
 public final class EnduserAttributesCapturer {
+
+  // copied from EnduserIncubatingAttributes
+  private static final AttributeKey<String> ENDUSER_ID = AttributeKey.stringKey("enduser.id");
+  private static final AttributeKey<String> ENDUSER_ROLE = AttributeKey.stringKey("enduser.role");
+  private static final AttributeKey<String> ENDUSER_SCOPE = AttributeKey.stringKey("enduser.scope");
 
   private static final String DEFAULT_ROLE_PREFIX = "ROLE_";
   private static final String DEFAULT_SCOPE_PREFIX = "SCOPE_";
@@ -67,8 +72,7 @@ public final class EnduserAttributesCapturer {
       Span localRootSpan = LocalRootSpan.fromContext(otelContext);
 
       if (enduserIdEnabled && authentication.getName() != null) {
-        localRootSpan.setAttribute(
-            EnduserIncubatingAttributes.ENDUSER_ID, authentication.getName());
+        localRootSpan.setAttribute(ENDUSER_ID, authentication.getName());
       }
 
       StringBuilder roleBuilder = null;
@@ -85,12 +89,10 @@ public final class EnduserAttributesCapturer {
         }
       }
       if (roleBuilder != null) {
-        localRootSpan.setAttribute(
-            EnduserIncubatingAttributes.ENDUSER_ROLE, roleBuilder.toString());
+        localRootSpan.setAttribute(ENDUSER_ROLE, roleBuilder.toString());
       }
       if (scopeBuilder != null) {
-        localRootSpan.setAttribute(
-            EnduserIncubatingAttributes.ENDUSER_SCOPE, scopeBuilder.toString());
+        localRootSpan.setAttribute(ENDUSER_SCOPE, scopeBuilder.toString());
       }
     }
   }

--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-sdk")
   api("io.opentelemetry:opentelemetry-sdk-testing")
+  api("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
   api(project(":instrumentation-api"))
 
   api("org.assertj:assertj-core")


### PR DESCRIPTION
This PR removes `io.opentelemetry.semconv:opentelemetry-semconv-incubating` dependency from instrumentation api and library instrumentations. Incubating semconv dependency is still used in javaagent instrumentations and tests. Library instrumentations copy the needed keys from incubating semconv classes.