### PR TITLE
Remove unneeded groovy dependencies from lambda tests

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/build.gradle.kts
@@ -12,8 +12,6 @@ dependencies {
 
   implementation("com.google.guava:guava")
 
-  implementation("org.apache.groovy:groovy")
   implementation("io.opentelemetry:opentelemetry-api")
-  implementation("org.spockframework:spock-core")
   implementation("com.github.stefanbirkner:system-lambda")
 }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/build.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
 
   implementation("com.google.guava:guava")
 
-  implementation("org.apache.groovy:groovy")
   implementation("io.opentelemetry:opentelemetry-api")
-  implementation("org.spockframework:spock-core")
   implementation("com.github.stefanbirkner:system-lambda")
 }


### PR DESCRIPTION
Stumbled across these groovy dependencies, but found there was no groovy code.

Sort of Related to #7195 

