### PR TITLE
Add note to readme for difference between 1.x and 2.x releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ This package includes the instrumentation agent as well as
 instrumentations for all supported libraries and all available data exporters.
 The package provides a completely automatic, out-of-the-box experience.
 
+*Note: There are 2.x releases and 1.x releases. The 2.0 release included significant breaking
+changes, the details of which can be found in the [release notes](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0).
+It is recommended to use the latest 2.x release which will have the latest features and improvements.
+1.x will receive security patches for a limited time and will not include other bug fixes and
+enhancements.*
+
+
 Enable the instrumentation agent using the `-javaagent` flag to the JVM.
 
 ```


### PR DESCRIPTION
This question has come up a few times in discussions, and [someone requested](https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/11964#discussioncomment-10608758) we add it to the readme

Discussions:
https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/11964
https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/10980

