### PR TITLE
Small changes to servlet3 tests

### DIFF
--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/RequestDispatcherServlet.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/RequestDispatcherServlet.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat;
+package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
 import java.io.IOException;
 import javax.servlet.RequestDispatcher;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TestServlet3.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TestServlet3.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat;
+package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.controller;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3AsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3AsyncTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 
-public class JettyServlet3AsyncTest extends JettyServlet3Test {
+class JettyServlet3AsyncTest extends JettyServlet3Test {
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3FakeAsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3FakeAsyncTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 
-public class JettyServlet3FakeAsyncTest extends JettyServlet3Test {
+class JettyServlet3FakeAsyncTest extends JettyServlet3Test {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.FakeAsync.class;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3SyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServlet3SyncTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 
-public class JettyServlet3SyncTest extends JettyServlet3Test {
+class JettyServlet3SyncTest extends JettyServlet3Test {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.Sync.class;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServletHandlerTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServletHandlerTest.java
@@ -15,7 +15,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.AbstractServlet3Test;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.HttpAttributes;
@@ -30,7 +30,7 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandler> {
+class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandler> {
 
   @RegisterExtension
   protected static final InstrumentationExtension testing =

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyDispatchTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyDispatchTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty.dispatch;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty.JettyServlet3Test;
 
-public abstract class JettyDispatchTest extends JettyServlet3Test {
+abstract class JettyDispatchTest extends JettyServlet3Test {
 
   @Override
   protected void configure(HttpServerTestOptions options) {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3DispatchAsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3DispatchAsyncTest.java
@@ -15,11 +15,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
-public class JettyServlet3DispatchAsyncTest extends JettyDispatchTest {
+class JettyServlet3DispatchAsyncTest extends JettyDispatchTest {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.Async.class;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3DispatchImmediateTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3DispatchImmediateTest.java
@@ -15,11 +15,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
-public class JettyServlet3DispatchImmediateTest extends JettyDispatchTest {
+class JettyServlet3DispatchImmediateTest extends JettyDispatchTest {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.Async.class;

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3ForwardTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3ForwardTest.java
@@ -15,12 +15,12 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.RequestDispatcherServlet;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
-public class JettyServlet3ForwardTest extends JettyDispatchTest {
+class JettyServlet3ForwardTest extends JettyDispatchTest {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.Sync.class; // dispatch to sync servlet

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3IncludeTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/dispatch/JettyServlet3IncludeTest.java
@@ -15,12 +15,12 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.RequestDispatcherServlet;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
-public class JettyServlet3IncludeTest extends JettyDispatchTest {
+class JettyServlet3IncludeTest extends JettyDispatchTest {
   @Override
   public Class<? extends Servlet> servlet() {
     return TestServlet3.Sync.class; // dispatch to sync servlet

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3AsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3AsyncTest.java
@@ -5,16 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3AsyncTest extends TomcatServlet3Test {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3FakeAsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3FakeAsyncTest.java
@@ -5,16 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3FakeAsyncTest extends TomcatServlet3Test {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3SyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3SyncTest.java
@@ -5,16 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3SyncTest extends TomcatServlet3Test {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3Test.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/TomcatServlet3Test.java
@@ -12,6 +12,8 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.AbstractServlet3Test;
@@ -38,10 +40,15 @@ import org.apache.catalina.startup.Tomcat;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> {
+
+  @RegisterExtension
+  protected static final InstrumentationExtension testing =
+      HttpServerInstrumentationExtension.forAgent();
 
   private static final ServerEndpoint ACCESS_LOG_SUCCESS =
       new ServerEndpoint(

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3DispatchAsyncTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3DispatchAsyncTest.java
@@ -15,19 +15,12 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.apache.catalina.Context;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3DispatchAsyncTest extends TomcatDispatchTest {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   protected void configure(HttpServerTestOptions options) {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3DispatchImmediateTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3DispatchImmediateTest.java
@@ -15,19 +15,12 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.apache.catalina.Context;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3DispatchImmediateTest extends TomcatDispatchTest {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3ForwardTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3ForwardTest.java
@@ -15,20 +15,13 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.RequestDispatcherServlet;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.apache.catalina.Context;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3ForwardTest extends TomcatDispatchTest {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3IncludeTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/tomcat/dispatch/TomcatServlet3IncludeTest.java
@@ -14,20 +14,13 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.tomcat.TestServlet3;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.RequestDispatcherServlet;
+import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import javax.servlet.Servlet;
 import org.apache.catalina.Context;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatServlet3IncludeTest extends TomcatDispatchTest {
-
-  @RegisterExtension
-  protected static final InstrumentationExtension testing =
-      HttpServerInstrumentationExtension.forAgent();
 
   @Override
   public Class<? extends Servlet> servlet() {


### PR DESCRIPTION
- move classes used by both jetty and tomcat out of tomcat package
- make classes that don't need to be public package private
- for tomcat tests move registering testing extension to base class similarly to how it is for jetty tests