### PR TITLE
Build image for testing early jdk8

### DIFF
--- a/.github/workflows/pr-smoke-test-early-jdk8-images.yml
+++ b/.github/workflows/pr-smoke-test-early-jdk8-images.yml
@@ -1,0 +1,35 @@
+name: PR build early jdk8 images for smoke tests
+
+on:
+  pull_request:
+    paths:
+      - "smoke-tests/images/early-jdk8/**"
+      - ".github/workflows/pr-smoke-test-early-jdk8-images.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Free disk space
+        run: .github/scripts/gha-free-disk-space.sh
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          distribution: temurin
+          java-version-file: .java-version
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@d9336dac04dea2507a617466bc058a3def92b18b # v3.4.0
+        with:
+          cache-read-only: true
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
+
+      - name: Build Docker image
+        run: ./gradlew :smoke-tests:images:early-jdk8:imageBuild

--- a/.github/workflows/publish-smoke-test-early-jdk8-images.yml
+++ b/.github/workflows/publish-smoke-test-early-jdk8-images.yml
@@ -1,0 +1,53 @@
+name: Publish early jdk8 images for smoke tests
+
+on:
+  push:
+    paths:
+      - "smoke-tests/images/early-jdk8/**"
+      - ".github/workflows/pr-smoke-test-early-jdk8-images.yml"
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: .github/scripts/gha-free-disk-space.sh
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version-file: .java-version
+
+      - name: Login to GitHub package registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set tag
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@d9336dac04dea2507a617466bc058a3def92b18b # v3.4.0
+
+      - name: Build Docker image
+        run: ./gradlew :smoke-tests:images:early-jdk8:dockerPush -PextraTag=${{ env.TAG }}
+
+  workflow-notification:
+    needs:
+      - publish
+    if: always()
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: >-
+        ${{
+          needs.publishLinux.result == 'success' &&
+          needs.publishWindows.result == 'success'
+        }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -145,6 +145,7 @@ include(":testing-common:library-for-integration-tests")
 
 // smoke tests
 include(":smoke-tests")
+include(":smoke-tests:images:early-jdk8")
 include(":smoke-tests:images:fake-backend")
 include(":smoke-tests:images:grpc")
 include(":smoke-tests:images:play")

--- a/smoke-tests/images/early-jdk8/Dockerfile
+++ b/smoke-tests/images/early-jdk8/Dockerfile
@@ -1,0 +1,16 @@
+# https://github.com/zulu-openjdk/zulu-openjdk/blob/master/ubuntu/8u412-8.78/Dockerfile
+FROM ubuntu:jammy
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install software-properties-common locales curl tzdata unzip && \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    curl -sLO https://cdn.azul.com/zulu/bin/zulu1.8.0_31-8.5.0.1-x86lx64.zip && \
+    unzip zulu1.8.0_31-8.5.0.1-x86lx64.zip -d /opt && \
+    apt-get -qq -y purge --auto-remove software-properties-common curl unzip && \
+    rm zulu1.8.0_31-8.5.0.1-x86lx64.zip
+
+ENV JAVA_HOME=/opt/zulu1.8.0_31-8.5.0.1-x86lx64
+ENV PATH="${PATH}:/opt/zulu1.8.0_31-8.5.0.1-x86lx64/bin"

--- a/smoke-tests/images/early-jdk8/build.gradle.kts
+++ b/smoke-tests/images/early-jdk8/build.gradle.kts
@@ -1,0 +1,25 @@
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+plugins {
+  id("com.bmuschko.docker-remote-api")
+}
+
+val extraTag = findProperty("extraTag")
+  ?: DateTimeFormatter.ofPattern("yyyyMMdd.HHmmSS").format(LocalDateTime.now())
+
+tasks {
+  val imageBuild by registering(DockerBuildImage::class) {
+    images.add("ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-zulu-openjdk-8u31:$extraTag")
+    dockerFile.set(File("Dockerfile"))
+  }
+
+  val dockerPush by registering(DockerPushImage::class) {
+    group = "publishing"
+    description = "Push all Docker images"
+    dependsOn(imageBuild)
+    images.add("ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-zulu-openjdk-8u31:$extraTag")
+  }
+}

--- a/smoke-tests/images/early-jdk8/build.gradle.kts
+++ b/smoke-tests/images/early-jdk8/build.gradle.kts
@@ -11,9 +11,19 @@ val extraTag = findProperty("extraTag")
   ?: DateTimeFormatter.ofPattern("yyyyMMdd.HHmmSS").format(LocalDateTime.now())
 
 tasks {
+  val dockerWorkingDir = layout.buildDirectory.dir("docker")
+
+  val imagePrepare by registering(Copy::class) {
+    into(dockerWorkingDir)
+    from("Dockerfile")
+  }
+
   val imageBuild by registering(DockerBuildImage::class) {
+    dependsOn(imagePrepare)
+    inputDir.set(dockerWorkingDir)
+
     images.add("ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-zulu-openjdk-8u31:$extraTag")
-    dockerFile.set(File("Dockerfile"))
+    dockerFile.set(dockerWorkingDir.get().file("Dockerfile"))
   }
 
   val dockerPush by registering(DockerPushImage::class) {


### PR DESCRIPTION
`azul/zulu-openjdk:8u31` that we used to use doesn't work any more because of
```
8u31: Pulling from azul/zulu-openjdk
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/azul/zulu-openjdk:8u31 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```