### PR TITLE
Don't sanitize postgre parameter markers

### DIFF
--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -18,19 +18,20 @@ import java.util.regex.Pattern;
 %unicode
 %ignorecase
 
-COMMA               = ","
-OPEN_PAREN          = "("
-CLOSE_PAREN         = ")"
-OPEN_COMMENT        = "/*"
-CLOSE_COMMENT       = "*/"
-IDENTIFIER          = ([:letter:] | "_") ([:letter:] | [0-9] | [_.])*
-BASIC_NUM           = [.+-]* [0-9] ([0-9] | [eE.+-])*
-HEX_NUM             = "0x" ([a-f] | [A-F] | [0-9])+
-QUOTED_STR          = "'" ("''" | [^'])* "'"
-DOUBLE_QUOTED_STR   = "\"" ("\"\"" | [^\"])* "\""
-DOLLAR_QUOTED_STR   = "$$" [^$]* "$$"
-BACKTICK_QUOTED_STR = "`" [^`]* "`"
-WHITESPACE          = [ \t\r\n]+
+COMMA                = ","
+OPEN_PAREN           = "("
+CLOSE_PAREN          = ")"
+OPEN_COMMENT         = "/*"
+CLOSE_COMMENT        = "*/"
+IDENTIFIER           = ([:letter:] | "_") ([:letter:] | [0-9] | [_.])*
+BASIC_NUM            = [.+-]* [0-9] ([0-9] | [eE.+-])*
+HEX_NUM              = "0x" ([a-f] | [A-F] | [0-9])+
+QUOTED_STR           = "'" ("''" | [^'])* "'"
+DOUBLE_QUOTED_STR    = "\"" ("\"\"" | [^\"])* "\""
+DOLLAR_QUOTED_STR    = "$$" [^$]* "$$"
+BACKTICK_QUOTED_STR  = "`" [^`]* "`"
+POSTGRE_PARAM_MARKER = "$"[0-9]*
+WHITESPACE           = [ \t\r\n]+
 
 %{
   static SqlStatementInfo sanitize(String statement, SqlDialect dialect) {
@@ -520,7 +521,7 @@ WHITESPACE          = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
 
-  {BACKTICK_QUOTED_STR} {
+  {BACKTICK_QUOTED_STR} | {POSTGRE_PARAM_MARKER} {
         if (!insideComment && !extractionDone) {
           extractionDone = operation.handleIdentifier();
         }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -216,8 +216,7 @@ public class SqlStatementSanitizerTest {
 
           // PostgreSQL native parameter marker, we want to keep $1 instead of replacing it with ?
           Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $1",
-              "SELECT * FROM TABLE WHERE FIELD = $1"),
+              "SELECT * FROM TABLE WHERE FIELD = $1", "SELECT * FROM TABLE WHERE FIELD = $1"),
 
           // Unicode, including a unicode identifier with a trailing number
           Arguments.of(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -140,7 +140,7 @@ public class SqlStatementSanitizerTest {
   static class SqlArgs implements ArgumentsProvider {
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           Arguments.of("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=?"),
           Arguments.of(
@@ -214,6 +214,11 @@ public class SqlStatementSanitizerTest {
           Arguments.of(
               "SELECT * FROM TABLE WHERE FIELD = $$\\\\$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
 
+          // PostgreSQL native parameter marker, we want to keep $1 instead of replacing it with ?
+          Arguments.of(
+              "SELECT * FROM TABLE WHERE FIELD = $1",
+              "SELECT * FROM TABLE WHERE FIELD = $1"),
+
           // Unicode, including a unicode identifier with a trailing number
           Arguments.of(
               "SELECT * FROM TABLEओ7 WHERE FIELD = 'ɣ'", "SELECT * FROM TABLEओ7 WHERE FIELD = ?"),
@@ -231,7 +236,7 @@ public class SqlStatementSanitizerTest {
   static class CouchbaseArgs implements ArgumentsProvider {
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           // Some databases support/encourage " instead of ' with same escape rules
           Arguments.of(
@@ -268,7 +273,7 @@ public class SqlStatementSanitizerTest {
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           // Select
           Arguments.of("SELECT x, y, z FROM schema.table", expect("SELECT", "schema.table")),
@@ -381,7 +386,7 @@ public class SqlStatementSanitizerTest {
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           Arguments.of("CREATE TABLE `table`", expect("CREATE TABLE", "table")),
           Arguments.of("CREATE TABLE IF NOT EXISTS table", expect("CREATE TABLE", "table")),

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
@@ -308,7 +308,7 @@ class HibernateReactiveTest {
                             equalTo(DB_USER, USER_DB),
                             equalTo(
                                 DB_STATEMENT,
-                                "select value0_.id as id1_0_0_, value0_.name as name2_0_0_ from Value value0_ where value0_.id=$?"),
+                                "select value0_.id as id1_0_0_, value0_.name as name2_0_0_ from Value value0_ where value0_.id=$1"),
                             equalTo(DB_OPERATION, "SELECT"),
                             equalTo(DB_SQL_TABLE, "Value"),
                             equalTo(SERVER_ADDRESS, host),

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
@@ -300,7 +300,7 @@ class HibernateReactiveTest {
                             equalTo(DB_USER, USER_DB),
                             equalTo(
                                 DB_STATEMENT,
-                                "select v1_0.id,v1_0.name from Value v1_0 where v1_0.id=$?"),
+                                "select v1_0.id,v1_0.name from Value v1_0 where v1_0.id=$1"),
                             equalTo(DB_OPERATION, "SELECT"),
                             equalTo(DB_SQL_TABLE, "Value"),
                             equalTo(SERVER_ADDRESS, host),

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
@@ -229,7 +229,7 @@ class VertxSqlClientTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(DB_NAME, DB),
                             equalTo(DB_USER, USER_DB),
-                            equalTo(DB_STATEMENT, "select * from test where id = $?"),
+                            equalTo(DB_STATEMENT, "select * from test where id = $1"),
                             equalTo(DB_OPERATION, "SELECT"),
                             equalTo(DB_SQL_TABLE, "test"),
                             equalTo(SERVER_ADDRESS, host),
@@ -259,7 +259,7 @@ class VertxSqlClientTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(DB_NAME, DB),
                             equalTo(DB_USER, USER_DB),
-                            equalTo(DB_STATEMENT, "insert into test values ($?, $?) returning *"),
+                            equalTo(DB_STATEMENT, "insert into test values ($1, $2) returning *"),
                             equalTo(DB_OPERATION, "INSERT"),
                             equalTo(DB_SQL_TABLE, "test"),
                             equalTo(SERVER_ADDRESS, host),
@@ -410,7 +410,7 @@ class VertxSqlClientTest {
                             .hasAttributesSatisfyingExactly(
                                 equalTo(DB_NAME, DB),
                                 equalTo(DB_USER, USER_DB),
-                                equalTo(DB_STATEMENT, "select * from test where id = $?"),
+                                equalTo(DB_STATEMENT, "select * from test where id = $1"),
                                 equalTo(DB_OPERATION, "SELECT"),
                                 equalTo(DB_SQL_TABLE, "test"),
                                 equalTo(SERVER_ADDRESS, host),

--- a/smoke-tests-otel-starter/spring-boot-reactive-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelReactiveSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-reactive-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelReactiveSpringStarterSmokeTest.java
@@ -77,7 +77,7 @@ public class AbstractOtelReactiveSpringStarterSmokeTest extends AbstractSpringSt
                             a ->
                                 assertThat(a.get(DbIncubatingAttributes.DB_STATEMENT))
                                     .isEqualToIgnoringCase(
-                                        "SELECT PLAYER.* FROM PLAYER WHERE PLAYER.ID = $? LIMIT ?"))
+                                        "SELECT PLAYER.* FROM PLAYER WHERE PLAYER.ID = $1 LIMIT ?"))
                         .hasAttribute(DbIncubatingAttributes.DB_SYSTEM, "h2")));
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11379
Postgre and H2 support parameter markers like `$1` we don't wish to replace them with `$?`