### PR TITLE
Fix flaky couchbase tests

### DIFF
--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
@@ -41,9 +41,8 @@ public class CouchbaseCoreInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class CouchbaseCoreAdvice {
 
-    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void addOperationIdToSpan(@Advice.Argument(0) CouchbaseRequest request) {
-
       VirtualField<CouchbaseRequest, CouchbaseRequestInfo> virtualField =
           VirtualField.find(CouchbaseRequest.class, CouchbaseRequestInfo.class);
       CouchbaseRequestInfo requestInfo = virtualField.get(request);


### PR DESCRIPTION
https://ge.opentelemetry.io/s/xz3tis5zw7xec/tests/task/:instrumentation:couchbase:couchbase-2.6:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.couchbase.v2_6.springdata.CouchbaseSpringTemplate26Test/remove(CouchbaseTemplate)%5B2%5D?expanded-stacktrace=WyIxIiwiMCJd&top-execution=1
During java conversion I made attributes that were previously optional, like `network.type`, required. This made tests flaky because there is race condition in the instrumentation where virtual field could be read before the value is set on another thread. Hopefully moving setting virtual field to the start of the method resolves the issue.