### PR TITLE
remove conditional indy test in CI

### DIFF
--- a/.github/workflows/reusable-test-indy.yml
+++ b/.github/workflows/reusable-test-indy.yml
@@ -19,7 +19,6 @@ permissions:
 jobs:
   test-indy:
     name: testIndy${{ matrix.test-partition }}
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test indy') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
As discussed during June 13th Java SIG meeting, we should start always testing for "indy compatibility" in CI.

This helps for sub-tasks of #11457 that do not require to have the `test indy` label added to PRs for the test to be effective.

This also helps to prevent adding new instrumentations that are not "indy compatible" as the ones that were fixed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11582

Once this PR is merged then the `test indy` label could be removed.