### PR TITLE
Fix derby directory connection string parser

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -752,7 +752,12 @@ public enum JdbcConnectionUrlParser {
         builder.subtype("directory").host(null).port(null);
         String urlInstance = details.substring("directory:".length());
         if (!urlInstance.isEmpty()) {
-          instance = urlInstance;
+          int dbNameStartLocation = urlInstance.lastIndexOf('/');
+          if (dbNameStartLocation != -1) {
+            instance = urlInstance.substring(dbNameStartLocation + 1);
+          } else {
+            instance = urlInstance;
+          }
         }
       } else if (details.startsWith("classpath:")) {
         builder.subtype("classpath").host(null).port(null);


### PR DESCRIPTION
Related to #12400 

Updates the derby connection parser to use the value after the last `/` to account for directory structures when pulling the database name out of a connection string like: `/usr/ibm/pep/was9/ibm/websphere/appserver/profiles/<REDACTED>/databases/ejbtimers/<HOST_REDACTED>/ejbtimerdb`

Unrelated to this change, I also refactored the tests a bit to have separate test methods and argument classes for each database type because I found having all databases in the same test made it annoying when debugging. If we would prefer to keep it the way it was I can swap it back.

The [issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12400) also reported a problem with Oracle parsing, but when using the connection string provided in a test, things seem to work as expected.