### PR TITLE
Fix flaky finagle http client tests

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/build.gradle.kts
+++ b/instrumentation/finagle-http-23.11/javaagent/build.gradle.kts
@@ -30,6 +30,8 @@ val scalified = fun(pack: String): String {
 }
 
 dependencies {
+  bootstrap(project(":instrumentation:executors:bootstrap"))
+
   library("${scalified("com.twitter:finagle-http")}:$finagleVersion")
 
   // should wire netty contexts

--- a/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/LocalSchedulerActivationInstrumentation.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/LocalSchedulerActivationInstrumentation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.bootstrap.executors.ContextPropagatingRunnable;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class LocalSchedulerActivationInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.twitter.concurrent.LocalScheduler$Activation");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("submit").and(takesArguments(Runnable.class)),
+        this.getClass().getName() + "$WrapRunnableAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class WrapRunnableAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrap(@Advice.Argument(value = 0, readOnly = false) Runnable task) {
+      if (task == null) {
+        return;
+      }
+
+      Context context = Java8BytecodeBridge.currentContext();
+      task = ContextPropagatingRunnable.propagateContext(task, context);
+    }
+  }
+}

--- a/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/TwitterUtilCoreInstrumentationModule.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/TwitterUtilCoreInstrumentationModule.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+@AutoService(InstrumentationModule.class)
+public class TwitterUtilCoreInstrumentationModule extends InstrumentationModule {
+
+  public TwitterUtilCoreInstrumentationModule() {
+    super("twitter-util-core");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new LocalSchedulerActivationInstrumentation());
+  }
+}


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe%2FTallinn&tests.container=io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.ClientTest&tests.sortField=FLAKY&tests.unstableOnly=true
Hopefully this PR will fix context propagation issues in finagle concurrency tests.