### PR TITLE
Enable tests for jedis 2.7.2

### DIFF
--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -39,7 +39,11 @@ testing {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  }
+
+  check {
+    dependsOn(testing.suites)
   }
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10982 added test suite for jedis 2.7.2 but forgot to enable it