### PR TITLE
Fix: `http_route` is not recorded by server metric while using servlet 2/3 #12353

### DIFF
--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -39,6 +39,12 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
+  public String getHttpRoute(ServletRequestContext<REQUEST> requestContext) {
+    return accessor.getRequestUri(requestContext.request());
+  }
+
+  @Nullable
+  @Override
   public String getUrlQuery(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestQueryString(requestContext.request());
   }


### PR DESCRIPTION
Class `ServletHttpAttributesGetter`always returns null for the getHttpRoute() function because it does not override the getHttpRoute() method. As a result, the class uses the default function from its superclass and `http_route` will be assigned to `null`