### PR TITLE
Correct protocol version assertion for http 2

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -753,7 +753,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
             assertThat(attrs)
                 .hasEntrySatisfying(
                     NetworkAttributes.NETWORK_PROTOCOL_VERSION,
-                    entry -> assertThat(entry).isIn("1.1", "2.0"));
+                    entry -> assertThat(entry).isIn("1.1", "2"));
           }
 
           assertThat(attrs).containsEntry(ServerAttributes.SERVER_ADDRESS, "localhost");


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md uses `2` instead of `2.0`