### PR TITLE
Fix rabbitmq NullPointerException

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
@@ -128,6 +128,9 @@ public class RabbitChannelInstrumentation implements TypeInstrumentation {
       if (callDepth.decrementAndGet() > 0) {
         return;
       }
+      if (scope == null) {
+        return;
+      }
 
       scope.close();
 


### PR DESCRIPTION
when `ChannelMethodAdvice` dont start a span, the end method will cause NullPointerException, because the scope is null.

```java
public static class ChannelMethodAdvice {

    @Advice.OnMethodEnter
    public static void onEnter(
        @Advice.This Channel channel,
        @Advice.Origin("Channel.#m") String method,
        @Advice.Local("otelCallDepth") CallDepth callDepth,
        @Advice.Local("otelContext") Context context,
        @Advice.Local("otelScope") Scope scope,
        @Advice.Local("otelRequest") ChannelAndMethod request) {
      callDepth = CallDepth.forClass(Channel.class);
      if (callDepth.getAndIncrement() > 0) {
        return;
      }

      Context parentContext = Java8BytecodeBridge.currentContext();
      request = ChannelAndMethod.create(channel, method);

      if (!channelInstrumenter(request).shouldStart(parentContext, request)) {
       // return here, so the scope is null.
        return;
      }
      ...
    }

    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
      public static void stopSpan(
          @Advice.Thrown Throwable throwable,
          @Advice.Local("otelCallDepth") CallDepth callDepth,
          @Advice.Local("otelContext") Context context,
          @Advice.Local("otelScope") Scope scope,
          @Advice.Local("otelRequest") ChannelAndMethod request) {
        if (callDepth.decrementAndGet() > 0) {
          return;
        }
        // add code here to avoid NullPointerException
        if (scope == null) {
          return;
        }
  
        scope.close();
  
        CURRENT_RABBIT_CONTEXT.remove();
        channelInstrumenter(request).end(context, request, null, throwable);
      }
```
