### PR TITLE
Update to new play smoke test image

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
@@ -17,7 +17,7 @@ import static io.opentelemetry.smoketest.TestContainerManager.useWindowsContaine
 class PlaySmokeTest extends SmokeTest {
 
   protected String getTargetImage(String jdk) {
-    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-play:jdk$jdk-20241018.11404849345"
+    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-play:jdk$jdk-20241021.11443123992"
   }
 
   @Override


### PR DESCRIPTION
Making sure these didn't break the play smoke test (given the current limitation of running the latest play version)
* https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12474
* https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12473