### PR TITLE
Improve awaitGc reliability

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeoutException;
 
 public final class GcUtils {
 
+  private static final StringBuilder garbage = new StringBuilder();
+
   public static void awaitGc(Duration timeout) throws InterruptedException, TimeoutException {
     Object obj = new Object();
     WeakReference<Object> ref = new WeakReference<>(obj);
@@ -27,6 +29,15 @@ public final class GcUtils {
       if (Thread.interrupted()) {
         throw new InterruptedException();
       }
+      // generate garbage to give gc some work
+      for (int i = 0; i < 26; i++) {
+        if (garbage.length() == 0) {
+          garbage.append("ab");
+        } else {
+          garbage.append(garbage);
+        }
+      }
+      garbage.setLength(0);
       System.gc();
     }
     if (ref.get() != null) {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/ukmijol46kpzc/tests/task/:javaagent-tooling:test/details/io.opentelemetry.javaagent.test.HelperInjectionTest/check%20hard%20references%20on%20class%20injection?top-execution=1
HelperInjection test is flaky on openj9 because gc fails to clear the reference in timely fashion. This PR aims to improve the `awaitGc` reliability by generating garbage while waiting for the target reference to be cleared.