### PR TITLE
Remove unneeded groovy dependencies

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/build.gradle.kts
@@ -7,7 +7,5 @@ dependencies {
   implementation("org.apache.rocketmq:rocketmq-test:4.8.0")
 
   implementation("com.google.guava:guava")
-  implementation("org.apache.groovy:groovy")
   implementation("io.opentelemetry:opentelemetry-api")
-  implementation("org.spockframework:spock-core")
 }


### PR DESCRIPTION
related to #7195

Was looking through the remaining tests in need of conversion and noticed this was not checked off in the issue checklist of instrumentations, and it still had the groovy dependencies. 

Here is the original PR if we want to update the checklist and link it:
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10520