### PR TITLE
Armeria http client reports wrong protocol

### DIFF
--- a/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
+++ b/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
@@ -43,7 +43,7 @@ class ArmeriaHttp2Test {
       new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-          sb.service("/", (ctx, req) -> createWebClient(server1).execute(req));
+          sb.service("/", (ctx, req) -> createWebClient(server1).get("/"));
         }
       };
 

--- a/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
+++ b/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
@@ -14,6 +16,12 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.semconv.ClientAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.UserAgentAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -52,10 +60,77 @@ class ArmeriaHttp2Test {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasNoParent(),
-                span -> span.hasName("GET /").hasKind(SpanKind.SERVER).hasParent(trace.getSpan(0)),
-                span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(1)),
                 span ->
-                    span.hasName("GET /").hasKind(SpanKind.SERVER).hasParent(trace.getSpan(2))));
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(UrlAttributes.URL_FULL, server2.httpUri() + "/"),
+                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_PORT, server2.httpPort()),
+                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(
+                                NetworkAttributes.NETWORK_PEER_PORT,
+                                val -> val.isInstanceOf(Long.class))),
+                span ->
+                    span.hasName("GET /")
+                        .hasKind(SpanKind.SERVER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(UrlAttributes.URL_PATH, "/"),
+                            equalTo(HttpAttributes.HTTP_ROUTE, "/"),
+                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_PORT, server2.httpPort()),
+                            satisfies(
+                                UserAgentAttributes.USER_AGENT_ORIGINAL,
+                                val -> val.isInstanceOf(String.class)),
+                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(
+                                NetworkAttributes.NETWORK_PEER_PORT,
+                                val -> val.isInstanceOf(Long.class))),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(UrlAttributes.URL_FULL, server1.httpUri() + "/"),
+                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_PORT, server1.httpPort()),
+                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(
+                                NetworkAttributes.NETWORK_PEER_PORT,
+                                val -> val.isInstanceOf(Long.class))),
+                span ->
+                    span.hasName("GET /")
+                        .hasKind(SpanKind.SERVER)
+                        .hasParent(trace.getSpan(2))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(UrlAttributes.URL_PATH, "/"),
+                            equalTo(HttpAttributes.HTTP_ROUTE, "/"),
+                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(ServerAttributes.SERVER_PORT, server1.httpPort()),
+                            satisfies(
+                                UserAgentAttributes.USER_AGENT_ORIGINAL,
+                                val -> val.isInstanceOf(String.class)),
+                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(
+                                NetworkAttributes.NETWORK_PEER_PORT,
+                                val -> val.isInstanceOf(Long.class)))));
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
@@ -73,7 +73,8 @@ public enum ArmeriaHttpClientAttributesGetter
 
   @Override
   public String getNetworkProtocolVersion(RequestContext ctx, @Nullable RequestLog requestLog) {
-    SessionProtocol protocol = ctx.sessionProtocol();
+    SessionProtocol protocol =
+        requestLog != null ? requestLog.sessionProtocol() : ctx.sessionProtocol();
     return protocol.isMultiplex() ? "2" : "1.1";
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -23,6 +24,19 @@ public enum ArmeriaHttpClientAttributesGetter
     implements HttpClientAttributesGetter<RequestContext, RequestLog> {
   INSTANCE;
 
+  private static final ClassValue<Method> authorityMethodCache =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("authority");
+          } catch (NoSuchMethodException e) {
+            return null;
+          }
+        }
+      };
+
   @Override
   public String getHttpRequestMethod(RequestContext ctx) {
     return ctx.method().name();
@@ -33,10 +47,16 @@ public enum ArmeriaHttpClientAttributesGetter
     HttpRequest request = request(ctx);
     StringBuilder uri = new StringBuilder();
     String scheme = request.scheme();
+    if (scheme == null) {
+      String name = ctx.sessionProtocol().uriText();
+      if ("http".equals(name) || "https".equals(name)) {
+        scheme = name;
+      }
+    }
     if (scheme != null) {
       uri.append(scheme).append("://");
     }
-    String authority = request.authority();
+    String authority = authority(ctx);
     if (authority != null) {
       uri.append(authority);
     }
@@ -81,8 +101,7 @@ public enum ArmeriaHttpClientAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(RequestContext ctx) {
-    HttpRequest request = request(ctx);
-    String authority = request.authority();
+    String authority = authority(ctx);
     if (authority == null) {
       return null;
     }
@@ -93,8 +112,7 @@ public enum ArmeriaHttpClientAttributesGetter
   @Nullable
   @Override
   public Integer getServerPort(RequestContext ctx) {
-    HttpRequest request = request(ctx);
-    String authority = request.authority();
+    String authority = authority(ctx);
     if (authority == null) {
       return null;
     }
@@ -114,6 +132,25 @@ public enum ArmeriaHttpClientAttributesGetter
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       RequestContext ctx, @Nullable RequestLog requestLog) {
     return RequestContextAccess.remoteAddress(ctx);
+  }
+
+  @Nullable
+  private static String authority(RequestContext ctx) {
+    // newer armeria versions expose authority through DefaultClientRequestContext#authority
+    // we are using this method as it provides default values based on endpoint
+    // in older versions armeria wraps the request, and we can get the same default values through
+    // the request
+    Method method = authorityMethodCache.get(ctx.getClass());
+    if (method != null) {
+      try {
+        return (String) method.invoke(ctx);
+      } catch (Exception e) {
+        return null;
+      }
+    }
+
+    HttpRequest request = request(ctx);
+    return request.authority();
   }
 
   private static HttpRequest request(RequestContext ctx) {

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
@@ -111,6 +111,15 @@ public abstract class AbstractArmeriaHttpClientTest extends AbstractHttpClientTe
     optionsBuilder.disableTestReusedRequest();
     // can only use methods from HttpMethod enum
     optionsBuilder.disableTestNonStandardHttpMethod();
+    // armeria uses http/2
+    optionsBuilder.setHttpProtocolVersion(
+        uri -> {
+          String uriString = uri.toString();
+          if (uriString.equals("http://localhost:61/") || uriString.equals("https://192.0.2.1/")) {
+            return "1.1";
+          }
+          return "2";
+        });
   }
 
   @Test

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -972,8 +972,10 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
                   .doesNotContainKey(NetworkAttributes.NETWORK_TYPE)
                   .doesNotContainKey(NetworkAttributes.NETWORK_PROTOCOL_NAME);
               if (httpClientAttributes.contains(NetworkAttributes.NETWORK_PROTOCOL_VERSION)) {
-                // TODO(anuraaga): Support HTTP/2
-                assertThat(attrs).containsEntry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1");
+                assertThat(attrs)
+                    .containsEntry(
+                        NetworkAttributes.NETWORK_PROTOCOL_VERSION,
+                        options.getHttpProtocolVersion().apply(uri));
               }
 
               if (httpClientAttributes.contains(ServerAttributes.SERVER_ADDRESS)) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
@@ -89,6 +89,8 @@ public abstract class HttpClientTestOptions {
 
   public abstract boolean getTestNonStandardHttpMethod();
 
+  public abstract Function<URI, String> getHttpProtocolVersion();
+
   static Builder builder() {
     return new AutoValue_HttpClientTestOptions.Builder().withDefaults();
   }
@@ -116,7 +118,8 @@ public abstract class HttpClientTestOptions {
           .setTestCallback(true)
           .setTestCallbackWithParent(true)
           .setTestErrorWithCallback(true)
-          .setTestNonStandardHttpMethod(true);
+          .setTestNonStandardHttpMethod(true)
+          .setHttpProtocolVersion(uri -> "1.1");
     }
 
     Builder setHttpAttributes(Function<URI, Set<AttributeKey<?>>> value);
@@ -156,6 +159,8 @@ public abstract class HttpClientTestOptions {
     Builder setTestErrorWithCallback(boolean value);
 
     Builder setTestNonStandardHttpMethod(boolean value);
+
+    Builder setHttpProtocolVersion(Function<URI, String> value);
 
     @CanIgnoreReturnValue
     default Builder disableTestWithClientParent() {


### PR DESCRIPTION
Apparently the protocol in `RequestLog` contains the actual protocol that was used (`H1` or `H2`) while the one from `RequestContext` is what was request (`HTTP`)