### PR TITLE
Align SpringConfigProperties with DefaultConfigProperties

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
@@ -66,7 +66,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Nullable
   @Override
   public String getString(String name) {
-    String normalizedName = ConfigUtil.normalizePropertyKey(name);
+    String normalizedName = ConfigUtil.normalizeEnvironmentVariableKey(name);
     String value = environment.getProperty(normalizedName, String.class);
     if (value == null && normalizedName.equals("otel.exporter.otlp.protocol")) {
       // SDK autoconfigure module defaults to `grpc`, but this module aligns with recommendation
@@ -80,7 +80,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Boolean getBoolean(String name) {
     return or(
-        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Boolean.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Boolean.class),
         otelSdkProperties.getBoolean(name));
   }
 
@@ -88,7 +88,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Integer getInt(String name) {
     return or(
-        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Integer.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Integer.class),
         otelSdkProperties.getInt(name));
   }
 
@@ -96,7 +96,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Long getLong(String name) {
     return or(
-        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Long.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Long.class),
         otelSdkProperties.getLong(name));
   }
 
@@ -104,14 +104,15 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Double getDouble(String name) {
     return or(
-        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Double.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Double.class),
         otelSdkProperties.getDouble(name));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public List<String> getList(String name) {
-    String normalizedName = ConfigUtil.normalizePropertyKey(name);
+
+    String normalizedName = ConfigUtil.normalizeEnvironmentVariableKey(name);
 
     if (normalizedName.equals("otel.propagators")) {
       return propagationProperties.getPropagators();
@@ -136,7 +137,7 @@ public class SpringConfigProperties implements ConfigProperties {
   public Map<String, String> getMap(String name) {
     Map<String, String> otelSdkMap = otelSdkProperties.getMap(name);
 
-    String normalizedName = ConfigUtil.normalizePropertyKey(name);
+    String normalizedName = ConfigUtil.normalizeEnvironmentVariableKey(name);
     // maps from config properties are not supported by Environment, so we have to fake it
     switch (normalizedName) {
       case "otel.resource.attributes":

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties;
 
+import io.opentelemetry.api.internal.ConfigUtil;
 import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
@@ -65,8 +66,9 @@ public class SpringConfigProperties implements ConfigProperties {
   @Nullable
   @Override
   public String getString(String name) {
-    String value = environment.getProperty(name, String.class);
-    if (value == null && name.equals("otel.exporter.otlp.protocol")) {
+    String normalizedName = ConfigUtil.normalizePropertyKey(name);
+    String value = environment.getProperty(normalizedName, String.class);
+    if (value == null && normalizedName.equals("otel.exporter.otlp.protocol")) {
       // SDK autoconfigure module defaults to `grpc`, but this module aligns with recommendation
       // in specification to default to `http/protobuf`
       return OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
@@ -77,35 +79,45 @@ public class SpringConfigProperties implements ConfigProperties {
   @Nullable
   @Override
   public Boolean getBoolean(String name) {
-    return or(environment.getProperty(name, Boolean.class), otelSdkProperties.getBoolean(name));
+    return or(
+        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Boolean.class),
+        otelSdkProperties.getBoolean(name));
   }
 
   @Nullable
   @Override
   public Integer getInt(String name) {
-    return or(environment.getProperty(name, Integer.class), otelSdkProperties.getInt(name));
+    return or(
+        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Integer.class),
+        otelSdkProperties.getInt(name));
   }
 
   @Nullable
   @Override
   public Long getLong(String name) {
-    return or(environment.getProperty(name, Long.class), otelSdkProperties.getLong(name));
+    return or(
+        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Long.class),
+        otelSdkProperties.getLong(name));
   }
 
   @Nullable
   @Override
   public Double getDouble(String name) {
-    return or(environment.getProperty(name, Double.class), otelSdkProperties.getDouble(name));
+    return or(
+        environment.getProperty(ConfigUtil.normalizePropertyKey(name), Double.class),
+        otelSdkProperties.getDouble(name));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public List<String> getList(String name) {
-    if (name.equals("otel.propagators")) {
+    String normalizedName = ConfigUtil.normalizePropertyKey(name);
+
+    if (normalizedName.equals("otel.propagators")) {
       return propagationProperties.getPropagators();
     }
 
-    return or(environment.getProperty(name, List.class), otelSdkProperties.getList(name));
+    return or(environment.getProperty(normalizedName, List.class), otelSdkProperties.getList(name));
   }
 
   @Nullable
@@ -123,8 +135,10 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Map<String, String> getMap(String name) {
     Map<String, String> otelSdkMap = otelSdkProperties.getMap(name);
+
+    String normalizedName = ConfigUtil.normalizePropertyKey(name);
     // maps from config properties are not supported by Environment, so we have to fake it
-    switch (name) {
+    switch (normalizedName) {
       case "otel.resource.attributes":
         return mergeWithOtel(resourceProperties.getAttributes(), otelSdkMap);
       case "otel.exporter.otlp.headers":
@@ -139,7 +153,7 @@ public class SpringConfigProperties implements ConfigProperties {
         break;
     }
 
-    String value = environment.getProperty(name);
+    String value = environment.getProperty(normalizedName);
     if (value == null) {
       return otelSdkMap;
     }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -110,8 +110,12 @@ class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest 
       return customizer ->
           customizer.addResourceCustomizer(
               (resource, config) -> {
-                String propValue = config.getString("APPLICATION-PROP");
-                assertThat(propValue).isNotEmpty();
+                String valueForKeyDeclaredZsEnvVariable = config.getString("APPLICATION_PROP");
+                assertThat(valueForKeyDeclaredZsEnvVariable).isNotEmpty();
+
+                String valueForKeyWithDash = config.getString("application.prop-with-dash");
+                assertThat(valueForKeyWithDash).isNotEmpty();
+
                 return resource;
               });
     }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -104,6 +104,17 @@ class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest 
                           Attributes.of(
                               AttributeKey.booleanKey("keyFromResourceCustomizer"), true))));
     }
+
+    @Bean
+    AutoConfigurationCustomizerProvider customizerUsingPropertyDefinedInASpringFile() {
+      return customizer ->
+          customizer.addResourceCustomizer(
+              (resource, config) -> {
+                String propValue = config.getString("APPLICATION-PROP");
+                assertThat(propValue).isNotEmpty();
+                return resource;
+              });
+    }
   }
 
   @Test

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -106,7 +106,7 @@ class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest 
     }
 
     @Bean
-    AutoConfigurationCustomizerProvider customizerUsingPropertyDefinedInASpringFile() {
+    AutoConfigurationCustomizerProvider customizerUsingPropertyDefinedInaSpringFile() {
       return customizer ->
           customizer.addResourceCustomizer(
               (resource, config) -> {

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/resources/application.yaml
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/resources/application.yaml
@@ -19,6 +19,9 @@ otel:
     attributes:
       attributeFromYaml: true # boolean will be automatically converted to string by spring
 
+application:
+  prop: propValue
+
 spring:
   kafka:
     bootstrap-servers: localhost:9094

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/resources/application.yaml
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/resources/application.yaml
@@ -21,6 +21,7 @@ otel:
 
 application:
   prop: propValue
+  prop-with-dash: provWithDashValue
 
 spring:
   kafka:


### PR DESCRIPTION
`DefaultConfigProperties` allows the user to retrieve a property value from an environment variable.

This modification allows the user to get a property value from an environment variable and from the implementation of an [OTel SDK SPI](https://opentelemetry.io/docs/languages/java/configuration/#spi-service-provider-interface) declared as a bean.