### PR TITLE
Exclude javalin 3.2.0 from muzzle

### DIFF
--- a/instrumentation/javalin-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/javalin-5.0/javaagent/build.gradle.kts
@@ -7,6 +7,8 @@ muzzle {
     group.set("io.javalin")
     module.set("javalin")
     versions.set("[5.0.0,)")
+    // 3.2.0 depends on org.meteogroup.jbrotli:jbrotli:0.5.0 that is not available in central
+    skip("3.2.0")
     assertInverse.set(true)
   }
 }


### PR DESCRIPTION
resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11761
javalin 3.2.0 can't find jbrotli dependency that should come from http://dl.bintray.com/nitram509/jbrotli that is not available any more