### PR TITLE
make aws-sdk indy compatible

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AbstractAwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AbstractAwsSdkInstrumentationModule.java
@@ -12,12 +12,14 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 // TODO: Copy & paste with only trivial adaptions from v2
-abstract class AbstractAwsSdkInstrumentationModule extends InstrumentationModule {
+abstract class AbstractAwsSdkInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
 
   protected AbstractAwsSdkInstrumentationModule(String additionalInstrumentationName) {
     super("aws-sdk", "aws-sdk-1.11", additionalInstrumentationName);
@@ -29,8 +31,8 @@ abstract class AbstractAwsSdkInstrumentationModule extends InstrumentationModule
   }
 
   @Override
-  public boolean isIndyModule() {
-    return false;
+  public String getModuleGroup() {
+    return "aws-sdk";
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
@@ -10,10 +10,12 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class AwsSdkInstrumentationModule extends InstrumentationModule {
+public class AwsSdkInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public AwsSdkInstrumentationModule() {
     super("aws-sdk", "aws-sdk-1.11", "aws-sdk-1.11-core");
   }
@@ -24,8 +26,8 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    return false;
+  public String getModuleGroup() {
+    return "aws-sdk";
   }
 
   @Override


### PR DESCRIPTION
using a common classloader for all "aws-sdk" instrumentation.

Part of #11457

"indy compatible" is defined in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11546/files#diff-c01c02c7d6cde11986ed4c95f749da6318b0deb89c371d866319371cc1757bd0

This PR needs to have the `indy test` label added for validation in CI.
Local validation can be done with `gradle test -PtestIndy=true`