### PR TITLE
Test undertow and armeria http2 server

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class HttpProtocolUtil {
+
+  public static String getProtocol(@Nullable String protocol) {
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  public static String getVersion(@Nullable String protocol) {
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return normalizeHttpVersion(protocol.substring("HTTP/".length()));
+    }
+    return null;
+  }
+
+  public static String normalizeHttpVersion(String version) {
+    if ("2.0".equals(version)) {
+      return "2";
+    }
+
+    return version;
+  }
+
+  private HttpProtocolUtil() {}
+}

--- a/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2ServerTest.java
+++ b/instrumentation/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2ServerTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
+
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
+
+class ArmeriaHttp2ServerTest extends ArmeriaHttpServerTest {
+
+  @Override
+  protected void configure(HttpServerTestOptions options) {
+    super.configure(options);
+    options.useHttp2();
+  }
+}

--- a/instrumentation/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttp2ServerTest.java
+++ b/instrumentation/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttp2ServerTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.armeria.v1_3;
+
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
+
+class ArmeriaHttp2ServerTest extends ArmeriaHttpServerTest {
+
+  @Override
+  protected void configure(HttpServerTestOptions options) {
+    super.configure(options);
+    options.useHttp2();
+  }
+}

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/HttpServerConnectionInstrumentation.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/HttpServerConnectionInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.undertow;
 
 import static io.opentelemetry.javaagent.instrumentation.undertow.UndertowSingletons.helper;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.context.Context;
@@ -18,16 +19,18 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class HttpTransferEncodingInstrumentation implements TypeInstrumentation {
+public class HttpServerConnectionInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("io.undertow.server.protocol.http.HttpTransferEncoding");
+    return namedOneOf(
+        "io.undertow.server.protocol.http.HttpServerConnection",
+        "io.undertow.server.protocol.http2.Http2ServerConnection");
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("createSinkConduit")
+        named("getSinkConduit")
             .and(takesArgument(0, named("io.undertow.server.HttpServerExchange"))),
         this.getClass().getName() + "$ResponseAdvice");
   }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
+import io.opentelemetry.instrumentation.api.internal.HttpProtocolUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
@@ -65,22 +66,14 @@ public class UndertowHttpAttributesGetter
   @Override
   public String getNetworkProtocolName(
       HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
-    String protocol = exchange.getProtocol().toString();
-    if (protocol.startsWith("HTTP/")) {
-      return "http";
-    }
-    return null;
+    return HttpProtocolUtil.getProtocol(exchange.getProtocol().toString());
   }
 
   @Nullable
   @Override
   public String getNetworkProtocolVersion(
       HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
-    String protocol = exchange.getProtocol().toString();
-    if (protocol.startsWith("HTTP/")) {
-      return protocol.substring("HTTP/".length());
-    }
-    return null;
+    return HttpProtocolUtil.getVersion(exchange.getProtocol().toString());
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowInstrumentationModule.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowInstrumentationModule.java
@@ -32,6 +32,6 @@ public class UndertowInstrumentationModule extends InstrumentationModule {
     return asList(
         new HandlerInstrumentation(),
         new HttpServerExchangeInstrumentation(),
-        new HttpTransferEncodingInstrumentation());
+        new HttpServerConnectionInstrumentation());
   }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowHttp2ServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowHttp2ServerTest.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.undertow.Undertow
+import io.undertow.UndertowOptions
+
+class UndertowHttp2ServerTest extends UndertowServerTest {
+
+  void configureUndertow(Undertow.Builder builder) {
+    builder.setServerOption(UndertowOptions.ENABLE_HTTP2, true)
+  }
+
+  boolean useHttp2() {
+    true
+  }
+}

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -34,6 +34,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS
+import static org.junit.jupiter.api.Assumptions.assumeFalse
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 
 @Unroll
@@ -78,6 +79,10 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
 
   String getContextPath() {
     return ""
+  }
+
+  boolean useHttp2() {
+    false
   }
 
   boolean hasHandlerSpan(ServerEndpoint endpoint) {
@@ -249,6 +254,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
       if (!testNonStandardHttpMethod()) {
         options.disableTestNonStandardHttpMethod()
       }
+      options.useHttp2 = useHttp2()
     }
 
     // Override trace assertion method. We can call java assertions from groovy but not the other
@@ -352,12 +358,16 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
 
   def "http pipelining test"() {
     assumeTrue(testHttpPipelining())
+    // test uses http 1.1
+    assumeFalse(useHttp2())
     expect:
     junitTest.httpPipelining()
   }
 
   def "non standard http method"() {
     assumeTrue(testNonStandardHttpMethod())
+    // test uses http 1.1
+    assumeFalse(useHttp2())
     expect:
     junitTest.requestWithNonStandardHttpMethod()
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -753,7 +753,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
             assertThat(attrs)
                 .hasEntrySatisfying(
                     NetworkAttributes.NETWORK_PROTOCOL_VERSION,
-                    entry -> assertThat(entry).isIn("1.1", "2.0"));
+                    entry -> assertThat(entry).isIn("1.1", "2"));
           }
 
           assertThat(attrs).containsEntry(ServerAttributes.SERVER_ADDRESS, "localhost");

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
@@ -87,9 +87,13 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
   }
 
   protected String resolveAddress(ServerEndpoint uri) {
+    return resolveAddress(uri, "h1c://");
+  }
+
+  protected String resolveAddress(ServerEndpoint uri, String protocolPrefix) {
     String url = uri.resolvePath(address).toString();
     // Force HTTP/1 via h1c so upgrade requests don't show up as traces
-    url = url.replace("http://", "h1c://");
+    url = url.replace("http://", protocolPrefix);
     if (uri.getQuery() != null) {
       url += "?" + uri.getQuery();
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
@@ -65,6 +65,7 @@ public final class HttpServerTestOptions {
   boolean testHttpPipelining = true;
   boolean testNonStandardHttpMethod = true;
   boolean verifyServerSpanEndTime = true;
+  boolean useHttp2 = false;
 
   HttpServerTestOptions() {}
 
@@ -225,6 +226,17 @@ public final class HttpServerTestOptions {
   public HttpServerTestOptions setVerifyServerSpanEndTime(boolean verifyServerSpanEndTime) {
     this.verifyServerSpanEndTime = verifyServerSpanEndTime;
     return this;
+  }
+
+  @CanIgnoreReturnValue
+  public HttpServerTestOptions setUseHttp2(boolean useHttp2) {
+    this.useHttp2 = useHttp2;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public HttpServerTestOptions useHttp2() {
+    return setUseHttp2(true);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
This PR adds http2 server tests for armeria and undertow. It also fixes a bug in undertow instrumentation where `HttpServerResponseMutator` didn't work in undertow with http2.