### PR TITLE
Simplify jetty9 http client instrumentation

### DIFF
--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/TracingHttpClient.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/TracingHttpClient.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.Je
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.JettyHttpClient9TracingInterceptor;
+import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.JettyClientTracingListener;
 import java.util.List;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
@@ -60,10 +60,12 @@ class TracingHttpClient extends HttpClient {
   @Override
   protected void send(HttpRequest request, List<Response.ResponseListener> listeners) {
     Context parentContext = Context.current();
-    JettyHttpClient9TracingInterceptor requestInterceptor =
-        new JettyHttpClient9TracingInterceptor(parentContext, this.instrumenter);
-    requestInterceptor.attachToRequest(request);
-    List<Response.ResponseListener> wrapped = wrapResponseListeners(parentContext, listeners);
-    super.send(request, wrapped);
+    Context context =
+        JettyClientTracingListener.handleRequest(parentContext, request, instrumenter);
+    // wrap listeners only when a span was started (context is not null)
+    if (context != null) {
+      listeners = wrapResponseListeners(parentContext, listeners);
+    }
+    super.send(request, listeners);
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
@@ -50,7 +50,7 @@ public final class JettyClientWrapUtil {
 
   private static Response.ResponseListener wrapTheListener(
       Response.ResponseListener listener, Context context) {
-    if (listener == null || listener instanceof JettyHttpClient9TracingInterceptor) {
+    if (listener == null || listener instanceof JettyClientTracingListener) {
       return listener;
     }
 


### PR DESCRIPTION
Replace
```java
if (!instrumenter().shouldStart(parentContext, httpRequest)) {
  return;
}
JettyHttpClient9TracingInterceptor requestInterceptor = new JettyHttpClient9TracingInterceptor(parentContext, this.instrumenter);
requestInterceptor.attachToRequest(request);
context = requestInterceptor.getContext();
```
with
```java
context = JettyClientTracingListener.handleRequest(parentContext, httpRequest, instrumenter());
```
`handleRequest` returns `null` when span was not created and also skips attaching the listener to the request so context can't be null in the listener any more.