### PR TITLE
Limit vaadin latest dep version

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.base.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.base.gradle.kts
@@ -38,6 +38,7 @@ abstract class TestLatestDepsRule : ComponentMetadataRule {
       || version.contains("-beta", true)
       || version.contains("-rc", true)
       || version.contains("-m", true) // e.g. spring milestones are published to grails repo
+      || version.contains(".m", true) // e.g. lettuce
       || version.contains(".alpha", true) // e.g. netty
       || version.contains(".beta", true) // e.g. hibernate
       || version.contains(".cr", true) // e.g. hibernate

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -66,7 +66,8 @@ testing {
     val vaadinLatestTest by registering(JvmTestSuite::class) {
       dependencies {
         implementation(project(":instrumentation:vaadin-14.2:testing"))
-        implementation("com.vaadin:vaadin-spring-boot-starter:+")
+        // tests fail with 24.4.1
+        implementation("com.vaadin:vaadin-spring-boot-starter:24.3.13")
       }
     }
   }


### PR DESCRIPTION
Besides the CI failing because a dependency of `com.vaadin:vaadin-spring-boot-starter:24.4.0` can not be found (probably this will go away after a while as `24.4.1` has already been released) the tests also don't pass with `24.4.1`.