### PR TITLE
Don't reuse port for couchbase tests

### DIFF
--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
@@ -39,7 +39,6 @@ public abstract class AbstractCouchbaseTest {
   protected static final String USERNAME = "Administrator";
   protected static final String PASSWORD = "password";
 
-  private static final int port = PortUtils.findOpenPort();
   protected static final BucketSettings bucketCouchbase =
       DefaultBucketSettings.builder()
           .enableFlush(true)
@@ -56,6 +55,7 @@ public abstract class AbstractCouchbaseTest {
           .type(BucketType.MEMCACHED)
           .quota(100)
           .build();
+  private final int port = PortUtils.findOpenPort();
   private CouchbaseMock mock;
 
   @BeforeAll


### PR DESCRIPTION
https://ge.opentelemetry.io/s/6xjq4nwkrw2vg/console-log/task/:instrumentation:couchbase:couchbase-2.0:javaagent:test?anchor=449&page=1
when the `port` field it static tests in the same module that extend `AbstractCouchbaseTest` will use the same port which may cause `java.net.BindException: Address already in use`