### PR TITLE
Update docs for bundled exporters

### DIFF
--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -4,9 +4,8 @@ This lists out some of the features specific to java agents that OpenTelemetry A
 provides.
 
 - Bundled exporters
-  - [OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md)
-  - Jaeger gRPC
-  - Logging
+  - [OTLP](https://opentelemetry.io/docs/specs/otlp/)
+  - Console
   - Zipkin
 - Bundled propagators
   - [W3C TraceContext / Baggage](https://www.w3.org/TR/trace-context/)


### PR DESCRIPTION
What I changed:
* OTLP link was linking to [a page](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) that linked to another page. Updated that.
* Jaeger exporter was removed (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10241)
* Logging exporter was renamed to `Console` (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11100)