### PR TITLE
don't use test keystore for vaadin

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -360,8 +360,10 @@ tasks.withType<Test>().configureEach {
 
   val trustStore = project(":testing-common").file("src/misc/testing-keystore.p12")
   // Work around payara not working when this is set for some reason.
-  // Don't set for camel as we have tests that interact with AWS and need normal trustStore
-  if (project.name != "jaxrs-2.0-payara-testing" && project.description != "camel-2-20") {
+  // Don't set for:
+  // - camel as we have tests that interact with AWS and need normal trustStore
+  // - vaadin as tests need to be able to download nodejs when not cached in ~/.vaadin/
+  if (project.name != "jaxrs-2.0-payara-testing" && !project.path.contains("vaadin") && project.description != "camel-2-20") {
     jvmArgumentProviders.add(KeystoreArgumentsProvider(trustStore))
   }
 


### PR DESCRIPTION
The vaadin tests download a copy of node.js from a public server.
As a custom keystore with only a test key is used, and as a consequence calls to https services fail with `javax.net.ssl.SSLHandshakeException` as the keystore is missing trusted certificates.

A "better solution" to this test keystore could be to:
- instead of using an empty keystore, copy a recent JDK keystore and add the needed keys for testing (not sure about this from a licence perspective)
- automate the process of copying the JDK keystore and adding the key at build time

When test has been executed at least once, the content is cached in `~/.vaadin` which is probably cached in CI and explains why it can only be reproduced locally.

### Changes summary

Quick fix: exclude vaadin tests from using the test keystore like the camel instrumentation.

### Steps to reproduce/validate
- delete Vaadin cache: `rm -rf ~/.vaadin`
- execute Vaadin test: `./gradlew --rerun-tasks :instrumentation:vaadin-14.2:javaagent:vaadin16Test`
- the test will fail due to timeout, but the real error is visible in the logs:

```
4:03:28.083 [http-nio-11001-exec-1] ERROR c.v.flow.server.DefaultErrorHandler - 
java.lang.IllegalStateException: Failed to install Node
	at com.vaadin.flow.server.frontend.FrontendTools.installNode(FrontendTools.java:349)
	at com.vaadin.flow.server.frontend.FrontendTools.getExecutable(FrontendTools.java:462)
	at com.vaadin.flow.server.frontend.FrontendTools.getNodeExecutable(FrontendTools.java:180)
	at com.vaadin.flow.server.frontend.FrontendTools.validateNodeAndNpmVersion(FrontendTools.java:261)
	at com.vaadin.flow.server.DevModeHandler.doStartDevModeServer(DevModeHandler.java:510)
	at com.vaadin.flow.server.DevModeHandler.runOnFutureComplete(DevModeHandler.java:460)
	at com.vaadin.flow.server.DevModeHandler.lambda$new$0(DevModeHandler.java:131)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: com.vaadin.flow.server.frontend.installer.InstallationException: Could not download Node.js
	at com.vaadin.flow.server.frontend.installer.NodeInstaller.installNode(NodeInstaller.java:251)
	at com.vaadin.flow.server.frontend.installer.NodeInstaller.install(NodeInstaller.java:215)
	at com.vaadin.flow.server.frontend.FrontendTools.installNode(FrontendTools.java:347)
	... 14 common frames omitted
Caused by: com.vaadin.flow.server.frontend.installer.DownloadException: Could not download https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-x64.tar.gz
	at com.vaadin.flow.server.frontend.installer.DefaultFileDownloader.download(DefaultFileDownloader.java:87)
	at com.vaadin.flow.server.frontend.installer.NodeInstaller.downloadFileIfMissing(NodeInstaller.java:440)
	at com.vaadin.flow.server.frontend.installer.NodeInstaller.installNode(NodeInstaller.java:246)
	... 16 common frames omitted
Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:130)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:378)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:321)
```