### PR TITLE
Fix gc duration metric in runtime-telemetry-java17

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtil.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtil.java
@@ -14,16 +14,11 @@ import java.util.concurrent.TimeUnit;
  */
 public final class DurationUtil {
   private static final double NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
-  private static final double MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
 
   /** Returns the duration as seconds, with fractional part included. */
   public static double toSeconds(Duration duration) {
     double epochSecs = (double) duration.getSeconds();
     return epochSecs + duration.getNano() / NANOS_PER_SECOND;
-  }
-
-  public static double millisToSeconds(long milliseconds) {
-    return milliseconds / MILLIS_PER_SECOND;
   }
 
   private DurationUtil() {}

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/G1GarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/G1GarbageCollectionHandler.java
@@ -41,7 +41,7 @@ public final class G1GarbageCollectionHandler implements RecordedEventHandler {
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), ATTR);
+    histogram.record(DurationUtil.toSeconds(ev.getDuration()), ATTR);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/OldGarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/OldGarbageCollectionHandler.java
@@ -41,7 +41,7 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), attributes);
+    histogram.record(DurationUtil.toSeconds(ev.getDuration()), attributes);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/YoungGarbageCollectionHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/garbagecollection/YoungGarbageCollectionHandler.java
@@ -42,7 +42,7 @@ public final class YoungGarbageCollectionHandler implements RecordedEventHandler
 
   @Override
   public void accept(RecordedEvent ev) {
-    histogram.record(DurationUtil.millisToSeconds(ev.getLong(Constants.DURATION)), attributes);
+    histogram.record(DurationUtil.toSeconds(ev.getDuration()), attributes);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtilTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/DurationUtilTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.runtimemetrics.java17.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class DurationUtilTest {
@@ -18,11 +17,5 @@ class DurationUtilTest {
     Duration duration = Duration.ofSeconds(7, 144);
     double seconds = DurationUtil.toSeconds(duration);
     assertThat(seconds).isEqualTo(7.000000144);
-  }
-
-  @Test
-  void convertMillisSeconds() {
-    double seconds = DurationUtil.millisToSeconds(TimeUnit.SECONDS.toMillis(5));
-    assertThat(seconds).isEqualTo(5);
   }
 }


### PR DESCRIPTION
As pointed out in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12244#issuecomment-2351207187 the raw duration value isn't necessarily in millis (for me it is in nanos).