### PR TITLE
Set read timeout only when testing read-timeout endpoint

### DIFF
--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientTest.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientTest.java
@@ -35,12 +35,24 @@ class AsyncHttpClientTest extends AbstractHttpClientTest<Request> {
   private static final int CONNECTION_TIMEOUT_MS = (int) CONNECTION_TIMEOUT.toMillis();
   private static final int READ_TIMEOUT_MS = (int) READ_TIMEOUT.toMillis();
 
-  private static final AsyncHttpClient client =
-      new AsyncHttpClient(
-          new AsyncHttpClientConfig.Builder()
-              .setConnectTimeout(CONNECTION_TIMEOUT_MS)
-              .setReadTimeout(READ_TIMEOUT_MS)
-              .build());
+  private static final AsyncHttpClient client = buildClient(false);
+  private static final AsyncHttpClient clientWithReadTimeout = buildClient(true);
+
+  private static AsyncHttpClient buildClient(boolean readTimeout) {
+    AsyncHttpClientConfig.Builder builder =
+        new AsyncHttpClientConfig.Builder().setConnectTimeout(CONNECTION_TIMEOUT_MS);
+    if (readTimeout) {
+      builder.setReadTimeout(READ_TIMEOUT_MS);
+    }
+    return new AsyncHttpClient(builder.build());
+  }
+
+  private static AsyncHttpClient getClient(URI uri) {
+    if (uri.toString().contains("/read-timeout")) {
+      return clientWithReadTimeout;
+    }
+    return client;
+  }
 
   @Override
   public Request buildRequest(String method, URI uri, Map<String, String> headers) {
@@ -54,7 +66,7 @@ class AsyncHttpClientTest extends AbstractHttpClientTest<Request> {
   @Override
   public int sendRequest(Request request, String method, URI uri, Map<String, String> headers)
       throws ExecutionException, InterruptedException {
-    return client.executeRequest(request).get().getStatusCode();
+    return getClient(uri).executeRequest(request).get().getStatusCode();
   }
 
   @Override
@@ -64,20 +76,21 @@ class AsyncHttpClientTest extends AbstractHttpClientTest<Request> {
       URI uri,
       Map<String, String> headers,
       HttpClientResult requestResult) {
-    client.executeRequest(
-        request,
-        new AsyncCompletionHandler<Void>() {
-          @Override
-          public Void onCompleted(Response response) {
-            requestResult.complete(response.getStatusCode());
-            return null;
-          }
+    getClient(uri)
+        .executeRequest(
+            request,
+            new AsyncCompletionHandler<Void>() {
+              @Override
+              public Void onCompleted(Response response) {
+                requestResult.complete(response.getStatusCode());
+                return null;
+              }
 
-          @Override
-          public void onThrowable(Throwable throwable) {
-            requestResult.complete(throwable);
-          }
-        });
+              @Override
+              public void onThrowable(Throwable throwable) {
+                requestResult.complete(throwable);
+              }
+            });
   }
 
   @Override


### PR DESCRIPTION
https://ge.opentelemetry.io/s/2vtarlavww7wa/tests/task/:instrumentation:async-http-client:async-http-client-1.9:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.asynchttpclient.v1_9.AsyncHttpClientTest/shouldSuppressNestedClientSpanIfAlreadyUnderParentClientSpan(String)%5B1%5D?top-execution=1