### PR TITLE
Add GraalVM Kafka hints

### DIFF
--- a/smoke-tests-otel-starter/spring-boot-3/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
+++ b/smoke-tests-otel-starter/spring-boot-3/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
@@ -24,9 +24,6 @@ public class RuntimeHints implements RuntimeHintsRegistrar {
         .registerType(
             TypeReference.of(
                 "org.springframework.data.mongodb.core.aggregation.AggregationOperation"),
-            hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
-        .registerType(
-            TypeReference.of("org.apache.kafka.common.serialization.StringDeserializer"),
-            hint -> hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS));
+            hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/resources/META-INF/native-image/reflect-config.json
@@ -544,5 +544,706 @@
       "typeReachable": "com.zaxxer.hikari.util.Sequence$Factory"
     },
     "name": "java.util.concurrent.atomic.LongAdder"
+  },
+  ,
+  {
+    "name": "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.consumer.RangeAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.consumer.RoundRobinAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.consumer.StickyAssignor",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.clients.producer.RoundRobinPartitioner",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.metrics.JmxReporter",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.Utils"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.authenticator.AbstractLogin$DefaultLoginCallbackHandler",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.LoginManager"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.authenticator.DefaultLogin",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.LoginManager"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.authenticator.SaslClientCallbackHandler",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.network.SaslChannelBuilder"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.security.plain.PlainLoginModule",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.security.authenticator.AbstractLogin"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BooleanDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BooleanSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteArraySerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteBufferDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ByteBufferSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BytesDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.BytesSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.DoubleDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.DoubleSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.FloatDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.FloatSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.IntegerDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.IntegerSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ListDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ListSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.LongDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.LongSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListDeserializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ByteArraySerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ByteBufferSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$BytesSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$DoubleSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$FloatSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$LongSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$ShortSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$StringSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$UUIDSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.Serdes$VoidSerde",
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.serialization.ListSerializer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ShortDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.ShortSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.StringDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.StringSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.UUIDDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.UUIDSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.VoidDeserializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.consumer.KafkaConsumer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.serialization.VoidSerializer",
+    "condition": {
+      "typeReachable": "org.apache.kafka.clients.producer.KafkaProducer"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.apache.kafka.common.utils.AppInfoParser$AppInfo",
+    "queryAllPublicConstructors": true,
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.AppInfoParser"
+    }
+  },
+  {
+    "name": "org.apache.kafka.common.utils.AppInfoParser$AppInfoMBean",
+    "queryAllPublicMethods": true,
+    "condition": {
+      "typeReachable": "org.apache.kafka.common.utils.AppInfoParser"
+    }
   }
 ]


### PR DESCRIPTION
The dailly GraalVM native build is failing the last days: https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/native-tests-daily.yml

The errors reported in the first (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11687) and last (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11727) failing builds are related to 2 different missing GraalVM hints. These hints shoud be provided by the GraalVM metadata repository for Kafka client (https://github.com/oracle/graalvm-reachability-metadata/blob/1fa4797283d5512b4fc2d98728083cde63ae07a9/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json
).  However, it's not possible for our tests to use the remote hints because of a Gradle issue (see https://github.com/graalvm/native-build-tools/issues/572).

So, this PR copies the GraaVM hints from https://github.com/oracle/graalvm-reachability-metadata/blob/1fa4797283d5512b4fc2d98728083cde63ae07a9/metadata/org.apache.kafka/kafka-clients/3.5.1/reflect-config.json to the OTel Java instrumentation repository for the test  executions. I don't explain which recent change makes that these hints have to be added.

