### PR TITLE
Read timeout in jetty http client tests

### DIFF
--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/AbstractJettyClient12Test.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/AbstractJettyClient12Test.java
@@ -67,7 +67,9 @@ public abstract class AbstractJettyClient12Test extends AbstractHttpClientTest<R
     request.agent("Jetty");
 
     request.method(method);
-    request.timeout(READ_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    if (uri.toString().contains("/read-timeout")) {
+      request.timeout(READ_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    }
 
     return request;
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.java
@@ -31,7 +31,7 @@ public abstract class AbstractJettyClient9Test extends AbstractHttpClientTest<Re
   public void before() throws Exception {
     // Start the main Jetty HttpClient and a https client
     client = createStandardClient();
-    client.setConnectTimeout(5000L);
+    client.setConnectTimeout(CONNECTION_TIMEOUT.toMillis());
     client.start();
 
     SslContextFactory tlsCtx = new SslContextFactory();
@@ -59,9 +59,15 @@ public abstract class AbstractJettyClient9Test extends AbstractHttpClientTest<Re
         theClient
             .newRequest(uri)
             .method(method)
-            .agent("Jetty")
-            .timeout(5000L, TimeUnit.MILLISECONDS);
+            .agent("Jetty");
     headers.forEach(request::header);
+
+    if (uri.toString().contains("/read-timeout")) {
+      request.timeout(READ_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    } else if (uri.toString().contains("192.0.2.1")) {
+      request.timeout(CONNECTION_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
     return request;
   }
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.java
@@ -55,11 +55,7 @@ public abstract class AbstractJettyClient9Test extends AbstractHttpClientTest<Re
   @Override
   public Request buildRequest(String method, URI uri, Map<String, String> headers) {
     HttpClient theClient = uri.getScheme().equalsIgnoreCase("https") ? httpsClient : client;
-    Request request =
-        theClient
-            .newRequest(uri)
-            .method(method)
-            .agent("Jetty");
+    Request request = theClient.newRequest(uri).method(method).agent("Jetty");
     headers.forEach(request::header);
 
     if (uri.toString().contains("/read-timeout")) {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/kxxxaljzvgias/tests/task/:instrumentation:jetty-httpclient:jetty-httpclient-12.0:library:test/details/io.opentelemetry.instrumentation.jetty.httpclient.v12_0.JettyHttpClient12LibraryTest/shouldSuppressNestedClientSpanIfAlreadyUnderParentClientSpan(String)%5B1%5D?expanded-stacktrace=WyIwIl0&top-execution=2

We want to enforce the 2s read timeout only in read timeout test to avoid spurious failures in slow requests.