### PR TITLE
Fix flaky spring integration test

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractComplexPropagationTest {
                     Payload payload = externalQueue().take();
                     receiveChannel().send(payload.toMessage());
                   } catch (InterruptedException e) {
-                    throw new IllegalStateException(e);
+                    Thread.currentThread().interrupt();
                   }
                 }
               });


### PR DESCRIPTION
Hopefully resolves https://ge.opentelemetry.io/s/psy4jx32ac5rc/tests/task/:instrumentation:spring:spring-integration-4.1:library:test/details/io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.ComplexPropagationTest/shouldPropagateContextThroughAcomplexFlow()?expanded-stacktrace=WyIwLTEiLCIwIl0&top-execution=1

Exception thrown from executor execute method gets handled by uncaught exception handler. This is problematic because awaitility, that we use in the test cleanup, by default installs an uncaught exception handler. If awaitility uncaught exception handler catches an exception while awaitility is waiting for a condition that exception will get rethrown from the await method. This way an exception from a random background thread can end up on main test thread an make the test fail.

