### PR TITLE
Don't write build scan link for the test partions task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ if (project.findProperty("skipTests") as String? == "true") {
   }
 }
 
-if (gradle.startParameter.taskNames.any { it.equals("listTestsInPartition") }) {
+if (gradle.startParameter.taskNames.contains("listTestsInPartition")) {
   tasks {
     val listTestsInPartition by registering {
       group = "Help"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,9 +65,11 @@ if (useScansGradleCom) {
         fileFingerprints = true
       }
 
-      buildScanPublished {
-        File("build-scan.txt").printWriter().use { writer ->
-          writer.println(buildScanUri)
+      if (!gradle.startParameter.taskNames.contains("listTestsInPartition")) {
+        buildScanPublished {
+          File("build-scan.txt").printWriter().use { writer ->
+            writer.println(buildScanUri)
+          }
         }
       }
     }
@@ -89,9 +91,11 @@ if (useScansGradleCom) {
         value("Smoke test suite", it)
       }
 
-      buildScanPublished {
-        File("build-scan.txt").printWriter().use { writer ->
-          writer.println(buildScanUri)
+      if (!gradle.startParameter.taskNames.contains("listTestsInPartition")) {
+        buildScanPublished {
+          File("build-scan.txt").printWriter().use { writer ->
+            writer.println(buildScanUri)
+          }
         }
       }
     }


### PR DESCRIPTION
Our tests invoke gradle twice. First to figure out which tests tasks to run, using the `listTestsInPartition` task, and after that to actually run the tasks. To make finding the build scan link easier at the end of the gradle build we write it to `build-scan.txt`. This PR skips writing `build-scan.txt` when the `listTestsInPartition` task is run. Sometimes gradle publish fails in the main build and we end up having `build-scan.txt` containing the link from `listTestsInPartition` which is not useful, might as well not write it.