### PR TITLE
Add rules for basic JVM monitoring to intstrumentation/jmx-metrics

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jvm.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/jvm.yaml
@@ -1,0 +1,77 @@
+---
+# based on: https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+rules:
+  - bean: java.lang:type=ClassLoading
+    prefix: jvm.classes.loaded.
+    mapping:
+      LoadedClassCount:
+        metric: count
+        type: updowncounter
+        unit: "{class}"
+        desc: number of loaded classes
+
+  - bean: java.lang:type=GarbageCollector,*
+    prefix: jvm.gc.collections.
+    metricAttribute:
+      name: param(name)
+    mapping:
+      CollectionCount:
+        metric: count
+        type: updowncounter
+        unit: "{collection}"
+        desc: total number of collections that have occurred
+      CollectionTime:
+        metric: elapsed
+        type: updowncounter
+        unit: ms
+        desc: the approximate accumulated collection elapsed time in milliseconds
+
+  - bean: java.lang:type=Memory
+    prefix: jvm.memory.
+    mapping:
+      HeapMemoryUsage.used:
+        metric: heap.used
+        type: updowncounter
+        unit: By
+        desc: current heap usage
+      HeapMemoryUsage.max:
+        metric: heap.max
+        type: gauge
+        unit: By
+        desc: max allowed heap
+      NonHeapMemoryUsage.used:
+        metric: nonHeap
+        type: updowncounter
+        unit: By
+        desc: current non-heap usage
+      NonHeapMemoryUsage.max:
+        metric: nonHeap.max
+        type: gauge
+        unit: By
+        desc: max allowed non-heap
+
+  - bean: java.lang:type=MemoryPool,*
+    prefix: jvm.memory.
+    metricAttribute:
+      name: param(name)
+    mapping:
+      Usage.used:
+        metric: pool.used
+        type: updowncounter
+        unit: By
+        desc: current memory pool usage
+      Usage.max:
+        metric: pool.max
+        type: gauge
+        unit: By
+        desc: max allowed memory pool 
+
+  - bean: java.lang:type=Threading
+    prefix: jvm.threads.
+    mapping:
+      ThreadCount:
+        metric: count
+        type: updowncounter
+        unit: "{thread}"
+        desc: number of threads
+      


### PR DESCRIPTION
I'd like to propose adding a set of rules for reporting basic JVM metrics (GC, memory, classloaders). I've seen some of these mentioned in the [README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/0c22a8e0c64cddbcb404a6159ee397b765481654/instrumentation/jmx-metrics/javaagent/README.md), though there's no built-in ruleset.

I've created my own basing on another otel project, and maybe this might be useful for others as well? (probably in combination with the rule sets already defined (for tomcat, kafka etc.)). Initially, I kind of expected these to be reported by default, but it turned out otherwise :) Unless there are other mechanisms for funnelling the basic JVM metrics into otel, that are preferable?