### PR TITLE
Fix missing throw statement in RestClientWrapper (#11892)

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/RestClientWrapper.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/RestClientWrapper.java
@@ -74,6 +74,7 @@ class RestClientWrapper {
                       response = (Response) method.invoke(target, args);
                     } catch (Throwable exception) {
                       throwable = exception;
+                      throw throwable;
                     } finally {
                       instrumenter.end(context, otelRequest, response, throwable);
                     }
@@ -102,6 +103,7 @@ class RestClientWrapper {
                       return method.invoke(target, args);
                     } catch (Throwable exception) {
                       throwable = exception;
+                      throw throwable;
                     } finally {
                       if (throwable != null) {
                         instrumenter.end(context, otelRequest, null, throwable);


### PR DESCRIPTION
Currently `RestClientWrapper` would suppress the Exception thrown by the underlying `RestClient` due to missing `throw` statement. This can change the behaviour of the caller such as `RestHighLevelClient` and hide the real problem. I opened an issue to demonstrate it #11892.

This PR tries to fix it and make sure `RestClientWrapper` passes through the underlying result.
