### PR TITLE
Convert gc duration metrics to seconds

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtil.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtil.java
@@ -6,18 +6,24 @@
 package io.opentelemetry.instrumentation.runtimemetrics.java17.internal;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 public final class DurationUtil {
-  private static final double NANOS_PER_SECOND = 1e9;
+  private static final double NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+  private static final double MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
 
   /** Returns the duration as seconds, with fractional part included. */
   public static double toSeconds(Duration duration) {
     double epochSecs = (double) duration.getSeconds();
     return epochSecs + duration.getNano() / NANOS_PER_SECOND;
+  }
+
+  public static double millisToSeconds(long milliseconds) {
+    return milliseconds / MILLIS_PER_SECOND;
   }
 
   private DurationUtil() {}

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/G1GarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/G1GarbageCollectionHandler.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.Constants;
+import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.DurationUtil;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.RecordedEventHandler;
 import java.time.Duration;
 import java.util.Optional;
@@ -40,7 +41,7 @@ public final class G1GarbageCollectionHandler implements RecordedEventHandler {
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(ev.getDouble(Constants.DURATION), ATTR);
+    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), ATTR);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/OldGarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/OldGarbageCollectionHandler.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.Constants;
+import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.DurationUtil;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.RecordedEventHandler;
 import java.time.Duration;
 import java.util.Optional;
@@ -40,7 +41,7 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(ev.getDouble(Constants.DURATION), attributes);
+    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), attributes);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/YoungGarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/YoungGarbageCollectionHandler.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.Constants;
+import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.DurationUtil;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.RecordedEventHandler;
 import java.time.Duration;
 import java.util.Optional;
@@ -41,7 +42,7 @@ public final class YoungGarbageCollectionHandler implements RecordedEventHandler
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(ev.getDouble(Constants.DURATION), attributes);
+    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), attributes);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtilTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtilTest.java
@@ -5,22 +5,24 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17.internal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class DurationUtilTest {
 
   @Test
-  void shouldConvertDurationToSeconds() {
-    // Given
+  void convertDurationToSeconds() {
     Duration duration = Duration.ofSeconds(7, 144);
-
-    // When
     double seconds = DurationUtil.toSeconds(duration);
+    assertThat(seconds).isEqualTo(7.000000144);
+  }
 
-    // Then
-    assertEquals(7.000000144, seconds);
+  @Test
+  void convertMillisSeconds() {
+    double seconds = DurationUtil.millisToSeconds(TimeUnit.SECONDS.toMillis(5));
+    assertThat(seconds).isEqualTo(5);
   }
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12084 changed the unit to seconds but forgot to convert the value from millis to seconds