### PR TITLE
Revert "Remove db.connection_string (#11089)"

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesExtractor.java
@@ -23,6 +23,8 @@ abstract class DbClientCommonAttributesExtractor<
   private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
   private static final AttributeKey<String> DB_SYSTEM = AttributeKey.stringKey("db.system");
   private static final AttributeKey<String> DB_USER = AttributeKey.stringKey("db.user");
+  private static final AttributeKey<String> DB_CONNECTION_STRING =
+      AttributeKey.stringKey("db.connection_string");
 
   final GETTER getter;
 
@@ -35,6 +37,7 @@ abstract class DbClientCommonAttributesExtractor<
     internalSet(attributes, DB_SYSTEM, getter.getSystem(request));
     internalSet(attributes, DB_USER, getter.getUser(request));
     internalSet(attributes, DB_NAME, getter.getName(request));
+    internalSet(attributes, DB_CONNECTION_STRING, getter.getConnectionString(request));
   }
 
   @Override

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientCommonAttributesGetter.java
@@ -19,10 +19,6 @@ public interface DbClientCommonAttributesGetter<REQUEST> {
   @Nullable
   String getName(REQUEST request);
 
-  // to be removed in 2.4.0, use `server.address` and `server.port` instead
   @Nullable
-  @Deprecated
-  default String getConnectionString(REQUEST request) {
-    return null;
-  }
+  String getConnectionString(REQUEST request);
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
@@ -37,6 +37,11 @@ class DbClientAttributesExtractorTest {
     }
 
     @Override
+    public String getConnectionString(Map<String, String> map) {
+      return map.get("db.connection_string");
+    }
+
+    @Override
     public String getStatement(Map<String, String> map) {
       return map.get("db.statement");
     }
@@ -47,6 +52,7 @@ class DbClientAttributesExtractorTest {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void shouldExtractAllAvailableAttributes() {
     // given
@@ -54,6 +60,7 @@ class DbClientAttributesExtractorTest {
     request.put("db.system", "myDb");
     request.put("db.user", "username");
     request.put("db.name", "potatoes");
+    request.put("db.connection_string", "mydb:///potatoes");
     request.put("db.statement", "SELECT * FROM potato");
     request.put("db.operation", "SELECT");
 
@@ -75,6 +82,7 @@ class DbClientAttributesExtractorTest {
             entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
             entry(DbIncubatingAttributes.DB_USER, "username"),
             entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
+            entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
             entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato"),
             entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"));
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -42,8 +42,14 @@ class SqlClientAttributesExtractorTest {
     public String getName(Map<String, String> map) {
       return map.get("db.name");
     }
+
+    @Override
+    public String getConnectionString(Map<String, String> map) {
+      return map.get("db.connection_string");
+    }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void shouldExtractAllAttributes() {
     // given
@@ -51,6 +57,7 @@ class SqlClientAttributesExtractorTest {
     request.put("db.system", "myDb");
     request.put("db.user", "username");
     request.put("db.name", "potatoes");
+    request.put("db.connection_string", "mydb:///potatoes");
     request.put("db.statement", "SELECT * FROM potato WHERE id=12345");
 
     Context context = Context.root();
@@ -71,6 +78,7 @@ class SqlClientAttributesExtractorTest {
             entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
             entry(DbIncubatingAttributes.DB_USER, "username"),
             entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
+            entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
             entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato WHERE id=?"),
             entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
             entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"));

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
@@ -30,6 +30,12 @@ final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<Ca
 
   @Override
   @Nullable
+  public String getConnectionString(CassandraRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getRawStatement(CassandraRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
@@ -31,6 +31,12 @@ final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<Ca
 
   @Override
   @Nullable
+  public String getConnectionString(CassandraRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getRawStatement(CassandraRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
@@ -32,6 +32,12 @@ final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<Ca
 
   @Override
   @Nullable
+  public String getConnectionString(CassandraRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getRawStatement(CassandraRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
@@ -30,6 +30,12 @@ final class CouchbaseAttributesGetter implements DbClientAttributesGetter<Couchb
 
   @Override
   @Nullable
+  public String getConnectionString(CouchbaseRequestInfo couchbaseRequest) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(CouchbaseRequestInfo couchbaseRequest) {
     return couchbaseRequest.statement();
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/internal/ElasticsearchDbAttributesGetter.java
@@ -55,6 +55,12 @@ final class ElasticsearchDbAttributesGetter
 
   @Override
   @Nullable
+  public String getConnectionString(ElasticsearchRestRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(ElasticsearchRestRequest request) {
     ElasticsearchEndpointDefinition epDefinition = request.getEndpointDefinition();
     HttpEntity httpEntity = request.getHttpEntity();

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportAttributesGetter.java
@@ -31,6 +31,12 @@ final class ElasticsearchTransportAttributesGetter
 
   @Override
   @Nullable
+  public String getConnectionString(ElasticTransportRequest s) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(ElasticTransportRequest s) {
     return null;
   }

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
@@ -34,6 +34,12 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
 
   @Override
   @Nullable
+  public String getConnectionString(GeodeRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(GeodeRequest request) {
     // sanitized statement is cached
     return sanitizer.sanitize(request.getQuery()).getFullStatement();

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
@@ -57,6 +57,7 @@ abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
@@ -64,11 +65,13 @@ abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
             satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent, String verb) {
     return span.hasName(verb.concat(" db1.Value"))
         .hasKind(SpanKind.CLIENT)
@@ -77,6 +80,7 @@ abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(
                 DbIncubatingAttributes.DB_STATEMENT,
                 stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
@@ -69,6 +69,7 @@ class CriteriaTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 stringAssert -> stringAssert.startsWith("select")),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityManagerTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityManagerTest.java
@@ -34,6 +34,7 @@ class EntityManagerTest extends AbstractHibernateTest {
   static final EntityManagerFactory entityManagerFactory =
       Persistence.createEntityManagerFactory("test-pu");
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateActionParameters")
   void testHibernateActions(Parameter parameter) {
@@ -102,6 +103,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -132,6 +134,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -181,6 +184,7 @@ class EntityManagerTest extends AbstractHibernateTest {
         Arguments.of(named("remove", new Parameter("delete", true, true, EntityManager::remove))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testHibernatePersist() {
     EntityManager entityManager = entityManagerFactory.createEntityManager();
@@ -216,6 +220,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -241,6 +246,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -250,6 +256,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsAttachesState")
   void testAttachesStateToQuery(Function<EntityManager, Query> queryBuildMethod) {
@@ -288,6 +295,7 @@ class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class QueryTest extends AbstractHibernateTest {
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateQueryExecuteUpdateWithTransaction() {
     testing.runWithSpan(
@@ -63,6 +64,7 @@ class QueryTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -83,6 +85,7 @@ class QueryTest extends AbstractHibernateTest {
                                     .get(stringKey("hibernate.session_id"))))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("providesArgumentsSingleCall")
   void testHibernateQuerySingleCall(Parameter parameter) {
@@ -119,6 +122,7 @@ class QueryTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -151,6 +155,7 @@ class QueryTest extends AbstractHibernateTest {
                 new Parameter("SELECT Value", sess -> sess.createQuery("from Value").scroll()))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateQueryIterate() {
     testing.runWithSpan(
@@ -191,6 +196,7 @@ class QueryTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @SuppressWarnings("deprecation") // 'lock' is a deprecated method in the Session class
 class SessionTest extends AbstractHibernateTest {
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateAction")
   void testHibernateAction(Parameter parameter) {
@@ -66,6 +67,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -142,6 +144,7 @@ class SessionTest extends AbstractHibernateTest {
                     null))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateActionStateless")
   void testHibernateActionStateless(Parameter parameter) {
@@ -175,6 +178,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -288,6 +292,7 @@ class SessionTest extends AbstractHibernateTest {
                     }))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateReplicate")
   void testHibernateReplicate(Parameter parameter) {
@@ -320,6 +325,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -345,6 +351,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -433,6 +440,7 @@ class SessionTest extends AbstractHibernateTest {
                                     .get(stringKey("hibernate.session_id"))))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateCommitAction")
   void testHibernateCommitAction(Parameter parameter) {
@@ -477,6 +485,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -621,6 +630,7 @@ class SessionTest extends AbstractHibernateTest {
                     null))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsStateQuery")
   void testAttachesStateToQueryCreated(Consumer<Session> queryBuilder) {
@@ -654,6 +664,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -692,6 +703,7 @@ class SessionTest extends AbstractHibernateTest {
                             session -> session.createSQLQuery("SELECT * FROM Value").list())))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateOverlappingSessions() {
     testing.runWithSpan(
@@ -753,6 +765,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 stringAssert -> stringAssert.startsWith("insert")),
@@ -796,6 +809,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 stringAssert -> stringAssert.startsWith("insert")),
@@ -809,6 +823,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 stringAssert -> stringAssert.startsWith("delete")),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/spring/jpa/SpringJpaTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/spring/jpa/SpringJpaTest.java
@@ -31,6 +31,7 @@ class SpringJpaTest {
       new AnnotationConfigApplicationContext(PersistenceConfig.class);
   CustomerRepository repo = context.getBean(CustomerRepository.class);
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testCrud() {
     String version = Version.getVersionString();
@@ -68,6 +69,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -122,6 +124,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -167,6 +170,7 @@ class SpringJpaTest {
                             equalTo(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 "call next value for hibernate_sequence"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
                 span ->
                     span.hasName("Transaction.commit")
@@ -187,6 +191,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -233,6 +238,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -260,6 +266,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 "update Customer set firstName=?, lastName=? where id=?"),
@@ -297,6 +304,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -334,6 +342,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -365,6 +374,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 "delete from Customer where id=?"),
@@ -397,6 +407,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val ->
@@ -436,6 +447,7 @@ class SpringJpaTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 "delete from Customer where id=?"),

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
@@ -36,6 +36,7 @@ public class CriteriaTest extends AbstractHibernateTest {
         Arguments.of(named("getSingleResultOrNull", interactions.get(2))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideParameters")
   void testCriteriaQuery(Consumer<Query<Value>> interaction) {
@@ -78,6 +79,7 @@ public class CriteriaTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 stringAssert -> stringAssert.startsWith("select")),

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/EntityManagerTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/EntityManagerTest.java
@@ -112,6 +112,7 @@ public class EntityManagerTest extends AbstractHibernateTest {
         });
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideAttachesStateParameters")
   void testAttachesStateToQuery(Parameter parameter) {
@@ -140,6 +141,7 @@ public class EntityManagerTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -286,6 +288,7 @@ public class EntityManagerTest extends AbstractHibernateTest {
     public final Function<EntityManager, Query> queryBuildMethod;
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
@@ -293,11 +296,13 @@ public class EntityManagerTest extends AbstractHibernateTest {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
             satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(
       SpanDataAssert span, SpanData parent, String spanName) {
     return span.hasName(spanName)
@@ -307,6 +312,7 @@ public class EntityManagerTest extends AbstractHibernateTest {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
             satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/ProcedureCallTest.java
@@ -69,6 +69,7 @@ public class ProcedureCallTest {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testProcedureCall() {
     testing.runWithSpan(
@@ -104,6 +105,7 @@ public class ProcedureCallTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(DbIncubatingAttributes.DB_STATEMENT, "{call TEST_PROC()}"),
                             equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
                 span ->

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
@@ -219,6 +219,7 @@ public class SessionTest extends AbstractHibernateTest {
                 span -> assertClientSpan(span, trace.getSpan(2))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideAttachesStateToQueryParameters")
   void testAttachesStateToQuery(Parameter parameter) {
@@ -245,6 +246,7 @@ public class SessionTest extends AbstractHibernateTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.isInstanceOf(String.class)),
@@ -801,6 +803,7 @@ public class SessionTest extends AbstractHibernateTest {
             equalTo(AttributeKey.stringKey("hibernate.session_id"), sessionId));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
@@ -808,11 +811,13 @@ public class SessionTest extends AbstractHibernateTest {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
             satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(
       SpanDataAssert span, SpanData parent, String verb) {
     return span.hasName(verb.concat(" db1.Value"))
@@ -822,6 +827,7 @@ public class SessionTest extends AbstractHibernateTest {
             equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
             equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(
                 DbIncubatingAttributes.DB_STATEMENT,
                 stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),

--- a/instrumentation/hibernate/hibernate-6.0/spring-testing/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-6.0/spring-testing/src/test/groovy/SpringJpaTest.groovy
@@ -23,6 +23,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
   @Shared
   def repo = context.getBean(CustomerRepository)
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def "test CRUD"() {
     setup:
     def isHibernate4 = Version.getVersionString().startsWith("4.")
@@ -63,6 +64,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "sa"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" ~/select ([^.]+)\.id([^,]*),([^.]+)\.firstName([^,]*),([^.]+)\.lastName(.*)from Customer(.*)/
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -119,6 +121,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "sa"
               "$DbIncubatingAttributes.DB_STATEMENT" "call next value for Customer_SEQ"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_OPERATION" "CALL"
             }
           }
@@ -138,6 +141,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "sa"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" ~/insert into Customer \(.*\) values \(.*\)/
               "$DbIncubatingAttributes.DB_OPERATION" "INSERT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -152,6 +156,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "sa"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" ~/insert into Customer \(.*\) values \(.*\)/
               "$DbIncubatingAttributes.DB_OPERATION" "INSERT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -206,6 +211,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "sa"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" ~/select ([^.]+)\.id([^,]*),([^.]+)\.firstName([^,]*),([^.]+)\.lastName (.*)from Customer (.*)where ([^.]+)\.id( ?)=( ?)\?/
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -226,6 +232,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "sa"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" ~/update Customer set firstName=\?,(.*)lastName=\? where id=\?/
             "$DbIncubatingAttributes.DB_OPERATION" "UPDATE"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -268,6 +275,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "sa"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" ~/select ([^.]+)\.id([^,]*),([^.]+)\.firstName([^,]*),([^.]+)\.lastName (.*)from Customer (.*)(where ([^.]+)\.lastName( ?)=( ?)\?|)/
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -311,6 +319,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "sa"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" ~/select ([^.]+)\.id([^,]*),([^.]+)\.firstName([^,]*),([^.]+)\.lastName (.*)from Customer (.*)where ([^.]+)\.id( ?)=( ?)\?/
               "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -335,6 +344,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "sa"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" ~/select ([^.]+)\.id([^,]*),([^.]+)\.firstName([^,]*),([^.]+)\.lastName (.*)from Customer (.*)where ([^.]+)\.id( ?)=( ?)\?/
               "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"
@@ -364,6 +374,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "sa"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" "delete from Customer where id=?"
             "$DbIncubatingAttributes.DB_OPERATION" "DELETE"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "Customer"

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
@@ -76,6 +76,7 @@ class ProcedureCallTest {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testProcedureCall() {
 
@@ -117,6 +118,7 @@ class ProcedureCallTest {
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
                             equalTo(DbIncubatingAttributes.DB_STATEMENT, "{call TEST_PROC()}"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
                 span ->
                     span.hasName("Transaction.commit")

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
@@ -45,4 +45,10 @@ final class InfluxDbAttributesGetter implements DbClientAttributesGetter<InfluxD
     String dbName = request.getDbName();
     return StringUtils.isNullOrEmpty(dbName) ? null : dbName;
   }
+
+  @Nullable
+  @Override
+  public String getConnectionString(InfluxDbRequest influxDbRequest) {
+    return null;
+  }
 }

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -167,6 +167,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def "basic statement with #connection.getClass().getCanonicalName() on #system generates spans"() {
     setup:
     Statement statement = connection.createStatement()
@@ -194,6 +195,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             if (username != null) {
               "$DbIncubatingAttributes.DB_USER" username
             }
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -253,6 +255,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             if (username != null) {
               "$DbIncubatingAttributes.DB_USER" username
             }
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -304,6 +307,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             if (username != null) {
               "$DbIncubatingAttributes.DB_USER" username
             }
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -355,6 +359,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             if (username != null) {
               "$DbIncubatingAttributes.DB_USER" username
             }
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -407,6 +412,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_USER" username
             }
             "$DbIncubatingAttributes.DB_STATEMENT" query
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_OPERATION" "CREATE TABLE"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
           }
@@ -461,6 +467,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_USER" username
             }
             "$DbIncubatingAttributes.DB_STATEMENT" query
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_OPERATION" "CREATE TABLE"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
           }
@@ -526,6 +533,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             if (username != null) {
               "$DbIncubatingAttributes.DB_USER" username
             }
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" url
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -582,6 +590,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" system
             "$DbIncubatingAttributes.DB_USER" { user == null | user == it }
             "$DbIncubatingAttributes.DB_NAME" "jdbcunittest"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" connectionString
           }
         }
         if (recursive) {
@@ -595,6 +604,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" system
               "$DbIncubatingAttributes.DB_USER" { user == null | user == it }
               "$DbIncubatingAttributes.DB_NAME" "jdbcunittest"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" connectionString
             }
           }
         }
@@ -643,6 +653,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           attributes {
             "$DbIncubatingAttributes.DB_SYSTEM" "other_sql"
             "$DbIncubatingAttributes.DB_STATEMENT" "testing ?"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "testdb://localhost"
             "$ServerAttributes.SERVER_ADDRESS" "localhost"
           }
         }
@@ -683,6 +694,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           attributes {
             "$DbIncubatingAttributes.DB_SYSTEM" "other_sql"
             "$DbIncubatingAttributes.DB_NAME" databaseName
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "testdb://localhost"
             "$DbIncubatingAttributes.DB_STATEMENT" sanitizedQuery
             "$DbIncubatingAttributes.DB_OPERATION" operation
             "$DbIncubatingAttributes.DB_SQL_TABLE" table
@@ -740,6 +752,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" dbNameLower
               "$DbIncubatingAttributes.DB_USER" "SA"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"
               "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "INFORMATION_SCHEMA.SYSTEM_USERS"
@@ -786,6 +799,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           childOf span(0)
           attributes {
             "$DbIncubatingAttributes.DB_SYSTEM" "other_sql"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "testdb://localhost"
             "$DbIncubatingAttributes.DB_STATEMENT" "SELECT * FROM table"
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "table"

--- a/instrumentation/jdbc/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/SlickTest.scala
+++ b/instrumentation/jdbc/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/SlickTest.scala
@@ -85,6 +85,10 @@ class SlickTest {
                     ),
                     equalTo(DbIncubatingAttributes.DB_NAME, Db),
                     equalTo(DbIncubatingAttributes.DB_USER, Username),
+                    equalTo(
+                      DbIncubatingAttributes.DB_CONNECTION_STRING,
+                      "h2:mem:"
+                    ),
                     equalTo(DbIncubatingAttributes.DB_STATEMENT, "SELECT ?"),
                     equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT")
                   )

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceDbAttributesExtractor.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceDbAttributesExtractor.java
@@ -22,10 +22,13 @@ enum DataSourceDbAttributesExtractor implements AttributesExtractor<DataSource, 
   private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
   private static final AttributeKey<String> DB_SYSTEM = AttributeKey.stringKey("db.system");
   private static final AttributeKey<String> DB_USER = AttributeKey.stringKey("db.user");
+  private static final AttributeKey<String> DB_CONNECTION_STRING =
+      AttributeKey.stringKey("db.connection_string");
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, DataSource dataSource) {}
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Override
   public void onEnd(
       AttributesBuilder attributes,
@@ -39,6 +42,7 @@ enum DataSourceDbAttributesExtractor implements AttributesExtractor<DataSource, 
     internalSet(attributes, DB_SYSTEM, dbInfo.getSystem());
     internalSet(attributes, DB_USER, dbInfo.getUser());
     internalSet(attributes, DB_NAME, getName(dbInfo));
+    internalSet(attributes, DB_CONNECTION_STRING, dbInfo.getShortUrl());
   }
 
   private static String getName(DbInfo dbInfo) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -36,6 +36,12 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
 
   @Nullable
   @Override
+  public String getConnectionString(DbRequest request) {
+    return request.getDbInfo().getShortUrl();
+  }
+
+  @Nullable
+  @Override
   public String getRawStatement(DbRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -886,13 +886,36 @@ public enum JdbcConnectionUrlParser {
     try {
       if (typeParsers.containsKey(type)) {
         // Delegate to specific parser
-        return typeParsers.get(type).doParse(jdbcUrl, parsedProps).build();
+        return withUrl(typeParsers.get(type).doParse(jdbcUrl, parsedProps), type);
       }
-      return GENERIC_URL_LIKE.doParse(jdbcUrl, parsedProps).build();
+      return withUrl(GENERIC_URL_LIKE.doParse(jdbcUrl, parsedProps), type);
     } catch (RuntimeException e) {
       logger.log(FINE, "Error parsing URL", e);
       return parsedProps.build();
     }
+  }
+
+  private static DbInfo withUrl(DbInfo.Builder builder, String type) {
+    DbInfo info = builder.build();
+    StringBuilder url = new StringBuilder();
+    url.append(type);
+    url.append(':');
+    String subtype = info.getSubtype();
+    if (subtype != null) {
+      url.append(subtype);
+      url.append(':');
+    }
+    String host = info.getHost();
+    if (host != null) {
+      url.append("//");
+      url.append(host);
+      Integer port = info.getPort();
+      if (port != null) {
+        url.append(':');
+        url.append(port);
+      }
+    }
+    return builder.shortUrl(url.toString()).build();
   }
 
   // Source: https://stackoverflow.com/a/13592567

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -27,6 +27,10 @@ public abstract class DbInfo {
   @Nullable
   public abstract String getSubtype();
 
+  // "type:[subtype:]//host:port"
+  @Nullable
+  public abstract String getShortUrl();
+
   @Nullable
   public abstract String getUser();
 
@@ -46,6 +50,7 @@ public abstract class DbInfo {
     return builder()
         .system(getSystem())
         .subtype(getSubtype())
+        .shortUrl(getShortUrl())
         .user(getUser())
         .name(getName())
         .db(getDb())
@@ -63,6 +68,8 @@ public abstract class DbInfo {
     public abstract Builder system(String system);
 
     public abstract Builder subtype(String subtype);
+
+    public abstract Builder shortUrl(String shortUrl);
 
     public abstract Builder user(String user);
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
@@ -33,6 +33,7 @@ class OpenTelemetryDataSourceTest {
   @RegisterExtension
   static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @ArgumentsSource(GetConnectionMethods.class)
   void shouldEmitGetConnectionSpans(GetConnectionFunction getConnection) throws SQLException {
@@ -55,7 +56,10 @@ class OpenTelemetryDataSourceTest {
                                 TestDataSource.class.getName()),
                             equalTo(CodeIncubatingAttributes.CODE_FUNCTION, "getConnection"),
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "postgresql"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "dbname"))));
+                            equalTo(DbIncubatingAttributes.DB_NAME, "dbname"),
+                            equalTo(
+                                DbIncubatingAttributes.DB_CONNECTION_STRING,
+                                "postgresql://127.0.0.1:5432"))));
 
     assertThat(connection).isExactlyInstanceOf(OpenTelemetryConnection.class);
     DbInfo dbInfo = ((OpenTelemetryConnection) connection).getDbInfo();
@@ -97,6 +101,7 @@ class OpenTelemetryDataSourceTest {
   private static void assertDbInfo(DbInfo dbInfo) {
     assertThat(dbInfo.getSystem()).isEqualTo("postgresql");
     assertNull(dbInfo.getSubtype());
+    assertThat(dbInfo.getShortUrl()).isEqualTo("postgresql://127.0.0.1:5432");
     assertNull(dbInfo.getUser());
     assertNull(dbInfo.getName());
     assertThat(dbInfo.getDb()).isEqualTo("dbname");

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -55,6 +55,7 @@ class JdbcConnectionUrlParserTest {
   void testVerifySystemSubtypeParsingOfUrl(ParseTestArgument argument) {
     DbInfo info = parse(argument.url, argument.properties);
     DbInfo expected = argument.dbInfo;
+    assertThat(info.getShortUrl()).isEqualTo(expected.getShortUrl());
     assertThat(info.getSystem()).isEqualTo(expected.getSystem());
     assertThat(info.getHost()).isEqualTo(expected.getHost());
     assertThat(info.getPort()).isEqualTo(expected.getPort());
@@ -71,12 +72,14 @@ class JdbcConnectionUrlParserTest {
       return args(
           // https://jdbc.postgresql.org/documentation/94/connect.html
           arg("jdbc:postgresql:///")
+              .setShortUrl("postgresql://localhost:5432")
               .setSystem("postgresql")
               .setHost("localhost")
               .setPort(5432)
               .build(),
           arg("jdbc:postgresql:///")
               .setProperties(stdProps())
+              .setShortUrl("postgresql://stdServerName:9999")
               .setSystem("postgresql")
               .setUser("stdUserName")
               .setHost("stdServerName")
@@ -84,11 +87,13 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:postgresql://pg.host")
+              .setShortUrl("postgresql://pg.host:5432")
               .setSystem("postgresql")
               .setHost("pg.host")
               .setPort(5432)
               .build(),
           arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
+              .setShortUrl("postgresql://pg.host:11")
               .setSystem("postgresql")
               .setUser("pguser")
               .setHost("pg.host")
@@ -97,6 +102,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
               .setProperties(stdProps())
+              .setShortUrl("postgresql://pg.host:11")
               .setSystem("postgresql")
               .setUser("pguser")
               .setHost("pg.host")
@@ -106,23 +112,36 @@ class JdbcConnectionUrlParserTest {
 
           // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html
           // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
-          arg("jdbc:mysql:///").setSystem("mysql").setHost("localhost").setPort(3306).build(),
+          arg("jdbc:mysql:///")
+              .setShortUrl("mysql://localhost:3306")
+              .setSystem("mysql")
+              .setHost("localhost")
+              .setPort(3306)
+              .build(),
           arg("jdbc:mysql:///")
               .setProperties(stdProps())
+              .setShortUrl("mysql://stdServerName:9999")
               .setSystem("mysql")
               .setUser("stdUserName")
               .setHost("stdServerName")
               .setPort(9999)
               .setDb("stdDatabaseName")
               .build(),
-          arg("jdbc:mysql://my.host").setSystem("mysql").setHost("my.host").setPort(3306).build(),
+          arg("jdbc:mysql://my.host")
+              .setShortUrl("mysql://my.host:3306")
+              .setSystem("mysql")
+              .setHost("my.host")
+              .setPort(3306)
+              .build(),
           arg("jdbc:mysql://my.host?user=myuser&password=PW")
+              .setShortUrl("mysql://my.host:3306")
               .setSystem("mysql")
               .setUser("myuser")
               .setHost("my.host")
               .setPort(3306)
               .build(),
           arg("jdbc:mysql://my.host:22/mydb?user=myuser&password=PW")
+              .setShortUrl("mysql://my.host:22")
               .setSystem("mysql")
               .setUser("myuser")
               .setHost("my.host")
@@ -131,6 +150,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:mysql://127.0.0.1:22/mydb?user=myuser&password=PW")
               .setProperties(stdProps())
+              .setShortUrl("mysql://127.0.0.1:22")
               .setSystem("mysql")
               .setUser("myuser")
               .setHost("127.0.0.1")
@@ -138,6 +158,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mydb")
               .build(),
           arg("jdbc:mysql://myuser:password@my.host:22/mydb")
+              .setShortUrl("mysql://my.host:22")
               .setSystem("mysql")
               .setUser("myuser")
               .setHost("my.host")
@@ -147,12 +168,14 @@ class JdbcConnectionUrlParserTest {
 
           // https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings
           arg("jdbc:mariadb:127.0.0.1:33/mdbdb")
+              .setShortUrl("mariadb://127.0.0.1:33")
               .setSystem("mariadb")
               .setHost("127.0.0.1")
               .setPort(33)
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:localhost/mdbdb")
+              .setShortUrl("mariadb://localhost:3306")
               .setSystem("mariadb")
               .setHost("localhost")
               .setPort(3306)
@@ -160,6 +183,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:mariadb:localhost/mdbdb?user=mdbuser&password=PW")
               .setProperties(stdProps())
+              .setShortUrl("mariadb://localhost:9999")
               .setSystem("mariadb")
               .setUser("mdbuser")
               .setHost("localhost")
@@ -168,6 +192,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:mariadb:localhost:33/mdbdb")
               .setProperties(stdProps())
+              .setShortUrl("mariadb://localhost:33")
               .setSystem("mariadb")
               .setUser("stdUserName")
               .setHost("localhost")
@@ -175,6 +200,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
+              .setShortUrl("mariadb://mdb.host:33")
               .setSystem("mariadb")
               .setUser("mdbuser")
               .setHost("mdb.host")
@@ -182,6 +208,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:aurora://mdb.host/mdbdb")
+              .setShortUrl("mariadb:aurora://mdb.host:3306")
               .setSystem("mariadb")
               .setSubtype("aurora")
               .setHost("mdb.host")
@@ -189,6 +216,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mysql:aurora://mdb.host/mdbdb")
+              .setShortUrl("mysql:aurora://mdb.host:3306")
               .setSystem("mysql")
               .setSubtype("aurora")
               .setHost("mdb.host")
@@ -196,6 +224,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mysql:failover://localhost/mdbdb?autoReconnect=true")
+              .setShortUrl("mysql:failover://localhost:3306")
               .setSystem("mysql")
               .setSubtype("failover")
               .setHost("localhost")
@@ -203,6 +232,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:failover://mdb.host1:33,mdb.host/mdbdb?characterEncoding=utf8")
+              .setShortUrl("mariadb:failover://mdb.host1:33")
               .setSystem("mariadb")
               .setSubtype("failover")
               .setHost("mdb.host1")
@@ -210,6 +240,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:sequential://mdb.host1,mdb.host2:33/mdbdb")
+              .setShortUrl("mariadb:sequential://mdb.host1:3306")
               .setSystem("mariadb")
               .setSubtype("sequential")
               .setHost("mdb.host1")
@@ -217,6 +248,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:loadbalance://127.0.0.1:33,mdb.host/mdbdb")
+              .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
               .setSystem("mariadb")
               .setSubtype("loadbalance")
               .setHost("127.0.0.1")
@@ -224,6 +256,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:loadbalance://127.0.0.1:33/mdbdb")
+              .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
               .setSystem("mariadb")
               .setSubtype("loadbalance")
               .setHost("127.0.0.1")
@@ -231,6 +264,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb")
+              .setShortUrl("mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33")
               .setSystem("mariadb")
               .setSubtype("loadbalance")
               .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
@@ -238,6 +272,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mysql:loadbalance://127.0.0.1,127.0.0.1:3306/mdbdb?user=mdbuser&password=PW")
+              .setShortUrl("mysql:loadbalance://127.0.0.1:3306")
               .setSystem("mysql")
               .setSubtype("loadbalance")
               .setUser("mdbuser")
@@ -246,6 +281,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mariadb:replication://localhost:33,anotherhost:3306/mdbdb")
+              .setShortUrl("mariadb:replication://localhost:33")
               .setSystem("mariadb")
               .setSubtype("replication")
               .setHost("localhost")
@@ -253,6 +289,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mysql:replication://address=(HOST=127.0.0.1)(port=33)(user=mdbuser)(password=PW),address=(host=mdb.host)(port=3306)(user=otheruser)(password=PW)/mdbdb?user=wrong&password=PW")
+              .setShortUrl("mysql:replication://127.0.0.1:33")
               .setSystem("mysql")
               .setSubtype("replication")
               .setUser("mdbuser")
@@ -261,6 +298,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("mdbdb")
               .build(),
           arg("jdbc:mysql:replication://address=(HOST=mdb.host),address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW")
+              .setShortUrl("mysql:replication://mdb.host:3306")
               .setSystem("mysql")
               .setSubtype("replication")
               .setUser("mdbuser")
@@ -271,33 +309,39 @@ class JdbcConnectionUrlParserTest {
 
           // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
           arg("jdbc:microsoft:sqlserver://;")
+              .setShortUrl("microsoft:sqlserver://localhost:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("localhost")
               .setPort(1433)
               .build(),
           arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
+              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
               .setSystem("mssql")
               .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
               .setPort(1433)
               .build(),
           arg("jdbc:sqlserver://;serverName=2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+              .setShortUrl("sqlserver://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1433")
               .setSystem("mssql")
               .setHost("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")
               .setPort(1433)
               .build(),
           arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
+              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
               .setSystem("mssql")
               .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
               .setPort(43)
               .build(),
           arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance")
+              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
               .setSystem("mssql")
               .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
               .setPort(1433)
               .setName("ssinstance")
               .build(),
           arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance]:43")
+              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
               .setSystem("mssql")
               .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
               .setPort(43)
@@ -305,6 +349,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:microsoft:sqlserver://;")
               .setProperties(stdProps())
+              .setShortUrl("microsoft:sqlserver://stdServerName:9999")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setUser("stdUserName")
@@ -313,6 +358,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:sqlserver://ss.host\\ssinstance:44;databaseName=ssdb;user=ssuser;password=pw")
+              .setShortUrl("sqlserver://ss.host:44")
               .setSystem("mssql")
               .setUser("ssuser")
               .setHost("ss.host")
@@ -321,18 +367,21 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:sqlserver://;serverName=ss.host\\ssinstance:44;DatabaseName=;")
+              .setShortUrl("sqlserver://ss.host:44")
               .setSystem("mssql")
               .setHost("ss.host")
               .setPort(44)
               .setName("ssinstance")
               .build(),
           arg("jdbc:sqlserver://ss.host;serverName=althost;DatabaseName=ssdb;")
+              .setShortUrl("sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setHost("ss.host")
               .setPort(1433)
               .setDb("ssdb")
               .build(),
           arg("jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;")
+              .setShortUrl("microsoft:sqlserver://ss.host:44")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setUser("ssuser")
@@ -343,6 +392,7 @@ class JdbcConnectionUrlParserTest {
 
           // http://jtds.sourceforge.net/faq.html#urlFormat
           arg("jdbc:jtds:sqlserver://ss.host/ssdb")
+              .setShortUrl("jtds:sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("ss.host")
@@ -350,6 +400,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb")
+              .setShortUrl("jtds:sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("ss.host")
@@ -357,6 +408,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;user=ssuser")
+              .setShortUrl("jtds:sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setUser("ssuser")
@@ -365,6 +417,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:jtds:sqlserver://ss.host/ssdb;instance=ssinstance")
+              .setShortUrl("jtds:sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("ss.host")
@@ -373,6 +426,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:jtds:sqlserver://ss.host:1444/ssdb;instance=ssinstance")
+              .setShortUrl("jtds:sqlserver://ss.host:1444")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("ss.host")
@@ -381,6 +435,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("ssdb")
               .build(),
           arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;instance=ssinstance;user=ssuser")
+              .setShortUrl("jtds:sqlserver://ss.host:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setUser("ssuser")
@@ -393,6 +448,7 @@ class JdbcConnectionUrlParserTest {
           // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
           // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
           arg("jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn")
+              .setShortUrl("oracle:thin://localhost:55")
               .setSystem("oracle")
               .setSubtype("thin")
               .setUser("orcluser")
@@ -401,6 +457,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:thin:orcluser/PW@//orcl.host:55/orclsn")
+              .setShortUrl("oracle:thin://orcl.host:55")
               .setSystem("oracle")
               .setSubtype("thin")
               .setUser("orcluser")
@@ -409,6 +466,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:thin:orcluser/PW@127.0.0.1:orclsn")
+              .setShortUrl("oracle:thin://127.0.0.1:1521")
               .setSystem("oracle")
               .setSubtype("thin")
               .setUser("orcluser")
@@ -417,6 +475,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:thin:orcluser/PW@//orcl.host/orclsn")
+              .setShortUrl("oracle:thin://orcl.host:1521")
               .setSystem("oracle")
               .setSubtype("thin")
               .setUser("orcluser")
@@ -425,6 +484,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:thin:@//orcl.host:55/orclsn")
+              .setShortUrl("oracle:thin://orcl.host:55")
               .setSystem("oracle")
               .setSubtype("thin")
               .setHost("orcl.host")
@@ -432,6 +492,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:thin:@ldap://orcl.host:55/some,cn=OracleContext,dc=com")
+              .setShortUrl("oracle:thin://orcl.host:55")
               .setSystem("oracle")
               .setSubtype("thin")
               .setHost("orcl.host")
@@ -439,6 +500,7 @@ class JdbcConnectionUrlParserTest {
               .setName("some,cn=oraclecontext,dc=com")
               .build(),
           arg("jdbc:oracle:thin:127.0.0.1:orclsn")
+              .setShortUrl("oracle:thin://127.0.0.1:1521")
               .setSystem("oracle")
               .setSubtype("thin")
               .setHost("127.0.0.1")
@@ -447,6 +509,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:oracle:thin:orcl.host:orclsn")
               .setProperties(stdProps())
+              .setShortUrl("oracle:thin://orcl.host:9999")
               .setSystem("oracle")
               .setSubtype("thin")
               .setUser("stdUserName")
@@ -457,6 +520,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=666))"
                   + "(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=orclsn)))")
+              .setShortUrl("oracle:thin://127.0.0.1:666")
               .setSystem("oracle")
               .setSubtype("thin")
               .setHost("127.0.0.1")
@@ -466,6 +530,7 @@ class JdbcConnectionUrlParserTest {
 
           // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
           arg("jdbc:oracle:drivertype:orcluser/PW@orcl.host:55/orclsn")
+              .setShortUrl("oracle:drivertype://orcl.host:55")
               .setSystem("oracle")
               .setSubtype("drivertype")
               .setUser("orcluser")
@@ -473,9 +538,15 @@ class JdbcConnectionUrlParserTest {
               .setPort(55)
               .setName("orclsn")
               .build(),
-          arg("jdbc:oracle:oci8:@").setSystem("oracle").setSubtype("oci8").setPort(1521).build(),
+          arg("jdbc:oracle:oci8:@")
+              .setShortUrl("oracle:oci8:")
+              .setSystem("oracle")
+              .setSubtype("oci8")
+              .setPort(1521)
+              .build(),
           arg("jdbc:oracle:oci8:@")
               .setProperties(stdProps())
+              .setShortUrl("oracle:oci8://stdServerName:9999")
               .setSystem("oracle")
               .setSubtype("oci8")
               .setUser("stdUserName")
@@ -484,12 +555,14 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:oracle:oci8:@orclsn")
+              .setShortUrl("oracle:oci8:")
               .setSystem("oracle")
               .setSubtype("oci8")
               .setPort(1521)
               .setName("orclsn")
               .build(),
           arg("jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=orcl.host)(PORT=55))(CONNECT_DATA=(SERVICE_NAME=orclsn)))")
+              .setShortUrl("oracle:oci://orcl.host:55")
               .setSystem("oracle")
               .setSubtype("oci")
               .setHost("orcl.host")
@@ -499,9 +572,15 @@ class JdbcConnectionUrlParserTest {
 
           // https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/java/src/tpc/imjcc_tjvjcccn.html
           // https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052342.html
-          arg("jdbc:db2://db2.host").setSystem("db2").setHost("db2.host").setPort(50000).build(),
+          arg("jdbc:db2://db2.host")
+              .setShortUrl("db2://db2.host:50000")
+              .setSystem("db2")
+              .setHost("db2.host")
+              .setPort(50000)
+              .build(),
           arg("jdbc:db2://db2.host")
               .setProperties(stdProps())
+              .setShortUrl("db2://db2.host:9999")
               .setSystem("db2")
               .setUser("stdUserName")
               .setHost("db2.host")
@@ -509,6 +588,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
+              .setShortUrl("db2://db2.host:77")
               .setSystem("db2")
               .setUser("db2user")
               .setHost("db2.host")
@@ -517,6 +597,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
               .setProperties(stdProps())
+              .setShortUrl("db2://db2.host:77")
               .setSystem("db2")
               .setUser("db2user")
               .setHost("db2.host")
@@ -525,6 +606,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:as400://ashost:66/asdb:user=asuser;password=PW;")
+              .setShortUrl("as400://ashost:66")
               .setSystem("db2")
               .setUser("asuser")
               .setHost("ashost")
@@ -533,16 +615,23 @@ class JdbcConnectionUrlParserTest {
               .build(),
 
           // http://www.h2database.com/html/features.html#database_url
-          arg("jdbc:h2:mem:").setSystem("h2").setSubtype("mem").build(),
+          arg("jdbc:h2:mem:").setShortUrl("h2:mem:").setSystem("h2").setSubtype("mem").build(),
           arg("jdbc:h2:mem:")
               .setProperties(stdProps())
+              .setShortUrl("h2:mem:")
               .setSystem("h2")
               .setSubtype("mem")
               .setUser("stdUserName")
               .setDb("stdDatabaseName")
               .build(),
-          arg("jdbc:h2:mem:h2db").setSystem("h2").setSubtype("mem").setName("h2db").build(),
+          arg("jdbc:h2:mem:h2db")
+              .setShortUrl("h2:mem:")
+              .setSystem("h2")
+              .setSubtype("mem")
+              .setName("h2db")
+              .build(),
           arg("jdbc:h2:tcp://h2.host:111/path/h2db;user=h2user;password=PW")
+              .setShortUrl("h2:tcp://h2.host:111")
               .setSystem("h2")
               .setSubtype("tcp")
               .setUser("h2user")
@@ -551,6 +640,7 @@ class JdbcConnectionUrlParserTest {
               .setName("path/h2db")
               .build(),
           arg("jdbc:h2:ssl://h2.host:111/path/h2db;user=h2user;password=PW")
+              .setShortUrl("h2:ssl://h2.host:111")
               .setSystem("h2")
               .setSubtype("ssl")
               .setUser("h2user")
@@ -559,26 +649,31 @@ class JdbcConnectionUrlParserTest {
               .setName("path/h2db")
               .build(),
           arg("jdbc:h2:/data/h2file")
+              .setShortUrl("h2:file:")
               .setSystem("h2")
               .setSubtype("file")
               .setName("/data/h2file")
               .build(),
           arg("jdbc:h2:file:~/h2file;USER=h2user;PASSWORD=PW")
+              .setShortUrl("h2:file:")
               .setSystem("h2")
               .setSubtype("file")
               .setName("~/h2file")
               .build(),
           arg("jdbc:h2:file:/data/h2file")
+              .setShortUrl("h2:file:")
               .setSystem("h2")
               .setSubtype("file")
               .setName("/data/h2file")
               .build(),
           arg("jdbc:h2:file:C:/data/h2file")
+              .setShortUrl("h2:file:")
               .setSystem("h2")
               .setSubtype("file")
               .setName("c:/data/h2file")
               .build(),
           arg("jdbc:h2:zip:~/db.zip!/h2zip")
+              .setShortUrl("h2:zip:")
               .setSystem("h2")
               .setSubtype("zip")
               .setName("~/db.zip!/h2zip")
@@ -586,6 +681,7 @@ class JdbcConnectionUrlParserTest {
 
           // http://hsqldb.org/doc/2.0/guide/dbproperties-chapt.html
           arg("jdbc:hsqldb:hsdb")
+              .setShortUrl("hsqldb:mem:")
               .setSystem("hsqldb")
               .setSubtype("mem")
               .setUser("SA")
@@ -593,6 +689,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:hsqldb:hsdb")
               .setProperties(stdProps())
+              .setShortUrl("hsqldb:mem:")
               .setSystem("hsqldb")
               .setSubtype("mem")
               .setUser("stdUserName")
@@ -600,66 +697,77 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:hsqldb:mem:hsdb")
+              .setShortUrl("hsqldb:mem:")
               .setSystem("hsqldb")
               .setSubtype("mem")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:mem:hsdb;shutdown=true")
+              .setShortUrl("hsqldb:mem:")
               .setSystem("hsqldb")
               .setSubtype("mem")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:mem:hsdb?shutdown=true")
+              .setShortUrl("hsqldb:mem:")
               .setSystem("hsqldb")
               .setSubtype("mem")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:file:hsdb")
+              .setShortUrl("hsqldb:file:")
               .setSystem("hsqldb")
               .setSubtype("file")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:file:hsdb;user=aUserName;password=3xLVz")
+              .setShortUrl("hsqldb:file:")
               .setSystem("hsqldb")
               .setSubtype("file")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:file:hsdb;create=false?user=aUserName&password=3xLVz")
+              .setShortUrl("hsqldb:file:")
               .setSystem("hsqldb")
               .setSubtype("file")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:file:/loc/hsdb")
+              .setShortUrl("hsqldb:file:")
               .setSystem("hsqldb")
               .setSubtype("file")
               .setUser("SA")
               .setName("/loc/hsdb")
               .build(),
           arg("jdbc:hsqldb:file:C:/hsdb")
+              .setShortUrl("hsqldb:file:")
               .setSystem("hsqldb")
               .setSubtype("file")
               .setUser("SA")
               .setName("c:/hsdb")
               .build(),
           arg("jdbc:hsqldb:res:hsdb")
+              .setShortUrl("hsqldb:res:")
               .setSystem("hsqldb")
               .setSubtype("res")
               .setUser("SA")
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:res:/cp/hsdb")
+              .setShortUrl("hsqldb:res:")
               .setSystem("hsqldb")
               .setSubtype("res")
               .setUser("SA")
               .setName("/cp/hsdb")
               .build(),
           arg("jdbc:hsqldb:hsql://hs.host:333/hsdb")
+              .setShortUrl("hsqldb:hsql://hs.host:333")
               .setSystem("hsqldb")
               .setSubtype("hsql")
               .setUser("SA")
@@ -668,6 +776,7 @@ class JdbcConnectionUrlParserTest {
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:hsqls://hs.host/hsdb")
+              .setShortUrl("hsqldb:hsqls://hs.host:9001")
               .setSystem("hsqldb")
               .setSubtype("hsqls")
               .setUser("SA")
@@ -676,6 +785,7 @@ class JdbcConnectionUrlParserTest {
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:http://hs.host")
+              .setShortUrl("hsqldb:http://hs.host:80")
               .setSystem("hsqldb")
               .setSubtype("http")
               .setUser("SA")
@@ -683,6 +793,7 @@ class JdbcConnectionUrlParserTest {
               .setPort(80)
               .build(),
           arg("jdbc:hsqldb:http://hs.host:333/hsdb")
+              .setShortUrl("hsqldb:http://hs.host:333")
               .setSystem("hsqldb")
               .setSubtype("http")
               .setUser("SA")
@@ -691,6 +802,7 @@ class JdbcConnectionUrlParserTest {
               .setName("hsdb")
               .build(),
           arg("jdbc:hsqldb:https://127.0.0.1/hsdb")
+              .setShortUrl("hsqldb:https://127.0.0.1:443")
               .setSystem("hsqldb")
               .setSubtype("https")
               .setUser("SA")
@@ -702,6 +814,7 @@ class JdbcConnectionUrlParserTest {
           // https://db.apache.org/derby/papers/DerbyClientSpec.html#Connection+URL+Format
           // https://db.apache.org/derby/docs/10.8/devguide/cdevdvlp34964.html
           arg("jdbc:derby:derbydb")
+              .setShortUrl("derby:directory:")
               .setSystem("derby")
               .setSubtype("directory")
               .setUser("APP")
@@ -709,6 +822,7 @@ class JdbcConnectionUrlParserTest {
               .build(),
           arg("jdbc:derby:derbydb")
               .setProperties(stdProps())
+              .setShortUrl("derby:directory:")
               .setSystem("derby")
               .setSubtype("directory")
               .setUser("stdUserName")
@@ -716,24 +830,28 @@ class JdbcConnectionUrlParserTest {
               .setDb("stdDatabaseName")
               .build(),
           arg("jdbc:derby:derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:directory:")
               .setSystem("derby")
               .setSubtype("directory")
               .setUser("derbyuser")
               .setName("derbydb")
               .build(),
           arg("jdbc:derby:memory:derbydb")
+              .setShortUrl("derby:memory:")
               .setSystem("derby")
               .setSubtype("memory")
               .setUser("APP")
               .setName("derbydb")
               .build(),
           arg("jdbc:derby:memory:;databaseName=derbydb")
+              .setShortUrl("derby:memory:")
               .setSystem("derby")
               .setSubtype("memory")
               .setUser("APP")
               .setDb("derbydb")
               .build(),
           arg("jdbc:derby:memory:derbydb;databaseName=altdb")
+              .setShortUrl("derby:memory:")
               .setSystem("derby")
               .setSubtype("memory")
               .setUser("APP")
@@ -741,12 +859,14 @@ class JdbcConnectionUrlParserTest {
               .setDb("altdb")
               .build(),
           arg("jdbc:derby:memory:derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:memory:")
               .setSystem("derby")
               .setSubtype("memory")
               .setUser("derbyuser")
               .setName("derbydb")
               .build(),
           arg("jdbc:derby://derby.host:222/memory:derbydb;create=true")
+              .setShortUrl("derby:network://derby.host:222")
               .setSystem("derby")
               .setSubtype("network")
               .setUser("APP")
@@ -755,6 +875,7 @@ class JdbcConnectionUrlParserTest {
               .setName("derbydb")
               .build(),
           arg("jdbc:derby://derby.host/memory:derbydb;create=true;user=derbyuser;password=pw")
+              .setShortUrl("derby:network://derby.host:1527")
               .setSystem("derby")
               .setSubtype("network")
               .setUser("derbyuser")
@@ -763,6 +884,7 @@ class JdbcConnectionUrlParserTest {
               .setName("derbydb")
               .build(),
           arg("jdbc:derby://127.0.0.1:1527/memory:derbydb;create=true;user=derbyuser;password=pw")
+              .setShortUrl("derby:network://127.0.0.1:1527")
               .setSystem("derby")
               .setSubtype("network")
               .setUser("derbyuser")
@@ -771,24 +893,28 @@ class JdbcConnectionUrlParserTest {
               .setName("derbydb")
               .build(),
           arg("jdbc:derby:directory:derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:directory:")
               .setSystem("derby")
               .setSubtype("directory")
               .setUser("derbyuser")
               .setName("derbydb")
               .build(),
           arg("jdbc:derby:classpath:/some/derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:classpath:")
               .setSystem("derby")
               .setSubtype("classpath")
               .setUser("derbyuser")
               .setName("/some/derbydb")
               .build(),
           arg("jdbc:derby:jar:/derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:jar:")
               .setSystem("derby")
               .setSubtype("jar")
               .setUser("derbyuser")
               .setName("/derbydb")
               .build(),
           arg("jdbc:derby:jar:(~/path/to/db.jar)/other/derbydb;user=derbyuser;password=pw")
+              .setShortUrl("derby:jar:")
               .setSystem("derby")
               .setSubtype("jar")
               .setUser("derbyuser")
@@ -797,6 +923,7 @@ class JdbcConnectionUrlParserTest {
 
           // https://docs.progress.com/bundle/datadirect-connect-jdbc-51/page/URL-Formats-DataDirect-Connect-for-JDBC-Drivers.html
           arg("jdbc:datadirect:sqlserver://server_name:1433;DatabaseName=dbname")
+              .setShortUrl("datadirect:sqlserver://server_name:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("server_name")
@@ -804,18 +931,21 @@ class JdbcConnectionUrlParserTest {
               .setDb("dbname")
               .build(),
           arg("jdbc:datadirect:oracle://server_name:1521;ServiceName=your_servicename")
+              .setShortUrl("datadirect:oracle://server_name:1521")
               .setSystem("oracle")
               .setSubtype("oracle")
               .setHost("server_name")
               .setPort(1521)
               .build(),
           arg("jdbc:datadirect:mysql://server_name:3306")
+              .setShortUrl("datadirect:mysql://server_name:3306")
               .setSystem("mysql")
               .setSubtype("mysql")
               .setHost("server_name")
               .setPort(3306)
               .build(),
           arg("jdbc:datadirect:postgresql://server_name:5432;DatabaseName=dbname")
+              .setShortUrl("datadirect:postgresql://server_name:5432")
               .setSystem("postgresql")
               .setSubtype("postgresql")
               .setHost("server_name")
@@ -823,6 +953,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("dbname")
               .build(),
           arg("jdbc:datadirect:db2://server_name:50000;DatabaseName=dbname")
+              .setShortUrl("datadirect:db2://server_name:50000")
               .setSystem("db2")
               .setSubtype("db2")
               .setHost("server_name")
@@ -833,6 +964,7 @@ class JdbcConnectionUrlParserTest {
           // "the TIBCO JDBC drivers are based on the Progress DataDirect Connect drivers"
           // https://community.jaspersoft.com/documentation/tibco-jasperreports-server-administrator-guide/v601/working-data-sources
           arg("jdbc:tibcosoftware:sqlserver://server_name:1433;DatabaseName=dbname")
+              .setShortUrl("tibcosoftware:sqlserver://server_name:1433")
               .setSystem("mssql")
               .setSubtype("sqlserver")
               .setHost("server_name")
@@ -840,18 +972,21 @@ class JdbcConnectionUrlParserTest {
               .setDb("dbname")
               .build(),
           arg("jdbc:tibcosoftware:oracle://server_name:1521;ServiceName=your_servicename")
+              .setShortUrl("tibcosoftware:oracle://server_name:1521")
               .setSystem("oracle")
               .setSubtype("oracle")
               .setHost("server_name")
               .setPort(1521)
               .build(),
           arg("jdbc:tibcosoftware:mysql://server_name:3306")
+              .setShortUrl("tibcosoftware:mysql://server_name:3306")
               .setSystem("mysql")
               .setSubtype("mysql")
               .setHost("server_name")
               .setPort(3306)
               .build(),
           arg("jdbc:tibcosoftware:postgresql://server_name:5432;DatabaseName=dbname")
+              .setShortUrl("tibcosoftware:postgresql://server_name:5432")
               .setSystem("postgresql")
               .setSubtype("postgresql")
               .setHost("server_name")
@@ -859,6 +994,7 @@ class JdbcConnectionUrlParserTest {
               .setDb("dbname")
               .build(),
           arg("jdbc:tibcosoftware:db2://server_name:50000;DatabaseName=dbname")
+              .setShortUrl("tibcosoftware:db2://server_name:50000")
               .setSystem("db2")
               .setSubtype("db2")
               .setHost("server_name")
@@ -868,17 +1004,20 @@ class JdbcConnectionUrlParserTest {
 
           // https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_jdbc.html
           arg("jdbc-secretsmanager:mysql://example.com:50000")
+              .setShortUrl("mysql://example.com:50000")
               .setSystem("mysql")
               .setHost("example.com")
               .setPort(50000)
               .build(),
           arg("jdbc-secretsmanager:postgresql://example.com:50000/dbname")
+              .setShortUrl("postgresql://example.com:50000")
               .setSystem("postgresql")
               .setHost("example.com")
               .setPort(50000)
               .setDb("dbname")
               .build(),
           arg("jdbc-secretsmanager:oracle:thin:@example.com:50000/ORCL")
+              .setShortUrl("oracle:thin://example.com:50000")
               .setSystem("oracle")
               .setSubtype("thin")
               .setHost("example.com")
@@ -886,6 +1025,7 @@ class JdbcConnectionUrlParserTest {
               .setName("orcl")
               .build(),
           arg("jdbc-secretsmanager:sqlserver://example.com:50000")
+              .setShortUrl("sqlserver://example.com:50000")
               .setSystem("mssql")
               .setHost("example.com")
               .setPort(50000)
@@ -903,6 +1043,7 @@ class JdbcConnectionUrlParserTest {
       this.properties = builder.properties;
       this.dbInfo =
           DbInfo.builder()
+              .shortUrl(builder.shortUrl)
               .system(builder.system)
               .subtype(builder.subtype)
               .user(builder.user)
@@ -922,6 +1063,7 @@ class JdbcConnectionUrlParserTest {
   static class ParseTestArgumentBuilder {
     String url;
     Properties properties;
+    String shortUrl;
     String system;
     String subtype;
     String user;
@@ -936,6 +1078,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setProperties(Properties properties) {
       this.properties = properties;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setShortUrl(String shortUrl) {
+      this.shortUrl = shortUrl;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
@@ -190,7 +190,8 @@ class OpenTelemetryConnectionTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, dbInfo.getSystem()),
                             equalTo(DbIncubatingAttributes.DB_NAME, dbInfo.getName()),
                             equalTo(DbIncubatingAttributes.DB_USER, dbInfo.getUser()),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, dbInfo.getShortUrl()),
+                            equalTo(
+                                DbIncubatingAttributes.DB_CONNECTION_STRING, dbInfo.getShortUrl()),
                             equalTo(DbIncubatingAttributes.DB_STATEMENT, query),
                             equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
                             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "users"),

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
@@ -167,6 +167,7 @@ class OpenTelemetryConnectionTest {
     return DbInfo.builder()
         .system("my_system")
         .subtype("my_sub_type")
+        .shortUrl("my_connection_string")
         .user("my_user")
         .name("my_name")
         .db("my_db")
@@ -175,6 +176,7 @@ class OpenTelemetryConnectionTest {
         .build();
   }
 
+  @SuppressWarnings("deprecation") // old semconv
   private static void jdbcTraceAssertion(DbInfo dbInfo, String query) {
     testing.waitAndAssertTraces(
         trace ->
@@ -188,6 +190,7 @@ class OpenTelemetryConnectionTest {
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, dbInfo.getSystem()),
                             equalTo(DbIncubatingAttributes.DB_NAME, dbInfo.getName()),
                             equalTo(DbIncubatingAttributes.DB_USER, dbInfo.getUser()),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, dbInfo.getShortUrl()),
                             equalTo(DbIncubatingAttributes.DB_STATEMENT, query),
                             equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
                             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "users"),

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
@@ -33,6 +33,11 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
   }
 
   @Override
+  public String getConnectionString(JedisRequest request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(JedisRequest request) {
     return sanitizer.sanitize(request.getCommand().name(), request.getArgs());
   }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
@@ -28,6 +28,11 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
   }
 
   @Override
+  public String getConnectionString(JedisRequest request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(JedisRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
@@ -28,6 +28,11 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
   }
 
   @Override
+  public String getConnectionString(JedisRequest request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(JedisRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
@@ -30,6 +30,12 @@ final class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisC
   }
 
   @Override
+  @Nullable
+  public String getConnectionString(RedisCommand<?, ?, ?> request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(RedisCommand<?, ?, ?> request) {
     return null;
   }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
@@ -38,6 +38,12 @@ final class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisC
   }
 
   @Override
+  @Nullable
+  public String getConnectionString(RedisCommand<?, ?, ?> request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(RedisCommand<?, ?, ?> request) {
     String command = LettuceInstrumentationUtil.getCommandName(request);
     List<String> args =

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.mongo.v3_1;
 
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import java.lang.reflect.InvocationTargetException;
@@ -62,6 +64,24 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
   @Nullable
   public String getName(CommandStartedEvent event) {
     return event.getDatabaseName();
+  }
+
+  @Override
+  @Nullable
+  public String getConnectionString(CommandStartedEvent event) {
+    ConnectionDescription connectionDescription = event.getConnectionDescription();
+    if (connectionDescription != null) {
+      ServerAddress sa = connectionDescription.getServerAddress();
+      if (sa != null) {
+        // https://docs.mongodb.com/manual/reference/connection-string/
+        String host = sa.getHost();
+        int port = sa.getPort();
+        if (host != null && port != 0) {
+          return "mongodb://" + host + ":" + port;
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/instrumentation/mongo/mongo-common/testing/src/main/groovy/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-common/testing/src/main/groovy/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.groovy
@@ -402,6 +402,7 @@ abstract class AbstractMongoClientTest<T> extends InstrumentationSpecification {
     return "testCollection-${collectionIndex.getAndIncrement()}"
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def mongoSpan(TraceAssert trace, int index,
                 String operation, String collection,
                 String dbName, Object parentSpan,
@@ -421,6 +422,7 @@ abstract class AbstractMongoClientTest<T> extends InstrumentationSpecification {
           statementEval.call(it.replaceAll(" ", ""))
         }
         "$DbIncubatingAttributes.DB_SYSTEM" "mongodb"
+        "$DbIncubatingAttributes.DB_CONNECTION_STRING" "mongodb://localhost:" + port
         "$DbIncubatingAttributes.DB_NAME" dbName
         "$DbIncubatingAttributes.DB_OPERATION" operation
         "$DbIncubatingAttributes.DB_MONGODB_COLLECTION" collection

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestAttributesGetter.java
@@ -31,6 +31,12 @@ final class OpenSearchRestAttributesGetter
 
   @Override
   @Nullable
+  public String getConnectionString(OpenSearchRestRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(OpenSearchRestRequest request) {
     return request.getMethod() + " " + request.getOperation();
   }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -34,6 +34,12 @@ public enum R2dbcSqlAttributesGetter implements SqlClientAttributesGetter<DbExec
 
   @Override
   @Nullable
+  public String getConnectionString(DbExecution request) {
+    return request.getConnectionString();
+  }
+
+  @Override
+  @Nullable
   public String getRawStatement(DbExecution request) {
     return request.getRawStatement();
   }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -44,6 +44,7 @@ class DbExecutionTest {
     assertEquals("db", dbExecution.getName());
     assertEquals("localhost", dbExecution.getHost());
     assertEquals(3306, dbExecution.getPort());
+    assertEquals("mariadb://localhost:3306", dbExecution.getConnectionString());
     assertEquals("SELECT * from person where last_name = 'tom'", dbExecution.getRawStatement());
   }
 }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.r2dbc.v1_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
@@ -123,6 +124,7 @@ public abstract class AbstractR2dbcStatementTest {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideParameters")
   void testQueries(Parameter parameter) {
@@ -164,6 +166,9 @@ public abstract class AbstractR2dbcStatementTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
+                                equalTo(
+                                    DB_CONNECTION_STRING,
+                                    parameter.system + "://localhost:" + port),
                                 equalTo(DB_SYSTEM, parameter.system),
                                 equalTo(DB_NAME, DB),
                                 equalTo(DB_USER, USER_DB),

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaAttributesGetter.java
@@ -32,6 +32,12 @@ final class RediscalaAttributesGetter implements DbClientAttributesGetter<RedisC
 
   @Override
   @Nullable
+  public String getConnectionString(RedisCommand<?, ?> redisCommand) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(RedisCommand<?, ?> redisCommand) {
     return null;
   }

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesGetter.java
@@ -29,6 +29,11 @@ final class RedissonDbAttributesGetter implements DbClientAttributesGetter<Redis
   }
 
   @Override
+  public String getConnectionString(RedissonRequest request) {
+    return null;
+  }
+
+  @Override
   public String getStatement(RedissonRequest request) {
     return request.getStatement();
   }

--- a/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/ReactiveSpringDataTest.java
+++ b/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/ReactiveSpringDataTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.spring.data.v3_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
@@ -48,6 +49,7 @@ class ReactiveSpringDataTest {
     applicationContext.close();
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testFindAll() {
     long count =
@@ -85,6 +87,7 @@ class ReactiveSpringDataTest {
                             equalTo(DB_STATEMENT, "SELECT CUSTOMER.* FROM CUSTOMER"),
                             equalTo(DB_OPERATION, "SELECT"),
                             equalTo(DB_SQL_TABLE, "CUSTOMER"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem://localhost"),
                             equalTo(SERVER_ADDRESS, "localhost"))));
   }
 }

--- a/instrumentation/spring/spring-data/spring-data-common/testing/src/main/java/AbstractSpringJpaTest.java
+++ b/instrumentation/spring/spring-data/spring-data-common/testing/src/main/java/AbstractSpringJpaTest.java
@@ -66,6 +66,7 @@ public abstract class AbstractSpringJpaTest<
                 span -> span.hasName("toString test").hasTotalAttributeCount(0)));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   static void assertHibernate4Trace(TraceAssert trace, String repoClassName) {
     trace.hasSpansSatisfyingExactly(
         span ->
@@ -82,12 +83,14 @@ public abstract class AbstractSpringJpaTest<
                     equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                     equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                     equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                     satisfies(
                         DbIncubatingAttributes.DB_STATEMENT, val -> val.startsWith("insert ")),
                     equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
                     equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   static void assertHibernateTrace(TraceAssert trace, String repoClassName) {
     trace.hasSpansSatisfyingExactly(
         span ->
@@ -103,6 +106,7 @@ public abstract class AbstractSpringJpaTest<
                     equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                     equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                     equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                     satisfies(
                         DbIncubatingAttributes.DB_STATEMENT,
                         val -> val.startsWith("call next value for ")),
@@ -115,12 +119,14 @@ public abstract class AbstractSpringJpaTest<
                     equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                     equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                     equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                     satisfies(
                         DbIncubatingAttributes.DB_STATEMENT, val -> val.startsWith("insert ")),
                     equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
                     equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testCrud() {
     boolean isHibernate4 = Version.getVersionString().startsWith("4.");
@@ -149,6 +155,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -186,6 +193,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -199,6 +207,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("update ")),
@@ -224,6 +233,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -249,6 +259,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -262,6 +273,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("delete ")),
@@ -269,6 +281,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testCustomRepositoryMethod() {
     REPOSITORY repo = repository();
@@ -295,6 +308,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),
@@ -302,6 +316,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   @Test
   void testFailedRepositoryMethod() {
     // given
@@ -340,6 +355,7 @@ public abstract class AbstractSpringJpaTest<
                             equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
                             equalTo(DbIncubatingAttributes.DB_NAME, "test"),
                             equalTo(DbIncubatingAttributes.DB_USER, "sa"),
+                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
                                 DbIncubatingAttributes.DB_STATEMENT,
                                 val -> val.startsWith("select ")),

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedAttributesGetter.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedAttributesGetter.java
@@ -29,6 +29,12 @@ public class SpymemcachedAttributesGetter implements DbClientAttributesGetter<Sp
 
   @Override
   @Nullable
+  public String getConnectionString(SpymemcachedRequest spymemcachedRequest) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getStatement(SpymemcachedRequest spymemcachedRequest) {
     return null;
   }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientAttributesGetter.java
@@ -36,6 +36,12 @@ public enum VertxRedisClientAttributesGetter
   }
 
   @Override
+  @Nullable
+  public String getConnectionString(VertxRedisClientRequest request) {
+    return request.getConnectionString();
+  }
+
+  @Override
   public String getStatement(VertxRedisClientRequest request) {
     return sanitizer.sanitize(request.getCommand(), request.getArgs());
   }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientRequest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientRequest.java
@@ -41,6 +41,10 @@ public final class VertxRedisClientRequest {
     return select != null ? select.longValue() : null;
   }
 
+  public String getConnectionString() {
+    return null;
+  }
+
   public String getHost() {
     return redisUri.socketAddress().host();
   }

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
@@ -53,6 +53,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
 
   //Verifies that context is correctly propagated and sql query span has correct parent.
   //Tests io.opentelemetry.javaagent.instrumentation.vertx.reactive.VertxRxInstrumentation
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def "should propagate context over vert.x rx-java framework"() {
     setup:
     def response = client.get("/listProducts").aggregate().join()
@@ -100,6 +101,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "SA"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" "SELECT id, name, price, weight FROM products"
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "products"
@@ -109,6 +111,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
     }
   }
 
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def "should propagate context correctly over vert.x rx-java framework with high concurrency"() {
     setup:
     int count = 100
@@ -198,6 +201,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "SA"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" "SELECT id AS request$requestId, name, price, weight FROM products"
               "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "products"

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
@@ -53,6 +53,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
 
   //Verifies that context is correctly propagated and sql query span has correct parent.
   //Tests io.opentelemetry.javaagent.instrumentation.vertx.reactive.VertxRxInstrumentation
+  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
   def "should propagate context over vert.x rx-java framework"() {
     setup:
     def response = client.get("/listProducts").aggregate().join()
@@ -100,6 +101,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
             "$DbIncubatingAttributes.DB_NAME" "test"
             "$DbIncubatingAttributes.DB_USER" "SA"
+            "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
             "$DbIncubatingAttributes.DB_STATEMENT" "SELECT id, name, price, weight FROM products"
             "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
             "$DbIncubatingAttributes.DB_SQL_TABLE" "products"
@@ -198,6 +200,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$DbIncubatingAttributes.DB_SYSTEM" "hsqldb"
               "$DbIncubatingAttributes.DB_NAME" "test"
               "$DbIncubatingAttributes.DB_USER" "SA"
+              "$DbIncubatingAttributes.DB_CONNECTION_STRING" "hsqldb:mem:"
               "$DbIncubatingAttributes.DB_STATEMENT" "SELECT id AS request$requestId, name, price, weight FROM products"
               "$DbIncubatingAttributes.DB_OPERATION" "SELECT"
               "$DbIncubatingAttributes.DB_SQL_TABLE" "products"

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientAttributesGetter.java
@@ -31,6 +31,12 @@ public enum VertxSqlClientAttributesGetter
 
   @Override
   @Nullable
+  public String getConnectionString(VertxSqlClientRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
   public String getRawStatement(VertxSqlClientRequest request) {
     return request.getStatement();
   }


### PR DESCRIPTION
while writing the release notes, I noticed this and remembered that we aren't supposed to implement any of the new database semconv changes until they're stable (and we bump java instrumentation major version number)

unfortunately not a clean merge, but mainly in the tests where there was groovy -> java conversion since #11089