### PR TITLE
Add timeout to apache http client 5 async test

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpAsyncClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpAsyncClientTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -114,7 +115,7 @@ class ApacheHttpAsyncClientTest {
 
     @Override
     HttpResponse executeRequest(SimpleHttpRequest request, URI uri) throws Exception {
-      return client.execute(request, getContext(), null).get();
+      return client.execute(request, getContext(), null).get(30, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12333
```
2024-09-26T05:22:58.6869224Z * What went wrong:
2024-09-26T05:22:58.6870806Z Execution failed for task ':instrumentation:apache-httpclient:apache-httpclient-5.0:javaagent:test'.
2024-09-26T05:22:58.6872059Z > Timeout has been exceeded
```
Hopefully adding a timeout will let the test fail in better way.