### PR TITLE
Fix caller data lost in logback mdc library instrumentation

### DIFF
--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
@@ -7,25 +7,39 @@ package io.opentelemetry.instrumentation.logback.mdc.v1_0;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
-import ch.qos.logback.classic.spi.LoggingEventVO;
+import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachable;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
 import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.UnionMap;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
     implements AppenderAttachable<ILoggingEvent> {
+  private static final Field MDC_MAP_FIELD;
+
+  static {
+    Field field;
+    try {
+      field = LoggingEvent.class.getDeclaredField("mdcPropertyMap");
+      field.setAccessible(true);
+    } catch (Exception ignored) {
+      // ignored
+      field = null;
+    }
+    MDC_MAP_FIELD = field;
+  }
+
   private boolean addBaggage;
   private String traceIdKey = LoggingContextConstants.TRACE_ID;
   private String spanIdKey = LoggingContextConstants.SPAN_ID;
@@ -59,7 +73,12 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
     this.traceFlagsKey = traceFlagsKey;
   }
 
-  public ILoggingEvent wrapEvent(ILoggingEvent event) {
+  @CanIgnoreReturnValue
+  private ILoggingEvent processEvent(ILoggingEvent event) {
+    if (MDC_MAP_FIELD == null || event.getClass() != LoggingEvent.class) {
+      return event;
+    }
+
     Map<String, String> eventContext = event.getMDCPropertyMap();
     if (eventContext != null && eventContext.containsKey(traceIdKey)) {
       // Assume already instrumented event if traceId is present.
@@ -98,32 +117,19 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
             ? new LoggerContextVO(oldVo.getName(), eventContextMap, oldVo.getBirthTime())
             : null;
 
-    ILoggingEvent wrappedEvent =
-        (ILoggingEvent)
-            Proxy.newProxyInstance(
-                ILoggingEvent.class.getClassLoader(),
-                new Class<?>[] {ILoggingEvent.class},
-                (proxy, method, args) -> {
-                  if ("getMDCPropertyMap".equals(method.getName())) {
-                    return eventContextMap;
-                  } else if ("getLoggerContextVO".equals(method.getName())) {
-                    return vo;
-                  }
-                  try {
-                    return method.invoke(event, args);
-                  } catch (InvocationTargetException exception) {
-                    throw exception.getCause();
-                  }
-                });
-    // https://github.com/qos-ch/logback/blob/9e833ec858953a2296afdc3292f8542fc08f2a45/logback-classic/src/main/java/ch/qos/logback/classic/net/LoggingEventPreSerializationTransformer.java#L29
-    // LoggingEventPreSerializationTransformer accepts only subclasses of LoggingEvent and
-    // LoggingEventVO, here we transform our wrapped event into a LoggingEventVO
-    return LoggingEventVO.build(wrappedEvent);
+    try {
+      MDC_MAP_FIELD.set(event, eventContextMap);
+    } catch (IllegalAccessException ignored) {
+      // setAccessible(true) was called on the field
+    }
+    ((LoggingEvent) event).setLoggerContextRemoteView(vo);
+
+    return event;
   }
 
   @Override
   protected void append(ILoggingEvent event) {
-    aai.appendLoopOnAppenders(wrapEvent(event));
+    aai.appendLoopOnAppenders(processEvent(event));
   }
 
   @Override

--- a/instrumentation/logback/logback-mdc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/AbstractLogbackTest.java
+++ b/instrumentation/logback/logback-mdc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/AbstractLogbackTest.java
@@ -65,18 +65,20 @@ public abstract class AbstractLogbackTest {
 
     assertThat(events.size()).isEqualTo(2);
     assertThat(events.get(0).getMessage()).isEqualTo("log message 1");
-    assertThat(events.get(0).getMDCPropertyMap().get(getLoggingKey("trace_id"))).isNull();
-    assertThat(events.get(0).getMDCPropertyMap().get(getLoggingKey("span_id"))).isNull();
-    assertThat(events.get(0).getMDCPropertyMap().get(getLoggingKey("trace_flags"))).isNull();
+    assertThat(events.get(0).getMDCPropertyMap())
+        .doesNotContainKeys(
+            getLoggingKey("trace_id"), getLoggingKey("span_id"), getLoggingKey("trace_flags"));
     assertThat(events.get(0).getMDCPropertyMap().get("baggage.baggage_key"))
         .isEqualTo(expectBaggage() ? "baggage_value" : null);
+    assertThat(events.get(0).getCallerData()).isNotNull();
 
     assertThat(events.get(1).getMessage()).isEqualTo("log message 2");
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("trace_id"))).isNull();
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("span_id"))).isNull();
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("trace_flags"))).isNull();
+    assertThat(events.get(1).getMDCPropertyMap())
+        .doesNotContainKeys(
+            getLoggingKey("trace_id"), getLoggingKey("span_id"), getLoggingKey("trace_flags"));
     assertThat(events.get(1).getMDCPropertyMap().get("baggage.baggage_key"))
         .isEqualTo(expectBaggage() ? "baggage_value" : null);
