### PR TITLE
Alter instrumentation suppression behavior

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -49,6 +49,10 @@ public abstract class InstrumentationModule implements Ordered {
    * InstrumentationModule} must have a default constructor (for SPI), so they have to pass the
    * instrumentation names to the super class constructor.
    *
+   * <p>When enabling or disabling the instrumentation module configuration property that
+   * corresponds to the main instrumentation name is considered first, after that additional
+   * instrumentation names are considered in the order they are listed here.
+   *
    * <p>The instrumentation names should follow several rules:
    *
    * <ul>

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -11,20 +11,14 @@ public final class AgentConfig {
 
   public static boolean isInstrumentationEnabled(
       ConfigProperties config, Iterable<String> instrumentationNames, boolean defaultEnabled) {
-    // If default is enabled, we want to enable individually,
-    // if default is disabled, we want to disable individually.
-    boolean anyEnabled = defaultEnabled;
     for (String name : instrumentationNames) {
       String propertyName = "otel.instrumentation." + name + ".enabled";
-      boolean enabled = config.getBoolean(propertyName, defaultEnabled);
-
-      if (defaultEnabled) {
-        anyEnabled &= enabled;
-      } else {
-        anyEnabled |= enabled;
+      Boolean enabled = config.getBoolean(propertyName);
+      if (enabled != null) {
+        return enabled;
       }
     }
-    return anyEnabled;
+    return defaultEnabled;
   }
 
   public static boolean isDebugModeEnabled(ConfigProperties config) {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -25,16 +25,14 @@ class AgentConfigTest {
   @ArgumentsSource(InstrumentationEnabledParams.class)
   void testIsInstrumentationEnabled(
       @SuppressWarnings("unused") String description,
-      boolean firstEnabled,
-      boolean secondEnabled,
+      Boolean firstEnabled,
+      Boolean secondEnabled,
       boolean defaultEnabled,
       boolean expected) {
 
     ConfigProperties config = mock(ConfigProperties.class);
-    when(config.getBoolean("otel.instrumentation.first.enabled", defaultEnabled))
-        .thenReturn(firstEnabled);
-    when(config.getBoolean("otel.instrumentation.second.enabled", defaultEnabled))
-        .thenReturn(secondEnabled);
+    when(config.getBoolean("otel.instrumentation.first.enabled")).thenReturn(firstEnabled);
+    when(config.getBoolean("otel.instrumentation.second.enabled")).thenReturn(secondEnabled);
 
     assertEquals(
         expected,
@@ -49,13 +47,41 @@ class AgentConfigTest {
       return Stream.of(
           Arguments.of(
               "enabled by default, both instrumentations are off", false, false, true, false),
-          Arguments.of("enabled by default, one instrumentation is on", true, false, true, false),
+          Arguments.of("enabled by default, first instrumentation is on", true, null, true, true),
+          Arguments.of("enabled by default, second instrumentation is on", null, true, true, true),
           Arguments.of("enabled by default, both instrumentations are on", true, true, true, true),
           Arguments.of(
-              "disabled by default, both instrumentations are off", false, false, false, false),
-          Arguments.of("disabled by default, one instrumentation is on", true, false, false, true),
+              "enabled by default, first instrumentation is off, second is on",
+              false,
+              true,
+              true,
+              false),
           Arguments.of(
-              "disabled by default, both instrumentation are on", true, true, false, true));
+              "enabled by default, first instrumentation is on, second is off",
+              true,
+              false,
+              true,
+              true),
+          Arguments.of("enabled by default", null, null, true, true),
+          Arguments.of(
+              "disabled by default, both instrumentations are off", false, false, false, false),
+          Arguments.of("disabled by default, first instrumentation is on", true, null, false, true),
+          Arguments.of(
+              "disabled by default, second instrumentation is on", null, true, false, true),
+          Arguments.of("disabled by default, both instrumentation are on", true, true, false, true),
+          Arguments.of(
+              "disabled by default, first instrumentation is off, second is on",
+              false,
+              true,
+              false,
+              false),
+          Arguments.of(
+              "disabled by default, first instrumentation is on, second is off",
+              true,
+              false,
+              false,
+              true),
+          Arguments.of("disabled by default", null, null, false, false));
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11635
Currently instrumentation that is enabled by default will be disabled if `otel.instrumentation.[name].enabled` flag is `false` for any of the names given for the instrumentation, even if the flag is `true` for some of the names. This PR alters the behavior so that instrumentation is enabled or disabled based on the value `otel.instrumentation.[name].enabled` for the first instrumentation name where the value is set, if it isn't set then the default value will be used. This allows using `otel.instrumentation.kafka-clients-metrics.enabled=true` `otel.instrumentation.kafka-clients.enabled=false` to enable only the kafka metrics instrumentation and disable the rest.