### PR TITLE
gRPC support request/response size

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesGetter.java
@@ -24,4 +24,20 @@ public interface RpcAttributesGetter<REQUEST> {
 
   @Nullable
   String getMethod(REQUEST request);
+
+  default int getClientRequestSize(REQUEST request) {
+    return 0;
+  }
+
+  default int getClientResponseSize(REQUEST request) {
+    return 0;
+  }
+
+  default int getServerRequestSize(REQUEST request) {
+    return 0;
+  }
+
+  default int getServerResponseSize(REQUEST request) {
+    return 0;
+  }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
@@ -20,6 +20,14 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
   static final AttributeKey<String> RPC_METHOD = AttributeKey.stringKey("rpc.method");
   static final AttributeKey<String> RPC_SERVICE = AttributeKey.stringKey("rpc.service");
   static final AttributeKey<String> RPC_SYSTEM = AttributeKey.stringKey("rpc.system");
+  static final AttributeKey<Long> RPC_CLIENT_REQUEST_BODY_SIZE =
+      AttributeKey.longKey("rpc.client.request.body.size");
+  static final AttributeKey<Long> RPC_CLIENT_RESPONSE_BODY_SIZE =
+      AttributeKey.longKey("rpc.client.response.body.size");
+  static final AttributeKey<Long> RPC_SERVER_REQUEST_BODY_SIZE =
+      AttributeKey.longKey("rpc.server.request.body.size");
+  static final AttributeKey<Long> RPC_SERVER_RESPONSE_BODY_SIZE =
+      AttributeKey.longKey("rpc.server.response.body.size");
 
   private final RpcAttributesGetter<REQUEST> getter;
 
@@ -41,6 +49,14 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
-    // No response attributes
+    internalSet(attributes, RPC_CLIENT_REQUEST_BODY_SIZE,
+        (long) getter.getClientRequestSize(request));
+    internalSet(attributes, RPC_CLIENT_RESPONSE_BODY_SIZE,
+        (long) getter.getClientResponseSize(request));
+
+    internalSet(attributes, RPC_SERVER_REQUEST_BODY_SIZE,
+        (long) getter.getServerRequestSize(request));
+    internalSet(attributes, RPC_SERVER_RESPONSE_BODY_SIZE,
+        (long) getter.getServerResponseSize(request));
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMessageBodySizeUtil.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMessageBodySizeUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import javax.annotation.Nullable;
+
+final class RpcMessageBodySizeUtil {
+
+  @Nullable
+  static Long getRpcClientRequestBodySize(Attributes... attributesList) {
+    return getAttribute(RpcCommonAttributesExtractor.RPC_CLIENT_REQUEST_BODY_SIZE, attributesList);
+  }
+
+  @Nullable
+  static Long getRpcClientResponseBodySize(Attributes... attributesList) {
+    return getAttribute(
+        RpcCommonAttributesExtractor.RPC_CLIENT_RESPONSE_BODY_SIZE, attributesList);
+  }
+
+  @Nullable
+  static Long getRpcServerRequestBodySize(Attributes... attributesList) {
+    return getAttribute(RpcCommonAttributesExtractor.RPC_SERVER_REQUEST_BODY_SIZE, attributesList);
+  }
+  @Nullable
+  static Long getRpcServerResponseBodySize(Attributes... attributesList) {
+    return getAttribute(
+        RpcCommonAttributesExtractor.RPC_SERVER_RESPONSE_BODY_SIZE, attributesList);
+  }
+
+  @Nullable
+  private static <T> T getAttribute(AttributeKey<T> key, Attributes... attributesList) {
+    for (Attributes attributes : attributesList) {
+      T value = attributes.get(key);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private RpcMessageBodySizeUtil() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
@@ -7,7 +7,9 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.ServerAttributes;
 import java.util.Arrays;
@@ -44,6 +46,43 @@ final class RpcMetricsAdvice {
     // the list of recommended metrics attributes is from
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
     ((ExtendedDoubleHistogramBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                RpcCommonAttributesExtractor.RPC_SYSTEM,
+                RpcCommonAttributesExtractor.RPC_SERVICE,
+                RpcCommonAttributesExtractor.RPC_METHOD,
+                RPC_GRPC_STATUS_CODE,
+                NetworkAttributes.NETWORK_TYPE,
+                NetworkAttributes.NETWORK_TRANSPORT,
+                ServerAttributes.SERVER_ADDRESS,
+                ServerAttributes.SERVER_PORT));
+  }
+  static void applyClientRequestSizeAdvice(LongHistogramBuilder builder) {
+    if (!(builder instanceof ExtendedLongHistogramBuilder)) {
+      return;
+    }
+    // the list of recommended metrics attributes is from
+    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
+    ((ExtendedLongHistogramBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                RpcCommonAttributesExtractor.RPC_SYSTEM,
+                RpcCommonAttributesExtractor.RPC_SERVICE,
+                RpcCommonAttributesExtractor.RPC_METHOD,
+                RPC_GRPC_STATUS_CODE,
+                NetworkAttributes.NETWORK_TYPE,
+                NetworkAttributes.NETWORK_TRANSPORT,
+                ServerAttributes.SERVER_ADDRESS,
+                ServerAttributes.SERVER_PORT));
+  }
+
+  static void applyServerRequestSizeAdvice(LongHistogramBuilder builder) {
+    if (!(builder instanceof ExtendedLongHistogramBuilder)) {
+      return;
+    }
+    // the list of recommended metrics attributes is from
+    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
+    ((ExtendedLongHistogramBuilder) builder)
         .setAttributesAdvice(
             Arrays.asList(
                 RpcCommonAttributesExtractor.RPC_SYSTEM,

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
@@ -11,6 +11,8 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -35,6 +37,8 @@ public final class RpcServerMetrics implements OperationListener {
   private static final Logger logger = Logger.getLogger(RpcServerMetrics.class.getName());
 
   private final DoubleHistogram serverDurationHistogram;
+  private final LongHistogram serverRequestSize;
+  private final LongHistogram serverResponseSize;
 
   private RpcServerMetrics(Meter meter) {
     DoubleHistogramBuilder durationBuilder =
@@ -44,6 +48,24 @@ public final class RpcServerMetrics implements OperationListener {
             .setUnit("ms");
     RpcMetricsAdvice.applyServerDurationAdvice(durationBuilder);
     serverDurationHistogram = durationBuilder.build();
+
+    LongHistogramBuilder requestSizeBuilder =
+        meter
+            .histogramBuilder("rpc.server.request.size")
+            .setUnit("By")
+            .setDescription("Measures the size of RPC request messages (uncompressed).")
+            .ofLongs();
+    RpcMetricsAdvice.applyServerRequestSizeAdvice(requestSizeBuilder);
+    serverRequestSize = requestSizeBuilder.build();
+
+    LongHistogramBuilder responseSizeBuilder =
+        meter
+            .histogramBuilder("rpc.server.response.size")
+            .setUnit("By")
+            .setDescription("Measures the size of RPC response messages (uncompressed).")
+            .ofLongs();
+    RpcMetricsAdvice.applyServerRequestSizeAdvice(responseSizeBuilder);
+    serverResponseSize = responseSizeBuilder.build();
   }
 
   /**
@@ -72,10 +94,21 @@ public final class RpcServerMetrics implements OperationListener {
           context);
       return;
     }
+    Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
     serverDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_MS,
-        state.startAttributes().toBuilder().putAll(endAttributes).build(),
-        context);
+        (endNanos - state.startTimeNanos()) / NANOS_PER_MS, attributes, context);
+
+    Long rpcServerRequestBodySize = RpcMessageBodySizeUtil.getRpcServerRequestBodySize(
+        endAttributes, state.startAttributes());
+    if (rpcServerRequestBodySize != null && rpcServerRequestBodySize >0 ) {
+      serverRequestSize.record(rpcServerRequestBodySize, attributes, context);
+    }
+
+    Long rpcServerResponseBodySize = RpcMessageBodySizeUtil.getRpcServerResponseBodySize(
+        endAttributes, state.startAttributes());
+    if (rpcServerResponseBodySize != null && rpcServerResponseBodySize > 0) {
+      serverResponseSize.record(rpcServerResponseBodySize, attributes, context);
+    }
   }
 
   @AutoValue

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.ServerAttributes;
@@ -46,6 +47,8 @@ class RpcClientMetricsTest {
             .put(ServerAttributes.SERVER_PORT, 8080)
             .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
             .put(NetworkAttributes.NETWORK_TYPE, "ipv4")
+            .put(RpcCommonAttributesExtractor.RPC_CLIENT_REQUEST_BODY_SIZE, 10)
+            .put(RpcCommonAttributesExtractor.RPC_CLIENT_RESPONSE_BODY_SIZE, 20)
             .build();
 
     Attributes responseAttributes2 =
@@ -76,6 +79,60 @@ class RpcClientMetricsTest {
 
     assertThat(metricReader.collectAllMetrics())
         .satisfiesExactlyInAnyOrder(
+            metric ->
+                OpenTelemetryAssertions.assertThat(metric)
+                    .hasName("rpc.client.response.size")
+                    .hasUnit("By")
+                    .hasDescription("Measures the size of RPC response messages (uncompressed).")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point.hasSum(20 /* bytes */)
+                                        .hasAttributesSatisfying(
+                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
+                                            equalTo(
+                                                RpcIncubatingAttributes.RPC_SERVICE,
+                                                "myservice.EchoService"),
+                                            equalTo(
+                                                RpcIncubatingAttributes.RPC_METHOD,
+                                                "exampleMethod"),
+                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
+                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
+                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                        .hasExemplarsSatisfying(
+                                            exemplar ->
+                                                exemplar
+                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
+                                                    .hasSpanId("090a0b0c0d0e0f00")))),
+            metric ->
+                OpenTelemetryAssertions.assertThat(metric)
+                    .hasName("rpc.client.request.size")
+                    .hasUnit("By")
+                    .hasDescription("Measures the size of RPC request messages (uncompressed).")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point.hasSum(10 /* bytes */)
+                                        .hasAttributesSatisfying(
+                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
+                                            equalTo(
+                                                RpcIncubatingAttributes.RPC_SERVICE,
+                                                "myservice.EchoService"),
+                                            equalTo(
+                                                RpcIncubatingAttributes.RPC_METHOD,
+                                                "exampleMethod"),
+                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
+                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
+                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                        .hasExemplarsSatisfying(
+                                            exemplar ->
+                                                exemplar
+                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
+                                                    .hasSpanId("090a0b0c0d0e0f00")))),
             metric ->
                 assertThat(metric)
                     .hasName("rpc.client.duration")

--- a/instrumentation/grpc-1.6/library/build.gradle.kts
+++ b/instrumentation/grpc-1.6/library/build.gradle.kts
@@ -7,6 +7,7 @@ val grpcVersion = "1.6.0"
 
 dependencies {
   library("io.grpc:grpc-core:$grpcVersion")
+  library("com.google.protobuf:protobuf-java:3.25.3")
 
   testLibrary("io.grpc:grpc-netty:$grpcVersion")
   testLibrary("io.grpc:grpc-protobuf:$grpcVersion")

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/BodySizeUtil.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/BodySizeUtil.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.grpc.v1_6;
+
+import com.google.protobuf.MessageLite;
+
+final class BodySizeUtil {
+
+  static <T> int getBodySize(T message) {
+    if (message instanceof MessageLite) {
+      return ((MessageLite) message).getSerializedSize();
+    } else {
+      // Message is not a protobuf message
+      return 0;
+    }
+  }
+
+  private BodySizeUtil() {}
+}

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
@@ -20,6 +20,11 @@ public final class GrpcRequest {
   private volatile int logicalPort = -1;
   @Nullable private volatile SocketAddress peerSocketAddress;
 
+  private int clientRequestSize;
+  private int clientResponseSize;
+
+  private int serverRequestSize;
+  private int serverResponseSize;
   GrpcRequest(
       MethodDescriptor<?, ?> method,
       @Nullable Metadata metadata,
@@ -77,5 +82,37 @@ public final class GrpcRequest {
 
   void setPeerSocketAddress(SocketAddress peerSocketAddress) {
     this.peerSocketAddress = peerSocketAddress;
+  }
+
+  public int getClientRequestSize() {
+    return clientRequestSize;
+  }
+
+  void setClientRequestSize(int clientRequestSize) {
+    this.clientRequestSize = clientRequestSize;
+  }
+
+  public int getClientResponseSize() {
+    return clientResponseSize;
+  }
+
+  void setClientResponseSize(int clientResponseSize) {
+    this.clientResponseSize = clientResponseSize;
+  }
+
+  public int getServerRequestSize() {
+    return serverRequestSize;
+  }
+
+  public void setServerRequestSize(int serverRequestSize) {
+    this.serverRequestSize = serverRequestSize;
+  }
+
+  public int getServerResponseSize() {
+    return serverResponseSize;
+  }
+
+  public void setServerResponseSize(int serverResponseSize) {
+    this.serverResponseSize = serverResponseSize;
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRpcAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRpcAttributesGetter.java
@@ -43,6 +43,27 @@ enum GrpcRpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
     return fullMethodName.substring(slashIndex + 1);
   }
 
+  @Override
+  public int getClientRequestSize(GrpcRequest request) {
+    return request.getClientRequestSize();
+  }
+
+  @Override
+  public int getClientResponseSize(GrpcRequest request) {
+    return request.getClientResponseSize();
+  }
+
+  @Override
+  public int getServerRequestSize(GrpcRequest request) {
+    return request.getServerRequestSize();
+  }
+
+  @Override
+  public int getServerResponseSize(GrpcRequest request) {
+    return request.getServerResponseSize();
+  }
+
+
   List<String> metadataValue(GrpcRequest request, String key) {
     if (request.getMetadata() == null) {
       return Collections.emptyList();

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -109,6 +109,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
 
     @Override
     public void sendMessage(REQUEST message) {
+      request.setClientRequestSize(BodySizeUtil.getBodySize(message));
       try (Scope ignored = context.makeCurrent()) {
         super.sendMessage(message);
       } catch (Throwable e) {
@@ -141,6 +142,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
 
       @Override
       public void onMessage(RESPONSE message) {
+        request.setClientResponseSize(BodySizeUtil.getBodySize(message));
         Span span = Span.fromContext(context);
         Attributes attributes =
             Attributes.of(

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -103,6 +103,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
     @Override
     public void sendMessage(RESPONSE message) {
+      request.setServerRequestSize(BodySizeUtil.getBodySize(message));
       try (Scope ignored = context.makeCurrent()) {
         super.sendMessage(message);
       }
@@ -136,6 +137,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
       @Override
       public void onMessage(REQUEST message) {
+        request.setServerResponseSize(BodySizeUtil.getBodySize(message));
         Attributes attributes =
             Attributes.of(
                 MESSAGE_TYPE,


### PR DESCRIPTION
Resolves #9736.

reference https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#metric-rpcserverrequestsize