### PR TITLE
Remove unused renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,8 +124,7 @@
       ],
       "matchPackageNames": [
         "org.slf4j:slf4j-api",
-        "org.springframework.boot",
-        "org.springframework.boot:org.springframework.boot.gradle.plugin",
+        "org.springframework.boot:org.springframework.boot.gradle.plugin", // this is for plugin id "org.springframework.boot"
         "org.springframework.boot:spring-boot-dependencies"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false,


### PR DESCRIPTION
I'm pretty sure I thought `"org.springframework.boot"` was for plugin id "org.springframework.boot"

(see #12059 and #11952)