### PR TITLE
Fix some assertions

### DIFF
--- a/instrumentation/azure-core/azure-core-1.14/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_14/AzureSdkTest.java
+++ b/instrumentation/azure-core/azure-core-1.14/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_14/AzureSdkTest.java
@@ -55,6 +55,6 @@ class AzureSdkTest {
                     span.hasName("hello")
                         .hasKind(SpanKind.INTERNAL)
                         .hasStatus(StatusData.ok())
-                        .hasAttributesSatisfying(Attributes::isEmpty)));
+                        .hasAttributes(Attributes.empty())));
   }
 }

--- a/instrumentation/azure-core/azure-core-1.19/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_19/AzureSdkTest.java
+++ b/instrumentation/azure-core/azure-core-1.19/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_19/AzureSdkTest.java
@@ -55,6 +55,6 @@ class AzureSdkTest {
                     span.hasName("hello")
                         .hasKind(SpanKind.INTERNAL)
                         .hasStatus(StatusData.ok())
-                        .hasAttributesSatisfying(Attributes::isEmpty)));
+                        .hasAttributes(Attributes.empty())));
   }
 }

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTest.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.azurecore.v1_36;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.core.annotation.ExpectedResponses;
@@ -22,6 +23,7 @@ import com.azure.core.test.http.MockHttpResponse;
 import com.azure.core.util.ClientOptions;
 import com.azure.core.util.Context;
 import com.azure.core.util.TracingOptions;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
@@ -66,7 +68,8 @@ class AzureSdkTest {
                     span.hasName("hello")
                         .hasKind(SpanKind.INTERNAL)
                         .hasStatus(StatusData.unset())
-                        .hasAttributesSatisfying(Attributes::isEmpty)));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(AttributeKey.stringKey("az.namespace"), "otel.tests"))));
   }
 
   @Test

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTestOld.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTestOld.java
@@ -50,7 +50,7 @@ class AzureSdkTestOld {
                     span.hasName("hello")
                         .hasKind(SpanKind.INTERNAL)
                         .hasStatus(StatusData.unset())
-                        .hasAttributesSatisfying(Attributes::isEmpty)));
+                        .hasAttributes(Attributes.empty())));
   }
 
   private static com.azure.core.util.tracing.Tracer createAzTracer() {

--- a/instrumentation/grails-3.0/javaagent/src/test/java/test/GrailsTest.java
+++ b/instrumentation/grails-3.0/javaagent/src/test/java/test/GrailsTest.java
@@ -14,6 +14,8 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 
 import grails.boot.GrailsApp;
 import grails.boot.config.GrailsAutoConfiguration;
@@ -27,6 +29,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
@@ -160,12 +164,19 @@ public class GrailsTest extends AbstractHttpServerTest<ConfigurableApplicationCo
   @Override
   public SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
+    String methodName;
     if (endpoint == REDIRECT) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
+      methodName = "sendRedirect";
+    } else if (endpoint == ERROR || endpoint == NOT_FOUND) {
+      methodName = "sendError";
     } else {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            satisfies(CodeIncubatingAttributes.CODE_NAMESPACE, AbstractStringAssert::isNotEmpty));
     return span;
   }
 
@@ -178,13 +189,17 @@ public class GrailsTest extends AbstractHttpServerTest<ConfigurableApplicationCo
             span.hasName(
                     endpoint == NOT_FOUND ? "ErrorController.notFound" : "ErrorController.index")
                 .hasKind(SpanKind.INTERNAL)
-                .hasAttributesSatisfying(Attributes::isEmpty));
+                .hasAttributes(Attributes.empty()));
     if (endpoint == NOT_FOUND) {
       spanAssertions.add(
           span ->
               span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"))
                   .hasKind(SpanKind.INTERNAL)
-                  .hasAttributesSatisfying(Attributes::isEmpty));
+                  .hasAttributesSatisfyingExactly(
+                      equalTo(CodeIncubatingAttributes.CODE_FUNCTION, "sendError"),
+                      satisfies(
+                          CodeIncubatingAttributes.CODE_NAMESPACE,
+                          AbstractStringAssert::isNotEmpty)));
     }
     return spanAssertions;
   }

--- a/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
@@ -238,7 +238,7 @@ public abstract class AbstractGraphqlTest {
                         span.hasName("GraphQL Operation")
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
-                            .hasAttributesSatisfying(Attributes::isEmpty)
+                            .hasAttributes(Attributes.empty())
                             .hasStatus(StatusData.error())
                             .hasEventsSatisfyingExactly(
                                 event ->
@@ -280,7 +280,7 @@ public abstract class AbstractGraphqlTest {
                         span.hasName("GraphQL Operation")
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
-                            .hasAttributesSatisfying(Attributes::isEmpty)
+                            .hasAttributes(Attributes.empty())
                             .hasStatus(StatusData.error())
                             .hasEventsSatisfyingExactly(
                                 event ->

--- a/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
+++ b/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
@@ -14,10 +14,10 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
@@ -26,6 +26,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -69,12 +70,19 @@ class Jetty12HandlerTest extends AbstractHttpServerTest<Server> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
+    String methodName;
     if (endpoint == REDIRECT) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
+      methodName = "sendRedirect";
     } else if (endpoint == ERROR) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            equalTo(CodeIncubatingAttributes.CODE_NAMESPACE, "org.eclipse.jetty.server.Response"));
     return span;
   }
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/JettyHandlerTest.java
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/JettyHandlerTest.java
@@ -14,10 +14,10 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
@@ -26,6 +26,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collections;
@@ -89,12 +90,19 @@ class JettyHandlerTest extends AbstractHttpServerTest<Server> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
+    String methodName;
     if (endpoint == REDIRECT) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
+      methodName = "sendRedirect";
     } else if (endpoint == ERROR) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            equalTo(CodeIncubatingAttributes.CODE_NAMESPACE, "org.eclipse.jetty.server.Response"));
     return span;
   }
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/boot/AbstractSpringBootBasedTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/boot/AbstractSpringBootBasedTest.java
@@ -149,7 +149,7 @@ public abstract class AbstractSpringBootBasedTest
         span ->
             span.hasName("BasicErrorController.error")
                 .hasKind(SpanKind.INTERNAL)
