### PR TITLE
make pekko test code more scala 3 friendly

### DIFF
--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpClientInstrumentationTest.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpClientInstrumentationTest.scala
@@ -43,8 +43,7 @@ class PekkoHttpClientInstrumentationTest
     HttpClientInstrumentationExtension.forAgent()
 
   val system: ActorSystem = ActorSystem.create()
-  implicit val materializer: ActorMaterializer =
-    ActorMaterializer.create(system)
+  val materializer: ActorMaterializer = ActorMaterializer.create(system)
 
   override def buildRequest(
       method: String,

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpServerRouteTest.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpServerRouteTest.scala
@@ -25,7 +25,6 @@ import org.apache.pekko.http.scaladsl.server.Directives.{
   pathPrefix,
   pathSingleSlash
 }
-import org.apache.pekko.stream.ActorMaterializer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.{AfterAll, Test, TestInstance}
@@ -42,7 +41,6 @@ class PekkoHttpServerRouteTest {
   private val client: WebClient = WebClient.of()
 
   implicit val system: ActorSystem = ActorSystem("my-system")
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   private def buildAddress(port: Int): URI = try
     new URI("http://localhost:" + port + "/")

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestAsyncWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestAsyncWebServer.scala
@@ -10,7 +10,6 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.Http.ServerBinding
 import org.apache.pekko.http.scaladsl.model.HttpMethods.GET
 import org.apache.pekko.http.scaladsl.model._
-import org.apache.pekko.stream.ActorMaterializer
 import io.opentelemetry.instrumentation.testing.junit.http.{
   AbstractHttpServerTest,
   ServerEndpoint
@@ -22,7 +21,6 @@ import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 object PekkoHttpTestAsyncWebServer {
   implicit val system: ActorSystem = ActorSystem("my-system")
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
   val asyncHandler: HttpRequest => Future[HttpResponse] = {

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
@@ -13,16 +13,14 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.Http.ServerBinding
 import org.apache.pekko.http.scaladsl.model.StatusCodes.Found
 import org.apache.pekko.http.scaladsl.server.Directives._
-import org.apache.pekko.stream.ActorMaterializer
 import org.apache.pekko.stream.scaladsl.Sink
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 
 object PekkoHttpTestServerSourceWebServer {
-  implicit val system = ActorSystem("my-system")
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("my-system")
   // needed for the future flatMap/onComplete in the end
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContext = system.dispatcher
 
   var route = get {
     concat(

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestSyncWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestSyncWebServer.scala
@@ -10,7 +10,6 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.Http.ServerBinding
 import org.apache.pekko.http.scaladsl.model.HttpMethods.GET
 import org.apache.pekko.http.scaladsl.model._
-import org.apache.pekko.stream.ActorMaterializer
 import io.opentelemetry.instrumentation.testing.junit.http.{
   AbstractHttpServerTest,
   ServerEndpoint
@@ -18,13 +17,12 @@ import io.opentelemetry.instrumentation.testing.junit.http.{
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint._
 
 import java.util.function.Supplier
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 
 object PekkoHttpTestSyncWebServer {
-  implicit val system = ActorSystem("my-system")
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("my-system")
   // needed for the future flatMap/onComplete in the end
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContext = system.dispatcher
   val syncHandler: HttpRequest => HttpResponse = {
     case HttpRequest(GET, uri: Uri, _, _, _) => {
       val endpoint = ServerEndpoint.forPath(uri.path.toString())

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
@@ -13,15 +13,13 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.Http.ServerBinding
 import org.apache.pekko.http.scaladsl.model.StatusCodes.Found
 import org.apache.pekko.http.scaladsl.server.Directives._
-import org.apache.pekko.stream.ActorMaterializer
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 
 object PekkoHttpTestWebServer {
-  implicit val system = ActorSystem("my-system")
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("my-system")
   // needed for the future flatMap/onComplete in the end
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContext = system.dispatcher
 
   var route = get {
     concat(


### PR DESCRIPTION
Scala 3 compiler requires that implicit variables have explicit types.