### PR TITLE
Fix testIndy on main

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleHttpInstrumentationModule.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleHttpInstrumentationModule.java
@@ -27,6 +27,12 @@ public class FinagleHttpInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isIndyModule() {
+    // injects helpers to access package-private members
+    return false;
+  }
+
+  @Override
   public boolean isHelperClass(String className) {
     return className.equals("com.twitter.finagle.ChannelTransportHelpers")
         || className.equals("io.netty.channel.OpenTelemetryChannelInitializerDelegate");

--- a/instrumentation/reactor/reactor-3.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/v3_4/operator/ContextPropagationOperator34InstrumentationModule.java
+++ b/instrumentation/reactor/reactor-3.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/v3_4/operator/ContextPropagationOperator34InstrumentationModule.java
@@ -31,4 +31,10 @@ public class ContextPropagationOperator34InstrumentationModule extends Instrumen
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new ContextPropagationOperator34Instrumentation());
   }
+
+  @Override
+  public boolean isIndyModule() {
+    // Requires Otel-API bride
+    return false;
+  }
 }


### PR DESCRIPTION
Looks like `-PtestIndy=true` is currently broken on main: There have been some moduels added, which did not properly disable indy for them yet:
 * GraphQL v20: Was an easy fix, fix included in this PR
  * Reactor and finagle: disabled via this PR and will be added to #11457
  
@open-telemetry/java-instrumentation-maintainers : Please add the `testIndy` label to this PR to verify that it actually fixes the tests