-                .hasAttributesSatisfying(Attributes::isEmpty));
+                .hasAttributes(Attributes.empty()));
     return spanAssertions;
   }
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/filter/AbstractServletFilterTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/filter/AbstractServletFilterTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractServletFilterTest
         span ->
             span.hasName("BasicErrorController.error")
                 .hasKind(SpanKind.INTERNAL)
-                .hasAttributesSatisfying(Attributes::isEmpty));
+                .hasAttributes(Attributes.empty()));
     return spanAssertions;
   }
 

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.java
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.java
@@ -14,9 +14,10 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -25,6 +26,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import jakarta.servlet.Servlet;
 import java.io.File;
 import java.nio.file.Files;
@@ -32,6 +34,7 @@ import java.util.UUID;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.Tomcat;
+import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatAsyncTest extends AbstractHttpServerTest<Tomcat> {
@@ -116,12 +119,19 @@ class TomcatAsyncTest extends AbstractHttpServerTest<Tomcat> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
-    if (endpoint.equals(REDIRECT)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
-    } else if (endpoint.equals(NOT_FOUND)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+    String methodName;
+    if (endpoint == REDIRECT) {
+      methodName = "sendRedirect";
+    } else if (endpoint == NOT_FOUND) {
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            satisfies(CodeIncubatingAttributes.CODE_NAMESPACE, AbstractStringAssert::isNotEmpty));
     return span;
   }
 }

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.java
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.java
@@ -18,10 +18,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -30,6 +31,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
@@ -37,6 +39,7 @@ import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.startup.Tomcat;
+import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatHandlerTest extends AbstractHttpServerTest<Tomcat> {
@@ -116,12 +119,19 @@ class TomcatHandlerTest extends AbstractHttpServerTest<Tomcat> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
-    if (endpoint.equals(REDIRECT)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
-    } else if (endpoint.equals(NOT_FOUND)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+    String methodName;
+    if (endpoint == REDIRECT) {
+      methodName = "sendRedirect";
+    } else if (endpoint == NOT_FOUND || endpoint == ERROR) {
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            satisfies(CodeIncubatingAttributes.CODE_NAMESPACE, AbstractStringAssert::isNotEmpty));
     return span;
   }
 }

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.java
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.java
@@ -14,9 +14,10 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -25,12 +26,14 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.UUID;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.Tomcat;
+import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatAsyncTest extends AbstractHttpServerTest<Tomcat> {
@@ -111,12 +114,19 @@ class TomcatAsyncTest extends AbstractHttpServerTest<Tomcat> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
-    if (endpoint.equals(REDIRECT)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
-    } else if (endpoint.equals(NOT_FOUND)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+    String methodName;
+    if (endpoint == REDIRECT) {
+      methodName = "sendRedirect";
+    } else if (endpoint == NOT_FOUND) {
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            satisfies(CodeIncubatingAttributes.CODE_NAMESPACE, AbstractStringAssert::isNotEmpty));
     return span;
   }
 }

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.java
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.java
@@ -18,10 +18,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -30,6 +31,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
@@ -37,6 +39,7 @@ import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.startup.Tomcat;
+import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TomcatHandlerTest extends AbstractHttpServerTest<Tomcat> {
@@ -116,12 +119,19 @@ class TomcatHandlerTest extends AbstractHttpServerTest<Tomcat> {
   @Override
   protected SpanDataAssert assertResponseSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
-    if (endpoint.equals(REDIRECT)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendRedirect"));
-    } else if (endpoint.equals(NOT_FOUND)) {
-      span.satisfies(spanData -> assertThat(spanData.getName()).endsWith(".sendError"));
+    String methodName;
+    if (endpoint == REDIRECT) {
+      methodName = "sendRedirect";
+    } else if (endpoint == NOT_FOUND || endpoint == ERROR) {
+      methodName = "sendError";
+    } else {
+      throw new AssertionError("Unexpected endpoint: " + endpoint.name());
     }
-    span.hasKind(SpanKind.INTERNAL).hasAttributesSatisfying(Attributes::isEmpty);
+    span.hasKind(SpanKind.INTERNAL)
+        .satisfies(spanData -> assertThat(spanData.getName()).endsWith("." + methodName))
+        .hasAttributesSatisfyingExactly(
+            equalTo(CodeIncubatingAttributes.CODE_FUNCTION, methodName),
+            satisfies(CodeIncubatingAttributes.CODE_NAMESPACE, AbstractStringAssert::isNotEmpty));
     return span;
   }
 }


### PR DESCRIPTION
`hasAttributesSatisfying(Attributes::isEmpty)))` always passes since `isEmpty()` never throws an exception