### PR TITLE
Update apidiff baseline to released version 2.9.0

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -94,9 +94,9 @@ jobs:
           else
             echo "Licenses are not up-to-date, please run './gradlew generateLicenseReport --no-build-cache' locally and commit."
             echo
-            echo "$(git diff --cached --stat licenses)"
+            git diff --cached --stat licenses
             echo
-            echo "$(git diff --cached licenses)"
+            git diff --cached licenses
             exit 1
           fi
 
@@ -165,8 +165,8 @@ jobs:
             echo "No diff detected."
           else
             echo "Diff detected - did you run './gradlew jApiCmp'?"
-            echo $(git diff --cached --name-only)
-            echo $(git diff --cached)
+            git diff --cached --name-only
+            git diff --cached
             exit 1
           fi
 

--- a/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 val latestReleasedVersion: String by lazy {
   // hack to find the current released version of the project
   val temp: Configuration = configurations.create("tempConfig")
+  temp.resolutionStrategy.cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
   // pick the bom, since we don't use dependency substitution on it.
   dependencies.add(temp.name, "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:latest.release")
   val moduleVersion = configurations["tempConfig"].resolvedConfiguration.firstLevelModuleDependencies.elementAt(0).moduleVersion

--- a/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-instrumentation-annotations.txt
+++ b/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-instrumentation-annotations.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-instrumentation-annotations-2.9.0.jar against opentelemetry-instrumentation-annotations-2.8.0.jar
+No changes.

--- a/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-instrumentation-api.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-instrumentation-api-2.9.0.jar against opentelemetry-instrumentation-api-2.8.0.jar
+No changes.

--- a/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-spring-boot-autoconfigure.txt
+++ b/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-spring-boot-autoconfigure.txt
@@ -1,0 +1,5 @@
+Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.9.0.jar against opentelemetry-spring-boot-autoconfigure-2.8.0.jar
+===  UNCHANGED CLASS: PUBLIC io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED ANNOTATION: org.springframework.boot.context.properties.EnableConfigurationProperties
+		***  MODIFIED ELEMENT: value=io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtlpExporterProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelSpringProperties (<- io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtlpExporterProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.PropagationProperties)

--- a/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-spring-boot-starter.txt
+++ b/docs/apidiffs/2.9.0_vs_2.8.0/opentelemetry-spring-boot-starter.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-spring-boot-starter-2.9.0.jar against opentelemetry-spring-boot-starter-2.8.0.jar
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-instrumentation-annotations-2.10.0-SNAPSHOT.jar against opentelemetry-instrumentation-annotations-2.8.0.jar
+Comparing source compatibility of opentelemetry-instrumentation-annotations-2.10.0-SNAPSHOT.jar against opentelemetry-instrumentation-annotations-2.9.0.jar
 No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-instrumentation-api-2.10.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.8.0.jar
+Comparing source compatibility of opentelemetry-instrumentation-api-2.10.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.9.0.jar
 No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.10.0-SNAPSHOT.jar against opentelemetry-spring-boot-autoconfigure-2.8.0.jar
+Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.10.0-SNAPSHOT.jar against opentelemetry-spring-boot-autoconfigure-2.9.0.jar
 ===  UNCHANGED CLASS: PUBLIC io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	***  MODIFIED ANNOTATION: org.springframework.boot.context.properties.EnableConfigurationProperties

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
@@ -1,5 +1,2 @@
 Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.10.0-SNAPSHOT.jar against opentelemetry-spring-boot-autoconfigure-2.9.0.jar
-===  UNCHANGED CLASS: PUBLIC io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	***  MODIFIED ANNOTATION: org.springframework.boot.context.properties.EnableConfigurationProperties
-		***  MODIFIED ELEMENT: value=io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtlpExporterProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelSpringProperties (<- io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtlpExporterProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties,io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.PropagationProperties)
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-spring-boot-starter-2.10.0-SNAPSHOT.jar against opentelemetry-spring-boot-starter-2.8.0.jar
+Comparing source compatibility of opentelemetry-spring-boot-starter-2.10.0-SNAPSHOT.jar against opentelemetry-spring-boot-starter-2.9.0.jar
 No changes.


### PR DESCRIPTION
I think it's failing because we aren't using `--refresh-dependencies` in the CI japicmp check, but I'm reluctant to add that flag b/c then it would slow down all builds

I think it should clear itself up in <24 hours, maybe we can think of something better...