### PR TITLE
To enable trace when transaction commit or rollback in jdbc

### DIFF
--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -323,6 +323,12 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
+  private class Commit extends Operation {
+  }
+
+  private class Rollback extends Operation {
+  }
+
   private class Create extends DdlOperation {
   }
 
@@ -457,6 +463,20 @@ WHITESPACE           = [ \t\r\n]+
             } else {
               extractionDone = operation.handleIdentifier();
             }
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "COMMIT" {
+          if (!insideComment) {
+            setOperation(new Commit());
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "ROLLBACK" {
+          if (!insideComment) {
+            setOperation(new Rollback());
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;


### PR DESCRIPTION
Contribute for #10381 

To enable trace when transaction commit or rollback in jdbc.

like below
![image](https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/59013192/70a80af4-36f8-400b-8185-64c7bcafe970)

