### PR TITLE
Remove aws sqs latest dep limit

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -21,9 +21,6 @@ dependencies {
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
-
-  // last version that does not use json protocol
-  latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")
 }
 
 tasks {
@@ -31,5 +28,6 @@ tasks {
     systemProperty("otel.instrumentation.aws-sdk.experimental-span-attributes", true)
     systemProperty("otel.instrumentation.aws-sdk.experimental-record-individual-http-error", true)
     systemProperty("otel.instrumentation.messaging.experimental.capture-headers", "test-message-header")
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 }


### PR DESCRIPTION
Forgot to remove it from `library-autoconfigure` module in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9902