+    assertThat(events.get(1).getCallerData()).isNotNull();
   }
 
   @Test
@@ -98,12 +100,16 @@ public abstract class AbstractLogbackTest {
     assertThat(events.get(0).getMDCPropertyMap().get(getLoggingKey("trace_flags"))).isEqualTo("01");
     assertThat(events.get(0).getMDCPropertyMap().get("baggage.baggage_key"))
         .isEqualTo(expectBaggage() ? "baggage_value" : null);
+    assertThat(events.get(0).getCallerData()).isNotNull();
 
     assertThat(events.get(1).getMessage()).isEqualTo("log message 2");
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("trace_id"))).isNull();
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("span_id"))).isNull();
-    assertThat(events.get(1).getMDCPropertyMap().get(getLoggingKey("trace_flags"))).isNull();
-    assertThat(events.get(1).getMDCPropertyMap().get("baggage.baggage_key")).isNull();
+    assertThat(events.get(1).getMDCPropertyMap())
+        .doesNotContainKeys(
+            getLoggingKey("trace_id"),
+            getLoggingKey("span_id"),
+            getLoggingKey("trace_flags"),
+            "baggage.baggage_key");
+    assertThat(events.get(1).getCallerData()).isNotNull();
 
     assertThat(events.get(2).getMessage()).isEqualTo("log message 3");
     assertThat(events.get(2).getMDCPropertyMap().get(getLoggingKey("trace_id")))
@@ -113,6 +119,7 @@ public abstract class AbstractLogbackTest {
     assertThat(events.get(2).getMDCPropertyMap().get(getLoggingKey("trace_flags"))).isEqualTo("01");
     assertThat(events.get(2).getMDCPropertyMap().get("baggage.baggage_key"))
         .isEqualTo(expectBaggage() ? "baggage_value" : null);
+    assertThat(events.get(2).getCallerData()).isNotNull();
   }
 
   void runWithBaggage(Baggage baggage, Runnable runnable) {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12198
Instead of wrapping the logging event use reflection to update it. The current event wrapping solution uses `LoggingEventVO.build` because `LoggingEventPreSerializationTransformer` accepts only `LoggingEventVO` or `LoggingEvent`, but using `LoggingEventVO` looses access to caller data. Instead of the jdk proxy that we currently use we could use a custom proxy that extends `LoggingEvent`, but that is also problematic because our proxy would need to implement all methods that exist in any version of `LoggingEvent` (https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LoggingEventToReplay.java is similar in that regard) and it wouldn't be future proof (can't proactively handle methods that are added in future versions).
A limitation of proposed implementation is that it can only handle events of type `LoggingEvent`. This means that our appender needs to be arranged before other appenders that wrap the event.