### PR TITLE
Add link to SDK configuration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ configured to send data to
 at `http://localhost:4317`.
 
 Configuration parameters are passed as Java system properties (`-D` flags) or
-as environment variables. See [the configuration documentation][config]
+as environment variables. See [the configuration documentation][config-agent]
 for the full list of configuration items. For example:
 
 ```
@@ -93,11 +93,14 @@ java -javaagent:path/to/opentelemetry-javaagent.jar \
 
 ## Configuring the Agent
 
-The agent is [highly configurable][config]!  Many aspects of the agent's behavior can be
+The agent is highly configurable! Many aspects of the agent's behavior can be
 configured for your needs, such as exporter choice, exporter config (like where
 data is sent), trace context propagation headers, and much more.
 
-[Click here to see the detailed list of configuration environment variables and system properties][config].
+For a detailed list of agent configuration options, see the [agent configuration docs][config-agent].
+
+For a detailed list of additional SDK configuration environment variables and system properties,
+see the [SDK configuration docs][config-sdk].
 
 *Note: Config parameter names are very likely to change over time, so please check
 back here when trying out a new version!
@@ -183,7 +186,9 @@ Thanks to all the people who already contributed!
   <img src="https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-java-instrumentation" />
 </a>
 
-[config]: https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/
+[config-agent]: https://opentelemetry.io/docs/zero-code/java/agent/configuration/
+
+[config-sdk]: https://opentelemetry.io/docs/languages/java/configuration/
 
 [manual]: https://opentelemetry.io/docs/instrumentation/java/manual/
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry.io/issues/4611

We currently have 3 links to the zero-code agent config page (The URL changed, so I updated that), and while that page does link to the SDK config page, it might not be obvious to users.

This change adds an additional link to the SDK configuration page which has additional properties a user might be looking for when configuring something like the exporter endpoint, which does not exist in the agent config docs.