### PR TITLE
make elasticsearch-* indy compatible

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchApiClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchApiClientInstrumentationModule.java
@@ -12,11 +12,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public class ElasticsearchApiClientInstrumentationModule extends InstrumentationModule {
+public class ElasticsearchApiClientInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public ElasticsearchApiClientInstrumentationModule() {
     super("elasticsearch-api-client", "elasticsearch-api-client-7.16", "elasticsearch");
   }
@@ -31,10 +33,8 @@ public class ElasticsearchApiClientInstrumentationModule extends Instrumentation
   }
 
   @Override
-  public boolean isIndyModule() {
-    // java.lang.ClassCastException: class
-    // io.opentelemetry.javaagent.shaded.instrumentation.elasticsearch.rest.internal.ElasticsearchEndpointDefinition cannot be cast to class io.opentelemetry.javaagent.shaded.instrumentation.elasticsearch.rest.internal.ElasticsearchEndpointDefinition (io.opentelemetry.javaagent.shaded.instrumentation.elasticsearch.rest.internal.ElasticsearchEndpointDefinition is in unnamed module of loader io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader @6baee63b; io.opentelemetry.javaagent.shaded.instrumentation.elasticsearch.rest.internal.ElasticsearchEndpointDefinition is in unnamed module of loader 'app')
-    return false;
+  public String getModuleGroup() {
+    return "elasticsearch";
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
@@ -12,11 +12,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public class ElasticsearchRest7InstrumentationModule extends InstrumentationModule {
+public class ElasticsearchRest7InstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public ElasticsearchRest7InstrumentationModule() {
     super("elasticsearch-rest", "elasticsearch-rest-7.0", "elasticsearch");
   }
@@ -33,9 +35,8 @@ public class ElasticsearchRest7InstrumentationModule extends InstrumentationModu
   }
 
   @Override
-  public boolean isIndyModule() {
-    // shares a virtual field with elasticsearch-api-client
-    return false;
+  public String getModuleGroup() {
+    return "elasticsearch";
   }
 
   @Override


### PR DESCRIPTION
using a common classloader for all "elasticsearch" instrumentation.

Part of #11457

"indy compatible" is defined in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11546/files#diff-c01c02c7d6cde11986ed4c95f749da6318b0deb89c371d866319371cc1757bd0

This PR needs to have the `indy test` label added for validation in CI.
Local validation can be done with `gradle test -PtestIndy=true`