### PR TITLE
Retry couchbase startup

### DIFF
--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1_6/CouchbaseClient316Test.java
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1_6/CouchbaseClient316Test.java
@@ -47,6 +47,7 @@ class CouchbaseClient316Test {
             .withEnabledServices(CouchbaseService.KV)
             .withBucket(new BucketDefinition("test"))
             .withLogConsumer(new Slf4jLogConsumer(logger))
+            .withStartupAttempts(5)
             .withStartupTimeout(Duration.ofMinutes(2));
     couchbase.start();
 

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseClient31Test.java
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseClient31Test.java
@@ -47,6 +47,7 @@ class CouchbaseClient31Test {
             .withEnabledServices(CouchbaseService.KV)
             .withBucket(new BucketDefinition("test"))
             .withLogConsumer(new Slf4jLogConsumer(logger))
+            .withStartupAttempts(5)
             .withStartupTimeout(Duration.ofMinutes(2));
     couchbase.start();
 


### PR DESCRIPTION
https://ge.opentelemetry.io/s/vrvifjmsbhx7w/tests/task/:instrumentation:couchbase:couchbase-3.1.6:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.couchbase.v3_1_6.CouchbaseClient316Test?expanded-stacktrace=WyIwLTEtMi0zLTQiLCIwIiwiMC0xLTItMyJd&top-execution=2
In couchbase 3.1 and 3.1.6 tests starting the container is flaky (in 3.2 test seems to work fine). Let testcontainers retry, hopefully this will avoid the test being marked as flaky.