### PR TITLE
Clean the Logback instrumentation of the OTel starter

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
@@ -30,15 +30,14 @@ class LogbackAppenderInstaller {
 
   private static boolean isLogbackAppenderAddable(
       ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent) {
-    Boolean otelSdkDisableProperty =
-        evaluateBooleanProperty(applicationEnvironmentPreparedEvent, "otel.sdk.disabled");
-    Boolean logbackInstrumentationEnabledProperty =
+    boolean otelSdkDisabled =
+        evaluateBooleanProperty(applicationEnvironmentPreparedEvent, "otel.sdk.disabled", false);
+    boolean logbackInstrumentationEnabled =
         evaluateBooleanProperty(
-            applicationEnvironmentPreparedEvent, "otel.instrumentation.logback-appender.enabled");
-    return otelSdkDisableProperty == null
-        || !otelSdkDisableProperty.booleanValue()
-        || logbackInstrumentationEnabledProperty == null
-        || logbackInstrumentationEnabledProperty.booleanValue();
+            applicationEnvironmentPreparedEvent,
+            "otel.instrumentation.logback-appender.enabled",
+            true);
+    return !otelSdkDisabled && logbackInstrumentationEnabled;
   }
 
   private static void reInitializeOpenTelemetryAppender(
@@ -139,6 +138,15 @@ class LogbackAppenderInstaller {
     return applicationEnvironmentPreparedEvent
         .getEnvironment()
         .getProperty(property, Boolean.class);
+  }
+
+  private static boolean evaluateBooleanProperty(
+      ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent,
+      String property,
+      boolean defaultValue) {
+    return applicationEnvironmentPreparedEvent
+        .getEnvironment()
+        .getProperty(property, Boolean.class, defaultValue);
   }
 
   private static Optional<OpenTelemetryAppender> findOpenTelemetryAppender() {

--- a/smoke-tests-otel-starter/spring-boot-3/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterWithLogbackInstrumentationDisabledSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-3/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterWithLogbackInstrumentationDisabledSmokeTest.java
@@ -8,14 +8,10 @@ package io.opentelemetry.spring.smoketest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 
 @SpringBootTest(
     classes = {
@@ -24,25 +20,17 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
       SpringSmokeOtelConfiguration.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {"otel.sdk.disabled=true"})
+    properties = {"otel.instrumentation.logback-appender.enabled=false"})
 @DisabledInNativeImage // Without this the native tests in the OtelSpringStarterSmokeTest class will
 // fail with org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "CUSTOMER" already exists
-class OtelSpringStarterDisabledSmokeTest extends AbstractSpringStarterSmokeTest {
-
-  @Autowired private TestRestTemplate testRestTemplate;
+class OtelSpringStarterWithLogbackInstrumentationDisabledSmokeTest
+    extends AbstractSpringStarterSmokeTest {
 
   @Test
-  void shouldNotSendTelemetry() throws InterruptedException {
-    testRestTemplate.getForObject(OtelSpringStarterSmokeTestController.PING, String.class);
+  void shouldNotSendLogRecordTelemetry() throws InterruptedException {
 
     // See SpringSmokeOtelConfiguration
     Thread.sleep(200);
-
-    List<SpanData> exportedSpans = testing.getExportedSpans();
-    assertThat(exportedSpans).isEmpty();
-
-    List<MetricData> exportedMetrics = testing.getExportedMetrics();
-    assertThat(exportedMetrics).isEmpty();
 
     List<LogRecordData> exportedLogRecords = testing.getExportedLogRecords();
     assertThat(exportedLogRecords).isEmpty();


### PR DESCRIPTION
Related to #11610

The new implementation does not change the behavior seen by te user (even if the OpenTelemetry appender was added even if it was not necessary) because the installation of `OpenTelemetry` into the appender depends on the `otel.sdk.disabled` and `otel.instrumentation.logback-appender.enabled` properties:

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/de11929beaca8a55bc8adf3cf34db01a4dd85c95/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/logging/OpenTelemetryAppenderAutoConfiguration.java#L35

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/de11929beaca8a55bc8adf3cf34db01a4dd85c95/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/ConditionalOnEnabledInstrumentation.java#L23

The new tests have the same behavior with the previous implementation and the new one.

