### PR TITLE
Remove runtime scope from README.md

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -27,7 +27,7 @@ For Maven, add to your `pom.xml` dependencies:
 For Gradle, add to your dependencies:
 
 ```groovy
-runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:OPENTELEMETRY_VERSION")
 ```
 
 ### Usage

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -20,7 +20,6 @@ For Maven, add to your `pom.xml` dependencies:
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-log4j-appender-2.17</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
-    <scope>runtime</scope>
   </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
A trivial issue, the `runtime` scope setting will prevent the user from [importing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/bb90e0835a571a2464c8cca0bbe39dd01a24c9e2/instrumentation/log4j/log4j-appender-2.17/library/README.md?plain=1#L64) the class as illustrated below

    import io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppender;

thus, the documentation has contradicting paragraphs, and the PR attempts to fix that.