### PR TITLE
jmx allow boolean and enum for metric attributes

### DIFF
--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanAttributeExtractor.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanAttributeExtractor.java
@@ -272,6 +272,12 @@ public class BeanAttributeExtractor implements MetricAttributeExtractor {
     if (value instanceof String) {
       return (String) value;
     }
+    if (value instanceof Boolean) {
+      return value.toString();
+    }
+    if (value instanceof Enum) {
+      return ((Enum<?>) value).name();
+    }
     return null;
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttributeExtractor.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/MetricAttributeExtractor.java
@@ -28,9 +28,7 @@ public interface MetricAttributeExtractor {
   String extractValue(@Nullable MBeanServer server, @Nullable ObjectName objectName);
 
   static MetricAttributeExtractor fromConstant(String constantValue) {
-    return (a, b) -> {
-      return constantValue;
-    };
+    return (a, b) -> constantValue;
   }
 
   static MetricAttributeExtractor fromObjectNameParameter(String parameterKey) {

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/AttributeExtractorTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/AttributeExtractorTest.java
@@ -34,6 +34,10 @@ class AttributeExtractorTest {
     double getDoubleAttribute();
 
     String getStringAttribute();
+
+    boolean getBooleanAttribute();
+
+    Enum<?> getEnumAttribute();
   }
 
   private static class Test1 implements Test1MBean {
@@ -71,6 +75,21 @@ class AttributeExtractorTest {
     public String getStringAttribute() {
       return "";
     }
+
+    @Override
+    public boolean getBooleanAttribute() {
+      return true;
+    }
+
+    @Override
+    public Enum<?> getEnumAttribute() {
+       return DummyEnum.ENUM_VALUE;
+    }
+
+    private enum DummyEnum {
+      ENUM_VALUE
+    }
+
   }
 
   private static final String DOMAIN = "otel.jmx.test";
@@ -201,5 +220,21 @@ class AttributeExtractorTest {
     BeanAttributeExtractor extractor = BeanAttributeExtractor.fromName("StringAttribute");
     AttributeInfo info = extractor.getAttributeInfo(theServer, objectName);
     assertThat(info == null).isTrue();
+  }
+
+  @Test
+  void testBooleanAttribute() throws Exception {
+    BeanAttributeExtractor extractor = BeanAttributeExtractor.fromName("BooleanAttribute");
+    AttributeInfo info = extractor.getAttributeInfo(theServer, objectName);
+    assertThat(info).isNull();
+    assertThat(extractor.extractValue(theServer, objectName)).isEqualTo("true");
+  }
+
+  @Test
+  void testEnumAttribute() throws Exception {
+    BeanAttributeExtractor extractor = BeanAttributeExtractor.fromName("EnumAttribute");
+    AttributeInfo info = extractor.getAttributeInfo(theServer, objectName);
+    assertThat(info).isNull();
+    assertThat(extractor.extractValue(theServer, objectName)).isEqualTo("ENUM_VALUE");
   }
 }

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/AttributeExtractorTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/AttributeExtractorTest.java
@@ -83,13 +83,12 @@ class AttributeExtractorTest {
 
     @Override
     public Enum<?> getEnumAttribute() {
-       return DummyEnum.ENUM_VALUE;
+      return DummyEnum.ENUM_VALUE;
     }
 
     private enum DummyEnum {
       ENUM_VALUE
     }
-
   }
 
   private static final String DOMAIN = "otel.jmx.test";


### PR DESCRIPTION
This PR adds the ability to use MBean attributes that have a `boolean` or an `enum` value to be used as metric attributes.

Relates to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12229