### PR TITLE
use daemon thread for scheduling in jmx-metrics BeanFinder

### DIFF
--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
@@ -25,7 +25,13 @@ class BeanFinder {
 
   private final MetricRegistrar registrar;
   private MetricConfiguration conf;
-  private final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService exec =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread result = new Thread(runnable, "jmx_bean_finder");
+            result.setDaemon(true);
+            return result;
+          });
   private final long discoveryDelay;
   private final long maxDelay;
   private long delay = 1000; // number of milliseconds until first attempt to discover MBeans


### PR DESCRIPTION
In jmx-metrics's BeanFinder, a non-daemon scheduling thread was used to refresh state.
This may interfere jvm's shutdown process in some situation. eg. standalone Tomcat's shutdown.sh process will get stuck if agent is attached to it.