### PR TITLE
Add support for informix connection string parsing in jdbc instrumentation

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -831,6 +831,54 @@ public enum JdbcConnectionUrlParser {
 
       return MODIFIED_URL_LIKE.doParse(jdbcUrl, builder);
     }
+  },
+  INFORMIX_SQLI("informix-sqli") {
+    @Override
+    DbInfo.Builder doParse(String jdbcUrl, DbInfo.Builder builder) {
+      builder = MODIFIED_URL_LIKE.doParse(jdbcUrl, builder);
+
+      int dbNameStartIdx = jdbcUrl.indexOf('/', jdbcUrl.indexOf("//") + 2) + 1;
+      int dbNameEndIdx = jdbcUrl.indexOf(':', dbNameStartIdx);
+
+      String name = jdbcUrl.substring(dbNameStartIdx, dbNameEndIdx);
+      if (name != null) {
+        builder.name(name);
+      }
+
+      return INFORMIX.doParse(jdbcUrl, builder);
+    }
+  },
+
+  INFORMIX_DIRECT("informix-direct") {
+    @Override
+    DbInfo.Builder doParse(String jdbcUrl, DbInfo.Builder builder) {
+      builder = MODIFIED_URL_LIKE.doParse(jdbcUrl, builder);
+
+      String[] split = jdbcUrl.split("//");
+      int dbNameEndIdx = split[1].indexOf(":");
+
+      String name = split[1].substring(0, dbNameEndIdx);
+      if (name != null) {
+        builder.name(name);
+      }
+
+      builder.host("infxhost");
+      return INFORMIX.doParse(jdbcUrl, builder);
+    }
+  },
+
+  INFORMIX {
+    private static final int DEFAULT_PORT = 9088;
+
+    @Override
+    DbInfo.Builder doParse(String jdbcUrl, DbInfo.Builder builder) {
+      DbInfo dbInfo = builder.build();
+      if (dbInfo.getPort() == null) {
+        builder.port(DEFAULT_PORT);
+      }
+
+      return builder;
+    }
   };
 
   private static final Logger logger = Logger.getLogger(JdbcConnectionUrlParser.class.getName());
@@ -1000,6 +1048,10 @@ public enum JdbcConnectionUrlParser {
         return DbSystemValues.H2;
       case "hsqldb": // Hyper SQL Database
         return "hsqldb";
+      case "informix-sqli": // IBM Informix
+        return DbSystemValues.INFORMIX_SQLI;
+      case "informix-direct":
+        return DbSystemValues.INFORMIX_DIRECT;
       case "mariadb": // MariaDB
         return DbSystemValues.MARIADB;
       case "mysql": // MySQL
@@ -1026,6 +1078,8 @@ public enum JdbcConnectionUrlParser {
     static final String MYSQL = "mysql";
     static final String ORACLE = "oracle";
     static final String DB2 = "db2";
+    static final String INFORMIX_SQLI = "informix-sqli";
+    static final String INFORMIX_DIRECT = "informix-direct";
     static final String POSTGRESQL = "postgresql";
     static final String HANADB = "hanadb";
     static final String DERBY = "derby";

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -638,6 +638,31 @@ class JdbcConnectionUrlParserTest {
               .setDb("sapdb")
               .build(),
 
+          // https://www.ibm.com/support/pages/how-configure-informix-jdbc-connection-string-connect-group
+          arg("jdbc:informix-sqli://infxhost:99/infxdb:INFORMIXSERVER=infxsn;user=infxuser;password=PW")
+              .setSystem("informix-sqli")
+              .setUser("infxuser")
+              .setShortUrl("informix-sqli://infxhost:99")
+              .setHost("infxhost")
+              .setPort(99)
+              .setName("infxdb")
+              .build(),
+          arg("jdbc:informix-sqli://localhost:9088/stores_demo:INFORMIXSERVER=informix")
+              .setSystem("informix-sqli")
+              .setShortUrl("informix-sqli://localhost:9088")
+              .setHost("localhost")
+              .setPort(9088)
+              .setName("stores_demo")
+              .build(),
+          arg("jdbc:informix-direct://infxdb:999;user=infxuser;password=PW")
+              .setSystem("informix-direct")
+              .setUser("infxuser")
+              .setShortUrl("informix-direct://infxhost:999")
+              .setHost("infxhost")
+              .setPort(999)
+              .setName("infxdb")
+              .build(),
+
           // http://www.h2database.com/html/features.html#database_url
           arg("jdbc:h2:mem:").setShortUrl("h2:mem:").setSystem("h2").setSubtype("mem").build(),
           arg("jdbc:h2:mem:")


### PR DESCRIPTION
When I was [converting the JDBC tests from groovy to java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11178) I noticed that there was an old TODO around instrumenting informix connection strings, with the [test cases commented out](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/1823f147eb0c18ac6259827f16d7808a7dc6774e/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.groovy#L155-L157).

I took a stab at closing this gap in the event we still would like to have this coverage. I admittedly don't have any experience with informix databases, but I searched for example connection strings across github and referenced [these docs](https://www.ibm.com/support/pages/how-configure-informix-jdbc-connection-string-connect-group). 

I added a default port value of 9098 after finding a few references to that online, although I wasn't able to find concrete documentation to validate it.

Here are the sources i did find, for reference:
* https://community.fabric.microsoft.com/t5/Desktop/Connecting-to-Informix/m-p/53829/highlight/true#:~:text=The%20default%20port%20number%20is,can%20be%20resolved%20by%20dns%3F
* https://docs.safe.com/fme/html/FME-Form-Documentation/FME-ReadersWriters/infx_jdbc_nonspatial/add-infx-connection.htm#:~:text=The%20default%20port%20is%209088.&text=The%20name%20of%20the%20IBM%20Informix%20database.&text=Enter%20the%20username%20and%20password%20to%20access%20the%20service.

I can remove the default port if that's not enough to go on