### PR TITLE
Pin play smoke test to guice 5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -150,6 +150,14 @@
       "enabled": false
     },
     {
+      // intentionally pinning specifically to guice 5 in the play smoke test
+      // until we are able to test against the latest version of play
+      "matchFileNames": ["smoke-tests/images/play/build.gradle.kts"],
+      "matchPackagePrefixes": ["com.google.inject:", "com.google.inject.extensions:"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       // intentionally aligning both netty 4.0 and 4.1 version in this convention
       "matchFileNames": ["conventions/src/main/kotlin/otel.java-conventions.gradle.kts"],
       "matchPackageNames": ["io.netty:netty-bom"],

--- a/smoke-tests/images/play/build.gradle.kts
+++ b/smoke-tests/images/play/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
   implementation("com.typesafe.play:play-guice_$scalaVer:$playVer")
   // Guice 5.1 is needed for Java 17 support on Play 2.8, see https://github.com/playframework/playframework/releases/tag/2.8.15
   // TODO (trask) remove these version overrides after updating to Play 2.9
-  implementation("com.google.inject:guice:7.0.0")
-  implementation("com.google.inject.extensions:guice-assistedinject:7.0.0")
+  implementation("com.google.inject:guice:5.1.0")
+  implementation("com.google.inject.extensions:guice-assistedinject:5.1.0")
   implementation("com.typesafe.play:play-logback_$scalaVer:$playVer")
   implementation("com.typesafe.play:filters-helpers_$scalaVer:$playVer")
 }


### PR DESCRIPTION
Guice 7 didn't work (#12486) because of api incompatibilities with older play version