### PR TITLE
compatible different command line style for find jar path 

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
@@ -49,7 +49,8 @@ class MainJarPathFinder {
       if ("-jar".equals(javaArg)) {
         jarOptionFound = true;
       }
-      if (jarOptionFound && !javaArg.startsWith("-")) {
+      // flags can appear between -jar and the jar path, ignore them
+      else if (jarOptionFound && !javaArg.startsWith("-")) {
         return Paths.get(javaArg);
       }
     }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
@@ -48,9 +48,9 @@ class MainJarPathFinder {
     for (String javaArg : javaArgs) {
       if ("-jar".equals(javaArg)) {
         jarOptionFound = true;
-      }
-      // flags can appear between -jar and the jar path, ignore them
-      else if (jarOptionFound && !javaArg.startsWith("-")) {
+      } else if (jarOptionFound
+          && !javaArg.startsWith(
+              "-")) { // flags can appear between -jar and the jar path, ignore them
         return Paths.get(javaArg);
       }
     }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -74,7 +74,7 @@ class JarServiceNameDetectorTest {
   }
 
   @Test
-  void createResource_processHandleJar_jar_command_variant() {
+  void createResource_processHandleJarExtraFlag() {
     String path = Paths.get("path", "to", "app", "my-service.jar").toString();
     JarServiceNameDetector serviceNameProvider =
         getDetector(

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -75,9 +75,10 @@ class JarServiceNameDetectorTest {
 
   @Test
   void createResource_processHandleJar_jar_command_variant() {
+    String path = Paths.get("path", "to", "app", "my-service.jar").toString();
     JarServiceNameDetector serviceNameProvider =
         getDetector(
-            getArgs_jar_command_variant("my-service.jar"),
+            new String[] {"-Dtest=42", "-jar", "-Xmx512m", path, "abc", "def"},
             prop -> null,
             JarServiceNameDetectorTest::failPath);
 
@@ -103,11 +104,6 @@ class JarServiceNameDetectorTest {
   static String[] getArgs(String jarName) {
     String path = Paths.get("path", "to", "app", jarName).toString();
     return new String[] {"-Dtest=42", "-Xmx666m", "-jar", path, "abc", "def"};
-  }
-
-  static String[] getArgs_jar_command_variant(String jarName) {
-    String path = Paths.get("path", "to", "app", jarName).toString();
-    return new String[] {"-Dtest=42", "-jar", "-Xmx512m", path, "abc", "def"};
   }
 
   @ParameterizedTest

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -74,6 +74,21 @@ class JarServiceNameDetectorTest {
   }
 
   @Test
+  void createResource_processHandleJar_jar_command_variant() {
+    JarServiceNameDetector serviceNameProvider =
+        getDetector(
+            getArgs_jar_command_variant("my-service.jar"),
+            prop -> null,
+            JarServiceNameDetectorTest::failPath);
+
+    Resource resource = serviceNameProvider.createResource(config);
+
+    assertThat(resource.getAttributes())
+        .hasSize(1)
+        .containsEntry(ServiceAttributes.SERVICE_NAME, "my-service");
+  }
+
+  @Test
   void createResource_processHandleJarWithoutExtension() {
     JarServiceNameDetector serviceNameProvider =
         getDetector(getArgs("my-service"), prop -> null, JarServiceNameDetectorTest::failPath);
@@ -88,6 +103,11 @@ class JarServiceNameDetectorTest {
   static String[] getArgs(String jarName) {
     String path = Paths.get("path", "to", "app", jarName).toString();
     return new String[] {"-Dtest=42", "-Xmx666m", "-jar", path, "abc", "def"};
+  }
+
+  static String[] getArgs_jar_command_variant(String jarName) {
+    String path = Paths.get("path", "to", "app", jarName).toString();
+    return new String[] {"-Dtest=42", "-jar", "-Xmx666m", path, "abc", "def"};
   }
 
   @ParameterizedTest

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -107,7 +107,7 @@ class JarServiceNameDetectorTest {
 
   static String[] getArgs_jar_command_variant(String jarName) {
     String path = Paths.get("path", "to", "app", jarName).toString();
-    return new String[] {"-Dtest=42", "-jar", "-Xmx666m", path, "abc", "def"};
+    return new String[] {"-Dtest=42", "-jar", "-Xmx512m", path, "abc", "def"};
   }
 
   @ParameterizedTest


### PR DESCRIPTION
compatible command like : **java -jar -XX:MaxRAM=128m app.jar**
The JAR file name does not always come immediately after the **-jar** command; there may be other JVM parameters in between the two.

by now, if we use the java -jar -XX:MaxRAM=128m app.jar command to start the applicaion. we can not get the real jar name.
we will get the warn log like below:
`
otel.javaagent 2024-10-29 09:24:19:600 +0000] [main] WARN io.opentelemetry.instrumentation.resources.ManifestResourceProvider - Error reading manifest java.nio.file.NoSuchFileException: -XX:MaxRAM=128m
`

Resolves #12545