### PR TITLE
Add grpc sent event before sending the message

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -109,16 +109,17 @@ final class TracingClientInterceptor implements ClientInterceptor {
 
     @Override
     public void sendMessage(REQUEST message) {
+      Span span = Span.fromContext(context);
+      Attributes attributes =
+          Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, MESSAGE_ID_UPDATER.incrementAndGet(this));
+      span.addEvent("message", attributes);
+
       try (Scope ignored = context.makeCurrent()) {
         super.sendMessage(message);
       } catch (Throwable e) {
         instrumenter.end(context, request, Status.UNKNOWN, e);
         throw e;
       }
-      Span span = Span.fromContext(context);
-      Attributes attributes =
-          Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, MESSAGE_ID_UPDATER.incrementAndGet(this));
-      span.addEvent("message", attributes);
     }
 
     final class TracingClientCallListener

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -103,13 +103,14 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
     @Override
     public void sendMessage(RESPONSE message) {
-      try (Scope ignored = context.makeCurrent()) {
-        super.sendMessage(message);
-      }
       Span span = Span.fromContext(context);
       Attributes attributes =
           Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, MESSAGE_ID_UPDATER.incrementAndGet(this));
       span.addEvent("message", attributes);
+
+      try (Scope ignored = context.makeCurrent()) {
+        super.sendMessage(message);
+      }
     }
 
     @Override


### PR DESCRIPTION
Hopefully fixes https://ge.opentelemetry.io/s/vs6vvuevyrcss/tests/task/:instrumentation:grpc-1.6:library:test/details/io.opentelemetry.instrumentation.grpc.v1_6.GrpcStreamingTest/conversation(int%2C%20int)%5B9%5D?top-execution=1
Currently it is possible that `RECEIVED` event appears before `SENT` event. Alternatively we could rework the assertion so that it would not fail when the order of the events is swapped. These events were introduced in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4098 @trask do you review whether moving adding the event before `sendMessage` is ok. 