### PR TITLE
Fix snapshot publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        run: ./gradlew assemble publishToSonatype
+        run: ./gradlew assemble spdxSbom publishToSonatype
 
       - name: Build and publish gradle plugin snapshots
         env:


### PR DESCRIPTION
`spdxSbom` was previously tied into `assemble`, but we decided it should be invoked directly.  I missed that it needed to be added here too.