### PR TITLE
Fix SpanKey bridging for unbridgeable span

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-api/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/SpanKeyInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-api/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/SpanKeyInstrumentation.java
@@ -99,7 +99,7 @@ final class SpanKeyInstrumentation implements TypeInstrumentation {
       io.opentelemetry.api.trace.Span agentSpan = agentSpanKey.fromContextOrNull(agentContext);
       if (agentSpan == null) {
         // Bridged agent span was not found. Run the original method, there could be an unbridged
-        // span stored it the application context.
+        // span stored in the application context.
         return null;
       }
 

--- a/instrumentation/opentelemetry-instrumentation-api/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/SpanKeyInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-api/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/SpanKeyInstrumentation.java
@@ -41,22 +41,16 @@ final class SpanKeyInstrumentation implements TypeInstrumentation {
 
   @SuppressWarnings("unused")
   public static class StoreInContextAdvice {
-    @Advice.OnMethodEnter(skipOn = Advice.OnDefaultValue.class)
-    public static Object onEnter() {
-      return null;
-    }
-
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(
+    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+    public static Context onEnter(
         @Advice.This SpanKey applicationSpanKey,
         @Advice.Argument(0) Context applicationContext,
-        @Advice.Argument(1) Span applicationSpan,
-        @Advice.Return(readOnly = false) Context newApplicationContext) {
+        @Advice.Argument(1) Span applicationSpan) {
 
       io.opentelemetry.instrumentation.api.internal.SpanKey agentSpanKey =
           SpanKeyBridging.toAgentOrNull(applicationSpanKey);
       if (agentSpanKey == null) {
-        return;
+        return null;
       }
 
       io.opentelemetry.context.Context agentContext =
@@ -64,41 +58,61 @@ final class SpanKeyInstrumentation implements TypeInstrumentation {
 
       io.opentelemetry.api.trace.Span agentSpan = Bridging.toAgentOrNull(applicationSpan);
       if (agentSpan == null) {
-        return;
+        // if application span can not be bridged to agent span, this could happen when it is not
+        // created through bridged GlobalOpenTelemetry, we'll let the original method run and
+        // store the span in context without bridging
+        return null;
       }
 
       io.opentelemetry.context.Context newAgentContext =
           agentSpanKey.storeInContext(agentContext, agentSpan);
 
-      newApplicationContext = AgentContextStorage.toApplicationContext(newAgentContext);
+      return AgentContextStorage.toApplicationContext(newAgentContext);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Enter Context newApplicationContext,
+        @Advice.Return(readOnly = false) Context result) {
+
+      if (newApplicationContext != null) {
+        result = newApplicationContext;
+      }
     }
   }
 
   @SuppressWarnings("unused")
   public static class FromContextOrNullAdvice {
-    @Advice.OnMethodEnter(skipOn = Advice.OnDefaultValue.class)
-    public static Object onEnter() {
-      return null;
-    }
-
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(
-        @Advice.This SpanKey applicationSpanKey,
-        @Advice.Argument(0) Context applicationContext,
-        @Advice.Return(readOnly = false) Span applicationSpan) {
+    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+    public static Span onEnter(
+        @Advice.This SpanKey applicationSpanKey, @Advice.Argument(0) Context applicationContext) {
 
       io.opentelemetry.instrumentation.api.internal.SpanKey agentSpanKey =
           SpanKeyBridging.toAgentOrNull(applicationSpanKey);
       if (agentSpanKey == null) {
-        return;
+        return null;
       }
 
       io.opentelemetry.context.Context agentContext =
           AgentContextStorage.getAgentContext(applicationContext);
 
       io.opentelemetry.api.trace.Span agentSpan = agentSpanKey.fromContextOrNull(agentContext);
+      if (agentSpan == null) {
+        // Bridged agent span was not found. Run the original method, there could be an unbridged
+        // span stored it the application context.
+        return null;
+      }
 
-      applicationSpan = agentSpan == null ? null : Bridging.toApplication(agentSpan);
+      return Bridging.toApplication(agentSpan);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Enter Span applicationSpan, @Advice.Return(readOnly = false) Span result) {
+
+      if (applicationSpan != null) {
+        result = applicationSpan;
+      }
     }
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.instrumentationapi;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.api.trace.Span;
@@ -18,6 +19,7 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.javaagent.instrumentation.testing.AgentSpanTesting;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.semconv.ErrorAttributes;
 import io.opentelemetry.semconv.HttpAttributes;
 import java.util.Arrays;
@@ -74,6 +76,18 @@ class ContextBridgeTest {
                   spanKeys.forEach(
                       spanKey -> assertNotNull(spanKey.fromContextOrNull(Context.current()))));
         });
+  }
+
+  @Test
+  void testSpanKeyBridge_unbridgedSpan() {
+    OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
+    // span is bridged only when it is created though a bridged OpenTelemetry instance obtained
+    // from GlobalOpenTelemetry
+    Span span = openTelemetry.getTracer("test").spanBuilder("test").startSpan();
+
+    Context context = SpanKey.HTTP_CLIENT.storeInContext(Context.current(), span);
+    assertThat(context).isNotNull();
+    assertThat(SpanKey.HTTP_CLIENT.fromContextOrNull(context)).isEqualTo(span);
   }
 
   @Test

--- a/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
@@ -79,7 +79,7 @@ class ContextBridgeTest {
   }
 
   @Test
-  void testSpanKeyBridge_unbridgedSpan() {
+  void testSpanKeyBridge_UnbridgedSpan() {
     OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().build();
     // span is bridged only when it is created though a bridged OpenTelemetry instance obtained
     // from GlobalOpenTelemetry


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12504
In case of unbridgeable span we currently return `null` context from `SpanKey.storeInContext` which is unexpected. This PR changes the behavior so that when the span can't be bridged we'll let the original method proceed and store the span using the unbridged key in the application context. Similarly reading the span will fall back to the application context when the span is not found from the agent context.