### PR TITLE
Fix task ordering problem between `SpdxSbomTask` and `Sign` when publishing

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
+import org.spdx.sbom.gradle.SpdxSbomTask
 import java.util.UUID
 
 plugins {
@@ -295,6 +296,9 @@ tasks.withType<AbstractPublishToMaven> {
   dependsOn("spdxSbom")
 }
 project.afterEvaluate {
+  tasks.withType<Sign>().configureEach {
+    mustRunAfter(tasks.withType<SpdxSbomTask>())
+  }
   tasks.withType<PublishToMavenLocal>().configureEach {
     this.publication.artifact("${layout.buildDirectory.get()}/spdx/opentelemetry-javaagent.spdx.json") {
       classifier = "spdx"


### PR DESCRIPTION
Should fix the following error:

```
    Reason: Task ':javaagent:signMavenPublication' uses this output of task ':javaagent:spdxSbomForOpentelemetry-javaagent' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':javaagent:spdxSbomForOpentelemetry-javaagent' as an input of ':javaagent:signMavenPublication'.
      2. Declare an explicit dependency on ':javaagent:spdxSbomForOpentelemetry-javaagent' from ':javaagent:signMavenPublication' using Task#dependsOn.
      3. Declare an explicit dependency on ':javaagent:spdxSbomForOpentelemetry-javaagent' from ':javaagent:signMavenPublication' using Task#mustRunAfter.
```