### PR TITLE
Allow JMX Insight reuse for remote connections

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
+++ b/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
@@ -36,7 +36,7 @@ public class JmxMetricInsightInstaller implements AgentListener {
           JmxMetricInsight.createService(
               GlobalOpenTelemetry.get(), beanDiscoveryDelay(config).toMillis());
       MetricConfiguration conf = buildMetricConfiguration(config);
-      service.start(conf);
+      service.startLocal(conf);
     }
   }
 

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanAttributeExtractor.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanAttributeExtractor.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
@@ -132,18 +132,17 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
    * including the internals of CompositeData and TabularData, if applicable, and that the provided
    * values will be numerical.
    *
-   * @param server the MBeanServer that reported knowledge of the ObjectName
-   * @param objectName the ObjectName identifying the MBean
-   * @return AttributeInfo if the attribute is properly recognized, or null
+   * @param connection the {@link MBeanServerConnection} that reported knowledge of the ObjectName
+   * @param objectName the {@link ObjectName} identifying the MBean
    */
   @Nullable
-  AttributeInfo getAttributeInfo(MBeanServer server, ObjectName objectName) {
+  AttributeInfo getAttributeInfo(MBeanServerConnection connection, ObjectName objectName) {
     if (logger.isLoggable(FINE)) {
       logger.log(FINE, "Resolving {0} for {1}", new Object[] {getAttributeName(), objectName});
     }
 
     try {
-      MBeanInfo info = server.getMBeanInfo(objectName);
+      MBeanInfo info = connection.getMBeanInfo(objectName);
       MBeanAttributeInfo[] allAttributes = info.getAttributes();
 
       for (MBeanAttributeInfo attr : allAttributes) {
@@ -152,7 +151,7 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
 
           // Verify correctness of configuration by attempting to extract the metric value.
           // The value will be discarded, but its type will be checked.
-          Object sampleValue = extractAttributeValue(server, objectName, logger);
+          Object sampleValue = extractAttributeValue(connection, objectName, logger);
 
           // Only numbers can be used to generate metric values
           if (sampleValue instanceof Number) {
@@ -199,18 +198,20 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
    * Extracts the specified attribute value. In case the value is a CompositeData, drills down into
    * it to find the correct singleton value (usually a Number or a String).
    *
-   * @param server the MBeanServer to use
-   * @param objectName the ObjectName specifying the MBean to use, it should not be a pattern
+   * @param connection the {@link MBeanServerConnection} to use
+   * @param objectName the {@link ObjectName} specifying the MBean to use, it should not be a
+   *     pattern
    * @param logger the logger to use, may be null. Typically we want to log any issues with the
    *     attributes during MBean discovery, but once the attribute is successfully detected and
    *     confirmed to be eligble for metric evaluation, any further attribute extraction
    *     malfunctions will be silent to avoid flooding the log.
-   * @return the attribute value, if found, or null if an error occurred
+   * @return the attribute value, if found, or {@literal null} if an error occurred
    */
   @Nullable
-  private Object extractAttributeValue(MBeanServer server, ObjectName objectName, Logger logger) {
+  private Object extractAttributeValue(
+      MBeanServerConnection connection, ObjectName objectName, Logger logger) {
     try {
-      Object value = server.getAttribute(objectName, baseName);
+      Object value = connection.getAttribute(objectName, baseName);
 
       int k = 0;
       while (k < nameChain.length) {
@@ -247,13 +248,13 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
   }
 
   @Nullable
-  private Object extractAttributeValue(MBeanServer server, ObjectName objectName) {
-    return extractAttributeValue(server, objectName, null);
+  private Object extractAttributeValue(MBeanServerConnection connection, ObjectName objectName) {
+    return extractAttributeValue(connection, objectName, null);
   }
 
   @Nullable
-  Number extractNumericalAttribute(MBeanServer server, ObjectName objectName) {
-    Object value = extractAttributeValue(server, objectName);
+  Number extractNumericalAttribute(MBeanServerConnection connection, ObjectName objectName) {
+    Object value = extractAttributeValue(connection, objectName);
     if (value instanceof Number) {
       return (Number) value;
     }
@@ -262,13 +263,13 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
 
   @Override
   @Nullable
-  public String extractValue(MBeanServer server, ObjectName objectName) {
-    return extractStringAttribute(server, objectName);
+  public String extractValue(MBeanServerConnection connection, ObjectName objectName) {
+    return extractStringAttribute(connection, objectName);
   }
 
   @Nullable
-  private String extractStringAttribute(MBeanServer server, ObjectName objectName) {
-    Object value = extractAttributeValue(server, objectName);
+  private String extractStringAttribute(MBeanServerConnection connection, ObjectName objectName) {
+    Object value = extractAttributeValue(connection, objectName);
     if (value instanceof String) {
       return (String) value;
     }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanFinder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.jmx.engine;
 
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -13,7 +14,10 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.management.MBeanServer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.management.MBeanServerConnection;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 
@@ -22,6 +26,8 @@ import javax.management.ObjectName;
  * MetricDefs.
  */
 class BeanFinder {
+
+  private static final Logger logger = Logger.getLogger(BeanFinder.class.getName());
 
   private final MetricRegistrar registrar;
   private MetricConfiguration conf;
@@ -42,12 +48,19 @@ class BeanFinder {
     this.maxDelay = Math.max(60000, discoveryDelay);
   }
 
-  void discoverBeans(MetricConfiguration conf) {
+  /**
+   * Starts bean discovery on a list of local or remote connections
+   *
+   * @param conf metric configuration
+   * @param connections supplier for instances of {@link MBeanServerConnection}
+   */
+  void discoverBeans(
+      MetricConfiguration conf, Supplier<List<? extends MBeanServerConnection>> connections) {
     this.conf = conf;
 
     exec.schedule(
         () -> {
-          // Issue 9336: Corner case: PlatformMBeanServer will remain unitialized until a direct
+          // Issue 9336: Corner case: PlatformMBeanServer will remain uninitialized until a direct
           // reference to it is made. This call makes sure that the PlatformMBeanServer will be in
           // the set of MBeanServers reported by MBeanServerFactory.
           // Issue 11143: This call initializes java.util.logging.LogManager. We should not call it
@@ -62,7 +75,7 @@ class BeanFinder {
         new Runnable() {
           @Override
           public void run() {
-            refreshState();
+            refreshState(connections);
             // Use discoveryDelay as the increment for the actual delay
             delay = Math.min(delay + discoveryDelay, maxDelay);
             exec.schedule(this, delay, TimeUnit.MILLISECONDS);
@@ -77,9 +90,11 @@ class BeanFinder {
    * found for a given metric definition, submit the definition to MetricRegistrar for further
    * handling. Successive invocations of this method may find matches that were previously
    * unavailable, in such cases MetricRegistrar will extend the coverage for the new MBeans
+   *
+   * @param connections supplier providing {@link MBeanServerConnection} instances to query
    */
-  private void refreshState() {
-    List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
+  private void refreshState(Supplier<List<? extends MBeanServerConnection>> connections) {
+    List<? extends MBeanServerConnection> servers = connections.get();
 
     for (MetricDef metricDef : conf.getMetricDefs()) {
       resolveBeans(metricDef, servers);
@@ -92,22 +107,28 @@ class BeanFinder {
    * collection of corresponding metrics.
    *
    * @param metricDef the MetricDef used to find matching MBeans
-   * @param servers the list of MBeanServers to query
+   * @param connections the list of {@link MBeanServerConnection} to query
    */
-  private void resolveBeans(MetricDef metricDef, List<MBeanServer> servers) {
+  private void resolveBeans(
+      MetricDef metricDef, List<? extends MBeanServerConnection> connections) {
     BeanGroup beans = metricDef.getBeanGroup();
 
-    for (MBeanServer server : servers) {
+    for (MBeanServerConnection connection : connections) {
       // The set of all matching ObjectNames recognized by the server
       Set<ObjectName> allObjectNames = new HashSet<>();
 
       for (ObjectName pattern : beans.getNamePatterns()) {
-        Set<ObjectName> objectNames = server.queryNames(pattern, beans.getQueryExp());
-        allObjectNames.addAll(objectNames);
+        Set<ObjectName> objectNames = null;
+        try {
+          objectNames = connection.queryNames(pattern, beans.getQueryExp());
+          allObjectNames.addAll(objectNames);
+        } catch (IOException e) {
+          logger.log(Level.WARNING, "IO error while querying mbean", e);
+        }
       }
 
       if (!allObjectNames.isEmpty()) {
-        resolveAttributes(allObjectNames, server, metricDef);
+        resolveAttributes(allObjectNames, connection, metricDef);
 
         // Assuming that only one MBeanServer has the required MBeans
         break;
@@ -119,19 +140,20 @@ class BeanFinder {
    * Go over the collection of matching MBeans and try to find all matching attributes. For every
    * successful match, activate metric value collection.
    *
-   * @param objectNames the collection of ObjectNames identifying the MBeans
-   * @param server the MBeanServer which recognized the collection of ObjectNames
-   * @param metricDef the MetricDef describing the attributes to look for
+   * @param objectNames the collection of {@link ObjectName}s identifying the MBeans
+   * @param connection the {@link MBeanServerConnection} which recognized the collection of
+   *     ObjectNames
+   * @param metricDef the {@link MetricDef} describing the attributes to look for
    */
   private void resolveAttributes(
-      Set<ObjectName> objectNames, MBeanServer server, MetricDef metricDef) {
+      Set<ObjectName> objectNames, MBeanServerConnection connection, MetricDef metricDef) {
     for (MetricExtractor extractor : metricDef.getMetricExtractors()) {
       // For each MetricExtractor, find the subset of MBeans that have the required attribute
       List<ObjectName> validObjectNames = new ArrayList<>();
       AttributeInfo attributeInfo = null;
       for (ObjectName objectName : objectNames) {
         AttributeInfo attr =
-            extractor.getMetricValueExtractor().getAttributeInfo(server, objectName);
+            extractor.getMetricValueExtractor().getAttributeInfo(connection, objectName);
         if (attr != null) {
           if (attributeInfo == null) {
             attributeInfo = attr;
@@ -143,7 +165,7 @@ class BeanFinder {
       }
       if (!validObjectNames.isEmpty()) {
         // Ready to collect metric values
-        registrar.enrollExtractor(server, validObjectNames, extractor, attributeInfo);
+        registrar.enrollExtractor(connection, validObjectNames, extractor, attributeInfo);
       }
     }
   }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/DetectionStatus.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/DetectionStatus.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.jmx.engine;
 
 import java.util.Collection;
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 /**
@@ -15,16 +15,16 @@ import javax.management.ObjectName;
  */
 class DetectionStatus {
 
-  private final MBeanServer server;
+  private final MBeanServerConnection connection;
   private final Collection<ObjectName> objectNames;
 
-  DetectionStatus(MBeanServer server, Collection<ObjectName> objectNames) {
-    this.server = server;
+  DetectionStatus(MBeanServerConnection connection, Collection<ObjectName> objectNames) {
+    this.connection = connection;
     this.objectNames = objectNames;
   }
 
-  MBeanServer getServer() {
-    return server;
+  MBeanServerConnection getConnection() {
+    return connection;
   }
 
   Collection<ObjectName> getObjectNames() {

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttribute.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttribute.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.jmx.engine;
 
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 /**
@@ -26,7 +26,7 @@ public class MetricAttribute {
     return name;
   }
 
-  String acquireAttributeValue(MBeanServer server, ObjectName objectName) {
-    return extractor.extractValue(server, objectName);
+  String acquireAttributeValue(MBeanServerConnection connection, ObjectName objectName) {
+    return extractor.extractValue(connection, objectName);
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttributeExtractor.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttributeExtractor.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.jmx.engine;
 
 import javax.annotation.Nullable;
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 /**
@@ -18,28 +18,24 @@ public interface MetricAttributeExtractor {
   /**
    * Provide a String value to be used as the value of a metric attribute.
    *
-   * @param server MBeanServer to query, must not be null if the extraction is from an MBean
+   * @param connection MBeanServer to query, must not be null if the extraction is from an MBean
    *     attribute
    * @param objectName the identifier of the MBean to query, must not be null if the extraction is
    *     from an MBean attribute, or from the ObjectName parameter
    * @return the value of the attribute, can be null if extraction failed
    */
   @Nullable
-  String extractValue(@Nullable MBeanServer server, @Nullable ObjectName objectName);
+  String extractValue(@Nullable MBeanServerConnection connection, @Nullable ObjectName objectName);
 
   static MetricAttributeExtractor fromConstant(String constantValue) {
-    return (a, b) -> {
-      return constantValue;
-    };
+    return (a, b) -> constantValue;
   }
 
   static MetricAttributeExtractor fromObjectNameParameter(String parameterKey) {
     if (parameterKey.isEmpty()) {
       throw new IllegalArgumentException("Empty parameter name");
     }
-    return (dummy, objectName) -> {
-      return objectName.getKeyProperty(parameterKey);
-    };
+    return (dummy, objectName) -> objectName.getKeyProperty(parameterKey);
   }
 
   static MetricAttributeExtractor fromBeanAttribute(String attributeName) {


### PR DESCRIPTION
When trying to reuse JMX Insight implementation in contrib (https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1445), the current implementation assumes that only local instances of `MBeanServer` are used, so we need to enable reusing it for remote connections.

Fortunately as `MBeanServer` (1) extends `MBeanServerConnection` (2), this mostly requires to replace (1) with (2).

PR opened as draft and does not need review for now until we have validated it works as we expect for remote connections with [related PR](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1445).

