### PR TITLE
Fix ending span in Ktor plugin

### DIFF
--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracing.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorClientTracing.kt
@@ -16,6 +16,9 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class KtorClientTracing internal constructor(
@@ -83,23 +86,21 @@ class KtorClientTracing internal constructor(
       }
     }
 
+    @OptIn(InternalCoroutinesApi::class)
     private fun installSpanEnd(plugin: KtorClientTracing, scope: HttpClient) {
       val endSpanPhase = PipelinePhase("OpenTelemetryEndSpan")
       scope.receivePipeline.insertPhaseBefore(HttpReceivePipeline.State, endSpanPhase)
 
       scope.receivePipeline.intercept(endSpanPhase) {
         val openTelemetryContext = it.call.attributes.getOrNull(openTelemetryContextKey)
+        openTelemetryContext ?: return@intercept
 
-        if (openTelemetryContext != null) {
-          try {
-            withContext(openTelemetryContext.asContextElement()) { proceed() }
-            plugin.endSpan(openTelemetryContext, it.call, null)
-          } catch (e: Throwable) {
-            plugin.endSpan(openTelemetryContext, it.call, e)
-            throw e
-          }
-        } else {
-          proceed()
+        scope.launch {
+          val job = it.call.coroutineContext.job
+          job.join()
+          val cause = job.getCancellationException()
+
+          plugin.endSpan(openTelemetryContext, it.call, cause)
         }
       }
     }

--- a/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
@@ -21,7 +21,6 @@ import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.TraceAssert
 import io.opentelemetry.semconv.NetworkAttributes
 import kotlinx.coroutines.*
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.net.URI
 import java.util.function.Consumer

--- a/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
@@ -17,7 +17,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.TraceAssert
 import io.opentelemetry.semconv.NetworkAttributes
 import kotlinx.coroutines.*
@@ -85,13 +85,13 @@ abstract class AbstractKtorHttpClientTest : AbstractHttpClientTest<HttpRequestBu
     val uri = resolveAddress(path)
     val responseCode = doRequest(method, uri)
 
-    Assertions.assertThat(responseCode).isEqualTo(200)
+    assertThat(responseCode).isEqualTo(200)
 
     testing.waitAndAssertTraces(
       Consumer { trace: TraceAssert ->
         val span = trace.getSpan(0)
-        OpenTelemetryAssertions.assertThat(span).hasKind(SpanKind.CLIENT)
-        Assertions.assertThat(span.endEpochNanos - span.startEpochNanos >= 1000000)
+        assertThat(span).hasKind(SpanKind.CLIENT)
+        assertThat(span.endEpochNanos - span.startEpochNanos >= 1_000_000_000)
           .describedAs("Span duration should be at least 1000ms")
           .isTrue()
       }

--- a/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
@@ -94,6 +94,7 @@ abstract class AbstractKtorHttpClientTest : AbstractHttpClientTest<HttpRequestBu
         Assertions.assertThat(span.endEpochNanos - span.startEpochNanos >= 1000000)
           .describedAs("Span duration should be at least 1000ms")
           .isTrue()
-      })
+      }
+    )
   }
 }

--- a/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/AbstractKtorHttpClientTest.kt
@@ -81,7 +81,7 @@ abstract class AbstractKtorHttpClientTest : AbstractHttpClientTest<HttpRequestBu
   @Test
   fun checkSpanEndsAfterBodyReceived() {
     val method = "GET"
-    val path = "/long_body_receiving"
+    val path = "/long-request"
     val uri = resolveAddress(path)
     val responseCode = doRequest(method, uri)
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -1048,7 +1048,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
     return span.hasName("test-http-server").hasKind(SpanKind.SERVER);
   }
 
-  private int doRequest(String method, URI uri) throws Exception {
+  protected int doRequest(String method, URI uri) throws Exception {
     return doRequest(method, uri, Collections.emptyMap());
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -102,7 +102,7 @@ public final class HttpClientTestServer extends ServerExtension {
             (ctx, req) ->
                 HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofSeconds(20)))
         .service(
-            "/long_body_receiving",
+            "/long-request",
             (ctx, req) -> {
               HttpResponseWriter writer = HttpResponse.streaming();
               writer.write(ResponseHeaders.of(HttpStatus.OK));

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -108,14 +108,17 @@ public final class HttpClientTestServer extends ServerExtension {
               writer.write(ResponseHeaders.of(HttpStatus.OK));
               writer.write(HttpData.ofUtf8("Hello"));
 
-              ctx.eventLoop().schedule(() -> {
-                writer.write(HttpData.ofUtf8("World"));
-                writer.close();
-              }, 1, TimeUnit.SECONDS);
+              ctx.eventLoop()
+                  .schedule(
+                      () -> {
+                        writer.write(HttpData.ofUtf8("World"));
+                        writer.close();
+                      },
+                      1,
+                      TimeUnit.SECONDS);
 
               return writer;
-            }
-        )
+            })
         .decorator(
             (delegate, ctx, req) -> {
               for (String field : openTelemetry.getPropagators().getTextMapPropagator().fields()) {


### PR DESCRIPTION
In the documentation written next:

> HTTP client spans SHOULD end sometime after the HTTP response headers are fully read (or when they fail to be read). This may or may not include reading the response body. (https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span-duration)

Right now, the span ends when headers are fully read. But in this case, users sometimes measure incorrect time of request, and this difference can be extremely big in the case of log-running calls, for example, SSE.

The current PR suggests changing the end of the span after reading the body.