### PR TITLE
Ability to set Logback argument capture with a property in Spring Boot Starter

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
@@ -115,6 +115,14 @@ class LogbackAppenderInstaller {
       openTelemetryAppender.setCaptureLoggerContext(loggerContextAttributes.booleanValue());
     }
 
+    Boolean captureArguments =
+        evaluateBooleanProperty(
+            applicationEnvironmentPreparedEvent,
+            "otel.instrumentation.logback-appender.experimental.capture-arguments");
+    if (captureArguments != null) {
+      openTelemetryAppender.setCaptureArguments(captureArguments.booleanValue());
+    }
+
     String mdcAttributeProperty =
         applicationEnvironmentPreparedEvent
             .getEnvironment()


### PR DESCRIPTION
Related to #12431

It was not possible the configure the argument capture of the Logback starter instrumentation from a property.