### PR TITLE
add muzzle checks for Scala 3 jars of Pekko

### DIFF
--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
@@ -16,6 +16,12 @@ muzzle {
     versions.set("[1.0,)")
     assertInverse.set(true)
   }
+  pass {
+    group.set("org.apache.pekko")
+    module.set("pekko-actor_3")
+    versions.set("[1.0,)")
+    assertInverse.set(true)
+  }
 }
 
 dependencies {

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -18,6 +18,13 @@ muzzle {
     assertInverse.set(true)
     extraDependency("org.apache.pekko:pekko-stream_2.13:1.0.1")
   }
+  pass {
+    group.set("org.apache.pekko")
+    module.set("pekko-http_3")
+    versions.set("[1.0,)")
+    assertInverse.set(true)
+    extraDependency("org.apache.pekko:pekko-stream_3:1.0.1")
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Seems useful to validate the Scala 3 jars for Pekko as well as the Scala 2.12/2.13 jars.