### PR TITLE
Try to fix disabling renovate updates for spring boot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,6 +125,7 @@
       "matchPackageNames": [
         "org.slf4j:slf4j-api",
         "org.springframework.boot",
+        "org.springframework.boot:org.springframework.boot.gradle.plugin",
         "org.springframework.boot:spring-boot-dependencies"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false,
@@ -163,7 +164,7 @@
     {
       // intentionally using scala 2.11 in otel.scala-conventions.gradle.kts
       "matchFileNames": ["conventions/src/main/kotlin/otel.scala-conventions.gradle.kts"],
-      "matchPackagePrefixes": ["org.scala-lang:scala-library"],
+      "matchPackageNames": ["org.scala-lang:scala-library"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },


### PR DESCRIPTION
I think we don't want https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11953 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11952