### PR TITLE
Allow library instrumentations to override span name

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -20,6 +20,7 @@ import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtr
 import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.dubbo.rpc.Result;
 
@@ -32,6 +33,12 @@ public final class DubboTelemetryBuilder {
   @Nullable private String peerService;
   private final List<AttributesExtractor<DubboRequest, Result>> attributesExtractors =
       new ArrayList<>();
+  private Function<
+          SpanNameExtractor<DubboRequest>, ? extends SpanNameExtractor<? super DubboRequest>>
+      clientSpanNameExtractorTransformer = Function.identity();
+  private Function<
+          SpanNameExtractor<DubboRequest>, ? extends SpanNameExtractor<? super DubboRequest>>
+      serverSpanNameExtractorTransformer = Function.identity();
 
   DubboTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -53,6 +60,24 @@ public final class DubboTelemetryBuilder {
     return this;
   }
 
+  /** Sets custom client {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public DubboTelemetryBuilder setClientSpanNameExtractor(
+      Function<SpanNameExtractor<DubboRequest>, ? extends SpanNameExtractor<? super DubboRequest>>
+          clientSpanNameExtractor) {
+    this.clientSpanNameExtractorTransformer = clientSpanNameExtractor;
+    return this;
+  }
+
+  /** Sets custom server {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public DubboTelemetryBuilder setServerSpanNameExtractor(
+      Function<SpanNameExtractor<DubboRequest>, ? extends SpanNameExtractor<? super DubboRequest>>
+          serverSpanNameExtractor) {
+    this.serverSpanNameExtractorTransformer = serverSpanNameExtractor;
+    return this;
+  }
+
   /**
    * Returns a new {@link DubboTelemetry} with the settings of this {@link DubboTelemetryBuilder}.
    */
@@ -60,6 +85,10 @@ public final class DubboTelemetryBuilder {
     DubboRpcAttributesGetter rpcAttributesGetter = DubboRpcAttributesGetter.INSTANCE;
     SpanNameExtractor<DubboRequest> spanNameExtractor =
         RpcSpanNameExtractor.create(rpcAttributesGetter);
+    SpanNameExtractor<? super DubboRequest> clientSpanNameExtractor =
+        clientSpanNameExtractorTransformer.apply(spanNameExtractor);
+    SpanNameExtractor<? super DubboRequest> serverSpanNameExtractor =
+        serverSpanNameExtractorTransformer.apply(spanNameExtractor);
     DubboClientNetworkAttributesGetter netClientAttributesGetter =
         new DubboClientNetworkAttributesGetter();
     DubboNetworkServerAttributesGetter netServerAttributesGetter =
@@ -67,14 +96,14 @@ public final class DubboTelemetryBuilder {
 
     InstrumenterBuilder<DubboRequest, Result> serverInstrumenterBuilder =
         Instrumenter.<DubboRequest, Result>builder(
-                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
+                openTelemetry, INSTRUMENTATION_NAME, serverSpanNameExtractor)
             .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
             .addAttributesExtractor(NetworkAttributesExtractor.create(netServerAttributesGetter))
             .addAttributesExtractors(attributesExtractors);
 
     InstrumenterBuilder<DubboRequest, Result> clientInstrumenterBuilder =
         Instrumenter.<DubboRequest, Result>builder(
-                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
+                openTelemetry, INSTRUMENTATION_NAME, clientSpanNameExtractor)
             .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
             .addAttributesExtractor(ServerAttributesExtractor.create(netClientAttributesGetter))
             .addAttributesExtractor(NetworkAttributesExtractor.create(netClientAttributesGetter))

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
@@ -17,6 +17,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpServerExp
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
@@ -63,6 +64,12 @@ public final class ArmeriaTelemetryBuilder {
       HttpSpanNameExtractor.builder(ArmeriaHttpClientAttributesGetter.INSTANCE);
   private final HttpSpanNameExtractorBuilder<RequestContext> httpServerSpanNameExtractorBuilder =
       HttpSpanNameExtractor.builder(ArmeriaHttpServerAttributesGetter.INSTANCE);
+  private Function<
+          SpanNameExtractor<RequestContext>, ? extends SpanNameExtractor<? super RequestContext>>
+      clientSpanNameExtractorTransformer = Function.identity();
+  private Function<
+          SpanNameExtractor<RequestContext>, ? extends SpanNameExtractor<? super RequestContext>>
+      serverSpanNameExtractorTransformer = Function.identity();
 
   private final HttpServerRouteBuilder<RequestContext> httpServerRouteBuilder =
       HttpServerRoute.builder(ArmeriaHttpServerAttributesGetter.INSTANCE);
@@ -210,18 +217,43 @@ public final class ArmeriaTelemetryBuilder {
     return this;
   }
 
+  /** Sets custom client {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public ArmeriaTelemetryBuilder setClientSpanNameExtractor(
+      Function<
+              SpanNameExtractor<RequestContext>,
+              ? extends SpanNameExtractor<? super RequestContext>>
+          clientSpanNameExtractor) {
+    this.clientSpanNameExtractorTransformer = clientSpanNameExtractor;
+    return this;
+  }
+
+  /** Sets custom server {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public ArmeriaTelemetryBuilder setServerSpanNameExtractor(
+      Function<
+              SpanNameExtractor<RequestContext>,
+              ? extends SpanNameExtractor<? super RequestContext>>
+          serverSpanNameExtractor) {
+    this.serverSpanNameExtractorTransformer = serverSpanNameExtractor;
+    return this;
+  }
+
   public ArmeriaTelemetry build() {
     ArmeriaHttpClientAttributesGetter clientAttributesGetter =
         ArmeriaHttpClientAttributesGetter.INSTANCE;
     ArmeriaHttpServerAttributesGetter serverAttributesGetter =
         ArmeriaHttpServerAttributesGetter.INSTANCE;
 
+    SpanNameExtractor<? super RequestContext> clientSpanNameExtractor =
+        clientSpanNameExtractorTransformer.apply(httpClientSpanNameExtractorBuilder.build());
+    SpanNameExtractor<? super RequestContext> serverSpanNameExtractor =
+        serverSpanNameExtractorTransformer.apply(httpServerSpanNameExtractorBuilder.build());
+
     InstrumenterBuilder<ClientRequestContext, RequestLog> clientInstrumenterBuilder =
-        Instrumenter.builder(
-            openTelemetry, INSTRUMENTATION_NAME, httpClientSpanNameExtractorBuilder.build());
+        Instrumenter.builder(openTelemetry, INSTRUMENTATION_NAME, clientSpanNameExtractor);
     InstrumenterBuilder<ServiceRequestContext, RequestLog> serverInstrumenterBuilder =
-        Instrumenter.builder(
-            openTelemetry, INSTRUMENTATION_NAME, httpServerSpanNameExtractorBuilder.build());
+        Instrumenter.builder(openTelemetry, INSTRUMENTATION_NAME, serverSpanNameExtractor);
 
     Stream.of(clientInstrumenterBuilder, serverInstrumenterBuilder)
         .forEach(instrumenter -> instrumenter.addAttributesExtractors(additionalExtractors));

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestJavaagentInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestJavaagentInstrumenterFactory.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.elasticsearch.rest.internal.Elasticsearc
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import java.util.Collections;
+import java.util.function.Function;
 import org.elasticsearch.client.Response;
 
 public final class ElasticsearchRestJavaagentInstrumenterFactory {
@@ -28,6 +29,7 @@ public final class ElasticsearchRestJavaagentInstrumenterFactory {
         GlobalOpenTelemetry.get(),
         instrumentationName,
         Collections.emptyList(),
+        Function.identity(),
         CommonConfig.get().getKnownHttpRequestMethods(),
         CAPTURE_SEARCH_QUERY);
   }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -35,14 +35,10 @@ public final class GrpcTelemetryBuilder {
   private final OpenTelemetry openTelemetry;
   @Nullable private String peerService;
 
-  @Nullable
   private Function<SpanNameExtractor<GrpcRequest>, ? extends SpanNameExtractor<? super GrpcRequest>>
-      clientSpanNameExtractorTransformer;
-
-  @Nullable
+      clientSpanNameExtractorTransformer = Function.identity();
   private Function<SpanNameExtractor<GrpcRequest>, ? extends SpanNameExtractor<? super GrpcRequest>>
-      serverSpanNameExtractorTransformer;
-
+      serverSpanNameExtractorTransformer = Function.identity();
   private final List<AttributesExtractor<? super GrpcRequest, ? super Status>>
       additionalExtractors = new ArrayList<>();
   private final List<AttributesExtractor<? super GrpcRequest, ? super Status>>
@@ -147,19 +143,12 @@ public final class GrpcTelemetryBuilder {
   }
 
   /** Returns a new {@link GrpcTelemetry} with the settings of this {@link GrpcTelemetryBuilder}. */
-  @SuppressWarnings("deprecation") // using createForServerSide() for the old->stable semconv story
   public GrpcTelemetry build() {
     SpanNameExtractor<GrpcRequest> originalSpanNameExtractor = new GrpcSpanNameExtractor();
-
-    SpanNameExtractor<? super GrpcRequest> clientSpanNameExtractor = originalSpanNameExtractor;
-    if (clientSpanNameExtractorTransformer != null) {
-      clientSpanNameExtractor = clientSpanNameExtractorTransformer.apply(originalSpanNameExtractor);
-    }
-
-    SpanNameExtractor<? super GrpcRequest> serverSpanNameExtractor = originalSpanNameExtractor;
-    if (serverSpanNameExtractorTransformer != null) {
-      serverSpanNameExtractor = serverSpanNameExtractorTransformer.apply(originalSpanNameExtractor);
-    }
+    SpanNameExtractor<? super GrpcRequest> clientSpanNameExtractor =
+        clientSpanNameExtractorTransformer.apply(originalSpanNameExtractor);
+    SpanNameExtractor<? super GrpcRequest> serverSpanNameExtractor =
+        serverSpanNameExtractorTransformer.apply(originalSpanNameExtractor);
 
     InstrumenterBuilder<GrpcRequest, Status> clientInstrumenterBuilder =
         Instrumenter.builder(openTelemetry, INSTRUMENTATION_NAME, clientSpanNameExtractor);

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JavaHttpClientSingletons.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JavaHttpClientSingletons.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.httpclient.internal.JavaHttpClientInstru
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.function.Function;
 
 public class JavaHttpClientSingletons {
 
@@ -34,6 +35,7 @@ public class JavaHttpClientSingletons {
                     .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                     .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
             builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+            Function.identity(),
             singletonList(
                 HttpClientPeerServiceAttributesExtractor.create(
                     JavaHttpClientAttributesGetter.INSTANCE,

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/httpclient/v9_2/JettyHttpClientSingletons.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/httpclient/v9_2/JettyHttpClientSingletons.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.JettyClientHttpAttributesGetter;
 import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.JettyClientInstrumenterFactory;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
+import java.util.function.Function;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 
@@ -27,6 +28,7 @@ public class JettyHttpClientSingletons {
                   .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                   .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
           builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+          Function.identity(),
           singletonList(
               HttpClientPeerServiceAttributesExtractor.create(
                   JettyClientHttpAttributesGetter.INSTANCE,

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
@@ -17,6 +17,7 @@ import io.opentelemetry.instrumentation.netty.v4.common.internal.client.NettySsl
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import java.util.Collections;
+import java.util.function.Function;
 
 public final class NettyClientSingletons {
 
@@ -48,6 +49,7 @@ public final class NettyClientSingletons {
                     .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                     .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
             builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+            Function.identity(),
             Collections.emptyList());
     CONNECTION_INSTRUMENTER = factory.createConnectionInstrumenter();
     SSL_INSTRUMENTER = factory.createSslInstrumenter();

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyClientSingletons.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.internal.client.NettyClientHa
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import java.util.Collections;
+import java.util.function.Function;
 
 public final class NettyClientSingletons {
 
@@ -50,6 +51,7 @@ public final class NettyClientSingletons {
                     .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                     .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
             builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+            Function.identity(),
             Collections.emptyList());
     CONNECTION_INSTRUMENTER = factory.createConnectionInstrumenter();
     SSL_INSTRUMENTER = factory.createSslInstrumenter();

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3Singletons.java
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3Singletons.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpAttributesGet
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpInstrumenterFactory;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.TracingInterceptor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
+import java.util.function.Function;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -34,6 +35,7 @@ public final class OkHttp3Singletons {
                   .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                   .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
           builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+          Function.identity(),
           singletonList(
               HttpClientPeerServiceAttributesExtractor.create(
                   OkHttpAttributesGetter.INSTANCE, CommonConfig.get().getPeerServiceResolver())),

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpInstrumenterFactory.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpInstrumenterFactory.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimen
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientMetrics;
@@ -21,6 +22,7 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBu
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -36,6 +38,8 @@ public final class OkHttpInstrumenterFactory {
       OpenTelemetry openTelemetry,
       Consumer<HttpClientAttributesExtractorBuilder<Request, Response>> extractorConfigurer,
       Consumer<HttpSpanNameExtractorBuilder<Request>> spanNameExtractorConfigurer,
+      Function<SpanNameExtractor<Request>, ? extends SpanNameExtractor<? super Request>>
+          spanNameExtractorTransformer,
       List<AttributesExtractor<Request, Response>> additionalAttributesExtractors,
       boolean emitExperimentalHttpClientMetrics) {
 
@@ -48,10 +52,12 @@ public final class OkHttpInstrumenterFactory {
     HttpSpanNameExtractorBuilder<Request> httpSpanNameExtractorBuilder =
         HttpSpanNameExtractor.builder(httpAttributesGetter);
     spanNameExtractorConfigurer.accept(httpSpanNameExtractorBuilder);
+    SpanNameExtractor<? super Request> spanNameExtractor =
+        spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
 
     InstrumenterBuilder<Request, Response> builder =
         Instrumenter.<Request, Response>builder(
-                openTelemetry, INSTRUMENTATION_NAME, httpSpanNameExtractorBuilder.build())
+                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesGetter))
             .addAttributesExtractor(extractorBuilder.build())
             .addAttributesExtractors(additionalAttributesExtractors)

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
@@ -12,21 +12,24 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttribute
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import org.quartz.JobExecutionContext;
 
 /** A builder of {@link QuartzTelemetry}. */
 public final class QuartzTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.quartz-2.0";
-
   private final OpenTelemetry openTelemetry;
-
   private final List<AttributesExtractor<? super JobExecutionContext, ? super Void>>
       additionalExtractors = new ArrayList<>();
-
   private boolean captureExperimentalSpanAttributes;
+  private Function<
+          SpanNameExtractor<JobExecutionContext>,
+          ? extends SpanNameExtractor<? super JobExecutionContext>>
+      spanNameExtractorTransformer = Function.identity();
 
   QuartzTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -55,12 +58,26 @@ public final class QuartzTelemetryBuilder {
     return this;
   }
 
+  /** Sets custom {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public QuartzTelemetryBuilder setSpanNameExtractor(
+      Function<
+              SpanNameExtractor<JobExecutionContext>,
+              ? extends SpanNameExtractor<? super JobExecutionContext>>
+          spanNameExtractorTransformer) {
+    this.spanNameExtractorTransformer = spanNameExtractorTransformer;
+    return this;
+  }
+
   /**
    * Returns a new {@link QuartzTelemetry} with the settings of this {@link QuartzTelemetryBuilder}.
    */
   public QuartzTelemetry build() {
+    SpanNameExtractor<? super JobExecutionContext> spanNameExtractor =
+        spanNameExtractorTransformer.apply(new QuartzSpanNameExtractor());
+
     InstrumenterBuilder<JobExecutionContext, Void> instrumenter =
-        Instrumenter.builder(openTelemetry, INSTRUMENTATION_NAME, new QuartzSpanNameExtractor());
+        Instrumenter.builder(openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor);
 
     if (captureExperimentalSpanAttributes) {
       instrumenter.addAttributesExtractor(

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
@@ -12,9 +12,11 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttrib
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -40,16 +42,22 @@ public final class R2dbcInstrumenterBuilder {
     return this;
   }
 
-  public Instrumenter<DbExecution, Void> build(boolean statementSanitizationEnabled) {
+  public Instrumenter<DbExecution, Void> build(
+      Function<SpanNameExtractor<DbExecution>, ? extends SpanNameExtractor<? super DbExecution>>
+          spanNameExtractorTransformer,
+      boolean statementSanitizationEnabled) {
+    SpanNameExtractor<? super DbExecution> spanNameExtractor =
+        spanNameExtractorTransformer.apply(
+            DbClientSpanNameExtractor.create(R2dbcSqlAttributesGetter.INSTANCE));
+
     return Instrumenter.<DbExecution, Void>builder(
-            openTelemetry,
-            INSTRUMENTATION_NAME,
-            DbClientSpanNameExtractor.create(R2dbcSqlAttributesGetter.INSTANCE))
+            openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
         .addAttributesExtractor(
             SqlClientAttributesExtractor.builder(R2dbcSqlAttributesGetter.INSTANCE)
                 .setStatementSanitizationEnabled(statementSanitizationEnabled)
                 .build())
         .addAttributesExtractor(ServerAttributesExtractor.create(R2dbcNetAttributesGetter.INSTANCE))
+        .addAttributesExtractors(additionalExtractors)
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
@@ -30,7 +30,7 @@ public final class RestletInstrumenterFactory {
   public static Instrumenter<Request, Response> newServerInstrumenter(
       OpenTelemetry openTelemetry,
       AttributesExtractor<Request, Response> httpServerAttributesExtractor,
-      SpanNameExtractor<Request> httpServerSpanNameExtractor,
+      SpanNameExtractor<? super Request> httpServerSpanNameExtractor,
       ContextCustomizer<Request> httpServerRoute,
       List<AttributesExtractor<Request, Response>> additionalExtractors,
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -129,7 +129,6 @@ public final class SpringWebTelemetryBuilder {
     SpringWebHttpAttributesGetter httpAttributesGetter = SpringWebHttpAttributesGetter.INSTANCE;
     SpanNameExtractor<? super HttpRequest> spanNameExtractor =
         spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
-    ;
 
     InstrumenterBuilder<HttpRequest, ClientHttpResponse> builder =
         Instrumenter.<HttpRequest, ClientHttpResponse>builder(

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
@@ -39,11 +38,9 @@ public final class SpringWebTelemetryBuilder {
           HttpClientAttributesExtractor.builder(SpringWebHttpAttributesGetter.INSTANCE);
   private final HttpSpanNameExtractorBuilder<HttpRequest> httpSpanNameExtractorBuilder =
       HttpSpanNameExtractor.builder(SpringWebHttpAttributesGetter.INSTANCE);
-  private boolean emitExperimentalHttpClientMetrics = false;
-
-  @Nullable
   private Function<SpanNameExtractor<HttpRequest>, ? extends SpanNameExtractor<? super HttpRequest>>
-      spanNameExtractorTransformer;
+      spanNameExtractorTransformer = Function.identity();
+  private boolean emitExperimentalHttpClientMetrics = false;
 
   SpringWebTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -130,12 +127,9 @@ public final class SpringWebTelemetryBuilder {
    */
   public SpringWebTelemetry build() {
     SpringWebHttpAttributesGetter httpAttributesGetter = SpringWebHttpAttributesGetter.INSTANCE;
-
-    SpanNameExtractor<HttpRequest> originalSpanNameExtractor = httpSpanNameExtractorBuilder.build();
-    SpanNameExtractor<? super HttpRequest> spanNameExtractor = originalSpanNameExtractor;
-    if (spanNameExtractorTransformer != null) {
-      spanNameExtractor = spanNameExtractorTransformer.apply(originalSpanNameExtractor);
-    }
+    SpanNameExtractor<? super HttpRequest> spanNameExtractor =
+        spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
+    ;
 
     InstrumenterBuilder<HttpRequest, ClientHttpResponse> builder =
         Instrumenter.<HttpRequest, ClientHttpResponse>builder(

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/client/WebClientHelper.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/client/WebClientHelper.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.spring.webflux.v5_3.internal.WebClientHt
 import io.opentelemetry.instrumentation.spring.webflux.v5_3.internal.WebClientTracingFilter;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import java.util.List;
+import java.util.function.Function;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -30,6 +31,7 @@ public final class WebClientHelper {
                   .setCapturedResponseHeaders(CommonConfig.get().getClientResponseHeaders())
                   .setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
           builder -> builder.setKnownMethods(CommonConfig.get().getKnownHttpRequestMethods()),
+          Function.identity(),
           singletonList(
               HttpClientPeerServiceAttributesExtractor.create(
                   WebClientHttpAttributesGetter.INSTANCE,

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -44,13 +43,10 @@ public final class SpringWebMvcTelemetryBuilder {
       HttpSpanNameExtractor.builder(SpringWebMvcHttpAttributesGetter.INSTANCE);
   private final HttpServerRouteBuilder<HttpServletRequest> httpServerRouteBuilder =
       HttpServerRoute.builder(SpringWebMvcHttpAttributesGetter.INSTANCE);
-
-  @Nullable
   private Function<
           SpanNameExtractor<HttpServletRequest>,
           ? extends SpanNameExtractor<? super HttpServletRequest>>
-      spanNameExtractorTransformer;
-
+      spanNameExtractorTransformer = Function.identity();
   private boolean emitExperimentalHttpServerMetrics = false;
 
   SpringWebMvcTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -142,13 +138,8 @@ public final class SpringWebMvcTelemetryBuilder {
   public SpringWebMvcTelemetry build() {
     SpringWebMvcHttpAttributesGetter httpAttributesGetter =
         SpringWebMvcHttpAttributesGetter.INSTANCE;
-
-    SpanNameExtractor<HttpServletRequest> originalSpanNameExtractor =
-        httpSpanNameExtractorBuilder.build();
-    SpanNameExtractor<? super HttpServletRequest> spanNameExtractor = originalSpanNameExtractor;
-    if (spanNameExtractorTransformer != null) {
-      spanNameExtractor = spanNameExtractorTransformer.apply(originalSpanNameExtractor);
-    }
+    SpanNameExtractor<? super HttpServletRequest> spanNameExtractor =
+        spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
 
     InstrumenterBuilder<HttpServletRequest, HttpServletResponse> builder =
         Instrumenter.<HttpServletRequest, HttpServletResponse>builder(

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 /** A builder of {@link SpringWebMvcTelemetry}. */
 public final class SpringWebMvcTelemetryBuilder {
@@ -44,13 +43,10 @@ public final class SpringWebMvcTelemetryBuilder {
       HttpSpanNameExtractor.builder(SpringWebMvcHttpAttributesGetter.INSTANCE);
   private final HttpServerRouteBuilder<HttpServletRequest> httpServerRouteBuilder =
       HttpServerRoute.builder(SpringWebMvcHttpAttributesGetter.INSTANCE);
-
-  @Nullable
   private Function<
           SpanNameExtractor<HttpServletRequest>,
           ? extends SpanNameExtractor<? super HttpServletRequest>>
-      spanNameExtractorTransformer;
-
+      spanNameExtractorTransformer = Function.identity();
   private boolean emitExperimentalHttpServerMetrics = false;
 
   SpringWebMvcTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -142,13 +138,8 @@ public final class SpringWebMvcTelemetryBuilder {
   public SpringWebMvcTelemetry build() {
     SpringWebMvcHttpAttributesGetter httpAttributesGetter =
         SpringWebMvcHttpAttributesGetter.INSTANCE;
-
-    SpanNameExtractor<HttpServletRequest> originalSpanNameExtractor =
-        httpSpanNameExtractorBuilder.build();
-    SpanNameExtractor<? super HttpServletRequest> spanNameExtractor = originalSpanNameExtractor;
-    if (spanNameExtractorTransformer != null) {
-      spanNameExtractor = spanNameExtractorTransformer.apply(originalSpanNameExtractor);
-    }
+    SpanNameExtractor<? super HttpServletRequest> spanNameExtractor =
+        spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
 
     InstrumenterBuilder<HttpServletRequest, HttpServletResponse> builder =
         Instrumenter.<HttpServletRequest, HttpServletResponse>builder(


### PR DESCRIPTION
This PR adds an option to override span name by letting user transform `SpanNameExtractor` to most of the library instrumentations. This functionality was already present in grpc and  spring webmvc instrumentations.

cc @LikeTheSalad 