### PR TITLE
Run class load listener only once

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -137,7 +137,6 @@ public class AgentInstaller {
             .with(new RedefinitionDiscoveryStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
-            .with(new ClassLoadListener())
             .with(AgentTooling.transformListener())
             .with(AgentTooling.locationStrategy());
     if (JavaModule.isSupported()) {
@@ -172,6 +171,7 @@ public class AgentInstaller {
       agentListener.beforeAgent(autoConfiguredSdk);
     }
 
+    agentBuilder = agentBuilder.with(new ClassLoadListener());
     agentBuilder = configureIgnoredTypes(sdkConfig, extensionClassLoader, agentBuilder);
 
     int numberOfLoadedExtensions = 0;


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12444 we set up byte buddy twice. First before otel sdk is built we set up some virtual field transforms so that classes loaded during otel sdk initialization wouldn't need to use fallback map for virtual fields. Later when otel sdk is built we set up rest of the transforms. This PR removes class load listener from early byte buddy instance to ensure that class load listeners are triggered only once. Currently on wildfly where running after agent listeners is triggered by loading `java.util.logging.LogManager` (see https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java#L309) class load listener for `java.util.logging.LogManager` is triggered twice which causes a lot of warnings like
```
2024-11-03T05:27:34.9145838Z     App - STDERR: [otel.javaagent 2024-11-03 05:27:34:893 +0000] [PeriodicMetricReader-1] WARN io.opentelemetry.sdk.metrics.internal.state.AsynchronousMetricStorage - Instrument jvm.memory.used has recorded multiple values for the same attributes: {jvm.memory.pool.name="PS Survivor Space", jvm.memory.type="heap"}
```