### PR TITLE
Add tests for sap db missed in migration

### DIFF
--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -532,6 +532,24 @@ class JdbcConnectionUrlParserTest {
               .setName("asdb")
               .build(),
 
+          // https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.03/en-US/ff15928cf5594d78b841fbbe649f04b4.html
+          arg("jdbc:sap://sap.host").setSystem("hanadb").setHost("sap.host").build(),
+          arg("jdbc:sap://sap.host")
+              .setProperties(stdProps())
+              .setSystem("hanadb")
+              .setUser("stdUserName")
+              .setHost("sap.host")
+              .setPort(9999)
+              .setDb("stdDatabaseName")
+              .build(),
+          arg("jdbc:sap://sap.host:88/?databaseName=sapdb&user=sapuser&password=PW")
+              .setSystem("hanadb")
+              .setUser("sapuser")
+              .setHost("sap.host")
+              .setPort(88)
+              .setDb("sapdb")
+              .build(),
+
           // http://www.h2database.com/html/features.html#database_url
           arg("jdbc:h2:mem:").setSystem("h2").setSubtype("mem").build(),
           arg("jdbc:h2:mem:")


### PR DESCRIPTION
@trask pointed out in #11178 that I missed the [`sap`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/1823f147eb0c18ac6259827f16d7808a7dc6774e/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.groovy#L150-L153) test cases during my conversion, this adds them back in.
