### PR TITLE
Attempt to align and cleanup some jmx metrics

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -32,6 +32,18 @@ No targets are enabled by default. The supported target environments are listed 
 - [wildfly](wildfly.md)
 - [hadoop](hadoop.md)
 
+### Predefined metrics mapping
+
+The pre-defined metrics do not provide an exhaustive mapping of every available JMX attribute as doing
+so would be verbose, tedious to maintain and brittle as it relies on implementation details of each
+of the targets supported.
+
+The following guidelines are recommended when modifying/extending pre-defined metrics:
+- stay consistent with [semconv general guidelines](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#general-guidelines) for metrics.
+- start with `{target}.` prefix, where `{target}` is the target system, for example `tomcat` or `hadoop`.
+- reuse the existing mbean attribute names as metric suffix to preserve semantics, for example `tomcat.errorCount` where tomcat reports as error any status >=400 and another app server might do differently.
+- optionally align with semconv when semantics are identical, for example `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
+
 ## Configuration Files
 
 To provide your own metric definitions, create one or more YAML configuration files, and specify their location using the `otel.jmx.config` property. Absolute or relative pathnames can be specified. For example

--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -44,7 +44,7 @@ The following guidelines are recommended when modifying/extending pre-defined me
 - start with `{target}.` prefix, where `{target}` is the target system, for example `tomcat` or `hadoop`.
 - align with semconv when semantics are identical, for example:
   - `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
-- when not fitting semconv, reuse the existing mbean attribute names as metric suffix to preserve semantics, for example `tomcat.errorCount` where tomcat reports as error any status >=400 and another app server might do differently.
+- when not fitting semconv, reuse the existing mbean attribute names as metric suffix to preserve semantics of the exposed MBeans, for example `tomcat.request.errorCount` where tomcat reports as error any status >=400 and another app server might do it differently.
 
 ## Configuration Files
 

--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -36,7 +36,8 @@ No targets are enabled by default. The supported target environments are listed 
 
 The pre-defined metrics do not provide an exhaustive mapping of every available JMX attribute as doing
 so would be verbose, tedious to maintain and brittle as it relies on implementation details of each
-of the targets supported.
+of the targets supported. The goal here is to provide a monitoring of the essential metrics, advanced
+use-cases will require dedicated configuration.
 
 The following guidelines are recommended when modifying/extending pre-defined metrics:
 - stay consistent with [semconv general guidelines](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#general-guidelines) for metrics.

--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -41,8 +41,8 @@ of the targets supported.
 The following guidelines are recommended when modifying/extending pre-defined metrics:
 - stay consistent with [semconv general guidelines](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#general-guidelines) for metrics.
 - start with `{target}.` prefix, where `{target}` is the target system, for example `tomcat` or `hadoop`.
-- reuse the existing mbean attribute names as metric suffix to preserve semantics, for example `tomcat.errorCount` where tomcat reports as error any status >=400 and another app server might do differently.
-- optionally align with semconv when semantics are identical, for example `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
+- align with semconv when semantics are identical, for example `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
+- when not fitting semconv, reuse the existing mbean attribute names as metric suffix to preserve semantics, for example `tomcat.errorCount` where tomcat reports as error any status >=400 and another app server might do differently.
 
 ## Configuration Files
 

--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -42,7 +42,8 @@ use-cases will require dedicated configuration.
 The following guidelines are recommended when modifying/extending pre-defined metrics:
 - stay consistent with [semconv general guidelines](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#general-guidelines) for metrics.
 - start with `{target}.` prefix, where `{target}` is the target system, for example `tomcat` or `hadoop`.
-- align with semconv when semantics are identical, for example `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
+- align with semconv when semantics are identical, for example:
+  - `wildfly.network.io` is consistent with [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)
 - when not fitting semconv, reuse the existing mbean attribute names as metric suffix to preserve semantics, for example `tomcat.errorCount` where tomcat reports as error any status >=400 and another app server might do differently.
 
 ## Configuration Files

--- a/instrumentation/jmx-metrics/javaagent/jetty.md
+++ b/instrumentation/jmx-metrics/javaagent/jetty.md
@@ -3,14 +3,14 @@
 Here is the list of metrics based on MBeans exposed by Jetty.
 
 | Metric Name                    | Type          | Attributes   | Description                                          |
-| ------------------------------ | ------------- | ------------ | ---------------------------------------------------- |
+|--------------------------------|---------------|--------------|------------------------------------------------------|
 | jetty.session.sessionsCreated  | Counter       | resource     | The number of sessions established in total          |
 | jetty.session.sessionTimeTotal | Counter       | resource     | The total time sessions have been active             |
 | jetty.session.sessionTimeMax   | Gauge         | resource     | The maximum amount of time a session has been active |
 | jetty.session.sessionTimeMean  | Gauge         | resource     | The mean time sessions remain active                 |
-| jetty.threads.busyThreads      | UpDownCounter |              | The current number of busy threads                   |
-| jetty.threads.idleThreads      | UpDownCounter |              | The current number of idle threads                   |
-| jetty.threads.maxThreads       | UpDownCounter |              | The maximum number of threads in the pool            |
-| jetty.threads.queueSize        | UpDownCounter |              | The current number of threads in the queue           |
+| jetty.thread.busyThreads       | UpDownCounter |              | The current number of busy threads                   |
+| jetty.thread.idleThreads       | UpDownCounter |              | The current number of idle threads                   |
+| jetty.thread.maxThreads        | UpDownCounter |              | The maximum number of threads in the pool            |
+| jetty.thread.queueSize         | UpDownCounter |              | The current number of threads in the queue           |
 | jetty.io.selectCount           | Counter       | resource, id | The number of select calls                           |
 | jetty.logging.LoggerCount      | UpDownCounter |              | The number of registered loggers by name             |

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jetty.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jetty.yaml
@@ -22,7 +22,7 @@ rules:
         desc: The mean time sessions remain active
 
   - bean: org.eclipse.jetty.util.thread:type=queuedthreadpool,id=*
-    prefix: jetty.threads.
+    prefix: jetty.thread.
     unit: "{threads}"
     type: updowncounter
     mapping:

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jetty.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jetty.yaml
@@ -8,7 +8,7 @@ rules:
       resource: param(context)
     mapping:
       sessionsCreated:
-        unit: "{sessions}"
+        unit: "{session}"
         type: counter
         desc: The number of sessions established in total
       sessionTimeTotal:
@@ -23,7 +23,7 @@ rules:
 
   - bean: org.eclipse.jetty.util.thread:type=queuedthreadpool,id=*
     prefix: jetty.thread.
-    unit: "{threads}"
+    unit: "{thread}"
     type: updowncounter
     mapping:
       busyThreads:

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -13,10 +13,12 @@ rules:
       errorCount:
         metric: request.errorCount
         type: gauge
+        unit: "{request}"
         desc: The number of errors per second on all request processors
       requestCount:
-        metric: requestCount
+        metric: request.requestCount
         type: gauge
+        unit: "{request}"
         desc: The number of requests per second across all request processors
       maxTime:
         metric: request.maxTime
@@ -51,10 +53,12 @@ rules:
       errorCount:
         metric: request.errorCount
         type: gauge
+        unit: "{request}"
         desc: The number of errors per second on all request processors
       requestCount:
         metric: request.requestCount
         type: gauge
+        unit: "{request}"
         desc: The number of requests per second across all request processors
       maxTime:
         metric: request.maxTime
@@ -82,7 +86,7 @@ rules:
           network.io.direction: const(transmit)
 
   - bean: Catalina:type=Manager,host=localhost,context=*
-    unit: "1"
+    unit: "{session}"
     prefix: tomcat.session.
     type: updowncounter
     metricAttribute:
@@ -92,7 +96,7 @@ rules:
         metric: activeSessions
         desc: The number of active sessions
   - bean: Tomcat:type=Manager,host=localhost,context=*
-    unit: "1"
+    unit: "{session}"
     prefix: tomcat.session.
     type: updowncounter
     metricAttribute:
@@ -103,8 +107,8 @@ rules:
         desc: The number of active sessions
 
   - bean: Catalina:type=ThreadPool,name=*
-    unit: "{threads}"
-    prefix: tomcat.threads.
+    unit: "{thread}"
+    prefix: tomcat.thread.
     type: updowncounter
     metricAttribute:
       name: param(name)
@@ -116,8 +120,8 @@ rules:
         metric: currentThreadsBusy
         desc: Busy thread count of the thread pool
   - bean: Tomcat:type=ThreadPool,name=*
-    unit: "{threads}"
-    prefix: tomcat.threads.
+    unit: "{thread}"
+    prefix: tomcat.thread.
     type: updowncounter
     metricAttribute:
       name: param(name)

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -83,7 +83,7 @@ rules:
 
   - bean: Catalina:type=Manager,host=localhost,context=*
     unit: "1"
-    prefix: tomcat.sessions.
+    prefix: tomcat.session.
     type: updowncounter
     metricAttribute:
       context: param(context)
@@ -93,7 +93,7 @@ rules:
         desc: The number of active sessions
   - bean: Tomcat:type=Manager,host=localhost,context=*
     unit: "1"
-    prefix: tomcat.sessions.
+    prefix: tomcat.session.
     type: updowncounter
     metricAttribute:
       context: param(context)

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -11,7 +11,7 @@ rules:
       name: param(name)
     mapping:
       errorCount:
-        metric: errorCount
+        metric: request.errorCount
         type: gauge
         desc: The number of errors per second on all request processors
       requestCount:
@@ -19,12 +19,12 @@ rules:
         type: gauge
         desc: The number of requests per second across all request processors
       maxTime:
-        metric: maxTime
+        metric: request.maxTime
         type: gauge
         unit: ms
         desc: The longest request processing time
       processingTime:
-        metric: processingTime
+        metric: request.processingTime
         type: counter
         unit: ms
         desc: Total time for processing all requests
@@ -49,20 +49,20 @@ rules:
       name: param(name)
     mapping:
       errorCount:
-        metric: errorCount
+        metric: request.errorCount
         type: gauge
         desc: The number of errors per second on all request processors
       requestCount:
-        metric: requestCount
+        metric: request.requestCount
         type: gauge
         desc: The number of requests per second across all request processors
       maxTime:
-        metric: maxTime
+        metric: request.maxTime
         type: gauge
         unit: ms
         desc: The longest request processing time
       processingTime:
-        metric: processingTime
+        metric: request.processingTime
         type: counter
         unit: ms
         desc: Total time for processing all requests

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -6,7 +6,7 @@
 rules:
   - bean: Catalina:type=GlobalRequestProcessor,name=*
     unit: "1"
-    prefix: http.server.tomcat.
+    prefix: tomcat.
     metricAttribute:
       name: param(name)
     mapping:
@@ -44,7 +44,7 @@ rules:
           direction: const(sent)
   - bean: Tomcat:type=GlobalRequestProcessor,name=*
     unit: "1"
-    prefix: http.server.tomcat.
+    prefix: tomcat.
     metricAttribute:
       name: param(name)
     mapping:
@@ -83,56 +83,48 @@ rules:
 
   - bean: Catalina:type=Manager,host=localhost,context=*
     unit: "1"
-    prefix: http.server.tomcat.
+    prefix: tomcat.sessions.
     type: updowncounter
     metricAttribute:
       context: param(context)
     mapping:
       activeSessions:
-        metric: sessions.activeSessions
+        metric: activeSessions
         desc: The number of active sessions
   - bean: Tomcat:type=Manager,host=localhost,context=*
     unit: "1"
-    prefix: http.server.tomcat.
+    prefix: tomcat.sessions.
     type: updowncounter
     metricAttribute:
       context: param(context)
     mapping:
       activeSessions:
-        metric: sessions.activeSessions
+        metric: activeSessions
         desc: The number of active sessions
 
   - bean: Catalina:type=ThreadPool,name=*
     unit: "{threads}"
-    prefix: http.server.tomcat.
+    prefix: tomcat.threads.
     type: updowncounter
     metricAttribute:
       name: param(name)
     mapping:
       currentThreadCount:
-        metric: threads
-        desc: Thread Count of the Thread Pool
-        metricAttribute:
-          state: const(idle)
+        metric: currentThreadCount
+        desc: Total thread count of the thread pool
       currentThreadsBusy:
-        metric: threads
-        desc: Thread Count of the Thread Pool
-        metricAttribute:
-          state: const(busy)
+        metric: currentThreadsBusy
+        desc: Busy thread count of the thread pool
   - bean: Tomcat:type=ThreadPool,name=*
     unit: "{threads}"
-    prefix: http.server.tomcat.
+    prefix: tomcat.threads.
     type: updowncounter
     metricAttribute:
       name: param(name)
     mapping:
       currentThreadCount:
-        metric: threads
-        desc: Thread Count of the Thread Pool
-        metricAttribute:
-          state: const(idle)
+        metric: currentThreadCount
+        desc: Total thread count of the thread pool
       currentThreadsBusy:
-        metric: threads
-        desc: Thread Count of the Thread Pool
-        metricAttribute:
-          state: const(busy)
+        metric: currentThreadsBusy
+        desc: Busy thread count of the thread pool

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -29,19 +29,19 @@ rules:
         unit: ms
         desc: Total time for processing all requests
       bytesReceived:
-        metric: traffic
+        metric: network.io
         type: counter
         unit: By
         desc: The number of bytes transmitted
         metricAttribute:
-          direction: const(received)
+          network.io.direction: const(receive)
       bytesSent:
-        metric: traffic
+        metric: network.io
         type: counter
         unit: By
         desc: The number of bytes transmitted
         metricAttribute:
-          direction: const(sent)
+          network.io.direction: const(transmit)
   - bean: Tomcat:type=GlobalRequestProcessor,name=*
     unit: "1"
     prefix: tomcat.
@@ -67,19 +67,19 @@ rules:
         unit: ms
         desc: Total time for processing all requests
       bytesReceived:
-        metric: traffic
+        metric: network.io
         type: counter
         unit: By
         desc: The number of bytes transmitted
         metricAttribute:
-          direction: const(received)
+          network.io.direction: const(receive)
       bytesSent:
-        metric: traffic
+        metric: network.io
         type: counter
         unit: By
         desc: The number of bytes transmitted
         metricAttribute:
-          direction: const(sent)
+          network.io.direction: const(transmit)
 
   - bean: Catalina:type=Manager,host=localhost,context=*
     unit: "1"

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -67,7 +67,7 @@ rules:
     unit: "{transaction}"
     mapping:
       numberOfTransactions:
-        metric: transaction.NumberOfTransactions
+        metric: transaction.numberOfTransactions
       numberOfApplicationRollbacks:
         metric: rollback.count
         metricAttribute:

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -3,7 +3,7 @@ rules:
   - bean: jboss.as:deployment=*,subsystem=undertow
     metricAttribute:
       deployment: param(deployment)
-    prefix: wildfly.sessions.
+    prefix: wildfly.session.
     type: counter
     unit: "1"
     mapping:
@@ -64,7 +64,7 @@ rules:
   - bean: jboss.as:subsystem=transactions
     type: counter
     prefix: wildfly.db.client.
-    unit: "{transactions}"
+    unit: "{transaction}"
     mapping:
       numberOfTransactions:
         metric: transaction.NumberOfTransactions

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -56,10 +56,11 @@ rules:
         metric: wildfly.db.client.connections.usage
         metricAttribute:
           state: const(idle)
-        desc: The number of open jdbc connections
+        desc: The number of idle jdbc connections
       WaitCount:
         metric: wildfly.db.client.connections.WaitCount
         type: counter
+        desc: The number of waiting jdbc connections
   - bean: jboss.as:subsystem=transactions
     type: counter
     prefix: wildfly.db.client.

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -51,16 +51,17 @@ rules:
         metric: wildfly.db.client.connection.count
         metricAttribute:
           db.client.connection.state: const(used)
-        desc: The number of open jdbc connections
+        desc: The number of in-use physical jdbc connections
       IdleCount:
-        metric: wildfly.db.client.connections.usage
+        metric: wildfly.db.client.connections.count
         metricAttribute:
           db.client.connection.state: const(idle)
-        desc: The number of idle jdbc connections
+        desc: The number of idle physical jdbc connections
       WaitCount:
-        metric: wildfly.db.client.connections.WaitCount
-        type: counter
-        desc: The number of waiting jdbc connections
+        metric: wildfly.db.client.connection.count
+        metricAttribute:
+          db.client.connection.state: const(idle)
+        desc: The number of waiting logical jdbc connections
   - bean: jboss.as:subsystem=transactions
     type: counter
     prefix: wildfly.db.client.

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -43,19 +43,19 @@ rules:
         metricAttribute:
           network.io.direction: const(receive)
   - bean: jboss.as:subsystem=datasources,data-source=*,statistics=pool
-    unit: "1"
+    unit: "{connection}"
     metricAttribute:
       data_source: param(data-source)
     mapping:
       ActiveCount:
-        metric: wildfly.db.client.connections.usage
+        metric: wildfly.db.client.connection.count
         metricAttribute:
-          state: const(used)
+          db.client.connection.state: const(used)
         desc: The number of open jdbc connections
       IdleCount:
         metric: wildfly.db.client.connections.usage
         metricAttribute:
-          state: const(idle)
+          db.client.connection.state: const(idle)
         desc: The number of idle jdbc connections
       WaitCount:
         metric: wildfly.db.client.connections.WaitCount

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -25,6 +25,7 @@ rules:
         unit: ns
       errorCount:
   - bean: jboss.as:subsystem=undertow,server=*,http-listener=*
+    metricPrefix: wildfly.
     metricAttribute:
       server: param(server)
       listener: param(http-listener)
@@ -32,15 +33,15 @@ rules:
     unit: By
     mapping:
       bytesSent:
-        metric: wildfly.network.io
+        metric: network.io
         desc: Total number of bytes transferred
         metricAttribute:
-          direction: const(out)
+          network.io.direction: const(transmit)
       bytesReceived:
-        metric: wildfly.network.io
+        metric: network.io
         desc: Total number of bytes transferred
         metricAttribute:
-          direction: const(in)
+          network.io.direction: const(receive)
   - bean: jboss.as:subsystem=datasources,data-source=*,statistics=pool
     unit: "1"
     metricAttribute:

--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/wildfly.yaml
@@ -3,7 +3,7 @@ rules:
   - bean: jboss.as:deployment=*,subsystem=undertow
     metricAttribute:
       deployment: param(deployment)
-    prefix: wildfly.session.
+    prefix: wildfly.sessions.
     type: counter
     unit: "1"
     mapping:

--- a/instrumentation/jmx-metrics/javaagent/tomcat.md
+++ b/instrumentation/jmx-metrics/javaagent/tomcat.md
@@ -4,11 +4,11 @@ Here is the list of metrics based on MBeans exposed by Tomcat.
 
 | Metric Name                       | Type          | Attributes                 | Description                                                     |
 |-----------------------------------|---------------|----------------------------|-----------------------------------------------------------------|
-| tomcat.sessions.activeSessions    | UpDownCounter | context                    | The number of active sessions                                   |
-| tomcat.errorCount                 | Gauge         | name                       | The number of errors per second on all request processors       |
-| tomcat.requestCount               | Gauge         | name                       | The number of requests per second across all request processors |
-| tomcat.maxTime                    | Gauge         | name                       | The longest request processing time                             |
-| tomcat.processingTime             | Counter       | name                       | Represents the total time for processing all requests           |
+| tomcat.session.activeSessions     | UpDownCounter | context                    | The number of active sessions                                   |
+| tomcat.request.errorCount         | Gauge         | name                       | The number of errors per second on all request processors       |
+| tomcat.request.requestCount       | Gauge         | name                       | The number of requests per second across all request processors |
+| tomcat.request.maxTime            | Gauge         | name                       | The longest request processing time                             |
+| tomcat.request.processingTime     | Counter       | name                       | Represents the total time for processing all requests           |
 | tomcat.network.io                 | Counter       | name, network.io.direction | The number of bytes transmitted                                 |
 | tomcat.threads.currentThreadCount | UpDownCounter | name                       | Total thread count of the thread pool                           |
 | tomcat.threads.currentThreadsBusy | UpDownCounter | name                       | Busy thread count of the thread pool                            |

--- a/instrumentation/jmx-metrics/javaagent/tomcat.md
+++ b/instrumentation/jmx-metrics/javaagent/tomcat.md
@@ -2,13 +2,13 @@
 
 Here is the list of metrics based on MBeans exposed by Tomcat.
 
-| Metric Name                       | Type          | Attributes                 | Description                                                     |
-|-----------------------------------|---------------|----------------------------|-----------------------------------------------------------------|
-| tomcat.session.activeSessions     | UpDownCounter | context                    | The number of active sessions                                   |
-| tomcat.request.errorCount         | Gauge         | name                       | The number of errors per second on all request processors       |
-| tomcat.request.requestCount       | Gauge         | name                       | The number of requests per second across all request processors |
-| tomcat.request.maxTime            | Gauge         | name                       | The longest request processing time                             |
-| tomcat.request.processingTime     | Counter       | name                       | Represents the total time for processing all requests           |
-| tomcat.network.io                 | Counter       | name, network.io.direction | The number of bytes transmitted                                 |
-| tomcat.threads.currentThreadCount | UpDownCounter | name                       | Total thread count of the thread pool                           |
-| tomcat.threads.currentThreadsBusy | UpDownCounter | name                       | Busy thread count of the thread pool                            |
+| Metric Name                      | Type          | Attributes                 | Description                                                     |
+|----------------------------------|---------------|----------------------------|-----------------------------------------------------------------|
+| tomcat.session.activeSessions    | UpDownCounter | context                    | The number of active sessions                                   |
+| tomcat.request.errorCount        | Gauge         | name                       | The number of errors per second on all request processors       |
+| tomcat.request.requestCount      | Gauge         | name                       | The number of requests per second across all request processors |
+| tomcat.request.maxTime           | Gauge         | name                       | The longest request processing time                             |
+| tomcat.request.processingTime    | Counter       | name                       | Represents the total time for processing all requests           |
+| tomcat.network.io                | Counter       | name, network.io.direction | The number of bytes transmitted                                 |
+| tomcat.thread.currentThreadCount | UpDownCounter | name                       | Total thread count of the thread pool                           |
+| tomcat.thread.currentThreadsBusy | UpDownCounter | name                       | Busy thread count of the thread pool                            |

--- a/instrumentation/jmx-metrics/javaagent/tomcat.md
+++ b/instrumentation/jmx-metrics/javaagent/tomcat.md
@@ -2,12 +2,13 @@
 
 Here is the list of metrics based on MBeans exposed by Tomcat.
 
-| Metric Name                                | Type          | Attributes      | Description                                                     |
-| ------------------------------------------ | ------------- | --------------- | --------------------------------------------------------------- |
-| http.server.tomcat.sessions.activeSessions | UpDownCounter | context         | The number of active sessions                                   |
-| http.server.tomcat.errorCount              | Gauge         | name            | The number of errors per second on all request processors       |
-| http.server.tomcat.requestCount            | Gauge         | name            | The number of requests per second across all request processors |
-| http.server.tomcat.maxTime                 | Gauge         | name            | The longest request processing time                             |
-| http.server.tomcat.processingTime          | Counter       | name            | Represents the total time for processing all requests           |
-| http.server.tomcat.traffic                 | Counter       | name, direction | The number of bytes transmitted                                 |
-| http.server.tomcat.threads                 | UpDownCounter | name, state     | Thread Count of the Thread Pool                                 |
+| Metric Name                       | Type          | Attributes                 | Description                                                     |
+|-----------------------------------|---------------|----------------------------|-----------------------------------------------------------------|
+| tomcat.sessions.activeSessions    | UpDownCounter | context                    | The number of active sessions                                   |
+| tomcat.errorCount                 | Gauge         | name                       | The number of errors per second on all request processors       |
+| tomcat.requestCount               | Gauge         | name                       | The number of requests per second across all request processors |
+| tomcat.maxTime                    | Gauge         | name                       | The longest request processing time                             |
+| tomcat.processingTime             | Counter       | name                       | Represents the total time for processing all requests           |
+| tomcat.network.io                 | Counter       | name, network.io.direction | The number of bytes transmitted                                 |
+| tomcat.threads.currentThreadCount | UpDownCounter | name                       | Total thread count of the thread pool                           |
+| tomcat.threads.currentThreadsBusy | UpDownCounter | name                       | Busy thread count of the thread pool                            |

--- a/instrumentation/jmx-metrics/javaagent/wildfly.md
+++ b/instrumentation/jmx-metrics/javaagent/wildfly.md
@@ -2,17 +2,17 @@
 
 Here is the list of metrics based on MBeans exposed by Wildfly.
 
-| Metric Name                                        | Type          | Attributes                   | Description                                                             |
-|----------------------------------------------------|---------------|------------------------------|-------------------------------------------------------------------------|
-| wildfly.network.io                                 | Counter       | server, network.io.direction | Total number of bytes transferred                                       |
-| wildfly.request.errorCount                         | Counter       | server, listener             | The number of 500 responses that have been sent by this listener        |
-| wildfly.request.requestCount                       | Counter       | server, listener             | The number of requests this listener has served                         |
-| wildfly.request.processingTime                     | Counter       | server, listener             | The total processing time of all requests handed by this listener       |
-| wildfly.session.expiredSession                     | Counter       | deployment                   | Number of sessions that have expired                                    |
-| wildfly.session.rejectedSessions                   | Counter       | deployment                   | Number of rejected sessions                                             |
-| wildfly.session.sessionsCreated                    | Counter       | deployment                   | Total sessions created                                                  |
-| wildfly.session.activeSessions                     | UpDownCounter | deployment                   | Number of active sessions                                               |
-| wildfly.db.client.connections.usage                | Gauge         | data_source, state           | The number of open jdbc connections                                     |
-| wildfly.db.client.connections.WaitCount            | Counter       | data_source                  | The number of requests that had to wait to obtain a physical connection |
-| wildfly.db.client.rollback.count                   | Counter       | cause                        | The total number of transactions rolled back                            |
-| wildfly.db.client.transaction.NumberOfTransactions | Counter       |                              | The total number of transactions (top-level and nested) created         |
+| Metric Name                                        | Type          | Attributes                               | Description                                                             |
+|----------------------------------------------------|---------------|------------------------------------------|-------------------------------------------------------------------------|
+| wildfly.network.io                                 | Counter       | server, network.io.direction             | Total number of bytes transferred                                       |
+| wildfly.request.errorCount                         | Counter       | server, listener                         | The number of 500 responses that have been sent by this listener        |
+| wildfly.request.requestCount                       | Counter       | server, listener                         | The number of requests this listener has served                         |
+| wildfly.request.processingTime                     | Counter       | server, listener                         | The total processing time of all requests handed by this listener       |
+| wildfly.session.expiredSession                     | Counter       | deployment                               | Number of sessions that have expired                                    |
+| wildfly.session.rejectedSessions                   | Counter       | deployment                               | Number of rejected sessions                                             |
+| wildfly.session.sessionsCreated                    | Counter       | deployment                               | Total sessions created                                                  |
+| wildfly.session.activeSessions                     | UpDownCounter | deployment                               | Number of active sessions                                               |
+| wildfly.db.client.connection.usage                 | Gauge         | data_source, db.client.connections.state | The number of open jdbc connections                                     |
+| wildfly.db.client.connection.WaitCount             | Counter       | data_source                              | The number of requests that had to wait to obtain a physical connection |
+| wildfly.db.client.rollback.count                   | Counter       | cause                                    | The total number of transactions rolled back                            |
+| wildfly.db.client.transaction.NumberOfTransactions | Counter       |                                          | The total number of transactions (top-level and nested) created         |

--- a/instrumentation/jmx-metrics/javaagent/wildfly.md
+++ b/instrumentation/jmx-metrics/javaagent/wildfly.md
@@ -2,17 +2,17 @@
 
 Here is the list of metrics based on MBeans exposed by Wildfly.
 
-| Metric Name                                        | Type          | Attributes         | Description                                                             |
-| -------------------------------------------------- | ------------- | ------------------ | ----------------------------------------------------------------------- |
-| wildfly.network.io                                 | Counter       | direction, server  | Total number of bytes transferred                                       |
-| wildfly.request.errorCount                         | Counter       | server, listener   | The number of 500 responses that have been sent by this listener        |
-| wildfly.request.requestCount                       | Counter       | server, listener   | The number of requests this listener has served                         |
-| wildfly.request.processingTime                     | Counter       | server, listener   | The total processing time of all requests handed by this listener       |
-| wildfly.session.expiredSession                     | Counter       | deployment         | Number of sessions that have expired                                    |
-| wildfly.session.rejectedSessions                   | Counter       | deployment         | Number of rejected sessions                                             |
-| wildfly.session.sessionsCreated                    | Counter       | deployment         | Total sessions created                                                  |
-| wildfly.session.activeSessions                     | UpDownCounter | deployment         | Number of active sessions                                               |
-| wildfly.db.client.connections.usage                | Gauge         | data_source, state | The number of open jdbc connections                                     |
-| wildfly.db.client.connections.WaitCount            | Counter       | data_source        | The number of requests that had to wait to obtain a physical connection |
-| wildfly.db.client.rollback.count                   | Counter       | cause              | The total number of transactions rolled back                            |
-| wildfly.db.client.transaction.NumberOfTransactions | Counter       |                    | The total number of transactions (top-level and nested) created         |
+| Metric Name                                        | Type          | Attributes                   | Description                                                             |
+|----------------------------------------------------|---------------|------------------------------|-------------------------------------------------------------------------|
+| wildfly.network.io                                 | Counter       | server, network.io.direction | Total number of bytes transferred                                       |
+| wildfly.request.errorCount                         | Counter       | server, listener             | The number of 500 responses that have been sent by this listener        |
+| wildfly.request.requestCount                       | Counter       | server, listener             | The number of requests this listener has served                         |
+| wildfly.request.processingTime                     | Counter       | server, listener             | The total processing time of all requests handed by this listener       |
+| wildfly.session.expiredSession                     | Counter       | deployment                   | Number of sessions that have expired                                    |
+| wildfly.session.rejectedSessions                   | Counter       | deployment                   | Number of rejected sessions                                             |
+| wildfly.session.sessionsCreated                    | Counter       | deployment                   | Total sessions created                                                  |
+| wildfly.session.activeSessions                     | UpDownCounter | deployment                   | Number of active sessions                                               |
+| wildfly.db.client.connections.usage                | Gauge         | data_source, state           | The number of open jdbc connections                                     |
+| wildfly.db.client.connections.WaitCount            | Counter       | data_source                  | The number of requests that had to wait to obtain a physical connection |
+| wildfly.db.client.rollback.count                   | Counter       | cause                        | The total number of transactions rolled back                            |
+| wildfly.db.client.transaction.NumberOfTransactions | Counter       |                              | The total number of transactions (top-level and nested) created         |

--- a/instrumentation/jmx-metrics/javaagent/wildfly.md
+++ b/instrumentation/jmx-metrics/javaagent/wildfly.md
@@ -12,7 +12,6 @@ Here is the list of metrics based on MBeans exposed by Wildfly.
 | wildfly.session.rejectedSessions                   | Counter       | deployment                               | Number of rejected sessions                                             |
 | wildfly.session.sessionsCreated                    | Counter       | deployment                               | Total sessions created                                                  |
 | wildfly.session.activeSessions                     | UpDownCounter | deployment                               | Number of active sessions                                               |
-| wildfly.db.client.connection.usage                 | Gauge         | data_source, db.client.connections.state | The number of open jdbc connections                                     |
-| wildfly.db.client.connection.WaitCount             | Counter       | data_source                              | The number of requests that had to wait to obtain a physical connection |
+| wildfly.db.client.connection.count                 | Gauge         | data_source, db.client.connections.state | The number of open jdbc connections                                     |
 | wildfly.db.client.rollback.count                   | Counter       | cause                                    | The total number of transactions rolled back                            |
 | wildfly.db.client.transaction.NumberOfTransactions | Counter       |                                          | The total number of transactions (top-level and nested) created         |


### PR DESCRIPTION
This is an attempt to fix a few errors and inconsistencies that I've found in the JMX metrics captured with the [JMX Metric Insight](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/README.md) feature.

I have intentionally limited the scope to `tomcat`, `jetty` and `wildfly`, but similar changes might be applied to other systems as a follow-up.

- clarify the strategy for pre-defined metrics
- simplify metric prefix for tomcat to `tomcat.` for consistency with `jetty`, `wildfly`, ...
- fix tomcat busy/idle threads, as explained in [this discussion](https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/10281).
- rename metrics to use singular form to fit (experimental) [metrics semconv recommendations](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#pluralization).
- rename units to use singular form to fit (stable) [units semconv recommendations](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-units).
- move tomcat request-related metrics to `tomcat.request.*` namespace for consistency with `wildfly.request.*`
- align tomcat on [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio) with `tomcat.network.io` for transferred bytes
- align wildfly on [`system.network.io`](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio) with: `wildfly.network.io` for transferred bytes (only direction attribute had to be changed).

For the overall strategy, I agree that covering every metric of every platform is not possible nor something we aim to. For example, with Wildfly the db pool exposes [more than 50 attributes](https://docs.wildfly.org/19/wildscribe/subsystem/datasources/data-source/ExampleDS/statistics/pool/index.html) that could be captured as metrics.

I think one of the important things that could make this type of mapping somehow manageable over time is to use the following strategy for metric names and their attributes:
- use or align to semconv when it fits
- keep the MBean attribute name otherwise: it allows to preserve the semantics of the observed system without having to try re-defining common metrics or deal with subtle implementation details.

### Checklist & follow-ups

- [ ] `wildfly.db.client.connection` check with impl. that state can be a partition active/idle/wait (in which case using a single metric + attribute would make sense), but the [wildfly documentation](https://docs.wildfly.org/19/wildscribe/subsystem/datasources/data-source/ExampleDS/statistics/pool/index.html) seems to imply it's not the case.
- [x] `wildfly.db.client.connection` should use the `db.client.connections.state` from semconv for the connectíon state.
  - update: plural form was removed in semconv in https://github.com/open-telemetry/semantic-conventions/pull/1125, to be released in 1.27.
- [x] fix case for `wildfly.db.client.transaction.NumberOfTransactions` should probably be using MBean attribute so `numberOfTransactions`
- [x] maybe try to fix the [database semconv metrics](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/) attributes to use singular form, for example `db.client.connections.pool.name` should probably be renamed to `db.client.connections.pool.name`
  - update: already covered in https://github.com/open-telemetry/semantic-conventions/pull/1125