### PR TITLE
Increase finalge request timeout

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/ClientTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/ClientTest.java
@@ -162,7 +162,7 @@ class ClientTest extends AbstractHttpClientTest<Request> {
   @Override
   public int sendRequest(Request request, String method, URI uri, Map<String, String> headers)
       throws Exception {
-    return Await.result(doSendRequest(request, uri), Duration.fromSeconds(10)).statusCode();
+    return Await.result(doSendRequest(request, uri), Duration.fromSeconds(30)).statusCode();
   }
 
   @Override


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe%2FTallinn&tests.container=io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.ClientTest&tests.sortField=FLAKY&tests.unstableOnly=true
Occasionally the first request from finagle http client tests times out.