### PR TITLE
Update api diff during release automation

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -22,4 +22,4 @@ sed -Ei "s/(opentelemetryJavaagentAlpha *: )\"[^\"]*\"/\1\"$alpha_version\"/" ex
 sed -Ei "s/(io.opentelemetry.instrumentation.muzzle-generation\" version )\"[^\"]*\"/\1\"$alpha_version\"/" examples/extension/build.gradle
 sed -Ei "s/(io.opentelemetry.instrumentation.muzzle-check\" version )\"[^\"]*\"/\1\"$alpha_version\"/" examples/extension/build.gradle
 
-sed -Ei "1 s/(Comparing source compatibility of [a-z-]+)-[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT.jar/\1-$version.jar/" docs/apidiffs/current_vs_latest/*.txt
+sed -Ei "1 s/(Comparing source compatibility of [a-z-]+)-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?.jar/\1-$version.jar/" docs/apidiffs/current_vs_latest/*.txt

--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -21,3 +21,5 @@ sed -Ei "s/(opentelemetryJavaagentAlpha *: )\"[^\"]*\"/\1\"$alpha_version\"/" ex
 
 sed -Ei "s/(io.opentelemetry.instrumentation.muzzle-generation\" version )\"[^\"]*\"/\1\"$alpha_version\"/" examples/extension/build.gradle
 sed -Ei "s/(io.opentelemetry.instrumentation.muzzle-check\" version )\"[^\"]*\"/\1\"$alpha_version\"/" examples/extension/build.gradle
+
+sed -Ei "1 s/(Comparing source compatibility of [a-z-]+)-[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT.jar/\1-$version.jar/" docs/apidiffs/current_vs_latest/*.txt


### PR DESCRIPTION
This part of #11612

> * [prepare-release-branch.yml](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/workflows/prepare-release-branch.yml) - need to incorporate ./gradlew jApiCmp into both PRs that it creates since version being updated in each one