### PR TITLE
test with pekko 1.1.1

### DIFF
--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
@@ -21,7 +21,7 @@ muzzle {
 dependencies {
   bootstrap(project(":instrumentation:executors:bootstrap"))
 
-  library("org.apache.pekko:pekko-actor_2.12:1.0.1")
+  library("org.apache.pekko:pekko-actor_2.12:1.1.1")
 
   latestDepTestLibrary("org.apache.pekko:pekko-actor_2.13:+")
 

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -9,20 +9,20 @@ muzzle {
     module.set("pekko-http_2.12")
     versions.set("[1.0,)")
     assertInverse.set(true)
-    extraDependency("org.apache.pekko:pekko-stream_2.12:1.0.1")
+    extraDependency("org.apache.pekko:pekko-stream_2.12:1.1.1")
   }
   pass {
     group.set("org.apache.pekko")
     module.set("pekko-http_2.13")
     versions.set("[1.0,)")
     assertInverse.set(true)
-    extraDependency("org.apache.pekko:pekko-stream_2.13:1.0.1")
+    extraDependency("org.apache.pekko:pekko-stream_2.13:1.1.1")
   }
 }
 
 dependencies {
-  library("org.apache.pekko:pekko-http_2.12:1.0.0")
-  library("org.apache.pekko:pekko-stream_2.12:1.0.1")
+  library("org.apache.pekko:pekko-http_2.12:1.1.0-M1")
+  library("org.apache.pekko:pekko-stream_2.12:1.1.1")
 
   testInstrumentation(project(":instrumentation:pekko:pekko-actor-1.0:javaagent"))
   testInstrumentation(project(":instrumentation:executors:javaagent"))


### PR DESCRIPTION
Pekko 1.1.1 enables Scala 2 compiler inlining and this has caused some trouble for tools like Kamon which instrument Pekko code at runtime using a similar approach to OpenTelemetry.
The aim is to test with Pekko 1.1.1 to see if any tests fail.

Related discussion at https://github.com/apache/pekko/discussions/1487 and related issues.