### PR TITLE
Fix spring boot smoke tests on arm mac

### DIFF
--- a/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
@@ -45,13 +45,13 @@ public abstract class AbstractSpringStarterSmokeTest {
         // not a warning in Spring Boot 2
         .doesNotContain("is not eligible for getting processed by all BeanPostProcessors")
         // only look for WARN and ERROR log level, e.g. [Test worker] WARN
-        .doesNotContain("] WARN")
         .satisfies(
             s -> {
               if (!s.toString()
                   .contains(
-                      "Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider")) {
-                assertThat(s).doesNotContain("] ERROR");
+                      "Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider")
+                  && !s.toString().contains("The architecture 'amd64' for image")) {
+                assertThat(s).doesNotContain("] WARN").doesNotContain("] ERROR");
               }
             });
   }

--- a/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
@@ -48,8 +48,8 @@ public abstract class AbstractSpringStarterSmokeTest {
         .satisfies(
             s -> {
               if (!s.toString()
-                  .contains(
-                      "Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider")
+                      .contains(
+                          "Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider")
                   && !s.toString().contains("The architecture 'amd64' for image")) {
                 assertThat(s).doesNotContain("] WARN").doesNotContain("] ERROR");
               }


### PR DESCRIPTION
```
09:28:19.494 [Test worker] WARN  tc.confluentinc/cp-kafka:6.2.10 - The architecture 'amd64' for image 'confluentinc/cp-kafka:6.2.10' (ID sha256:6de01032c6ddaa2c1d27d136ee0d8beafddf7fd93d03ec54fd1b3a0d04f5f53e) does not match the Docker server architecture 'arm64'. This will cause the container to execute much more slowly due to emulation and may lead to timeout failures.
```
makes the test fail