### PR TITLE
Apply async end strategy to all kotlin coroutine flows

### DIFF
--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/flow/AbstractFlowInstrumentation.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/flow/AbstractFlowInstrumentation.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.flow;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
-import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -17,8 +19,13 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class AbstractFlowInstrumentation implements TypeInstrumentation {
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("kotlinx.coroutines.flow.Flow");
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return namedOneOf("kotlinx.coroutines.flow.AbstractFlow", "kotlinx.coroutines.flow.SafeFlow");
+    return implementsInterface(named("kotlinx.coroutines.flow.Flow"));
   }
 
   @Override


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11035
Apparently there are more base classes for flows than the 2 that were previously used.