### PR TITLE
Extract sql operation even when the sanitizer is disabled

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
@@ -58,6 +58,6 @@ public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
    */
   public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new SqlClientAttributesExtractor<>(
-        getter, dbTableAttribute, SqlStatementSanitizer.create(statementSanitizationEnabled));
+        getter, dbTableAttribute, statementSanitizationEnabled);
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11369
Currently even when sanitizer is disabled we still use it to extract the operation in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/373224c4c09918de7eaa2aa24e456f94f3975c2f/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java#L98 to use it in the span name. Might as well always use the sanitizer to fill `db.operation`.