### PR TITLE
Rename spring-boot-autoconfigure artifacts

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-autoconfigure-spring-boot-3.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-autoconfigure-spring-boot-3.txt
@@ -1,2 +1,0 @@
-Comparing source compatibility of opentelemetry-autoconfigure-spring-boot-3-2.6.0-SNAPSHOT.jar against 
-No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-2.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-2.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-spring-2.6.0-SNAPSHOT.jar against 
+Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2-2.6.0-SNAPSHOT.jar against 
 +++  NEW CLASS: PUBLIC(+) io.opentelemetry.instrumentation.spring.autoconfigure.v2.OpenTelemetryAutoConfiguration  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-2.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-2.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-autoconfigure-spring-boot-2-2.6.0-SNAPSHOT.jar against 
+Comparing source compatibility of opentelemetry-spring-2.6.0-SNAPSHOT.jar against 
 +++  NEW CLASS: PUBLIC(+) io.opentelemetry.instrumentation.spring.autoconfigure.v2.OpenTelemetryAutoConfiguration  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-3.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure-3.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-3-2.6.0-SNAPSHOT.jar against 
+No changes.

--- a/instrumentation/spring/spring-boot-autoconfigure-2/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure-2/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("otel.japicmp-conventions")
 }
 
-base.archivesName.set("opentelemetry-autoconfigure-spring-boot-2")
+base.archivesName.set("opentelemetry-spring-boot-autoconfigure-2")
 group = "io.opentelemetry.instrumentation"
 
 val springBootVersion = "2.7.18" // AutoConfiguration is added in 2.7.0, but can be used with older versions

--- a/instrumentation/spring/spring-boot-autoconfigure-3/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure-3/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("otel.japicmp-conventions")
 }
 
-base.archivesName.set("opentelemetry-autoconfigure-spring-boot-3")
+base.archivesName.set("opentelemetry-spring-boot-autoconfigure-3")
 group = "io.opentelemetry.instrumentation"
 
 otelJava {


### PR DESCRIPTION
Renames two artifacts:

- `opentelemetry-autoconfigure-spring-boot-2` &rarr; `opentelemetry-spring-boot-autoconfigure-2`
- `opentelemetry-autoconfigure-spring-boot-3` &rarr; `opentelemetry-spring-boot-autoconfigure-3`

I think these match our naming better (and match the current directory names).