### PR TITLE
Statically import semconv constants in tests

### DIFF
--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
@@ -8,6 +8,11 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -16,8 +21,6 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.HelloServiceImpl;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -135,23 +138,22 @@ public abstract class AbstractDubboTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "$invoke"),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                satisfies(SERVER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    ServerAttributes.SERVER_PORT, k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                    NETWORK_PEER_ADDRESS,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(String.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
+                                    NETWORK_PEER_PORT,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(Long.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -170,14 +172,9 @@ public abstract class AbstractDubboTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "hello"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                    k -> k.isInstanceOf(String.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_TYPE, AbstractAssert::isNull))));
+                                satisfies(NETWORK_PEER_ADDRESS, k -> k.isInstanceOf(String.class)),
+                                satisfies(NETWORK_PEER_PORT, k -> k.isInstanceOf(Long.class)),
+                                satisfies(NETWORK_TYPE, AbstractAssert::isNull))));
   }
 
   @Test
@@ -235,23 +232,22 @@ public abstract class AbstractDubboTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "$invokeAsync"),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                satisfies(SERVER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    ServerAttributes.SERVER_PORT, k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                    NETWORK_PEER_ADDRESS,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(String.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
+                                    NETWORK_PEER_PORT,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(Long.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -270,14 +266,10 @@ public abstract class AbstractDubboTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "hello"),
+                                satisfies(NETWORK_PEER_ADDRESS, k -> k.isInstanceOf(String.class)),
+                                satisfies(NETWORK_PEER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                    k -> k.isInstanceOf(String.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
@@ -8,6 +8,11 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -18,8 +23,6 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.MiddleServiceImpl;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -178,23 +181,22 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "$invoke"),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                satisfies(SERVER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    ServerAttributes.SERVER_PORT, k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                    NETWORK_PEER_ADDRESS,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(String.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
+                                    NETWORK_PEER_PORT,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(Long.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -213,14 +215,10 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "hello"),
+                                satisfies(NETWORK_PEER_ADDRESS, k -> k.isInstanceOf(String.class)),
+                                satisfies(NETWORK_PEER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                    k -> k.isInstanceOf(String.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -238,23 +236,22 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "$invoke"),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                satisfies(SERVER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    ServerAttributes.SERVER_PORT, k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                    NETWORK_PEER_ADDRESS,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(String.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
+                                    NETWORK_PEER_PORT,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(Long.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -273,14 +270,10 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "hello"),
+                                satisfies(NETWORK_PEER_ADDRESS, k -> k.isInstanceOf(String.class)),
+                                satisfies(NETWORK_PEER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                    k -> k.isInstanceOf(String.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -359,23 +352,22 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "$invoke"),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                satisfies(SERVER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    ServerAttributes.SERVER_PORT, k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                    NETWORK_PEER_ADDRESS,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(String.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
+                                    NETWORK_PEER_PORT,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
                                             val -> assertThat(val).isInstanceOf(Long.class))),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),
@@ -394,14 +386,10 @@ public abstract class AbstractDubboTraceChainTest {
                                     RpcIncubatingAttributes.RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "hello"),
+                                satisfies(NETWORK_PEER_ADDRESS, k -> k.isInstanceOf(String.class)),
+                                satisfies(NETWORK_PEER_PORT, k -> k.isInstanceOf(Long.class)),
                                 satisfies(
-                                    NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                    k -> k.isInstanceOf(String.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    k -> k.isInstanceOf(Long.class)),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_TYPE,
+                                    NETWORK_TYPE,
                                     k ->
                                         k.satisfiesAnyOf(
                                             val -> assertThat(val).isNull(),

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/AbstractApacheHttpClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/AbstractApacheHttpClientTest.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashSet;
@@ -40,7 +41,7 @@ abstract class AbstractApacheHttpClientTest<T extends HttpRequest>
         || "https://192.0.2.1/".equals(uri.toString())
         || uri.toString().contains("/read-timeout")
         || uri.toString().contains("/circular-redirect")) {
-      attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+      attributes.remove(NETWORK_PROTOCOL_VERSION);
     }
     return attributes;
   }

--- a/instrumentation/armeria/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
+++ b/instrumentation/armeria/armeria-1.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaHttp2Test.java
@@ -7,6 +7,19 @@ package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.WebClient;
@@ -16,12 +29,6 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -65,72 +72,60 @@ class ArmeriaHttp2Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_FULL, server2.httpUri() + "/"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, server2.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class))),
+                            equalTo(URL_FULL, server2.httpUri() + "/"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, server2.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("GET /")
                         .hasKind(SpanKind.SERVER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, server2.httpPort()),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class))),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/"),
+                            equalTo(HTTP_ROUTE, "/"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, server2.httpPort()),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_FULL, server1.httpUri() + "/"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, server1.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class))),
+                            equalTo(URL_FULL, server1.httpUri() + "/"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, server1.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("GET /")
                         .hasKind(SpanKind.SERVER)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2"),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, server1.httpPort()),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)))));
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/"),
+                            equalTo(HTTP_ROUTE, "/"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "2"),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, server1.httpPort()),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)))));
   }
 }

--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.armeria.grpc.v1_14;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.linecorp.armeria.client.grpc.GrpcClients;
@@ -18,7 +20,6 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import org.junit.jupiter.api.Test;
@@ -81,8 +82,8 @@ class ArmeriaGrpcTest {
                             equalTo(
                                 RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                 (long) Status.Code.OK.value()),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, (long) server.httpPort()))
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, (long) server.httpPort()))
                         .hasEventsSatisfyingExactly(
                             event ->
                                 event
@@ -108,8 +109,8 @@ class ArmeriaGrpcTest {
                             equalTo(
                                 RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                 (long) Status.Code.OK.value()),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort()))
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, server.httpPort()))
                         .hasEventsSatisfyingExactly(
                             event ->
                                 event

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientTest.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v1_9;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import com.ning.http.client.AsyncCompletionHandler;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
@@ -18,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
@@ -107,7 +108,7 @@ class AsyncHttpClientTest extends AbstractHttpClientTest<Request> {
         endpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
   }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
@@ -6,6 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -16,9 +20,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,10 +85,10 @@ public class AwsLambdaApiGatewayHandlerTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-2024"),
                             equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "PUT"),
-                            equalTo(UserAgentAttributes.USER_AGENT_ORIGINAL, "Clever Client"),
-                            equalTo(UrlAttributes.URL_FULL, "http://localhost:2024/hello/world"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 201L))));
+                            equalTo(HTTP_REQUEST_METHOD, "PUT"),
+                            equalTo(USER_AGENT_ORIGINAL, "Clever Client"),
+                            equalTo(URL_FULL, "http://localhost:2024/hello/world"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 201L))));
   }
 
   public static class TestRequestHandlerApiGateway

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayWrapperTest.java
@@ -6,6 +6,10 @@
 package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -17,9 +21,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambda;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.util.HashMap;
@@ -105,11 +106,10 @@ public class AwsLambdaApiGatewayWrapperTest {
                             equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
                             equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
                             equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UserAgentAttributes.USER_AGENT_ORIGINAL, "Test Client"),
-                            equalTo(
-                                UrlAttributes.URL_FULL, "http://localhost:123/hello/world?a=b&c=d"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(USER_AGENT_ORIGINAL, "Test Client"),
+                            equalTo(URL_FULL, "http://localhost:123/hello/world?a=b&c=d"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L))));
   }
 
   @Test

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -86,11 +88,10 @@ public class AwsLambdaSqsEventWrapperTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))));
+                            equalTo(MESSAGING_OPERATION, "process"))));
   }
 
   public static final class TestRequestHandler implements RequestHandler<SQSEvent, Void> {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
@@ -7,6 +7,10 @@ package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -88,10 +92,10 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasParentSpanId(trace.getSpan(0).getSpanId())
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
+                            equalTo(MESSAGING_OPERATION, "process"))
                         .hasLinks(
                             LinkData.create(
                                 SpanContext.createFromRemoteParent(
@@ -111,13 +115,12 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "message1"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "queue1"))
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, "message1"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "queue1"))
                         .hasLinks(
                             LinkData.create(
                                 SpanContext.createFromRemoteParent(
@@ -131,13 +134,12 @@ public class AwsLambdaSqsMessageHandlerTest {
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "message2"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "queue1"))
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, "message2"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "queue1"))
                         .hasLinks(
                             LinkData.create(
                                 SpanContext.createFromRemoteParent(

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -82,11 +84,10 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
+                                equalTo(MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(
                                 links ->
                                     assertThat(links)
@@ -132,11 +133,10 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"))
+                                equalTo(MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(
                                 links ->
                                     assertThat(links)

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
@@ -8,6 +8,16 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -24,10 +34,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.semconv.incubating.AwsIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
@@ -105,12 +111,12 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "CreateQueue"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -129,24 +135,20 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSdkSqs"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                     span ->
                         span.hasName("testSdkSqs process")
                             .hasKind(SpanKind.CONSUMER)
@@ -163,24 +165,20 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSdkSqs"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                     span ->
                         span.hasName("process child")
                             .hasParent(trace.getSpan(1))
@@ -225,12 +223,12 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "CreateQueue"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -249,24 +247,20 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSdkSqs"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                     span ->
                         span.hasName("testSdkSqs process")
                             .hasKind(SpanKind.CONSUMER)
@@ -283,24 +277,20 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSdkSqs"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                     span ->
                         span.hasName("process child")
                             .hasParent(trace.getSpan(1))
@@ -328,12 +318,12 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))));
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -9,6 +9,17 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -30,10 +41,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.semconv.incubating.AwsIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
@@ -138,12 +145,12 @@ public abstract class AbstractSqsTracingTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "CreateQueue"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span -> {
@@ -161,24 +168,20 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                   equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                   equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
-                                  equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                  equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                  equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                  equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                  equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                  equalTo(SERVER_ADDRESS, "localhost"),
+                                  equalTo(SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MESSAGING_SYSTEM,
                                       MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                           .AWS_SQS),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                      "testSdkSqs"),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                  equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                  equalTo(MESSAGING_OPERATION, "publish"),
                                   satisfies(
-                                      MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                      val -> val.isInstanceOf(String.class)),
-                                  equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")));
+                                      MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
 
                       if (testCaptureHeaders) {
                         attributes.add(
@@ -209,24 +212,19 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                   equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                   equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                  equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                  equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                  equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                  equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                  equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                  equalTo(SERVER_ADDRESS, "localhost"),
+                                  equalTo(SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MESSAGING_SYSTEM,
                                       MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                           .AWS_SQS),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                      "testSdkSqs"),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-                                      1),
-                                  equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")));
+                                  equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                  equalTo(MESSAGING_OPERATION, "receive"),
+                                  equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
+                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
 
                       if (testCaptureHeaders) {
                         attributes.add(
@@ -255,24 +253,20 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                   equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                   equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                  equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                  equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                  equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                  equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                  equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                  equalTo(SERVER_ADDRESS, "localhost"),
+                                  equalTo(SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MESSAGING_SYSTEM,
                                       MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                           .AWS_SQS),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                      "testSdkSqs"),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                  equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                  equalTo(MESSAGING_OPERATION, "process"),
                                   satisfies(
-                                      MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                      val -> val.isInstanceOf(String.class)),
-                                  equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")));
+                                      MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
 
                       if (testCaptureHeaders) {
                         attributes.add(
@@ -329,12 +323,12 @@ public abstract class AbstractSqsTracingTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "CreateQueue"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -353,24 +347,20 @@ public abstract class AbstractSqsTracingTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                equalTo(UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
                                 equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                    MESSAGING_SYSTEM,
                                     MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                         .AWS_SQS),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSdkSqs"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"))),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
             trace -> {
               AtomicReference<SpanData> receiveSpan = new AtomicReference<>();
               AtomicReference<SpanData> processSpan = new AtomicReference<>();
@@ -401,13 +391,12 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                       equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                       equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                      equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                      equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                      equalTo(
-                                          UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                      equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                      equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                      equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                      equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                      equalTo(SERVER_ADDRESS, "localhost"),
+                                      equalTo(SERVER_PORT, sqsPort),
+                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                           span ->
                               span.hasName("testSdkSqs receive")
                                   .hasKind(SpanKind.CONSUMER)
@@ -427,27 +416,22 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                       equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                       equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                      equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                      equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                      equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                      equalTo(SERVER_ADDRESS, "localhost"),
+                                      equalTo(SERVER_PORT, sqsPort),
                                       equalTo(
-                                          UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                      equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                          MESSAGING_SYSTEM,
                                           MessagingIncubatingAttributes
                                               .MessagingSystemIncubatingValues.AWS_SQS),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                          "testSdkSqs"),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                          "receive"),
+                                      equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                      equalTo(MESSAGING_OPERATION, "receive"),
                                       equalTo(
                                           MessagingIncubatingAttributes
                                               .MESSAGING_BATCH_MESSAGE_COUNT,
                                           1),
-                                      equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                           span ->
                               span.hasName("testSdkSqs process")
                                   .hasKind(SpanKind.CONSUMER)
@@ -467,26 +451,21 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                       equalTo(RpcIncubatingAttributes.RPC_SERVICE, "AmazonSQS"),
                                       equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                      equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                      equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                      equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                      equalTo(SERVER_ADDRESS, "localhost"),
+                                      equalTo(SERVER_PORT, sqsPort),
                                       equalTo(
-                                          UrlAttributes.URL_FULL, "http://localhost:" + sqsPort),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                      equalTo(ServerAttributes.SERVER_PORT, sqsPort),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                          MESSAGING_SYSTEM,
                                           MessagingIncubatingAttributes
                                               .MessagingSystemIncubatingValues.AWS_SQS),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                          "testSdkSqs"),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                          "process"),
+                                      equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                      equalTo(MESSAGING_OPERATION, "process"),
                                       satisfies(
-                                          MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
+                                          MESSAGING_MESSAGE_ID,
                                           val -> val.isInstanceOf(String.class)),
-                                      equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1")),
+                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                           span ->
                               span.hasName("process child")
                                   .hasParent(processSpan.get())

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java
@@ -8,14 +8,17 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.AwsIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
@@ -166,10 +169,10 @@ public abstract class AbstractAws2ClientRecordHttpErrorTest {
                       span.hasKind(SpanKind.CLIENT);
                       span.hasNoParent();
                       span.hasAttributesSatisfyingExactly(
-                          equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                          equalTo(ServerAttributes.SERVER_PORT, server.httpPort()),
-                          equalTo(HttpAttributes.HTTP_REQUEST_METHOD, method),
-                          equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                          equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                          equalTo(SERVER_PORT, server.httpPort()),
+                          equalTo(HTTP_REQUEST_METHOD, method),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                           equalTo(
                               stringKey("url.full"), "http://127.0.0.1:" + server.httpPort() + "/"),
                           equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
@@ -178,15 +181,15 @@ public abstract class AbstractAws2ClientRecordHttpErrorTest {
                           equalTo(stringKey("aws.agent"), "java-aws-sdk"),
                           equalTo(AwsIncubatingAttributes.AWS_REQUEST_ID, requestId),
                           equalTo(stringKey("aws.table.name"), "sometable"),
-                          equalTo(DbIncubatingAttributes.DB_SYSTEM, "dynamodb"),
-                          equalTo(DbIncubatingAttributes.DB_OPERATION, operation));
+                          equalTo(DB_SYSTEM, "dynamodb"),
+                          equalTo(DB_OPERATION, operation));
                       if (isRecordIndividualHttpErrorEnabled()) {
                         span.hasEventsSatisfyingExactly(
                             event ->
                                 event
                                     .hasName("HTTP request failure")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 500),
+                                        equalTo(HTTP_RESPONSE_STATUS_CODE, 500),
                                         equalTo(
                                             stringKey("aws.http.error_message"),
                                             "DynamoDB could not process your request")),
@@ -194,7 +197,7 @@ public abstract class AbstractAws2ClientRecordHttpErrorTest {
                                 event
                                     .hasName("HTTP request failure")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 503),
+                                        equalTo(HTTP_RESPONSE_STATUS_CODE, 503),
                                         equalTo(
                                             stringKey("aws.http.error_message"),
                                             "DynamoDB is currently unavailable")));

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -9,6 +9,16 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,9 +28,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.semconv.incubating.AwsIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
@@ -179,13 +186,12 @@ public abstract class AbstractAws2SqsTracingTest {
                                 equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                 equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                 equalTo(RpcIncubatingAttributes.RPC_METHOD, "CreateQueue"),
-                                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                 satisfies(
-                                    UrlAttributes.URL_FULL,
-                                    v -> v.startsWith("http://localhost:" + sqsPort)),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, sqsPort))),
+                                    URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span -> {
@@ -209,25 +215,20 @@ public abstract class AbstractAws2SqsTracingTest {
                                   equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                   equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                   equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
-                                  equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                  equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                   satisfies(
-                                      UrlAttributes.URL_FULL,
-                                      v -> v.startsWith("http://localhost:" + sqsPort)),
-                                  equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                  equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                      URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                  equalTo(SERVER_ADDRESS, "localhost"),
+                                  equalTo(SERVER_PORT, sqsPort),
                                   equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                      MESSAGING_SYSTEM,
                                       MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                           .AWS_SQS),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                      "testSdkSqs"),
-                                  equalTo(
-                                      MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                  equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                  equalTo(MESSAGING_OPERATION, "publish"),
                                   satisfies(
-                                      MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                      v -> v.isInstanceOf(String.class))));
+                                      MESSAGING_MESSAGE_ID, v -> v.isInstanceOf(String.class))));
 
                       if (captureHeaders) {
                         attributes.add(
@@ -274,13 +275,12 @@ public abstract class AbstractAws2SqsTracingTest {
                                     equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                     equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                     equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                    equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                    equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                    equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                    equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                     satisfies(
-                                        UrlAttributes.URL_FULL,
-                                        v -> v.startsWith("http://localhost:" + sqsPort)),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, sqsPort))));
+                                        URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, sqsPort))));
               }
 
               spanAsserts.addAll(
@@ -293,26 +293,19 @@ public abstract class AbstractAws2SqsTracingTest {
                                     equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                     equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                     equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                    equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                    equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                    equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                    equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                     satisfies(
-                                        UrlAttributes.URL_FULL,
-                                        v -> v.startsWith("http://localhost:" + sqsPort)),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                        URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, sqsPort),
                                     equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                        MESSAGING_SYSTEM,
                                         MessagingIncubatingAttributes
                                             .MessagingSystemIncubatingValues.AWS_SQS),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                        "testSdkSqs"),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                        "receive"),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-                                        1)));
+                                    equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                    equalTo(MESSAGING_OPERATION, "receive"),
+                                    equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
 
                         if (captureHeaders) {
                           attributes.add(
@@ -340,26 +333,20 @@ public abstract class AbstractAws2SqsTracingTest {
                                     equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                     equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                     equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                    equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                    equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                    equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                    equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                     satisfies(
-                                        UrlAttributes.URL_FULL,
-                                        v -> v.startsWith("http://localhost:" + sqsPort)),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                        URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, sqsPort),
                                     equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                        MESSAGING_SYSTEM,
                                         MessagingIncubatingAttributes
                                             .MessagingSystemIncubatingValues.AWS_SQS),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                        "testSdkSqs"),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                        "process"),
+                                    equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                    equalTo(MESSAGING_OPERATION, "process"),
                                     satisfies(
-                                        MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                        v -> v.isInstanceOf(String.class))));
+                                        MESSAGING_MESSAGE_ID, v -> v.isInstanceOf(String.class))));
 
                         if (captureHeaders) {
                           attributes.add(
@@ -521,22 +508,17 @@ public abstract class AbstractAws2SqsTracingTest {
                               equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                               equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                               equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessageBatch"),
-                              equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                              equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                              satisfies(
-                                  UrlAttributes.URL_FULL,
-                                  v -> v.startsWith("http://localhost:" + sqsPort)),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                              equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                              equalTo(HTTP_REQUEST_METHOD, "POST"),
+                              equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                              satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                              equalTo(SERVER_ADDRESS, "localhost"),
+                              equalTo(SERVER_PORT, sqsPort),
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .AWS_SQS),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  "testSdkSqs"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish")));
+                              equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                              equalTo(MESSAGING_OPERATION, "publish")));
             },
             trace -> {
               List<Consumer<SpanDataAssert>> spanAsserts = new ArrayList<>();
@@ -551,23 +533,18 @@ public abstract class AbstractAws2SqsTracingTest {
                               equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                               equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                               equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                              equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                              equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                              satisfies(
-                                  UrlAttributes.URL_FULL,
-                                  v -> v.startsWith("http://localhost:" + sqsPort)),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                              equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                              equalTo(HTTP_REQUEST_METHOD, "POST"),
+                              equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                              satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                              equalTo(SERVER_ADDRESS, "localhost"),
+                              equalTo(SERVER_PORT, sqsPort),
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .AWS_SQS),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  "testSdkSqs"),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 3)));
+                              equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                              equalTo(MESSAGING_OPERATION, "receive"),
+                              equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3)));
 
               // one of the 3 process spans is expected to not have a span link
               for (int i = 0; i <= 2; i++) {
@@ -599,26 +576,21 @@ public abstract class AbstractAws2SqsTracingTest {
                                       equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "aws-api"),
                                       equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                                       equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
-                                      equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                                      equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
+                                      equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                      equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                                       satisfies(
-                                          UrlAttributes.URL_FULL,
+                                          URL_FULL,
                                           v -> v.startsWith("http://localhost:" + sqsPort)),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                      equalTo(ServerAttributes.SERVER_PORT, sqsPort),
+                                      equalTo(SERVER_ADDRESS, "localhost"),
+                                      equalTo(SERVER_PORT, sqsPort),
                                       equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                          MESSAGING_SYSTEM,
                                           MessagingIncubatingAttributes
                                               .MessagingSystemIncubatingValues.AWS_SQS),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                          "testSdkSqs"),
-                                      equalTo(
-                                          MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                          "process"),
+                                      equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                      equalTo(MESSAGING_OPERATION, "process"),
                                       satisfies(
-                                          MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                          v -> v.isInstanceOf(String.class)));
+                                          MESSAGING_MESSAGE_ID, v -> v.isInstanceOf(String.class)));
                             },
                             span ->
                                 span.hasName("process child")

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTest.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/testAzure/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.azurecore.v1_36;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.core.annotation.ExpectedResponses;
@@ -30,7 +31,6 @@ import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -103,7 +103,7 @@ class AzureSdkTest {
                     span.hasKind(SpanKind.CLIENT)
                         .hasName(Boolean.getBoolean("testLatestDeps") ? "GET" : "HTTP GET")
                         .hasStatus(StatusData.unset())
-                        .hasAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L)));
+                        .hasAttribute(HTTP_RESPONSE_STATUS_CODE, 200L)));
   }
 
   @Test

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.java
@@ -8,18 +8,25 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.AfterAll;
@@ -95,37 +102,33 @@ class RestCamelTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
                             equalTo(
                                 stringKey("camel.uri"),
                                 "rest://get:api/%7Bmodule%7D/unit/%7BunitId%7D"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)),
                 span ->
                     span.hasName("GET /api/{module}/unit/{unitId}")
                         .hasKind(SpanKind.SERVER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/api/firstModule/unit/unitOne"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/api/{module}/unit/{unitId}"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, Long.valueOf(port)),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class))),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/api/firstModule/unit/unitOne"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_ROUTE, "/api/{module}/unit/{unitId}"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, Long.valueOf(port)),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("GET /api/{module}/unit/{unitId}")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 "http://localhost:" + port + "/api/firstModule/unit/unitOne"),
                             satisfies(
                                 stringKey("camel.uri"), val -> val.isInstanceOf(String.class))),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/SingleServiceCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/SingleServiceCamelTest.java
@@ -7,14 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.net.URI;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -69,8 +69,8 @@ class SingleServiceCamelTest extends AbstractHttpServerUsingTest<ConfigurableApp
                     span.hasName("POST /camelService")
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(UrlAttributes.URL_FULL, requestUrl.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(URL_FULL, requestUrl.toString()),
                             equalTo(
                                 stringKey("camel.uri"),
                                 requestUrl.toString().replace("localhost", "0.0.0.0")))));

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.java
@@ -8,6 +8,19 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
@@ -15,12 +28,6 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -111,11 +118,9 @@ class TwoServicesWithDirectClientCamelTest
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(
-                                UrlAttributes.URL_FULL,
-                                "http://localhost:" + portOne + "/serviceOne"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
                             equalTo(
                                 stringKey("camel.uri"),
                                 "http://localhost:" + portOne + "/serviceOne")),
@@ -124,11 +129,9 @@ class TwoServicesWithDirectClientCamelTest
                         .hasKind(SpanKind.SERVER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(
-                                UrlAttributes.URL_FULL,
-                                "http://localhost:" + portOne + "/serviceOne"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
                             equalTo(
                                 stringKey("camel.uri"),
                                 "http://0.0.0.0:" + portOne + "/serviceOne")),
@@ -137,11 +140,9 @@ class TwoServicesWithDirectClientCamelTest
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(
-                                UrlAttributes.URL_FULL,
-                                "http://127.0.0.1:" + portTwo + "/serviceTwo"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
                             equalTo(
                                 stringKey("camel.uri"),
                                 "http://127.0.0.1:" + portTwo + "/serviceTwo")),
@@ -150,31 +151,25 @@ class TwoServicesWithDirectClientCamelTest
                         .hasKind(SpanKind.SERVER)
                         .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/serviceTwo"),
-                            equalTo(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                "Jakarta Commons-HttpClient/3.1"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/serviceTwo"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, portTwo),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class))),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/serviceTwo"),
+                            equalTo(USER_AGENT_ORIGINAL, "Jakarta Commons-HttpClient/3.1"),
+                            equalTo(HTTP_ROUTE, "/serviceTwo"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, portTwo),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("POST /serviceTwo")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(4))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(
-                                UrlAttributes.URL_FULL,
-                                "http://127.0.0.1:" + portTwo + "/serviceTwo"),
+                            equalTo(HTTP_REQUEST_METHOD, "POST"),
+                            equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
                             equalTo(
                                 stringKey("camel.uri"),
                                 "jetty:http://0.0.0.0:" + portTwo + "/serviceTwo?arg=value"))));

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/CassandraTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/CassandraTest.java
@@ -7,6 +7,9 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.google.common.collect.ImmutableMap;
@@ -14,7 +17,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.AfterAll;
@@ -117,10 +119,10 @@ class CassandraTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
                             equalTo(
                                 stringKey("camel.uri"),
                                 "cql://" + host + ":" + cassandraPort + "/test"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
+                            equalTo(DB_NAME, "test"),
                             equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 "select * from test.users where id=? ALLOW FILTERING"),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"))));
+                            equalTo(DB_SYSTEM, "cassandra"))));
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
@@ -4,6 +4,16 @@
  */
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.junit.jupiter.api.Named.named;
 
 import com.datastax.driver.core.Cluster;
@@ -13,9 +23,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -95,15 +102,14 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   "USE " + parameter.keyspace))),
           trace ->
               trace.hasSpansSatisfyingExactly(
@@ -112,27 +118,23 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_NAME),
+                                  SemconvStabilityUtil.getAttributeKey(DB_NAME),
                                   parameter.keyspace),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   parameter.expectedStatement),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_OPERATION),
+                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                   parameter.operation),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                   parameter.table))));
     } else {
       testing.waitAndAssertTraces(
@@ -143,23 +145,20 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   parameter.expectedStatement),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_OPERATION),
+                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                   parameter.operation),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                   parameter.table))));
     }
 
@@ -191,15 +190,14 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   "USE " + parameter.keyspace))),
           trace ->
               trace.hasSpansSatisfyingExactly(
@@ -209,27 +207,23 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_NAME),
+                                  SemconvStabilityUtil.getAttributeKey(DB_NAME),
                                   parameter.keyspace),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   parameter.expectedStatement),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_OPERATION),
+                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                   parameter.operation),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                   parameter.table)),
                   span ->
                       span.hasName("callbackListener")
@@ -245,23 +239,20 @@ class CassandraClientTest {
                           .hasKind(SpanKind.CLIENT)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(ServerAttributes.SERVER_ADDRESS, cassandraHost),
-                              equalTo(ServerAttributes.SERVER_PORT, cassandraPort),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "cassandra"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(SERVER_ADDRESS, cassandraHost),
+                              equalTo(SERVER_PORT, cassandraPort),
+                              equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                              equalTo(NETWORK_PEER_PORT, cassandraPort),
+                              equalTo(DB_SYSTEM, "cassandra"),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   parameter.expectedStatement),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_OPERATION),
+                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                   parameter.operation),
                               equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                   parameter.table)),
                   span ->
                       span.hasName("callbackListener")

--- a/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.cassandra.v4.common;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
@@ -16,6 +18,10 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASS
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_IDEMPOTENCE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_PAGE_SIZE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
@@ -28,8 +34,6 @@ import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfig
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -106,20 +110,17 @@ public abstract class AbstractCassandraTest {
                                             v -> assertThat(v).isEqualTo("ipv6"))),
                                 equalTo(SERVER_ADDRESS, cassandraHost),
                                 equalTo(SERVER_PORT, cassandraPort),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_NAME),
+                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
                                     parameter.keyspace),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_STATEMENT),
+                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                     parameter.expectedStatement),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_OPERATION),
+                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                     parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
@@ -132,8 +133,7 @@ public abstract class AbstractCassandraTest {
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                     parameter.table))));
 
     session.close();
@@ -172,20 +172,17 @@ public abstract class AbstractCassandraTest {
                                             v -> assertThat(v).isEqualTo("ipv6"))),
                                 equalTo(SERVER_ADDRESS, cassandraHost),
                                 equalTo(SERVER_PORT, cassandraPort),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_NAME),
+                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
                                     parameter.keyspace),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_STATEMENT),
+                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                     parameter.expectedStatement),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_OPERATION),
+                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                     parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
@@ -198,8 +195,7 @@ public abstract class AbstractCassandraTest {
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                     parameter.table)),
                     span ->
                         span.hasName("child")

--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -7,6 +7,8 @@ package io.opentelemetry.testing.cassandra.v4_4;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
@@ -16,6 +18,10 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASS
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_IDEMPOTENCE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_PAGE_SIZE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
@@ -24,8 +30,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.cassandra.v4.common.AbstractCassandraTest;
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -66,20 +70,17 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                             v -> assertThat(v).isEqualTo("ipv6"))),
                                 equalTo(SERVER_ADDRESS, cassandraHost),
                                 equalTo(SERVER_PORT, cassandraPort),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, cassandraIp),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_NAME),
+                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
                                     parameter.keyspace),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_STATEMENT),
+                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                     parameter.expectedStatement),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_OPERATION),
+                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                     parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
@@ -92,8 +93,7 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
                                 equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(
-                                        DbIncubatingAttributes.DB_CASSANDRA_TABLE),
+                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
                                     parameter.table)),
                     span ->
                         span.hasName("child")

--- a/instrumentation/clickhouse-client-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/ClickHouseClientTest.java
+++ b/instrumentation/clickhouse-client-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/ClickHouseClientTest.java
@@ -6,6 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -25,7 +31,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -335,13 +340,11 @@ class ClickHouseClientTest {
   @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> attributeAssertions(String statement, String operation) {
     return asList(
-        equalTo(
-            DbIncubatingAttributes.DB_SYSTEM,
-            DbIncubatingAttributes.DbSystemIncubatingValues.CLICKHOUSE),
-        equalTo(DbIncubatingAttributes.DB_NAME, dbName),
-        equalTo(ServerAttributes.SERVER_ADDRESS, host),
-        equalTo(ServerAttributes.SERVER_PORT, port),
-        equalTo(DbIncubatingAttributes.DB_STATEMENT, statement),
-        equalTo(DbIncubatingAttributes.DB_OPERATION, operation));
+        equalTo(DB_SYSTEM, DbIncubatingAttributes.DbSystemIncubatingValues.CLICKHOUSE),
+        equalTo(DB_NAME, dbName),
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
+        equalTo(DB_STATEMENT, statement),
+        equalTo(DB_OPERATION, operation));
   }
 }

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.couchbase;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 
@@ -89,11 +91,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "ClusterManager.hasBucket")
@@ -133,11 +134,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "Bucket.upsert", bucketSettings.name())
@@ -184,11 +184,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "Bucket.upsert", bucketSettings.name())
@@ -232,11 +231,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.couchbase;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 
@@ -108,11 +110,10 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -147,11 +148,10 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
+                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
                                 "Cluster.openBucket"))),
         trace ->
             trace.hasSpansSatisfyingExactly(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
@@ -7,6 +7,10 @@ package io.opentelemetry.instrumentation.couchbase;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import com.couchbase.client.java.bucket.BucketType;
 import com.couchbase.client.java.cluster.BucketSettings;
@@ -121,26 +125,17 @@ public abstract class AbstractCouchbaseTest {
     span.hasName(spanName).hasKind(SpanKind.CLIENT);
 
     List<AttributeAssertion> assertions = new ArrayList<>();
-    assertions.add(
-        equalTo(
-            DbIncubatingAttributes.DB_SYSTEM,
-            DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE));
+    assertions.add(equalTo(DB_SYSTEM, DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE));
     if (operation != null) {
-      assertions.add(
-          equalTo(
-              SemconvStabilityUtil.getAttributeKey(DbIncubatingAttributes.DB_OPERATION),
-              operation));
+      assertions.add(equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), operation));
     }
     if (bucketName != null) {
-      assertions.add(
-          equalTo(
-              SemconvStabilityUtil.getAttributeKey(DbIncubatingAttributes.DB_NAME), bucketName));
+      assertions.add(equalTo(SemconvStabilityUtil.getAttributeKey(DB_NAME), bucketName));
     }
     if (statement != null) {
       assertions.add(
           satisfies(
-              SemconvStabilityUtil.getAttributeKey(DbIncubatingAttributes.DB_STATEMENT),
-              s -> s.startsWith(statement)));
+              SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), s -> s.startsWith(statement)));
     }
     assertions.addAll(couchbaseAttributes());
 

--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchClientTest.java
@@ -7,6 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.apiclient;
 
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -18,11 +26,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -90,23 +93,23 @@ class ElasticsearchClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "info"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort())),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(DB_OPERATION, "info"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort())),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L))));
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L))));
   }
 
   @Test
@@ -126,13 +129,13 @@ class ElasticsearchClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "index"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "PUT"),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(DB_OPERATION, "index"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "PUT"),
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 httpHost.toURI() + "/test-index/_doc/test-id?timeout=10s"),
                             equalTo(
                                 AttributeKey.stringKey("db.elasticsearch.path_parts.index"),
@@ -145,14 +148,14 @@ class ElasticsearchClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "PUT"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "PUT"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 httpHost.toURI() + "/test-index/_doc/test-id?timeout=10s"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 201L))));
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 201L))));
   }
 
   @Test
@@ -187,23 +190,23 @@ class ElasticsearchClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "info"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/")),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(DB_OPERATION, "info"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L)),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -6,16 +6,18 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -96,23 +98,23 @@ class ElasticsearchRest5Test {
                     .hasKind(SpanKind.CLIENT)
                     .hasNoParent()
                     .hasAttributesSatisfyingExactly(
-                        equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"));
+                        equalTo(DB_SYSTEM, "elasticsearch"),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
               },
               span -> {
                 span.hasName("GET")
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(0))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200));
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
               });
         });
   }
@@ -172,23 +174,23 @@ class ElasticsearchRest5Test {
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(0))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"));
+                        equalTo(DB_SYSTEM, "elasticsearch"),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
               },
               span -> {
                 span.hasName("GET")
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(1))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200));
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
               },
               span -> {
                 span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0));

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -6,16 +6,18 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -87,23 +89,23 @@ class ElasticsearchRest6Test {
                     .hasKind(SpanKind.CLIENT)
                     .hasNoParent()
                     .hasAttributesSatisfyingExactly(
-                        equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"));
+                        equalTo(DB_SYSTEM, "elasticsearch"),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
               },
               span -> {
                 span.hasName("GET")
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(0))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L));
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200L));
               });
         });
   }
@@ -162,23 +164,23 @@ class ElasticsearchRest6Test {
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(0))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"));
+                        equalTo(DB_SYSTEM, "elasticsearch"),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
               },
               span -> {
                 span.hasName("GET")
                     .hasKind(SpanKind.CLIENT)
                     .hasParent(trace.getSpan(1))
                     .hasAttributesSatisfyingExactly(
-                        equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                        equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200));
+                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                        equalTo(SERVER_PORT, httpHost.getPort()),
+                        equalTo(HTTP_REQUEST_METHOD, "GET"),
+                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
               },
               span -> {
                 span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0));

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -7,15 +7,17 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -85,22 +87,22 @@ class ElasticsearchRest7Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L))));
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L))));
   }
 
   @Test
@@ -155,22 +157,22 @@ class ElasticsearchRest7Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L)),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -7,14 +7,15 @@ package io.opentelemetry.instrumentation.elasticsearch.rest.v7_0;
 
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -85,12 +86,11 @@ class ElasticsearchRest7Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(
-                                UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"))));
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"))));
   }
 
   @Test
@@ -145,11 +145,11 @@ class ElasticsearchRest7Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "elasticsearch"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                            equalTo(DB_SYSTEM, "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -87,9 +89,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SearchAction"),
+                            equalTo(DB_OPERATION, "SearchAction"),
                             equalTo(stringKey("elasticsearch.action"), "SearchAction"),
                             equalTo(stringKey("elasticsearch.request"), "SearchRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -121,9 +123,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "IndexAction"),
+                            equalTo(DB_OPERATION, "IndexAction"),
                             equalTo(stringKey("elasticsearch.action"), "IndexAction"),
                             equalTo(stringKey("elasticsearch.request"), "IndexRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -139,9 +141,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RefreshAction"),
+                            equalTo(DB_OPERATION, "RefreshAction"),
                             equalTo(stringKey("elasticsearch.action"), "RefreshAction"),
                             equalTo(stringKey("elasticsearch.request"), "RefreshRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -170,9 +172,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(stringKey("elasticsearch.action"), "GetAction"),
                             equalTo(stringKey("elasticsearch.request"), "GetRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -204,9 +206,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "IndexAction"),
+                            equalTo(DB_OPERATION, "IndexAction"),
                             equalTo(stringKey("elasticsearch.action"), "IndexAction"),
                             equalTo(stringKey("elasticsearch.request"), "IndexRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -222,9 +224,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RefreshAction"),
+                            equalTo(DB_OPERATION, "RefreshAction"),
                             equalTo(stringKey("elasticsearch.action"), "RefreshAction"),
                             equalTo(stringKey("elasticsearch.request"), "RefreshRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -248,9 +250,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(stringKey("elasticsearch.action"), "GetAction"),
                             equalTo(stringKey("elasticsearch.request"), "GetRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -280,9 +282,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DeleteAction"),
+                            equalTo(DB_OPERATION, "DeleteAction"),
                             equalTo(stringKey("elasticsearch.action"), "DeleteAction"),
                             equalTo(stringKey("elasticsearch.request"), "DeleteRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -297,9 +299,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RefreshAction"),
+                            equalTo(DB_OPERATION, "RefreshAction"),
                             equalTo(stringKey("elasticsearch.action"), "RefreshAction"),
                             equalTo(stringKey("elasticsearch.request"), "RefreshRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),
@@ -323,9 +325,9 @@ class Elasticsearch53SpringRepositoryTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SearchAction"),
+                            equalTo(DB_OPERATION, "SearchAction"),
                             equalTo(stringKey("elasticsearch.action"), "SearchAction"),
                             equalTo(stringKey("elasticsearch.request"), "SearchRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), "test-index"),

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3.
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -171,9 +173,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasException(expectedException)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RefreshAction"),
+                            equalTo(DB_OPERATION, "RefreshAction"),
                             equalTo(stringKey("elasticsearch.action"), "RefreshAction"),
                             equalTo(stringKey("elasticsearch.request"), "RefreshRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName))));
@@ -226,9 +228,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CreateIndexAction"),
+                            equalTo(DB_OPERATION, "CreateIndexAction"),
                             equalTo(stringKey("elasticsearch.action"), "CreateIndexAction"),
                             equalTo(stringKey("elasticsearch.request"), "CreateIndexRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName))),
@@ -240,9 +242,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "ClusterHealthAction"),
+                            equalTo(DB_OPERATION, "ClusterHealthAction"),
                             equalTo(stringKey("elasticsearch.action"), "ClusterHealthAction"),
                             equalTo(stringKey("elasticsearch.request"), "ClusterHealthRequest"))),
         trace ->
@@ -253,9 +255,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SearchAction"),
+                            equalTo(DB_OPERATION, "SearchAction"),
                             equalTo(stringKey("elasticsearch.action"), "SearchAction"),
                             equalTo(stringKey("elasticsearch.request"), "SearchRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName),
@@ -268,9 +270,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "IndexAction"),
+                            equalTo(DB_OPERATION, "IndexAction"),
                             equalTo(stringKey("elasticsearch.action"), "IndexAction"),
                             equalTo(stringKey("elasticsearch.request"), "IndexRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName),
@@ -288,9 +290,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RefreshAction"),
+                            equalTo(DB_OPERATION, "RefreshAction"),
                             equalTo(stringKey("elasticsearch.action"), "RefreshAction"),
                             equalTo(stringKey("elasticsearch.request"), "RefreshRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName),
@@ -305,9 +307,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SearchAction"),
+                            equalTo(DB_OPERATION, "SearchAction"),
                             equalTo(stringKey("elasticsearch.action"), "SearchAction"),
                             equalTo(stringKey("elasticsearch.request"), "SearchRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName),
@@ -389,9 +391,9 @@ class Elasticsearch53SpringTemplateTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SearchAction"),
+                            equalTo(DB_OPERATION, "SearchAction"),
                             equalTo(stringKey("elasticsearch.action"), "SearchAction"),
                             equalTo(stringKey("elasticsearch.request"), "SearchRequest"),
                             equalTo(stringKey("elasticsearch.request.indices"), indexName))));

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchNodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchNodeClientTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Named.named;
@@ -68,9 +70,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "ClusterHealthAction"),
+                            equalTo(DB_OPERATION, "ClusterHealthAction"),
                             equalTo(ELASTICSEARCH_ACTION, "ClusterHealthAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "ClusterHealthRequest")),
                 span ->
@@ -117,9 +119,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasException(expectedException)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                             equalTo(ELASTICSEARCH_REQUEST_INDICES, "invalid-index")),
@@ -179,9 +181,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CreateIndexAction"),
+                            equalTo(DB_OPERATION, "CreateIndexAction"),
                             equalTo(ELASTICSEARCH_ACTION, "CreateIndexAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "CreateIndexRequest"),
                             equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName))),
@@ -193,9 +195,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "ClusterHealthAction"),
+                            equalTo(DB_OPERATION, "ClusterHealthAction"),
                             equalTo(ELASTICSEARCH_ACTION, "ClusterHealthAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "ClusterHealthRequest"))),
         trace ->
@@ -206,9 +208,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                             equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),
@@ -224,9 +226,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasAttributesSatisfyingExactly(
                             addIndexActionAttributes(
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "IndexAction"),
+                                equalTo(DB_OPERATION, "IndexAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "IndexAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "IndexRequest"),
                                 equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),
@@ -243,9 +245,9 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                             equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchTransportClientTest.java
@@ -11,6 +11,11 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Named.named;
@@ -19,7 +24,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,12 +82,12 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             addNetworkTypeAttribute(
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, getPort()),
+                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                                equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "ClusterHealthAction"),
+                                equalTo(DB_OPERATION, "ClusterHealthAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "ClusterHealthAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "ClusterHealthRequest"))),
                 span ->
@@ -137,9 +141,9 @@ public abstract class AbstractElasticsearchTransportClientTest
                                             RemoteTransportException.class.getName())))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                            equalTo(DB_OPERATION, "GetAction"),
                             equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                             equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                             equalTo(ELASTICSEARCH_REQUEST_INDICES, "invalid-index")),
@@ -195,12 +199,12 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             addNetworkTypeAttribute(
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, getPort()),
+                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                                equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "CreateIndexAction"),
+                                equalTo(DB_OPERATION, "CreateIndexAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "CreateIndexAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "CreateIndexRequest"),
                                 equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName)))),
@@ -212,9 +216,9 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, getPutMappingActionName()),
+                            equalTo(DB_OPERATION, getPutMappingActionName()),
                             equalTo(ELASTICSEARCH_ACTION, getPutMappingActionName()),
                             equalTo(ELASTICSEARCH_REQUEST, "PutMappingRequest"))),
         trace ->
@@ -225,12 +229,12 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             addIndexActionAttributes(
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, getPort()),
+                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                                equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "IndexAction"),
+                                equalTo(DB_OPERATION, "IndexAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "IndexAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "IndexRequest"),
                                 equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),
@@ -248,12 +252,12 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             addNetworkTypeAttribute(
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, getPort()),
+                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                                equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                                equalTo(DB_OPERATION, "GetAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                                 equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),
@@ -268,12 +272,12 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             addNetworkTypeAttribute(
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NetworkAttributes.NETWORK_PEER_PORT, getPort()),
+                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                                equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_SYSTEM,
+                                    DB_SYSTEM,
                                     DbIncubatingAttributes.DbSystemIncubatingValues.ELASTICSEARCH),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "GetAction"),
+                                equalTo(DB_OPERATION, "GetAction"),
                                 equalTo(ELASTICSEARCH_ACTION, "GetAction"),
                                 equalTo(ELASTICSEARCH_REQUEST, "GetRequest"),
                                 equalTo(ELASTICSEARCH_REQUEST_INDICES, indexName),
@@ -291,7 +295,7 @@ public abstract class AbstractElasticsearchTransportClientTest
     if (hasNetworkType()) {
       result.add(
           satisfies(
-              NetworkAttributes.NETWORK_TYPE,
+              NETWORK_TYPE,
               k ->
                   k.satisfiesAnyOf(
                       val -> assertThat(val).isEqualTo("ipv4"),

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import com.google.common.collect.Sets;
 import com.twitter.finagle.ListeningServer;
@@ -33,7 +34,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.net.URI;
 import java.util.Collections;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,9 +48,7 @@ abstract class AbstractServerTest extends AbstractHttpServerTest<ListeningServer
     super.configure(options);
     options.setTestException(false);
     options.setHttpAttributes(
-        unused ->
-            Sets.difference(
-                DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HttpAttributes.HTTP_ROUTE)));
+        unused -> Sets.difference(DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HTTP_ROUTE)));
 
     options.setTestCaptureHttpHeaders(true);
   }

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/ClientTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/ClientTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11;
 
 import static io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.Utils.createClient;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.finagle.ConnectionFailedException;
@@ -30,7 +32,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.Utils.ClientType;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.ConnectException;
 import java.net.URI;
 import java.util.Collections;
@@ -194,8 +195,8 @@ class ClientTest extends AbstractHttpClientTest<Request> {
       return Collections.emptySet();
     }
     Set<AttributeKey<?>> attributes = new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/PutGetTest.java
@@ -6,13 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.geode;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -133,24 +136,24 @@ class PutGetTest {
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "geode"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test-region"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "clear")),
+                            equalTo(DB_SYSTEM, "geode"),
+                            equalTo(DB_NAME, "test-region"),
+                            equalTo(DB_OPERATION, "clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "geode"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test-region"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "put")),
+                            equalTo(DB_SYSTEM, "geode"),
+                            equalTo(DB_NAME, "test-region"),
+                            equalTo(DB_OPERATION, "put")),
                 span ->
                     span.hasName(verb.concat(" test-region"))
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "geode"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test-region"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, verb),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, query))));
+                            equalTo(DB_SYSTEM, "geode"),
+                            equalTo(DB_NAME, "test-region"),
+                            equalTo(DB_OPERATION, verb),
+                            equalTo(DB_STATEMENT, query))));
   }
 
   static class Card implements DataSerializable {

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
@@ -8,6 +8,13 @@ package io.opentelemetry.javaagent.instrumentation.googlehttpclient;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
@@ -23,11 +30,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -104,12 +106,12 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                satisfies(ServerAttributes.SERVER_PORT, AbstractLongAssert::isPositive),
-                equalTo(UrlAttributes.URL_FULL, uri.toString()),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 500),
-                equalTo(ErrorAttributes.ERROR_TYPE, "500")));
+                equalTo(SERVER_ADDRESS, "localhost"),
+                satisfies(SERVER_PORT, AbstractLongAssert::isPositive),
+                equalTo(URL_FULL, uri.toString()),
+                equalTo(HTTP_REQUEST_METHOD, "GET"),
+                equalTo(HTTP_RESPONSE_STATUS_CODE, 500),
+                equalTo(ERROR_TYPE, "500")));
 
     testing.waitAndAssertTraces(
         trace ->
@@ -139,7 +141,7 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
   }

--- a/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
@@ -9,6 +9,8 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -25,7 +27,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -245,11 +246,9 @@ public abstract class AbstractGraphqlTest {
                                     event
                                         .hasName("exception")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                ExceptionAttributes.EXCEPTION_TYPE,
-                                                "InvalidSyntax"),
+                                            equalTo(EXCEPTION_TYPE, "InvalidSyntax"),
                                             satisfies(
-                                                ExceptionAttributes.EXCEPTION_MESSAGE,
+                                                EXCEPTION_MESSAGE,
                                                 message ->
                                                     message.startsWithIgnoringCase(
                                                         "Invalid Syntax"))))));
@@ -287,11 +286,9 @@ public abstract class AbstractGraphqlTest {
                                     event
                                         .hasName("exception")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                ExceptionAttributes.EXCEPTION_TYPE,
-                                                "ValidationError"),
+                                            equalTo(EXCEPTION_TYPE, "ValidationError"),
                                             satisfies(
-                                                ExceptionAttributes.EXCEPTION_MESSAGE,
+                                                EXCEPTION_MESSAGE,
                                                 message ->
                                                     message.startsWith("Validation error"))))));
   }

--- a/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyFilterchainServerTest.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyFilterchainServerTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.grizzly;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.INDEXED_CHILD;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.glassfish.grizzly.memory.Buffers.wrap;
@@ -18,7 +19,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -71,7 +71,7 @@ class GrizzlyFilterchainServerTest extends AbstractHttpServerTest<Transport> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
 

--- a/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyTest.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyTest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -19,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -109,7 +109,7 @@ abstract class GrizzlyTest extends AbstractHttpServerTest<HttpServer> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
     options.setTestCaptureHttpHeaders(false);

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
@@ -9,6 +9,11 @@ import static io.opentelemetry.instrumentation.grpc.v1_6.AbstractGrpcTest.addExt
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 
 import example.GreeterGrpc;
 import example.Helloworld;
@@ -25,8 +30,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
 import io.opentelemetry.sdk.trace.data.EventData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.ArrayList;
@@ -190,8 +193,8 @@ public abstract class AbstractGrpcStreamingTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .satisfies(
                                 spanData ->
                                     assertThat(spanData.getEvents())
@@ -207,13 +210,11 @@ public abstract class AbstractGrpcStreamingTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .satisfies(
                                 spanData ->
                                     assertThat(spanData.getEvents())
@@ -232,8 +233,7 @@ public abstract class AbstractGrpcStreamingTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD,
                                                     "Conversation"),
@@ -258,10 +258,8 @@ public abstract class AbstractGrpcStreamingTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD,
                                                     "Conversation"),

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -8,6 +8,11 @@ package io.opentelemetry.instrumentation.grpc.v1_6;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -47,8 +52,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.ArrayList;
@@ -142,8 +145,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -171,13 +174,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -208,8 +209,7 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -233,10 +233,8 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -310,8 +308,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -339,13 +337,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -380,8 +376,7 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -405,10 +400,8 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -490,8 +483,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -519,13 +512,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -560,8 +551,7 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -585,10 +575,8 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -645,8 +633,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) status.getCode().value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -667,13 +655,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) status.getCode().value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).isNotEmpty();
@@ -704,8 +690,7 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -729,10 +714,8 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -797,8 +780,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.UNKNOWN.getCode().value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -819,13 +802,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.UNKNOWN.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).hasSize(2);
@@ -851,8 +832,7 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -876,10 +856,8 @@ public abstract class AbstractGrpcTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfying(
-                                                equalTo(
-                                                    ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                                equalTo(
-                                                    ServerAttributes.SERVER_PORT, server.getPort()),
+                                                equalTo(SERVER_ADDRESS, "localhost"),
+                                                equalTo(SERVER_PORT, server.getPort()),
                                                 equalTo(
                                                     RpcIncubatingAttributes.RPC_METHOD, "SayHello"),
                                                 equalTo(
@@ -1045,8 +1023,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1074,13 +1052,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1168,8 +1144,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.CANCELLED.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).hasSize(3);
@@ -1197,13 +1173,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.CANCELLED.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1290,8 +1264,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1322,13 +1296,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1400,8 +1372,8 @@ public abstract class AbstractGrpcTest {
                                     equalTo(
                                         RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                         (long) Status.Code.OK.value()),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                    equalTo(ServerAttributes.SERVER_PORT, (long) server.getPort())))
+                                    equalTo(SERVER_ADDRESS, "localhost"),
+                                    equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1429,13 +1401,11 @@ public abstract class AbstractGrpcTest {
                                 equalTo(
                                     RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE,
                                     (long) Status.Code.OK.value()),
-                                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                equalTo(ServerAttributes.SERVER_PORT, server.getPort()),
-                                equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(
-                                    NetworkAttributes.NETWORK_PEER_PORT,
-                                    val -> assertThat(val).isNotNull()))
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, server.getPort()),
+                                equalTo(NETWORK_TYPE, "ipv4"),
+                                equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1692,10 +1662,9 @@ public abstract class AbstractGrpcTest {
     List<AttributeAssertion> result = new ArrayList<>();
     result.addAll(Arrays.asList(assertions));
     if (Boolean.getBoolean("testLatestDeps")) {
-      result.add(equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"));
-      result.add(equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
-      result.add(
-          satisfies(NetworkAttributes.NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()));
+      result.add(equalTo(NETWORK_TYPE, "ipv4"));
+      result.add(equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
+      result.add(satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()));
     }
     return result;
   }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v3_3;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
@@ -15,7 +22,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -57,35 +63,35 @@ abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-            satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
-            satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent, String verb) {
     return span.hasName(verb.concat(" db1.Value"))
         .hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(
-                DbIncubatingAttributes.DB_STATEMENT,
+                DB_STATEMENT,
                 stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),
-            equalTo(DbIncubatingAttributes.DB_OPERATION, verb),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_OPERATION, verb),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 
   static SpanDataAssert assertSessionSpan(SpanDataAssert span, SpanData parent, String spanName) {

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
@@ -10,9 +10,15 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.hibernate.Criteria;
@@ -66,15 +72,14 @@ class CriteriaTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                stringAssert -> stringAssert.startsWith("select")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                                DB_STATEMENT, stringAssert -> stringAssert.startsWith("select")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityManagerTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityManagerTest.java
@@ -10,10 +10,16 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.junit.jupiter.api.Named.named;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -34,7 +40,7 @@ class EntityManagerTest extends AbstractHibernateTest {
   static final EntityManagerFactory entityManagerFactory =
       Persistence.createEntityManagerFactory("test-pu");
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateActionParameters")
   void testHibernateActions(Parameter parameter) {
@@ -100,17 +106,13 @@ class EntityManagerTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")));
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")));
 
           } else {
             trace.hasSpansSatisfyingExactly(
@@ -131,17 +133,13 @@ class EntityManagerTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -184,7 +182,7 @@ class EntityManagerTest extends AbstractHibernateTest {
         Arguments.of(named("remove", new Parameter("delete", true, true, EntityManager::remove))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testHibernatePersist() {
     EntityManager entityManager = entityManagerFactory.createEntityManager();
@@ -217,17 +215,13 @@ class EntityManagerTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -243,20 +237,16 @@ class EntityManagerTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value"))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsAttachesState")
   void testAttachesStateToQuery(Function<EntityManager, Query> queryBuildMethod) {
@@ -292,17 +282,13 @@ class EntityManagerTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryTest.java
@@ -10,10 +10,16 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.junit.jupiter.api.Named.named;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -25,7 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class QueryTest extends AbstractHibernateTest {
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateQueryExecuteUpdateWithTransaction() {
     testing.runWithSpan(
@@ -61,17 +67,13 @@ class QueryTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -85,7 +87,7 @@ class QueryTest extends AbstractHibernateTest {
                                     .get(stringKey("hibernate.session_id"))))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("providesArgumentsSingleCall")
   void testHibernateQuerySingleCall(Parameter parameter) {
@@ -119,15 +121,13 @@ class QueryTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value"))));
   }
 
   private static Stream<Arguments> providesArgumentsSingleCall() {
@@ -155,7 +155,7 @@ class QueryTest extends AbstractHibernateTest {
                 new Parameter("SELECT Value", sess -> sess.createQuery("from Value").scroll()))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateQueryIterate() {
     testing.runWithSpan(
@@ -193,15 +193,13 @@ class QueryTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
@@ -10,12 +10,18 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.junit.jupiter.api.Named.named;
 
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -34,7 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @SuppressWarnings("deprecation") // 'lock' is a deprecated method in the Session class
 class SessionTest extends AbstractHibernateTest {
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateAction")
   void testHibernateAction(Parameter parameter) {
@@ -64,17 +70,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -144,7 +146,7 @@ class SessionTest extends AbstractHibernateTest {
                     null))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateActionStateless")
   void testHibernateActionStateless(Parameter parameter) {
@@ -175,17 +177,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -292,7 +290,7 @@ class SessionTest extends AbstractHibernateTest {
                     }))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateReplicate")
   void testHibernateReplicate(Parameter parameter) {
@@ -322,17 +320,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -348,17 +342,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value"))));
   }
 
   private static Stream<Arguments> provideArgumentsHibernateReplicate() {
@@ -440,7 +430,7 @@ class SessionTest extends AbstractHibernateTest {
                                     .get(stringKey("hibernate.session_id"))))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsHibernateCommitAction")
   void testHibernateCommitAction(Parameter parameter) {
@@ -482,17 +472,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value"))));
   }
 
   private static Stream<Arguments> provideArgumentsHibernateCommitAction() {
@@ -630,7 +616,7 @@ class SessionTest extends AbstractHibernateTest {
                     null))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @MethodSource("provideArgumentsStateQuery")
   void testAttachesStateToQueryCreated(Consumer<Session> queryBuilder) {
@@ -661,17 +647,13 @@ class SessionTest extends AbstractHibernateTest {
                     span.hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            satisfies(
-                                DbIncubatingAttributes.DB_OPERATION,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -703,7 +685,7 @@ class SessionTest extends AbstractHibernateTest {
                             session -> session.createSQLQuery("SELECT * FROM Value").list())))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testHibernateOverlappingSessions() {
     testing.runWithSpan(
@@ -762,15 +744,14 @@ class SessionTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                stringAssert -> stringAssert.startsWith("insert")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                                DB_STATEMENT, stringAssert -> stringAssert.startsWith("insert")),
+                            equalTo(DB_OPERATION, "INSERT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span -> {
                   span.hasName("Session.save " + Value.class.getName())
                       .hasKind(INTERNAL)
@@ -806,29 +787,27 @@ class SessionTest extends AbstractHibernateTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(6))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                stringAssert -> stringAssert.startsWith("insert")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                                DB_STATEMENT, stringAssert -> stringAssert.startsWith("insert")),
+                            equalTo(DB_OPERATION, "INSERT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("DELETE db1.Value")
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(6))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                stringAssert -> stringAssert.startsWith("delete")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DELETE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"))));
+                                DB_STATEMENT, stringAssert -> stringAssert.startsWith("delete")),
+                            equalTo(DB_OPERATION, "DELETE"),
+                            equalTo(DB_SQL_TABLE, "Value"))));
 
     assertThat(sessionId1.get()).isNotEqualTo(sessionId2.get());
     assertThat(sessionId1.get()).isNotEqualTo(sessionId3.get());

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/spring/jpa/SpringJpaTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/spring/jpa/SpringJpaTest.java
@@ -10,12 +10,18 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.regex.Pattern;
 import org.hibernate.Version;
 import org.junit.jupiter.api.Test;
@@ -31,7 +37,7 @@ class SpringJpaTest {
       new AnnotationConfigApplicationContext(PersistenceConfig.class);
   CustomerRepository repo = context.getBean(CustomerRepository.class);
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testCrud() {
     String version = Version.getVersionString();
@@ -66,18 +72,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "select ([^.]+).id([^,]*), ([^.]+).firstName([^,]*), ([^.]+).lastName(.*)from Customer(.*)"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Customer")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -121,18 +127,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "insert into Customer (.*) values \\(.*, \\?, \\?\\)"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")),
+                            equalTo(DB_OPERATION, "INSERT"),
+                            equalTo(DB_SQL_TABLE, "Customer")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -164,14 +170,12 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "call next value for hibernate_sequence"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_STATEMENT, "call next value for hibernate_sequence"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_OPERATION, "CALL")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -188,18 +192,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "insert into Customer (.*) values \\(.* \\?, \\?\\)"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")));
+                            equalTo(DB_OPERATION, "INSERT"),
+                            equalTo(DB_SQL_TABLE, "Customer")));
           }
         });
     testing.clearData();
@@ -235,18 +239,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "select ([^.]+).id([^,]*), ([^.]+).firstName([^,]*), ([^.]+).lastName (.*)from Customer (.*)where ([^.]+).id=\\?"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Customer")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)
@@ -263,15 +267,15 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 "update Customer set firstName=?, lastName=? where id=?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "UPDATE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer"))));
+                            equalTo(DB_OPERATION, "UPDATE"),
+                            equalTo(DB_SQL_TABLE, "Customer"))));
     testing.clearData();
 
     Customer foundCustomer =
@@ -301,18 +305,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "select ([^.]+).id([^,]*), ([^.]+).firstName([^,]*), ([^.]+).lastName (.*)from Customer (.*)(where ([^.]+).lastName=\\?)"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer"))));
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Customer"))));
     testing.clearData();
 
     testing.runWithSpan("parent", () -> repo.delete(foundCustomer));
@@ -339,18 +343,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "select ([^.]+).id([^,]*), ([^.]+).firstName([^,]*), ([^.]+).lastName (.*)from Customer (.*)where ([^.]+).id=\\?"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Customer")),
                 span ->
                     span.hasName("Session.delete spring.jpa.Customer")
                         .hasKind(INTERNAL)
@@ -371,15 +375,13 @@ class SpringJpaTest {
                     span.hasName("DELETE test.Customer")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "delete from Customer where id=?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DELETE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_STATEMENT, "delete from Customer where id=?"),
+                            equalTo(DB_OPERATION, "DELETE"),
+                            equalTo(DB_SQL_TABLE, "Customer")));
 
           } else {
             String findAction;
@@ -404,18 +406,18 @@ class SpringJpaTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 val ->
                                     val.matches(
                                         Pattern.compile(
                                             "select ([^.]+).id([^,]*), ([^.]+).firstName([^,]*), ([^.]+).lastName (.*)from Customer (.*)where ([^.]+).id=\\?"))),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Customer")),
                 span ->
                     span.hasName("Session.merge spring.jpa.Customer")
                         .hasKind(INTERNAL)
@@ -444,15 +446,13 @@ class SpringJpaTest {
                     span.hasName("DELETE test.Customer")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "delete from Customer where id=?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DELETE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Customer")));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_STATEMENT, "delete from Customer where id=?"),
+                            equalTo(DB_OPERATION, "DELETE"),
+                            equalTo(DB_SQL_TABLE, "Customer")));
           }
         });
   }

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
@@ -7,11 +7,17 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v6_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.junit.jupiter.api.Named.named;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
@@ -36,7 +42,7 @@ public class CriteriaTest extends AbstractHibernateTest {
         Arguments.of(named("getSingleResultOrNull", interactions.get(2))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideParameters")
   void testCriteriaQuery(Consumer<Query<Value>> interaction) {
@@ -76,15 +82,14 @@ public class CriteriaTest extends AbstractHibernateTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
                             satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                stringAssert -> stringAssert.startsWith("select")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                                DB_STATEMENT, stringAssert -> stringAssert.startsWith("select")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/EntityManagerTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/EntityManagerTest.java
@@ -7,13 +7,19 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v6_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.junit.jupiter.api.Named.named;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
@@ -112,7 +118,7 @@ public class EntityManagerTest extends AbstractHibernateTest {
         });
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideAttachesStateParameters")
   void testAttachesStateToQuery(Parameter parameter) {
@@ -138,15 +144,13 @@ public class EntityManagerTest extends AbstractHibernateTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     assertTransactionCommitSpan(
                         span,
@@ -288,34 +292,34 @@ public class EntityManagerTest extends AbstractHibernateTest {
     public final Function<EntityManager, Query> queryBuildMethod;
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-            satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
-            satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(
       SpanDataAssert span, SpanData parent, String spanName) {
     return span.hasName(spanName)
         .hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-            satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
-            satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 
   private static SpanDataAssert assertSessionSpan(

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/ProcedureCallTest.java
@@ -7,13 +7,18 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v6_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import jakarta.persistence.ParameterMode;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -69,7 +74,7 @@ public class ProcedureCallTest {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testProcedureCall() {
     testing.runWithSpan(
@@ -102,12 +107,12 @@ public class ProcedureCallTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "{call TEST_PROC()}"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_STATEMENT, "{call TEST_PROC()}"),
+                            equalTo(DB_OPERATION, "CALL")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v6_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Named.named;
 
@@ -15,7 +22,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -219,7 +225,7 @@ public class SessionTest extends AbstractHibernateTest {
                 span -> assertClientSpan(span, trace.getSpan(2))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideAttachesStateToQueryParameters")
   void testAttachesStateToQuery(Parameter parameter) {
@@ -243,15 +249,13 @@ public class SessionTest extends AbstractHibernateTest {
                     span.hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value")),
+                            equalTo(DB_SYSTEM, "h2"),
+                            equalTo(DB_NAME, "db1"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value")),
                 span ->
                     assertSpanWithSessionId(
                         span,
@@ -803,35 +807,35 @@ public class SessionTest extends AbstractHibernateTest {
             equalTo(AttributeKey.stringKey("hibernate.session_id"), sessionId));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(SpanDataAssert span, SpanData parent) {
     return span.hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
-            satisfies(DbIncubatingAttributes.DB_STATEMENT, val -> val.isInstanceOf(String.class)),
-            satisfies(DbIncubatingAttributes.DB_OPERATION, val -> val.isInstanceOf(String.class)),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
+            satisfies(DB_STATEMENT, val -> val.isInstanceOf(String.class)),
+            satisfies(DB_OPERATION, val -> val.isInstanceOf(String.class)),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   private static SpanDataAssert assertClientSpan(
       SpanDataAssert span, SpanData parent, String verb) {
     return span.hasName(verb.concat(" db1.Value"))
         .hasKind(SpanKind.CLIENT)
         .hasParent(parent)
         .hasAttributesSatisfyingExactly(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "h2"),
-            equalTo(DbIncubatingAttributes.DB_NAME, "db1"),
-            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "h2:mem:"),
+            equalTo(DB_SYSTEM, "h2"),
+            equalTo(DB_NAME, "db1"),
+            equalTo(DB_USER, "sa"),
+            equalTo(DB_CONNECTION_STRING, "h2:mem:"),
             satisfies(
-                DbIncubatingAttributes.DB_STATEMENT,
+                DB_STATEMENT,
                 stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),
-            equalTo(DbIncubatingAttributes.DB_OPERATION, verb),
-            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"));
+            equalTo(DB_OPERATION, verb),
+            equalTo(DB_SQL_TABLE, "Value"));
   }
 }

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
@@ -10,6 +10,12 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -17,7 +23,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -76,7 +81,7 @@ class ProcedureCallTest {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testProcedureCall() {
 
@@ -114,12 +119,12 @@ class ProcedureCallTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "{call TEST_PROC()}"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_STATEMENT, "{call TEST_PROC()}"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            equalTo(DB_OPERATION, "CALL")),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.vertx.core.Vertx;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -301,13 +305,13 @@ class HibernateReactiveTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
                             equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 "select value0_.id as id1_0_0_, value0_.name as name2_0_0_ from Value value0_ where value0_.id=$1"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port)),
                 span ->

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v2_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.vertx.core.Vertx;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
@@ -293,13 +297,13 @@ class HibernateReactiveTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
                             equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
+                                DB_STATEMENT,
                                 "select v1_0.id,v1_0.name from Value v1_0 where v1_0.id=$1"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "Value"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "Value"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port)),
                 span ->

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
@@ -10,6 +10,13 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.javaagent.instrumentation.httpurlconnection.StreamUtils.readLines;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -21,11 +28,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -123,12 +125,12 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                equalTo(ServerAttributes.SERVER_PORT, url.getPort()),
-                equalTo(UrlAttributes.URL_FULL, url.toString()),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, STATUS)));
+                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                equalTo(SERVER_ADDRESS, "localhost"),
+                equalTo(SERVER_PORT, url.getPort()),
+                equalTo(URL_FULL, url.toString()),
+                equalTo(HTTP_REQUEST_METHOD, "GET"),
+                equalTo(HTTP_RESPONSE_STATUS_CODE, STATUS)));
 
     testing.waitAndAssertTraces(
         trace ->
@@ -168,12 +170,12 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                equalTo(ServerAttributes.SERVER_PORT, url.getPort()),
-                equalTo(UrlAttributes.URL_FULL, url.toString()),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, STATUS)));
+                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                equalTo(SERVER_ADDRESS, "localhost"),
+                equalTo(SERVER_PORT, url.getPort()),
+                equalTo(URL_FULL, url.toString()),
+                equalTo(HTTP_REQUEST_METHOD, "GET"),
+                equalTo(HTTP_RESPONSE_STATUS_CODE, STATUS)));
 
     testing.waitAndAssertTraces(
         trace ->
@@ -219,12 +221,12 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                equalTo(ServerAttributes.SERVER_PORT, url.getPort()),
-                equalTo(UrlAttributes.URL_FULL, url.toString()),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, STATUS)));
+                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                equalTo(SERVER_ADDRESS, "localhost"),
+                equalTo(SERVER_PORT, url.getPort()),
+                equalTo(URL_FULL, url.toString()),
+                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                equalTo(HTTP_RESPONSE_STATUS_CODE, STATUS)));
 
     testing.waitAndAssertTraces(
         trace ->
@@ -272,12 +274,12 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                equalTo(ServerAttributes.SERVER_PORT, url.getPort()),
-                equalTo(UrlAttributes.URL_FULL, url.toString()),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
-                equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, STATUS)));
+                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                equalTo(SERVER_ADDRESS, "localhost"),
+                equalTo(SERVER_PORT, url.getPort()),
+                equalTo(URL_FULL, url.toString()),
+                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                equalTo(HTTP_RESPONSE_STATUS_CODE, STATUS)));
 
     testing.waitAndAssertTraces(
         trace ->
@@ -314,12 +316,12 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     List<AttributeAssertion> attributes =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT),
-                equalTo(UrlAttributes.URL_FULL, uri),
-                equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                equalTo(ErrorAttributes.ERROR_TYPE, "java.net.ConnectException")));
+                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                equalTo(SERVER_ADDRESS, "localhost"),
+                equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT),
+                equalTo(URL_FULL, uri),
+                equalTo(HTTP_REQUEST_METHOD, "GET"),
+                equalTo(ERROR_TYPE, "java.net.ConnectException")));
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -6,6 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.influxdb.v2_4;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +19,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -318,13 +322,13 @@ class InfluxDbClientTest {
     List<AttributeAssertion> result = new ArrayList<>();
     result.addAll(
         asList(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "influxdb"),
-            equalTo(DbIncubatingAttributes.DB_NAME, databaseName),
-            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-            equalTo(ServerAttributes.SERVER_PORT, port),
-            equalTo(DbIncubatingAttributes.DB_OPERATION, operation)));
+            equalTo(DB_SYSTEM, "influxdb"),
+            equalTo(DB_NAME, databaseName),
+            equalTo(SERVER_ADDRESS, host),
+            equalTo(SERVER_PORT, port),
+            equalTo(DB_OPERATION, operation)));
     if (statement != null) {
-      result.add(equalTo(DbIncubatingAttributes.DB_STATEMENT, statement));
+      result.add(equalTo(DB_STATEMENT, statement));
     }
     return result;
   }

--- a/instrumentation/influxdb-2.4/javaagent/src/test24/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClient24Test.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test24/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClient24Test.java
@@ -6,6 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.influxdb.v2_4;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +19,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -147,13 +151,13 @@ class InfluxDbClient24Test {
     List<AttributeAssertion> result = new ArrayList<>();
     result.addAll(
         asList(
-            equalTo(DbIncubatingAttributes.DB_SYSTEM, "influxdb"),
-            equalTo(DbIncubatingAttributes.DB_NAME, databaseName),
-            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-            equalTo(ServerAttributes.SERVER_PORT, port),
-            equalTo(DbIncubatingAttributes.DB_OPERATION, operation)));
+            equalTo(DB_SYSTEM, "influxdb"),
+            equalTo(DB_NAME, databaseName),
+            equalTo(SERVER_ADDRESS, host),
+            equalTo(SERVER_PORT, port),
+            equalTo(DB_OPERATION, operation)));
     if (statement != null) {
-      result.add(equalTo(DbIncubatingAttributes.DB_STATEMENT, statement));
+      result.add(equalTo(DB_STATEMENT, statement));
     }
     return result;
   }

--- a/instrumentation/java-http-client/testing/src/main/java/io/opentelemetry/instrumentation/httpclient/AbstractJavaHttpClientTest.java
+++ b/instrumentation/java-http-client/testing/src/main/java/io/opentelemetry/instrumentation/httpclient/AbstractJavaHttpClientTest.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.instrumentation.httpclient;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -94,7 +95,7 @@ public abstract class AbstractJavaHttpClientTest extends AbstractHttpClientTest<
           if ("http://localhost:61/".equals(uri.toString())
               || "https://192.0.2.1/".equals(uri.toString())
               || uri.toString().contains("/read-timeout")) {
-            attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+            attributes.remove(NETWORK_PROTOCOL_VERSION);
           }
           return attributes;
         });

--- a/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
+++ b/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
@@ -8,13 +8,15 @@ package io.opentelemetry.javaagent.instrumentation.jul;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -117,11 +119,10 @@ class JavaUtilLoggingTest {
             .hasAttributesSatisfyingExactly(
                 equalTo(ThreadIncubatingAttributes.THREAD_NAME, Thread.currentThread().getName()),
                 equalTo(ThreadIncubatingAttributes.THREAD_ID, Thread.currentThread().getId()),
-                equalTo(ExceptionAttributes.EXCEPTION_TYPE, IllegalStateException.class.getName()),
-                equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                equalTo(EXCEPTION_MESSAGE, "hello"),
                 satisfies(
-                    ExceptionAttributes.EXCEPTION_STACKTRACE,
-                    v -> v.contains(JavaUtilLoggingTest.class.getName())));
+                    EXCEPTION_STACKTRACE, v -> v.contains(JavaUtilLoggingTest.class.getName())));
       } else {
         assertThat(log)
             .hasAttributesSatisfyingExactly(

--- a/instrumentation/javalin-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javalin/v5_0/JavalinTest.java
+++ b/instrumentation/javalin-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javalin/v5_0/JavalinTest.java
@@ -8,20 +8,25 @@ package io.opentelemetry.javaagent.instrumentation.javalin.v5_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 
 import io.javalin.Javalin;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.testing.internal.armeria.client.WebClient;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import org.junit.jupiter.api.AfterAll;
@@ -66,22 +71,18 @@ class JavalinTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/param/" + id),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/param/" + id),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/param/{id}"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)))));
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)))));
   }
 
   @Test
@@ -96,23 +97,19 @@ class JavalinTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/error"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 500),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/error"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 500),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/error"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "500"),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)))));
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(ERROR_TYPE, "500"),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)))));
   }
 
   @Test
@@ -128,22 +125,18 @@ class JavalinTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/async"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/async"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/async"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)))));
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)))));
   }
 
   @Test

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/JaxRsClientV1Test.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/JaxRsClientV1Test.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
@@ -17,7 +19,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
@@ -54,7 +55,7 @@ class JaxRsClientV1Test extends AbstractHttpClientTest<WebResource.Builder> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
   }

--- a/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/appender/v1_1/JbossLogmanagerTest.java
+++ b/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/appender/v1_1/JbossLogmanagerTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.jbosslogmanager.appender.v1_1
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -18,7 +21,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -156,12 +158,10 @@ class JbossLogmanagerTest {
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
+                          EXCEPTION_STACKTRACE,
                           v -> v.contains(JbossLogmanagerTest.class.getName()))));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);

--- a/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/test/JdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/test/JdbcInstrumentationTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.jdbc.test;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
@@ -33,6 +32,7 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.beans.PropertyVetoException;
 import java.io.Closeable;
 import java.io.IOException;
@@ -76,7 +76,8 @@ class JdbcInstrumentationTest {
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
-  static final AttributeKey<String> DB_CONNECTION_STRING = DB_CONNECTION_STRING;
+  static final AttributeKey<String> DB_CONNECTION_STRING =
+      DbIncubatingAttributes.DB_CONNECTION_STRING;
 
   private static final String dbName = "jdbcUnitTest";
   private static final String dbNameLower = dbName.toLowerCase(Locale.ROOT);

--- a/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/test/JdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/test/JdbcInstrumentationTest.java
@@ -7,6 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.jdbc.test;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,9 +32,7 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.beans.PropertyVetoException;
 import java.io.Closeable;
 import java.io.IOException;
@@ -69,9 +75,8 @@ class JdbcInstrumentationTest {
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
-  static final AttributeKey<String> DB_CONNECTION_STRING =
-      DbIncubatingAttributes.DB_CONNECTION_STRING;
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
+  static final AttributeKey<String> DB_CONNECTION_STRING = DB_CONNECTION_STRING;
 
   private static final String dbName = "jdbcUnitTest";
   private static final String dbNameLower = dbName.toLowerCase(Locale.ROOT);
@@ -365,19 +370,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   static Stream<Arguments> preparedStatementStream() throws SQLException {
@@ -490,19 +495,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   @ParameterizedTest
@@ -533,19 +538,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   @ParameterizedTest
@@ -576,19 +581,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   static Stream<Arguments> statementUpdateStream() throws SQLException {
@@ -718,19 +723,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, query),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CREATE TABLE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, query),
+                            equalTo(DB_OPERATION, "CREATE TABLE"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   static Stream<Arguments> preparedStatementUpdateStream() throws SQLException {
@@ -826,19 +831,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, query),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "CREATE TABLE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, query),
+                            equalTo(DB_OPERATION, "CREATE TABLE"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   static Stream<Arguments> connectionConstructorStream() {
@@ -939,19 +944,19 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
+                            equalTo(DB_SYSTEM, system),
+                            equalTo(DB_NAME, dbNameLower),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (username != null) {
                                     val.isEqualTo(username);
                                   }
                                 }),
                             equalTo(DB_CONNECTION_STRING, url),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, table))));
   }
 
   static Stream<Arguments> getConnectionStream() {
@@ -1015,15 +1020,15 @@ class JdbcInstrumentationTest {
                                       CodeIncubatingAttributes.CODE_NAMESPACE,
                                       datasource.getClass().getName()),
                                   equalTo(CodeIncubatingAttributes.CODE_FUNCTION, "getConnection"),
-                                  equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
+                                  equalTo(DB_SYSTEM, system),
                                   satisfies(
-                                      DbIncubatingAttributes.DB_USER,
+                                      DB_USER,
                                       val -> {
                                         if (user != null) {
                                           val.isEqualTo(user);
                                         }
                                       }),
-                                  equalTo(DbIncubatingAttributes.DB_NAME, "jdbcunittest"),
+                                  equalTo(DB_NAME, "jdbcunittest"),
                                   equalTo(DB_CONNECTION_STRING, connectionString))));
           if (recursive) {
             assertions.add(
@@ -1036,15 +1041,15 @@ class JdbcInstrumentationTest {
                                 CodeIncubatingAttributes.CODE_NAMESPACE,
                                 datasource.getClass().getName()),
                             equalTo(CodeIncubatingAttributes.CODE_FUNCTION, "getConnection"),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, system),
+                            equalTo(DB_SYSTEM, system),
                             satisfies(
-                                DbIncubatingAttributes.DB_USER,
+                                DB_USER,
                                 val -> {
                                   if (user != null) {
                                     val.isEqualTo(user);
                                   }
                                 }),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "jdbcunittest"),
+                            equalTo(DB_NAME, "jdbcunittest"),
                             equalTo(DB_CONNECTION_STRING, connectionString)));
           }
           trace.hasSpansSatisfyingExactly(assertions);
@@ -1078,10 +1083,10 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "other_sql"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "testing ?"),
+                            equalTo(DB_SYSTEM, "other_sql"),
+                            equalTo(DB_STATEMENT, "testing ?"),
                             equalTo(DB_CONNECTION_STRING, "testdb://localhost"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"))));
+                            equalTo(SERVER_ADDRESS, "localhost"))));
   }
 
   static Stream<Arguments> spanNameStream() {
@@ -1159,13 +1164,13 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "other_sql"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, databaseName),
+                            equalTo(DB_SYSTEM, "other_sql"),
+                            equalTo(DB_NAME, databaseName),
                             equalTo(DB_CONNECTION_STRING, "testdb://localhost"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, sanitizedQuery),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, operation),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, table),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"))));
+                            equalTo(DB_STATEMENT, sanitizedQuery),
+                            equalTo(DB_OPERATION, operation),
+                            equalTo(DB_SQL_TABLE, table),
+                            equalTo(SERVER_ADDRESS, "localhost"))));
   }
 
   @ParameterizedTest
@@ -1207,17 +1212,13 @@ class JdbcInstrumentationTest {
                     span.hasName("SELECT INFORMATION_SCHEMA.SYSTEM_USERS")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbNameLower),
-                            equalTo(DbIncubatingAttributes.DB_USER, "SA"),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, dbNameLower),
+                            equalTo(DB_USER, "SA"),
                             equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_SQL_TABLE,
-                                "INFORMATION_SCHEMA.SYSTEM_USERS")));
+                            equalTo(DB_STATEMENT, "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "INFORMATION_SCHEMA.SYSTEM_USERS")));
     for (int i = 0; i < numQueries; i++) {
       assertions.add(traceAssertConsumer);
     }
@@ -1281,12 +1282,12 @@ class JdbcInstrumentationTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfying(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "other_sql"),
+                            equalTo(DB_SYSTEM, "other_sql"),
                             equalTo(DB_CONNECTION_STRING, "testdb://localhost"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM table"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "table"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"))));
+                            equalTo(DB_STATEMENT, "SELECT * FROM table"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "table"),
+                            equalTo(SERVER_ADDRESS, "localhost"))));
   }
 
   // regression test for

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.instrumentation.jdbc.datasource;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryConnection;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -42,7 +42,7 @@ class JdbcTelemetryTest {
                 span -> span.hasName("TestDataSource.getConnection"),
                 span ->
                     span.hasName("SELECT dbname")
-                        .hasAttribute(equalTo(DbIncubatingAttributes.DB_STATEMENT, "SELECT ?;"))));
+                        .hasAttribute(equalTo(DB_STATEMENT, "SELECT ?;"))));
   }
 
   @Test
@@ -118,7 +118,7 @@ class JdbcTelemetryTest {
                 span -> span.hasName("TestDataSource.getConnection"),
                 span ->
                     span.hasName("SELECT dbname")
-                        .hasAttribute(equalTo(DbIncubatingAttributes.DB_STATEMENT, "SELECT 1;"))));
+                        .hasAttribute(equalTo(DB_STATEMENT, "SELECT 1;"))));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.jdbc.datasource;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -16,7 +19,6 @@ import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.stream.Stream;
@@ -33,7 +35,7 @@ class OpenTelemetryDataSourceTest {
   @RegisterExtension
   static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest
   @ArgumentsSource(GetConnectionMethods.class)
   void shouldEmitGetConnectionSpans(GetConnectionFunction getConnection) throws SQLException {
@@ -55,11 +57,9 @@ class OpenTelemetryDataSourceTest {
                                 CodeIncubatingAttributes.CODE_NAMESPACE,
                                 TestDataSource.class.getName()),
                             equalTo(CodeIncubatingAttributes.CODE_FUNCTION, "getConnection"),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "postgresql"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "dbname"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_CONNECTION_STRING,
-                                "postgresql://127.0.0.1:5432"))));
+                            equalTo(DB_SYSTEM, "postgresql"),
+                            equalTo(DB_NAME, "dbname"),
+                            equalTo(DB_CONNECTION_STRING, "postgresql://127.0.0.1:5432"))));
 
     assertThat(connection).isExactlyInstanceOf(OpenTelemetryConnection.class);
     DbInfo dbInfo = ((OpenTelemetryConnection) connection).getDbInfo();

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
@@ -7,6 +7,15 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.JdbcInstrumenterFactory.createStatementInstrumenter;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -17,8 +26,6 @@ import io.opentelemetry.instrumentation.jdbc.TestConnection;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -187,15 +194,14 @@ class OpenTelemetryConnectionTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, dbInfo.getSystem()),
-                            equalTo(DbIncubatingAttributes.DB_NAME, dbInfo.getName()),
-                            equalTo(DbIncubatingAttributes.DB_USER, dbInfo.getUser()),
-                            equalTo(
-                                DbIncubatingAttributes.DB_CONNECTION_STRING, dbInfo.getShortUrl()),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, query),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "users"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, dbInfo.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, dbInfo.getPort()))));
+                            equalTo(DB_SYSTEM, dbInfo.getSystem()),
+                            equalTo(DB_NAME, dbInfo.getName()),
+                            equalTo(DB_USER, dbInfo.getUser()),
+                            equalTo(DB_CONNECTION_STRING, dbInfo.getShortUrl()),
+                            equalTo(DB_STATEMENT, query),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "users"),
+                            equalTo(SERVER_ADDRESS, dbInfo.getHost()),
+                            equalTo(SERVER_PORT, dbInfo.getPort()))));
   }
 }

--- a/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
+++ b/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
@@ -6,13 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.jedis;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,11 +68,11 @@ public abstract class AbstractJedisTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))));
   }
 
   @Test
@@ -86,22 +89,22 @@ public abstract class AbstractJedisTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET foo"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET foo"),
+                            equalTo(DB_OPERATION, "GET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))));
   }
 
   @Test
@@ -118,21 +121,21 @@ public abstract class AbstractJedisTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))));
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/Jedis30ClientTest.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/Jedis30ClientTest.java
@@ -7,14 +7,19 @@ package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.assertj.core.api.AbstractLongAssert;
@@ -74,16 +79,14 @@ class Jedis30ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))));
   }
 
   @Test
@@ -100,32 +103,28 @@ class Jedis30ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET foo"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET foo"),
+                            equalTo(DB_OPERATION, "GET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))));
   }
 
   @Test
@@ -142,31 +141,27 @@ class Jedis30ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))));
   }
 }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/Jedis40ClientTest.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/Jedis40ClientTest.java
@@ -6,13 +6,17 @@
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.junit.jupiter.api.AfterAll;
@@ -68,12 +72,12 @@ class Jedis40ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))));
   }
 
   @Test
@@ -90,24 +94,24 @@ class Jedis40ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET foo"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET foo"),
+                            equalTo(DB_OPERATION, "GET"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))));
   }
 
   @Test
@@ -124,23 +128,23 @@ class Jedis40ClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET foo ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET foo ?"),
+                            equalTo(DB_OPERATION, "SET"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))));
   }
 }

--- a/instrumentation/jetty/jetty-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/JettyHandlerTest.java
+++ b/instrumentation/jetty/jetty-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/JettyHandlerTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
-import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletException;
@@ -79,9 +79,7 @@ class JettyHandlerTest extends AbstractHttpServerTest<Server> {
   @Override
   protected void configure(HttpServerTestOptions options) {
     options.setHttpAttributes(
-        unused ->
-            Sets.difference(
-                DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HttpAttributes.HTTP_ROUTE)));
+        unused -> Sets.difference(DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HTTP_ROUTE)));
     options.setHasResponseSpan(endpoint -> endpoint == REDIRECT || endpoint == ERROR);
     options.setHasResponseCustomizer(endpoint -> true);
   }

--- a/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
+++ b/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
-import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -60,9 +60,7 @@ class Jetty12HandlerTest extends AbstractHttpServerTest<Server> {
   @Override
   protected void configure(HttpServerTestOptions options) {
     options.setHttpAttributes(
-        unused ->
-            Sets.difference(
-                DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HttpAttributes.HTTP_ROUTE)));
+        unused -> Sets.difference(DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HTTP_ROUTE)));
     options.setHasResponseCustomizer(endpoint -> endpoint != EXCEPTION);
   }
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/JettyHandlerTest.java
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/JettyHandlerTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
-import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.io.IOException;
 import java.io.Writer;
@@ -79,9 +79,7 @@ class JettyHandlerTest extends AbstractHttpServerTest<Server> {
   @Override
   protected void configure(HttpServerTestOptions options) {
     options.setHttpAttributes(
-        unused ->
-            Sets.difference(
-                DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HttpAttributes.HTTP_ROUTE)));
+        unused -> Sets.difference(DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HTTP_ROUTE)));
     options.setHasResponseSpan(endpoint -> endpoint == REDIRECT || endpoint == ERROR);
     options.setHasResponseCustomizer(endpoint -> endpoint != EXCEPTION);
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
@@ -9,6 +9,11 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -18,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -168,12 +172,10 @@ public class Jms2InstrumentationTest {
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              destinationName),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                          equalTo(MESSAGING_SYSTEM, "jms"),
+                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                          equalTo(MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
           producerSpan.set(trace.getSpan(1));
@@ -187,12 +189,10 @@ public class Jms2InstrumentationTest {
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
 
@@ -235,24 +235,20 @@ public class Jms2InstrumentationTest {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
                     span.hasName(destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
@@ -279,9 +275,8 @@ public class Jms2InstrumentationTest {
 
   private static AttributeAssertion messagingTempDestination(boolean isTemporary) {
     return isTemporary
-        ? equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true)
-        : satisfies(
-            MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+        ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
+        : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
   }
 
   static final class EmptyReceiveArgumentsProvider implements ArgumentsProvider {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -10,6 +10,11 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -18,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -128,24 +132,20 @@ abstract class AbstractJms1Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
                     span.hasName(destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
@@ -211,12 +211,10 @@ abstract class AbstractJms1Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
@@ -229,12 +227,10 @@ abstract class AbstractJms1Test {
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
@@ -285,12 +281,10 @@ abstract class AbstractJms1Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -300,20 +294,17 @@ abstract class AbstractJms1Test {
                         .hasNoParent()
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
 
   static AttributeAssertion messagingTempDestination(boolean isTemporary) {
     return isTemporary
-        ? equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true)
-        : satisfies(
-            MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+        ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
+        : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
   }
 
   static final class EmptyReceiveArgumentsProvider implements ArgumentsProvider {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -8,11 +8,14 @@ package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -61,12 +64,10 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              destinationName),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                          equalTo(MESSAGING_SYSTEM, "jms"),
+                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                          equalTo(MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
           producerSpan.set(trace.getSpan(1));
@@ -80,12 +81,10 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -8,9 +8,12 @@ package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
@@ -57,12 +60,10 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
                     span.hasName(destinationName + " receive")
@@ -70,12 +71,10 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                destinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->
             trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer parent").hasNoParent()));

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -10,6 +10,11 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -18,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import jakarta.jms.Connection;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
@@ -144,24 +148,20 @@ abstract class AbstractJms3Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                producerDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
                     span.hasName(actualDestinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                actualDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId)),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
@@ -228,12 +228,10 @@ abstract class AbstractJms3Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                producerDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
@@ -246,12 +244,10 @@ abstract class AbstractJms3Test {
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                actualDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
                                 singletonList("test")),
@@ -263,9 +259,8 @@ abstract class AbstractJms3Test {
 
   static AttributeAssertion messagingTempDestination(boolean isTemporary) {
     return isTemporary
-        ? equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true)
-        : satisfies(
-            MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+        ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
+        : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
   }
 
   static final class EmptyReceiveArgumentsProvider implements ArgumentsProvider {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -8,11 +8,14 @@ package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageConsumer;
@@ -64,12 +67,10 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              producerDestinationName),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                          equalTo(MESSAGING_SYSTEM, "jms"),
+                          equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
+                          equalTo(MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
           producerSpan.set(trace.getSpan(1));
@@ -83,12 +84,9 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                actualDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId))));
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId))));
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -8,9 +8,12 @@ package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageConsumer;
@@ -60,12 +63,10 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                producerDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
                     span.hasName(actualDestinationName + " receive")
@@ -73,13 +74,10 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                actualDestinationName),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, messageId))),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId))),
         trace ->
             trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer parent").hasNoParent()));
   }

--- a/instrumentation/jsf/jsf-jakarta-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/jakarta/BaseJsfTest.java
+++ b/instrumentation/jsf/jsf-jakarta-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/jakarta/BaseJsfTest.java
@@ -7,6 +7,18 @@ package io.opentelemetry.javaagent.instrumentation.jsf.jakarta;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -16,12 +28,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpData;
@@ -110,21 +116,19 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
                     span.hasName(getContextPath() + "/hello.xhtml")
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, getContextPath() + "/" + path),
+                            equalTo(USER_AGENT_ORIGINAL, TEST_USER_AGENT),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(HTTP_ROUTE, getContextPath() + "/" + route),
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, getContextPath() + "/" + path),
-                            equalTo(UserAgentAttributes.USER_AGENT_ORIGINAL, TEST_USER_AGENT),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(HttpAttributes.HTTP_ROUTE, getContextPath() + "/" + route),
-                            satisfies(
-                                ClientAttributes.CLIENT_ADDRESS,
+                                CLIENT_ADDRESS,
                                 val ->
                                     val.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo(TEST_CLIENT_IP),

--- a/instrumentation/jsf/jsf-javax-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/javax/BaseJsfTest.java
+++ b/instrumentation/jsf/jsf-javax-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/javax/BaseJsfTest.java
@@ -7,6 +7,18 @@ package io.opentelemetry.javaagent.instrumentation.jsf.javax;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static java.util.Collections.addAll;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,12 +29,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpData;
@@ -119,21 +125,19 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
                     span.hasName(getContextPath() + "/hello.xhtml")
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, getContextPath() + "/" + path),
+                            equalTo(USER_AGENT_ORIGINAL, TEST_USER_AGENT),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(HTTP_ROUTE, getContextPath() + "/" + route),
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, getContextPath() + "/" + path),
-                            equalTo(UserAgentAttributes.USER_AGENT_ORIGINAL, TEST_USER_AGENT),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(HttpAttributes.HTTP_ROUTE, getContextPath() + "/" + route),
-                            satisfies(
-                                ClientAttributes.CLIENT_ADDRESS,
+                                CLIENT_ADDRESS,
                                 val ->
                                     val.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo(TEST_CLIENT_IP),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaClientBaseTest.java
@@ -7,10 +7,19 @@ package io.opentelemetry.instrumentation.kafka.internal;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_TOMBSTONE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -161,23 +170,17 @@ public abstract class KafkaClientBaseTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     if (messageValue == null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true));
     }
     if (testHeaders) {
       assertions.add(
@@ -193,16 +196,14 @@ public abstract class KafkaClientBaseTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "receive"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-                    AbstractLongAssert::isPositive)));
+                satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
     // consumer group is not available in version 0.11
     if (Boolean.getBoolean("testLatestDeps")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     if (testHeaders) {
       assertions.add(
@@ -219,35 +220,28 @@ public abstract class KafkaClientBaseTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "process"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(
                     AttributeKey.longKey("kafka.record.queue_time_ms"),
                     AbstractLongAssert::isNotNegative)));
     // consumer group is not available in version 0.11
     if (Boolean.getBoolean("testLatestDeps")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     if (messageValue == null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true));
     } else {
       assertions.add(
           equalTo(
-              MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-              messageValue.getBytes(StandardCharsets.UTF_8).length));
+              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
     }
     if (testHeaders) {
       assertions.add(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -7,9 +7,15 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
@@ -28,11 +34,9 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                SHARED_TOPIC),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                            equalTo(MESSAGING_OPERATION, "publish"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("producer"))),
@@ -41,23 +45,18 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                            equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                SHARED_TOPIC),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                MESSAGING_MESSAGE_BODY_SIZE,
                                 greeting.getBytes(StandardCharsets.UTF_8).length),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "test"),
+                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer"))),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
@@ -8,12 +8,19 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.AbstractLongAssert;
@@ -35,11 +42,9 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              SHARED_TOPIC),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))));
@@ -59,42 +64,32 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                         .hasNoParent()
                         .hasLinksSatisfying(links -> assertThat(links).isEmpty())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                SHARED_TOPIC),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "test"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)),
+                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
                 span ->
                     span.hasName(SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpanContext.get()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                            equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                SHARED_TOPIC),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                MESSAGING_MESSAGE_BODY_SIZE,
                                 greeting.getBytes(StandardCharsets.UTF_8).length),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "test"),
+                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer"))),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -7,11 +7,17 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,16 +64,12 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -82,22 +84,17 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "process"),
                 equalTo(
-                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                    greeting.getBytes(StandardCharsets.UTF_8).length),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative),
+                    MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(StandardCharsets.UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(
                     AttributeKey.longKey("kafka.record.queue_time_ms"),
                     AbstractLongAssert::isNotNegative),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                 satisfies(
                     MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer"))));
     if (testHeaders) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -7,6 +7,14 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -14,7 +22,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,16 +87,12 @@ class WrapperTest extends AbstractWrapperTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -104,22 +107,17 @@ class WrapperTest extends AbstractWrapperTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "process"),
                 equalTo(
-                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                    greeting.getBytes(StandardCharsets.UTF_8).length),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative),
+                    MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(StandardCharsets.UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(
                     AttributeKey.longKey("kafka.record.queue_time_ms"),
                     AbstractLongAssert::isNotNegative),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                 satisfies(
                     MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer"))));
     if (testHeaders) {
@@ -136,12 +134,12 @@ class WrapperTest extends AbstractWrapperTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, "receive"),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
                 satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
     if (testHeaders) {
       assertions.add(
           equalTo(

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsDefaultTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsDefaultTest.java
@@ -9,6 +9,15 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,19 +112,16 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(
                           equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                              MESSAGING_SYSTEM,
                               MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              STREAM_PENDING),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(MESSAGING_CLIENT_ID, k -> k.startsWith("producer")),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                              MESSAGING_DESTINATION_PARTITION_ID,
                               k -> k.isInstanceOf(String.class)),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10")));
+                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")));
           producerPendingRef.set(trace.getSpan(0));
         },
         trace -> {
@@ -126,21 +132,15 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                     new ArrayList<>(
                         asList(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .KAFKA),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                STREAM_PENDING),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
+                            equalTo(MESSAGING_OPERATION, "receive"),
                             satisfies(MESSAGING_CLIENT_ID, k -> k.endsWith("consumer")),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
                 if (Boolean.getBoolean("testLatestDeps")) {
-                  assertions.add(
-                      equalTo(
-                          MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                          "test-application"));
+                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
                 }
                 span.hasName(STREAM_PENDING + " receive")
                     .hasKind(SpanKind.CONSUMER)
@@ -153,33 +153,24 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                     new ArrayList<>(
                         asList(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .KAFKA),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                STREAM_PENDING),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
+                            equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(MESSAGING_CLIENT_ID, k -> k.endsWith("consumer")),
+                            satisfies(MESSAGING_MESSAGE_BODY_SIZE, k -> k.isInstanceOf(Long.class)),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                k -> k.isInstanceOf(Long.class)),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 k -> k.isInstanceOf(String.class)),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                             satisfies(
                                 longKey("kafka.record.queue_time_ms"),
                                 k -> k.isGreaterThanOrEqualTo(0)),
                             equalTo(stringKey("asdf"), "testing")));
                 if (Boolean.getBoolean("testLatestDeps")) {
-                  assertions.add(
-                      equalTo(
-                          MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                          "test-application"));
+                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
                 }
                 span.hasName(STREAM_PENDING + " process")
                     .hasKind(SpanKind.CONSUMER)
@@ -196,18 +187,15 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                       .hasSpanId(receivedContext.getSpanId())
                       .hasAttributesSatisfyingExactly(
                           equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                              MESSAGING_SYSTEM,
                               MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              STREAM_PROCESSED),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(MESSAGING_CLIENT_ID, k -> k.endsWith("producer")),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                              MESSAGING_DESTINATION_PARTITION_ID,
                               k -> k.isInstanceOf(String.class)),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0)));
+                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0)));
 
           producerProcessedRef.set(trace.getSpan(2));
         },
@@ -219,20 +207,15 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                       new ArrayList<>(
                           asList(
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .KAFKA),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  STREAM_PROCESSED),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
+                              equalTo(MESSAGING_OPERATION, "receive"),
                               satisfies(MESSAGING_CLIENT_ID, k -> k.startsWith("consumer")),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                              equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
                   if (Boolean.getBoolean("testLatestDeps")) {
-                    assertions.add(
-                        equalTo(
-                            MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
                   }
                   span.hasName(STREAM_PROCESSED + " receive")
                       .hasKind(SpanKind.CONSUMER)
@@ -245,32 +228,25 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                       new ArrayList<>(
                           asList(
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .KAFKA),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  STREAM_PROCESSED),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
+                              equalTo(MESSAGING_OPERATION, "process"),
                               satisfies(MESSAGING_CLIENT_ID, k -> k.startsWith("consumer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                  k -> k.isInstanceOf(Long.class)),
+                                  MESSAGING_MESSAGE_BODY_SIZE, k -> k.isInstanceOf(Long.class)),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   k -> k.isInstanceOf(String.class)),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                               satisfies(
                                   longKey("kafka.record.queue_time_ms"),
                                   k -> k.isGreaterThanOrEqualTo(0)),
                               equalTo(longKey("testing"), 123)));
                   if (Boolean.getBoolean("testLatestDeps")) {
-                    assertions.add(
-                        equalTo(
-                            MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
                   }
                   span.hasName(STREAM_PROCESSED + " process")
                       .hasKind(SpanKind.CONSUMER)

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSuppressReceiveSpansTest.java
@@ -9,6 +9,14 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,54 +102,42 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .KAFKA),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                STREAM_PENDING),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
+                            equalTo(MESSAGING_OPERATION, "publish"),
                             equalTo(MESSAGING_CLIENT_ID, "producer-1"),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 k -> k.isInstanceOf(String.class)),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
                 // kafka-stream CONSUMER
                 span -> {
                   List<AttributeAssertion> assertions =
                       new ArrayList<>(
                           asList(
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .KAFKA),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  STREAM_PENDING),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
+                              equalTo(MESSAGING_OPERATION, "process"),
                               satisfies(MESSAGING_CLIENT_ID, k -> k.endsWith("consumer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                  k -> k.isInstanceOf(Long.class)),
+                                  MESSAGING_MESSAGE_BODY_SIZE, k -> k.isInstanceOf(Long.class)),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   k -> k.isInstanceOf(String.class)),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                               satisfies(
                                   longKey("kafka.record.queue_time_ms"),
                                   k -> k.isGreaterThanOrEqualTo(0)),
                               equalTo(stringKey("asdf"), "testing")));
                   if (Boolean.getBoolean("testLatestDeps")) {
-                    assertions.add(
-                        equalTo(
-                            MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                            "test-application"));
+                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
                   }
                   span.hasName(STREAM_PENDING + " process")
                       .hasKind(SpanKind.CONSUMER)
@@ -158,17 +154,15 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
                       .hasSpanId(receivedContext.getSpanId())
                       .hasAttributesSatisfyingExactly(
                           equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                              MESSAGING_SYSTEM,
                               MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              STREAM_PROCESSED),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(MESSAGING_CLIENT_ID, k -> k.isInstanceOf(String.class)),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                              MESSAGING_DESTINATION_PARTITION_ID,
                               k -> k.isInstanceOf(String.class)),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0));
+                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0));
                 },
                 // kafka-clients CONSUMER process
                 span -> {
@@ -176,32 +170,25 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
                       new ArrayList<>(
                           asList(
                               equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                  MESSAGING_SYSTEM,
                                   MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                       .KAFKA),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  STREAM_PROCESSED),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
+                              equalTo(MESSAGING_OPERATION, "process"),
                               satisfies(MESSAGING_CLIENT_ID, k -> k.startsWith("consumer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                  k -> k.isInstanceOf(Long.class)),
+                                  MESSAGING_MESSAGE_BODY_SIZE, k -> k.isInstanceOf(Long.class)),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   k -> k.isInstanceOf(String.class)),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                               satisfies(
                                   longKey("kafka.record.queue_time_ms"),
                                   k -> k.isGreaterThanOrEqualTo(0)),
                               equalTo(longKey("testing"), 123)));
                   if (Boolean.getBoolean("testLatestDeps")) {
-                    assertions.add(
-                        equalTo(
-                            MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
                   }
                   span.hasName(STREAM_PROCESSED + " process")
                       .hasKind(SpanKind.CONSUMER)

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiCallback;
@@ -18,10 +24,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
@@ -80,13 +82,13 @@ class KubernetesClientTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy?path=path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name"))));
@@ -127,14 +129,14 @@ class KubernetesClientTest {
                         .hasException(apiException)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy?path=path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 451),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "451"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 451),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(ERROR_TYPE, "451"),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name"))));
@@ -181,13 +183,13 @@ class KubernetesClientTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy?path=path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name")),
@@ -242,14 +244,14 @@ class KubernetesClientTest {
                         .hasException(exceptionReference.get())
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy?path=path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 451),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "451"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 451),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(ERROR_TYPE, "451"),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name")),

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientVer20Test.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientVer20Test.java
@@ -7,6 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiCallback;
@@ -18,10 +24,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
@@ -84,13 +86,13 @@ class KubernetesClientVer20Test {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy/path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name"))));
@@ -131,14 +133,14 @@ class KubernetesClientVer20Test {
                         .hasException(apiException)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy/path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 451),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "451"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 451),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(ERROR_TYPE, "451"),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name"))));
@@ -184,13 +186,13 @@ class KubernetesClientVer20Test {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy/path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name")),
@@ -244,14 +246,14 @@ class KubernetesClientVer20Test {
                         .hasException(exceptionReference.get())
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 mockWebServer.httpUri()
                                     + "/api/v1/namespaces/namespace/pods/name/proxy/path"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 451),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(ServerAttributes.SERVER_PORT, mockWebServer.httpPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "451"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 451),
+                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                            equalTo(SERVER_PORT, mockWebServer.httpPort()),
+                            equalTo(ERROR_TYPE, "451"),
                             equalTo(
                                 AttributeKey.stringKey("kubernetes-client.namespace"), "namespace"),
                             equalTo(AttributeKey.stringKey("kubernetes-client.name"), "name")),

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -7,6 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -30,8 +34,6 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -143,9 +145,9 @@ class LettuceAsyncClientTest {
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @Test
@@ -171,9 +173,9 @@ class LettuceAsyncClientTest {
                         .hasStatus(StatusData.error())
                         .hasException(exception)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, incorrectPort),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, incorrectPort),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @Test
@@ -191,8 +193,7 @@ class LettuceAsyncClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "SET"))));
   }
 
   @Test
@@ -221,8 +222,7 @@ class LettuceAsyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET")),
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "GET")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -283,8 +283,7 @@ class LettuceAsyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET")),
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "GET")),
                 span ->
                     span.hasName("callback1")
                         .hasKind(SpanKind.INTERNAL)
@@ -324,8 +323,7 @@ class LettuceAsyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY")),
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "RANDOMKEY")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -368,16 +366,14 @@ class LettuceAsyncClientTest {
                     span.hasName("HMSET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HMSET"))),
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "HMSET"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("HGETALL")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HGETALL"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "HGETALL"))));
   }
 
   @Test
@@ -418,8 +414,7 @@ class LettuceAsyncClientTest {
                         .hasStatus(StatusData.error())
                         .hasException(new IllegalStateException("TestException"))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEL"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "DEL"))));
   }
 
   @Test
@@ -455,8 +450,8 @@ class LettuceAsyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SADD"),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_OPERATION, "SADD"),
                             equalTo(booleanKey("lettuce.command.cancelled"), true)),
                 span ->
                     span.hasName("callback")
@@ -492,8 +487,7 @@ class LettuceAsyncClientTest {
                     span.hasName("DEBUG")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEBUG"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "DEBUG"))));
   }
 
   @Test
@@ -526,7 +520,6 @@ class LettuceAsyncClientTest {
                     span.hasName("SHUTDOWN")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SHUTDOWN"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "SHUTDOWN"))));
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
@@ -6,6 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
@@ -20,8 +24,6 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -121,9 +123,9 @@ class LettuceSyncClientTest {
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @Test
@@ -144,9 +146,9 @@ class LettuceSyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasException(exception)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, incorrectPort),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, incorrectPort),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @Test
@@ -161,8 +163,7 @@ class LettuceSyncClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "SET"))));
   }
 
   @Test
@@ -177,8 +178,7 @@ class LettuceSyncClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -193,8 +193,7 @@ class LettuceSyncClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -209,8 +208,7 @@ class LettuceSyncClientTest {
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "RANDOMKEY"))));
   }
 
   @Test
@@ -225,8 +223,7 @@ class LettuceSyncClientTest {
                     span.hasName("LPUSH")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "LPUSH"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "LPUSH"))));
   }
 
   @Test
@@ -241,8 +238,7 @@ class LettuceSyncClientTest {
                     span.hasName("HMSET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HMSET"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "HMSET"))));
   }
 
   @Test
@@ -257,8 +253,7 @@ class LettuceSyncClientTest {
                     span.hasName("HGETALL")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HGETALL"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "HGETALL"))));
   }
 
   @Test
@@ -289,8 +284,7 @@ class LettuceSyncClientTest {
                     span.hasName("DEBUG")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEBUG"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "DEBUG"))));
   }
 
   @Test
@@ -323,7 +317,6 @@ class LettuceSyncClientTest {
                     span.hasName("SHUTDOWN")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SHUTDOWN"))));
+                            equalTo(DB_SYSTEM, "redis"), equalTo(DB_OPERATION, "SHUTDOWN"))));
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -8,6 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -28,8 +33,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
@@ -115,9 +118,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @SuppressWarnings("deprecation") // RedisURI constructor
@@ -146,9 +149,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, incorrectPort),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, incorrectPort),
+                            equalTo(DB_SYSTEM, "redis"))
                         .hasEventsSatisfyingExactly(
                             event ->
                                 event
@@ -185,9 +188,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET TESTSETKEY ?"),
+                            equalTo(DB_OPERATION, "SET"))));
   }
 
   @Test
@@ -217,9 +220,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET TESTKEY"),
+                            equalTo(DB_OPERATION, "GET")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -274,9 +277,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET NON_EXISTENT_KEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY"),
+                            equalTo(DB_OPERATION, "GET")),
                 span ->
                     span.hasName("callback1")
                         .hasKind(SpanKind.INTERNAL)
@@ -317,9 +320,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -363,20 +366,18 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("HMSET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "HMSET TESTHM firstname ? lastname ? age ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HMSET"))),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "HMSET TESTHM firstname ? lastname ? age ?"),
+                            equalTo(DB_OPERATION, "HMSET"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("HGETALL")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "HGETALL TESTHM"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HGETALL"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "HGETALL TESTHM"),
+                            equalTo(DB_OPERATION, "HGETALL"))));
   }
 
   @Test
@@ -417,9 +418,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasStatus(StatusData.error())
                         .hasException(new IllegalStateException("TestException"))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "DEL key1 key2"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEL"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "DEL key1 key2"),
+                            equalTo(DB_OPERATION, "DEL"))));
   }
 
   @Test
@@ -455,9 +456,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SADD SKEY ? ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SADD"),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SADD SKEY ? ?"),
+                            equalTo(DB_OPERATION, "SADD"),
                             equalTo(booleanKey("lettuce.command.cancelled"), true)),
                 span ->
                     span.hasName("callback")
@@ -480,9 +481,9 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("DEBUG")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "DEBUG SEGFAULT"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEBUG"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "DEBUG SEGFAULT"),
+                            equalTo(DB_OPERATION, "DEBUG"))));
   }
 
   @Test
@@ -500,8 +501,8 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("SHUTDOWN")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SHUTDOWN NOSAVE"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SHUTDOWN"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SHUTDOWN NOSAVE"),
+                            equalTo(DB_OPERATION, "SHUTDOWN"))));
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
@@ -7,6 +7,9 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lettuce.core.RedisClient;
@@ -16,7 +19,6 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
@@ -92,9 +94,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET TESTSETKEY ?"),
+                            equalTo(DB_OPERATION, "SET")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -123,9 +125,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET TESTKEY"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 
   // to make sure instrumentation's chained completion stages won't interfere with user's, while
@@ -162,9 +164,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET NON_EXISTENT_KEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY"),
+                            equalTo(DB_OPERATION, "GET")),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -192,9 +194,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY"))));
   }
 
   @Test
@@ -208,9 +210,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("COMMAND")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "COMMAND"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "COMMAND"),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "COMMAND"),
+                            equalTo(DB_OPERATION, "COMMAND"),
                             satisfies(
                                 AttributeKey.longKey("lettuce.command.results.count"),
                                 val -> val.isGreaterThan(100)))));
@@ -227,9 +229,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("COMMAND")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "COMMAND"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "COMMAND"),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "COMMAND"),
+                            equalTo(DB_OPERATION, "COMMAND"),
                             satisfies(
                                 AttributeKey.booleanKey("lettuce.command.cancelled"),
                                 AbstractBooleanAssert::isTrue),
@@ -261,9 +263,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("DEBUG")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "DEBUG SEGFAULT"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEBUG"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "DEBUG SEGFAULT"),
+                            equalTo(DB_OPERATION, "DEBUG"))));
   }
 
   @Test
@@ -281,9 +283,9 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                     span.hasName("SHUTDOWN")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SHUTDOWN NOSAVE"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SHUTDOWN"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SHUTDOWN NOSAVE"),
+                            equalTo(DB_OPERATION, "SHUTDOWN"))));
   }
 
   @Test
@@ -301,17 +303,17 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET a ?"),
+                            equalTo(DB_OPERATION, "SET")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET a"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -329,17 +331,17 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET a ?"),
+                            equalTo(DB_OPERATION, "SET")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET a"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -362,16 +364,16 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET")),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET a ?"),
+                            equalTo(DB_OPERATION, "SET")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET a"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -7,6 +7,11 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
@@ -19,8 +24,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
@@ -90,9 +93,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))));
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(DB_SYSTEM, "redis"))));
   }
 
   @Test
@@ -112,9 +115,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                            equalTo(ServerAttributes.SERVER_PORT, incorrectPort),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"))
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, incorrectPort),
+                            equalTo(DB_SYSTEM, "redis"))
                         .hasEventsSatisfyingExactly(
                             event ->
                                 event
@@ -148,9 +151,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SET TESTSETKEY ?"),
+                            equalTo(DB_OPERATION, "SET"))));
   }
 
   @Test
@@ -165,9 +168,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET TESTKEY"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -182,9 +185,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET NON_EXISTENT_KEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY"),
+                            equalTo(DB_OPERATION, "GET"))));
   }
 
   @Test
@@ -199,9 +202,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("RANDOMKEY")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "RANDOMKEY"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "RANDOMKEY"),
+                            equalTo(DB_OPERATION, "RANDOMKEY"))));
   }
 
   @Test
@@ -216,9 +219,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("LPUSH")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "LPUSH TESTLIST ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "LPUSH"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "LPUSH TESTLIST ?"),
+                            equalTo(DB_OPERATION, "LPUSH"))));
   }
 
   @Test
@@ -233,11 +236,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("HMSET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "HMSET user firstname ? lastname ? age ?"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HMSET"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "HMSET user firstname ? lastname ? age ?"),
+                            equalTo(DB_OPERATION, "HMSET"))));
   }
 
   @Test
@@ -252,9 +253,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("HGETALL")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "HGETALL TESTHM"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "HGETALL"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "HGETALL TESTHM"),
+                            equalTo(DB_OPERATION, "HGETALL"))));
   }
 
   @Test
@@ -272,9 +273,9 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("DEBUG")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "DEBUG SEGFAULT"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DEBUG"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "DEBUG SEGFAULT"),
+                            equalTo(DB_OPERATION, "DEBUG"))));
   }
 
   @Test
@@ -292,8 +293,8 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("SHUTDOWN")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "SHUTDOWN NOSAVE"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SHUTDOWN"))));
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(DB_STATEMENT, "SHUTDOWN NOSAVE"),
+                            equalTo(DB_OPERATION, "SHUTDOWN"))));
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.java
@@ -6,6 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.lettuce.core.RedisClient;
 import io.opentelemetry.api.common.Attributes;
@@ -13,9 +20,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.lettuce.v5_1.AbstractLettuceReactiveClientTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -54,13 +58,13 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest {
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET a ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")),
@@ -70,13 +74,13 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest {
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET a")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -6,6 +6,13 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -21,9 +28,6 @@ import io.lettuce.core.codec.StringCodec;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -156,14 +160,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET TESTSETKEY ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -203,14 +206,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
                                       addExtraAttributes(
-                                          equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                          equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                          equalTo(ServerAttributes.SERVER_PORT, port),
-                                          equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                          equalTo(
-                                              DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY")))
+                                          equalTo(NETWORK_TYPE, "ipv4"),
+                                          equalTo(NETWORK_PEER_ADDRESS, ip),
+                                          equalTo(NETWORK_PEER_PORT, port),
+                                          equalTo(SERVER_ADDRESS, host),
+                                          equalTo(SERVER_PORT, port),
+                                          equalTo(DB_SYSTEM, "redis"),
+                                          equalTo(DB_STATEMENT, "GET TESTKEY")))
                                   .hasEventsSatisfyingExactly(
                                       event -> event.hasName("redis.encode.start"),
                                       event -> event.hasName("redis.encode.end"))));
@@ -283,15 +285,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
                                       addExtraAttributes(
-                                          equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                          equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                          equalTo(ServerAttributes.SERVER_PORT, port),
-                                          equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                          equalTo(
-                                              DbIncubatingAttributes.DB_STATEMENT,
-                                              "GET NON_EXISTENT_KEY")))
+                                          equalTo(NETWORK_TYPE, "ipv4"),
+                                          equalTo(NETWORK_PEER_ADDRESS, ip),
+                                          equalTo(NETWORK_PEER_PORT, port),
+                                          equalTo(SERVER_ADDRESS, host),
+                                          equalTo(SERVER_PORT, port),
+                                          equalTo(DB_SYSTEM, "redis"),
+                                          equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY")))
                                   .hasEventsSatisfyingExactly(
                                       event -> event.hasName("redis.encode.start"),
                                       event -> event.hasName("redis.encode.end"))));
@@ -351,14 +351,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
                                       addExtraAttributes(
-                                          equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                          equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                          equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                          equalTo(ServerAttributes.SERVER_PORT, port),
-                                          equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                          equalTo(
-                                              DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY")))
+                                          equalTo(NETWORK_TYPE, "ipv4"),
+                                          equalTo(NETWORK_PEER_ADDRESS, ip),
+                                          equalTo(NETWORK_PEER_PORT, port),
+                                          equalTo(SERVER_ADDRESS, host),
+                                          equalTo(SERVER_PORT, port),
+                                          equalTo(DB_SYSTEM, "redis"),
+                                          equalTo(DB_STATEMENT, "RANDOMKEY")))
                                   .hasEventsSatisfyingExactly(
                                       event -> event.hasName("redis.encode.start"),
                                       event -> event.hasName("redis.encode.end"))));
@@ -412,15 +411,14 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
                                     equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT,
-                                        "HMSET TESTHM firstname ? lastname ? age ?")))
+                                        DB_STATEMENT, "HMSET TESTHM firstname ? lastname ? age ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))),
@@ -431,13 +429,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "HGETALL TESTHM")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "HGETALL TESTHM")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -83,7 +83,7 @@ abstract class AbstractLettuceClientTest {
   protected static List<AttributeAssertion> addExtraAttributes(AttributeAssertion... assertions) {
     List<AttributeAssertion> result = new ArrayList<>(Arrays.asList(assertions));
     if (Boolean.getBoolean("testLatestDeps")) {
-      result.add(equalTo(DbIncubatingAttributes.DB_NAMESPACE, "0"));
+      result.add(equalTo(DB_NAMESPACE, "0"));
     }
     return result;
   }

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
@@ -6,15 +6,19 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
@@ -94,14 +98,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET TESTSETKEY ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")),
@@ -134,13 +137,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET TESTKEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -184,15 +187,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT,
-                                        "GET NON_EXISTENT_KEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")),
@@ -224,13 +225,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "RANDOMKEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -249,13 +250,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "COMMAND")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "COMMAND")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -295,13 +296,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET a ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")),
@@ -311,13 +312,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET a")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -341,13 +342,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "SET a ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET a ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")),
@@ -357,13 +358,13 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET a")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET a")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
@@ -7,13 +7,17 @@ package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.junit.jupiter.api.AfterAll;
@@ -71,15 +75,13 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(ServerAttributes.SERVER_PORT, port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(
-                                          DbIncubatingAttributes.DB_STATEMENT,
-                                          "CLIENT SETINFO lib-name Lettuce")))),
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "CLIENT SETINFO lib-name Lettuce")))),
               trace ->
                   trace.hasSpansSatisfyingExactly(
                       span ->
@@ -87,14 +89,14 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(ServerAttributes.SERVER_PORT, port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, port),
+                                      equalTo(DB_SYSTEM, "redis"),
                                       satisfies(
-                                          DbIncubatingAttributes.DB_STATEMENT,
+                                          DB_STATEMENT,
                                           stringAssert ->
                                               stringAssert.startsWith("CLIENT SETINFO lib-ver"))))),
               trace ->
@@ -104,13 +106,13 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(ServerAttributes.SERVER_PORT, port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(DbIncubatingAttributes.DB_STATEMENT, "AUTH ?")))
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "AUTH ?")))
                               .hasEventsSatisfyingExactly(
                                   event -> event.hasName("redis.encode.start"),
                                   event -> event.hasName("redis.encode.end"))));
@@ -125,13 +127,13 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(ServerAttributes.SERVER_PORT, port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(DbIncubatingAttributes.DB_STATEMENT, "AUTH ?")))
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "AUTH ?")))
                               .hasEventsSatisfyingExactly(
                                   event -> event.hasName("redis.encode.start"),
                                   event -> event.hasName("redis.encode.end"))));

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -21,9 +28,6 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Base64;
@@ -120,14 +124,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "SET TESTSETKEY ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SET TESTSETKEY ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -147,13 +150,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET TESTKEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET TESTKEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -173,15 +176,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT,
-                                        "GET NON_EXISTENT_KEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "GET NON_EXISTENT_KEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -201,13 +202,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "RANDOMKEY")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "RANDOMKEY")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -237,16 +238,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(
-                                        NetworkAttributes.NETWORK_PEER_PORT,
-                                        containerConnection.port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, containerConnection.port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "LPUSH TESTLIST ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, containerConnection.port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "LPUSH TESTLIST ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -266,15 +264,14 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
                                     equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT,
-                                        "HMSET user firstname ? lastname ? age ?")))
+                                        DB_STATEMENT, "HMSET user firstname ? lastname ? age ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -294,13 +291,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(DbIncubatingAttributes.DB_STATEMENT, "HGETALL TESTHM")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "HGETALL TESTHM")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -327,15 +324,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT,
-                                        "EVAL " + b64Script + " 1 TESTLIST ? ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "EVAL " + b64Script + " 1 TESTLIST ? ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -356,14 +351,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "MSET key1 ? key2 ?")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "MSET key1 ? key2 ?")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end"))));
@@ -387,18 +381,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(
-                                          NetworkAttributes.NETWORK_PEER_PORT,
-                                          containerConnection.port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(
-                                          ServerAttributes.SERVER_PORT, containerConnection.port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(
-                                          DbIncubatingAttributes.DB_STATEMENT,
-                                          "CLIENT SETINFO lib-name Lettuce")))),
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, containerConnection.port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "CLIENT SETINFO lib-name Lettuce")))),
               trace ->
                   trace.hasSpansSatisfyingExactly(
                       span ->
@@ -406,17 +395,14 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(
-                                          NetworkAttributes.NETWORK_PEER_PORT,
-                                          containerConnection.port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(
-                                          ServerAttributes.SERVER_PORT, containerConnection.port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, containerConnection.port),
+                                      equalTo(DB_SYSTEM, "redis"),
                                       satisfies(
-                                          DbIncubatingAttributes.DB_STATEMENT,
+                                          DB_STATEMENT,
                                           stringAssert ->
                                               stringAssert.startsWith("CLIENT SETINFO lib-ver"))))),
               trace ->
@@ -426,18 +412,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(
-                                          NetworkAttributes.NETWORK_PEER_PORT,
-                                          containerConnection.port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(
-                                          ServerAttributes.SERVER_PORT, containerConnection.port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(
-                                          DbIncubatingAttributes.DB_STATEMENT,
-                                          "DEBUG SEGFAULT")))));
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, containerConnection.port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "DEBUG SEGFAULT")))));
     } else {
       testing()
           .waitAndAssertTraces(
@@ -448,17 +429,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                               .hasKind(SpanKind.CLIENT)
                               .hasAttributesSatisfyingExactly(
                                   addExtraAttributes(
-                                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                      equalTo(
-                                          NetworkAttributes.NETWORK_PEER_PORT,
-                                          containerConnection.port),
-                                      equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                      equalTo(
-                                          ServerAttributes.SERVER_PORT, containerConnection.port),
-                                      equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                      equalTo(
-                                          DbIncubatingAttributes.DB_STATEMENT, "DEBUG SEGFAULT")))
+                                      equalTo(NETWORK_TYPE, "ipv4"),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, containerConnection.port),
+                                      equalTo(DB_SYSTEM, "redis"),
+                                      equalTo(DB_STATEMENT, "DEBUG SEGFAULT")))
                               // these are no longer recorded since Lettuce 6.1.6
                               .hasEventsSatisfyingExactly(
                                   event -> event.hasName("redis.encode.start"),
@@ -492,16 +469,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                             .hasException(new RedisException("Connection disconnected"))
                             .hasAttributesSatisfyingExactly(
                                 addExtraAttributes(
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(
-                                        NetworkAttributes.NETWORK_PEER_PORT,
-                                        containerConnection.port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, containerConnection.port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "SHUTDOWN NOSAVE"))));
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, containerConnection.port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SHUTDOWN NOSAVE"))));
               } else {
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -511,16 +485,13 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                                 addExtraAttributes(
                                     equalTo(
                                         AttributeKey.stringKey("error"), "Connection disconnected"),
-                                    equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                                    equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                                    equalTo(
-                                        NetworkAttributes.NETWORK_PEER_PORT,
-                                        containerConnection.port),
-                                    equalTo(ServerAttributes.SERVER_ADDRESS, host),
-                                    equalTo(ServerAttributes.SERVER_PORT, containerConnection.port),
-                                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                                    equalTo(
-                                        DbIncubatingAttributes.DB_STATEMENT, "SHUTDOWN NOSAVE")))
+                                    equalTo(NETWORK_TYPE, "ipv4"),
+                                    equalTo(NETWORK_PEER_ADDRESS, ip),
+                                    equalTo(NETWORK_PEER_PORT, containerConnection.port),
+                                    equalTo(SERVER_ADDRESS, host),
+                                    equalTo(SERVER_PORT, containerConnection.port),
+                                    equalTo(DB_SYSTEM, "redis"),
+                                    equalTo(DB_STATEMENT, "SHUTDOWN NOSAVE")))
                             .hasEventsSatisfyingExactly(
                                 event -> event.hasName("redis.encode.start"),
                                 event -> event.hasName("redis.encode.end")));

--- a/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v1_2/Log4j1Test.java
+++ b/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v1_2/Log4j1Test.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.log4j.appender.v1_2;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -18,7 +21,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.time.Instant;
@@ -128,13 +130,10 @@ class Log4j1Test {
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
-                          v -> v.contains(Log4j1Test.class.getName()))));
+                          EXCEPTION_STACKTRACE, v -> v.contains(Log4j1Test.class.getName()))));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);
 

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -19,7 +22,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -118,13 +120,10 @@ class Log4j2Test {
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
-                          v -> v.contains(Log4j2Test.class.getName()))));
+                          EXCEPTION_STACKTRACE, v -> v.contains(Log4j2Test.class.getName()))));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);
 

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Slf4jToLog4jTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Slf4jToLog4jTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
@@ -16,7 +19,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,12 +111,10 @@ class Slf4jToLog4jTest {
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
+                          EXCEPTION_STACKTRACE,
                           v -> v.contains(Slf4jToLog4jTest.class.getName()))));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
@@ -9,6 +9,9 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.logs.Severity;
@@ -17,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.time.Instant;
 import org.apache.logging.log4j.LogManager;
@@ -131,13 +133,9 @@ abstract class AbstractOpenTelemetryAppenderTest {
                       equalTo(
                           ThreadIncubatingAttributes.THREAD_NAME, Thread.currentThread().getName()),
                       equalTo(ThreadIncubatingAttributes.THREAD_ID, Thread.currentThread().getId()),
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "Error!"),
-                      satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
-                          v -> v.contains("logWithExtras")));
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "Error!"),
+                      satisfies(EXCEPTION_STACKTRACE, v -> v.contains("logWithExtras")));
 
               LogRecordData logRecordData = AssertAccess.getActual(logRecord);
               assertThat(logRecordData.getTimestampEpochNanos())

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.logback.appender.v1_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
@@ -16,7 +19,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.util.ArrayList;
@@ -169,13 +171,10 @@ class LogbackTest {
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "hello"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
-                          v -> v.contains(LogbackTest.class.getName()))));
+                          EXCEPTION_STACKTRACE, v -> v.contains(LogbackTest.class.getName()))));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);
           });

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.logback.appender.v1_0;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.ContextBase;
@@ -17,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -110,13 +112,10 @@ abstract class AbstractOpenTelemetryAppenderTest {
                   .hasSeverity(Severity.INFO)
                   .hasSeverityText("INFO")
                   .hasAttributesSatisfyingExactly(
-                      equalTo(
-                          ExceptionAttributes.EXCEPTION_TYPE,
-                          IllegalStateException.class.getName()),
-                      equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "Error!"),
+                      equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
+                      equalTo(EXCEPTION_MESSAGE, "Error!"),
                       satisfies(
-                          ExceptionAttributes.EXCEPTION_STACKTRACE,
-                          stackTrace -> stackTrace.contains("logWithExtras")),
+                          EXCEPTION_STACKTRACE, stackTrace -> stackTrace.contains("logWithExtras")),
                       equalTo(
                           CodeIncubatingAttributes.CODE_FILEPATH,
                           AbstractOpenTelemetryAppenderTest.class.getSimpleName() + ".java"),

--- a/instrumentation/mongo/mongo-common/testing/src/main/java/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.java
+++ b/instrumentation/mongo/mongo-common/testing/src/main/java/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.java
@@ -8,6 +8,14 @@ package io.opentelemetry.instrumentation.mongo.testing;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_MONGODB_COLLECTION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -18,8 +26,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.net.Socket;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -503,7 +509,7 @@ public abstract class AbstractMongoClientTest<T> {
   }
 
   @SuppressWarnings("deprecation")
-  // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  // TODO DB_CONNECTION_STRING deprecation
   void mongoSpan(
       SpanDataAssert span,
       String operation,
@@ -519,17 +525,17 @@ public abstract class AbstractMongoClientTest<T> {
     }
 
     span.hasAttributesSatisfyingExactly(
-        equalTo(ServerAttributes.SERVER_ADDRESS, host),
-        equalTo(ServerAttributes.SERVER_PORT, port),
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
         satisfies(
-            DbIncubatingAttributes.DB_STATEMENT,
+            DB_STATEMENT,
             val ->
                 val.satisfies(
                     statement -> assertThat(statements).contains(statement.replaceAll(" ", "")))),
-        equalTo(DbIncubatingAttributes.DB_SYSTEM, "mongodb"),
-        equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "mongodb://localhost:" + port),
-        equalTo(DbIncubatingAttributes.DB_NAME, dbName),
-        equalTo(DbIncubatingAttributes.DB_OPERATION, operation),
-        equalTo(DbIncubatingAttributes.DB_MONGODB_COLLECTION, collection));
+        equalTo(DB_SYSTEM, "mongodb"),
+        equalTo(DB_CONNECTION_STRING, "mongodb://localhost:" + port),
+        equalTo(DB_NAME, dbName),
+        equalTo(DB_OPERATION, operation),
+        equalTo(DB_MONGODB_COLLECTION, collection));
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/Netty38ClientTest.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/Netty38ClientTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v3_8.client;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.Collections.emptySet;
 
 import com.ning.http.client.AsyncCompletionHandler;
@@ -21,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.net.URI;
@@ -170,8 +171,8 @@ class Netty38ClientTest extends AbstractHttpClientTest<Request> {
           }
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(ServerAttributes.SERVER_ADDRESS);
-          attributes.remove(ServerAttributes.SERVER_PORT);
+          attributes.remove(SERVER_ADDRESS);
+          attributes.remove(SERVER_PORT);
           return attributes;
         });
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.forPath;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.HashSet;
@@ -91,7 +91,7 @@ class Netty38ServerTest extends AbstractHttpServerTest<ServerBootstrap> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
@@ -9,6 +9,12 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.netty.bootstrap.Bootstrap;
@@ -30,8 +36,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -90,12 +94,12 @@ class Netty40ClientSslTest {
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfyingExactly(
-                      equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                      equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                      equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
+                      equalTo(NETWORK_TRANSPORT, "tcp"),
+                      equalTo(NETWORK_TYPE, "ipv4"),
+                      equalTo(SERVER_ADDRESS, uri.getHost()),
+                      equalTo(SERVER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
                 span -> {
                   span.hasName("SSL handshake")
@@ -103,10 +107,10 @@ class Netty40ClientSslTest {
                       .hasParent(trace.getSpan(0))
                       .hasStatus(StatusData.error());
                   span.hasAttributesSatisfyingExactly(
-                      equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
+                      equalTo(NETWORK_TRANSPORT, "tcp"),
+                      equalTo(NETWORK_TYPE, "ipv4"),
+                      equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 }));
   }
 
@@ -182,20 +186,20 @@ class Netty40ClientSslTest {
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfyingExactly(
-                      equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                      equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                      equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
+                      equalTo(NETWORK_TRANSPORT, "tcp"),
+                      equalTo(NETWORK_TYPE, "ipv4"),
+                      equalTo(SERVER_ADDRESS, uri.getHost()),
+                      equalTo(SERVER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
                 span -> {
                   span.hasName("SSL handshake").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfyingExactly(
-                      equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
+                      equalTo(NETWORK_TRANSPORT, "tcp"),
+                      equalTo(NETWORK_TYPE, "ipv4"),
+                      equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
                 span -> {
                   span.hasName("GET").hasKind(CLIENT).hasParent(trace.getSpan(0));

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientTest.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_0.client;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -27,7 +30,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
@@ -174,8 +176,8 @@ class Netty40ClientTest extends AbstractHttpClientTest<DefaultFullHttpRequest> {
         return Collections.emptySet();
     }
     Set<AttributeKey<?>> attributes = new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 }

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
@@ -10,6 +10,12 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -31,8 +37,6 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,12 +106,12 @@ class Netty40ConnectionSpanTest {
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfyingExactly(
-                      equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                      equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                      equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                      equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                      equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"));
+                      equalTo(NETWORK_TRANSPORT, "tcp"),
+                      equalTo(NETWORK_TYPE, "ipv4"),
+                      equalTo(SERVER_ADDRESS, uri.getHost()),
+                      equalTo(SERVER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                      equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
                 span -> span.hasName("GET").hasKind(CLIENT).hasParent(trace.getSpan(0)),
                 span ->
@@ -130,23 +134,22 @@ class Netty40ConnectionSpanTest {
                 span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent().hasException(thrown),
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
-                  span.hasAttributesSatisfying(equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"));
+                  span.hasAttributesSatisfying(equalTo(NETWORK_TRANSPORT, "tcp"));
                   satisfies(
-                      NetworkAttributes.NETWORK_TYPE,
+                      NETWORK_TYPE,
                       val ->
                           val.satisfiesAnyOf(
                               v -> assertThat(val).isNull(), v -> assertThat(v).isEqualTo("ipv4")));
                   span.hasAttributesSatisfying(
-                      equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                      equalTo(ServerAttributes.SERVER_PORT, uri.getPort()));
+                      equalTo(SERVER_ADDRESS, uri.getHost()), equalTo(SERVER_PORT, uri.getPort()));
                   satisfies(
-                      NetworkAttributes.NETWORK_PEER_PORT,
+                      NETWORK_PEER_PORT,
                       val ->
                           val.satisfiesAnyOf(
                               v -> assertThat(val).isNull(),
                               v -> assertThat(v).isEqualTo(uri.getPort())));
                   satisfies(
-                      NetworkAttributes.NETWORK_PEER_ADDRESS,
+                      NETWORK_PEER_ADDRESS,
                       val ->
                           val.satisfiesAnyOf(
                               v -> assertThat(val).isNull(),

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/Netty40ServerTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/Netty40ServerTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -46,7 +47,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
@@ -212,7 +212,7 @@ class Netty40ServerTest extends AbstractHttpServerTest<EventLoopGroup> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -34,8 +40,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -138,19 +142,19 @@ class Netty41ClientSslTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort())),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1")),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1")),
                 span ->
                     span.hasName("SSL handshake")
                         .hasKind(SpanKind.INTERNAL)
@@ -158,22 +162,22 @@ class Netty41ClientSslTest {
                         .hasStatus(StatusData.error())
                         .hasException(new SSLHandshakeException(null))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
                             satisfies(
-                                ServerAttributes.SERVER_ADDRESS,
+                                SERVER_ADDRESS,
                                 v ->
                                     v.satisfiesAnyOf(
                                         k -> assertThat(k).isNull(),
                                         k -> assertThat(k).isEqualTo(uri.getHost()))),
                             satisfies(
-                                ServerAttributes.SERVER_PORT,
+                                SERVER_PORT,
                                 v ->
                                     v.satisfiesAnyOf(
                                         k -> assertThat(k).isNull(),
                                         k -> assertThat(k).isEqualTo(uri.getPort()))),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"))));
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"))));
   }
 
   @Test
@@ -206,28 +210,28 @@ class Netty41ClientSslTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort())),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1")),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1")),
                 span ->
                     span.hasName("SSL handshake")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1")),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1")),
                 span -> span.hasName("GET").hasKind(SpanKind.CLIENT),
                 span -> span.hasName("test-http-server").hasKind(SpanKind.SERVER)));
   }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -31,8 +37,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,19 +125,19 @@ class Netty41ConnectionSpanTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort())),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, uri.getPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1")),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1")),
                 span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("test-http-server")
@@ -162,8 +166,8 @@ class Netty41ConnectionSpanTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort())),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(SpanKind.INTERNAL)
@@ -171,23 +175,23 @@ class Netty41ConnectionSpanTest {
                         .hasStatus(StatusData.error())
                         .hasException(finalThrownException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
                             satisfies(
-                                NetworkAttributes.NETWORK_TYPE,
+                                NETWORK_TYPE,
                                 k ->
                                     k.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo("ipv4"),
                                         v -> assertThat(v).isNull())),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
+                                NETWORK_PEER_PORT,
                                 k ->
                                     k.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo(uri.getPort()),
                                         v -> assertThat(v).isNull())),
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                NETWORK_PEER_ADDRESS,
                                 k ->
                                     k.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo("127.0.0.1"),

--- a/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.netty.v4_1;
 
 import static io.opentelemetry.instrumentation.test.base.HttpClientTest.getPort;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -19,7 +21,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
@@ -122,8 +123,8 @@ public abstract class AbstractNetty41ClientTest
       return Collections.emptySet();
     }
     Set<AttributeKey<?>> attributes = new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 

--- a/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ServerTest.java
+++ b/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ServerTest.java
@@ -18,6 +18,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import com.google.common.collect.Sets;
 import io.netty.bootstrap.ServerBootstrap;
@@ -44,7 +45,6 @@ import io.netty.util.CharsetUtil;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.net.URI;
 import java.util.Collections;
 
@@ -59,9 +59,7 @@ public abstract class AbstractNetty41ServerTest extends AbstractHttpServerTest<E
   protected void configure(HttpServerTestOptions options) {
     options.setTestException(false);
     options.setHttpAttributes(
-        unused ->
-            Sets.difference(
-                DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HttpAttributes.HTTP_ROUTE)));
+        unused -> Sets.difference(DEFAULT_HTTP_ATTRIBUTES, Collections.singleton(HTTP_ROUTE)));
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Test.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Test.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.okhttp.v2_2;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
@@ -18,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
@@ -104,7 +105,7 @@ public class OkHttp2Test extends AbstractHttpClientTest<Request> {
           if ("http://localhost:61/".equals(uri.toString())
               || "https://192.0.2.1/".equals(uri.toString())
               || resolveAddress("/read-timeout").toString().equals(uri.toString())) {
-            attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+            attributes.remove(NETWORK_PROTOCOL_VERSION);
           }
           return attributes;
         });

--- a/instrumentation/okhttp/okhttp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.java
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.okhttp.v3_0;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -12,7 +13,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -124,7 +124,7 @@ public abstract class AbstractOkHttp3Test extends AbstractHttpClientTest<Request
               || "https://192.0.2.1/".equals(uri.toString())
               || "http://192.0.2.1/".equals(uri.toString())
               || resolveAddress("/read-timeout").toString().equals(uri.toString())) {
-            attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+            attributes.remove(NETWORK_PROTOCOL_VERSION);
           }
 
           return attributes;

--- a/instrumentation/opensearch/opensearch-rest-1.0/javaagent/src/test/java/OpenSearchRestTest.java
+++ b/instrumentation/opensearch/opensearch-rest-1.0/javaagent/src/test/java/OpenSearchRestTest.java
@@ -4,14 +4,18 @@
  */
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -97,20 +101,20 @@ public class OpenSearchRestTest {
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "opensearch"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET _cluster/health")),
+                            equalTo(DB_SYSTEM, "opensearch"),
+                            equalTo(DB_OPERATION, "GET"),
+                            equalTo(DB_STATEMENT, "GET _cluster/health")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L))));
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L))));
   }
 
   @Test
@@ -162,20 +166,20 @@ public class OpenSearchRestTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "opensearch"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "GET"),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "GET _cluster/health")),
+                            equalTo(DB_SYSTEM, "opensearch"),
+                            equalTo(DB_OPERATION, "GET"),
+                            equalTo(DB_STATEMENT, "GET _cluster/health")),
                 span ->
                     span.hasName("GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, httpHost.getHostName()),
-                            equalTo(ServerAttributes.SERVER_PORT, httpHost.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L)),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/TracerTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/TracerTest.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.api.trace.StatusCode.ERROR;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -25,7 +27,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import org.junit.jupiter.api.DisplayName;
@@ -241,12 +242,8 @@ class TracerTest {
                                 event
                                     .hasName("exception")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_TYPE,
-                                            "java.lang.IllegalStateException"),
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_STACKTRACE,
-                                            writer.toString()),
+                                        equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+                                        equalTo(EXCEPTION_STACKTRACE, writer.toString()),
                                         equalTo(stringKey("dog"), "bark")))));
   }
 

--- a/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/ContextBridgeTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.instrumentationapi;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -20,8 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.javaagent.instrumentation.testing.AgentSpanTesting;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -106,9 +107,9 @@ class ContextBridgeTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/test/server/*"),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "_OTHER"))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_ROUTE, "/test/server/*"),
+                            equalTo(ERROR_TYPE, "_OTHER"))));
   }
 
   @Test
@@ -127,8 +128,8 @@ class ContextBridgeTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/test/controller/:id"),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "_OTHER"))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_ROUTE, "/test/controller/:id"),
+                            equalTo(ERROR_TYPE, "_OTHER"))));
   }
 }

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/client/PlayWsClientTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/client/PlayWsClientTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.play.v2_4.client;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -12,7 +14,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
@@ -86,7 +87,7 @@ class PlayWsClientTest extends AbstractHttpClientTest<WSRequest> {
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
 

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -22,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -119,7 +119,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
 

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -22,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -104,7 +104,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
 

--- a/instrumentation/play/play-ws/play-ws-2.1/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/playws/v2_1/PlayWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-2.1/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/playws/v2_1/PlayWsClientBaseTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.playws.v2_1;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import akka.actor.ActorSystem;
 import akka.stream.Materializer;
 import io.opentelemetry.api.common.AttributeKey;
@@ -12,8 +16,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -78,10 +80,10 @@ abstract class PlayWsClientBaseTest<REQUEST> extends AbstractHttpClientTest<REQU
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           if (uri.toString().endsWith("/circular-redirect")) {
-            attributes.remove(ServerAttributes.SERVER_ADDRESS);
-            attributes.remove(ServerAttributes.SERVER_PORT);
+            attributes.remove(SERVER_ADDRESS);
+            attributes.remove(SERVER_PORT);
           }
           return attributes;
         });

--- a/instrumentation/play/play-ws/play-ws-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientBaseTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.playws;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.ActorMaterializerSettings;
@@ -13,8 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -79,10 +81,10 @@ abstract class PlayWsClientBaseTest<REQUEST> extends AbstractHttpClientTest<REQU
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           if (uri.toString().endsWith("/circular-redirect")) {
-            attributes.remove(ServerAttributes.SERVER_ADDRESS);
-            attributes.remove(ServerAttributes.SERVER_PORT);
+            attributes.remove(SERVER_ADDRESS);
+            attributes.remove(SERVER_PORT);
           }
           return attributes;
         });

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -24,7 +25,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -350,7 +350,7 @@ abstract class AbstractPulsarClientTest {
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                 equalTo(MESSAGE_TYPE, "normal")));
@@ -388,7 +388,7 @@ abstract class AbstractPulsarClientTest {
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+                equalTo(MESSAGING_OPERATION, "receive"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
@@ -415,7 +415,7 @@ abstract class AbstractPulsarClientTest {
             Arrays.asList(
                 equalTo(MESSAGING_SYSTEM, "pulsar"),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_OPERATION, "process"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -124,7 +124,7 @@ public abstract class AbstractR2dbcStatementTest {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideParameters")
   void testQueries(Parameter parameter) {

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/ReactorRabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/ReactorRabbitMqTest.java
@@ -6,14 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -43,23 +45,20 @@ class ReactorRabbitMqTest extends AbstractRabbitMqTest {
                 span -> {
                   span.hasName("exchange.declare")
                       .hasKind(SpanKind.CLIENT)
-                      .hasAttribute(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq")
+                      .hasAttribute(MESSAGING_SYSTEM, "rabbitmq")
                       .hasAttribute(AttributeKey.stringKey("rabbitmq.command"), "exchange.declare")
                       .hasAttributesSatisfying(
                           attributes ->
                               assertThat(attributes)
                                   .satisfies(
                                       attrs -> {
-                                        String peerAddr =
-                                            attrs.get(NetworkAttributes.NETWORK_PEER_ADDRESS);
+                                        String peerAddr = attrs.get(NETWORK_PEER_ADDRESS);
                                         assertThat(peerAddr).isIn(rabbitMqIp, null);
 
-                                        String networkType =
-                                            attrs.get(NetworkAttributes.NETWORK_TYPE);
+                                        String networkType = attrs.get(NETWORK_TYPE);
                                         assertThat(networkType).isIn("ipv4", "ipv6", null);
 
-                                        assertNotNull(
-                                            attrs.get(NetworkAttributes.NETWORK_PEER_PORT));
+                                        assertNotNull(attrs.get(NETWORK_PEER_PORT));
                                       }));
                 }));
   }

--- a/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackForkedHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackForkedHttpClientTest.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.ratpack;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.ratpack.client.AbstractRatpackForkedHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
@@ -24,8 +26,8 @@ class RatpackForkedHttpClientTest extends AbstractRatpackForkedHttpClientTest {
   protected Set<AttributeKey<?>> computeHttpAttributes(URI uri) {
     Set<AttributeKey<?>> attributes = new HashSet<>(super.computeHttpAttributes(uri));
     // underlying netty instrumentation does not provide these
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 }

--- a/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackHttpClientTest.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.ratpack;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.ratpack.client.AbstractRatpackHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
@@ -24,8 +26,8 @@ class RatpackHttpClientTest extends AbstractRatpackHttpClientTest {
   protected Set<AttributeKey<?>> computeHttpAttributes(URI uri) {
     Set<AttributeKey<?>> attributes = new HashSet<>(super.computeHttpAttributes(uri));
     // underlying netty instrumentation does not provide these
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 }

--- a/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackPooledHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackPooledHttpClientTest.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.ratpack;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.ratpack.client.AbstractRatpackPooledHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
@@ -24,8 +26,8 @@ class RatpackPooledHttpClientTest extends AbstractRatpackPooledHttpClientTest {
   protected Set<AttributeKey<?>> computeHttpAttributes(URI uri) {
     Set<AttributeKey<?>> attributes = new HashSet<>(super.computeHttpAttributes(uri));
     // underlying netty instrumentation does not provide these
-    attributes.remove(ServerAttributes.SERVER_ADDRESS);
-    attributes.remove(ServerAttributes.SERVER_PORT);
+    attributes.remove(SERVER_ADDRESS);
+    attributes.remove(SERVER_PORT);
     return attributes;
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/AbstractRatpackHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/AbstractRatpackHttpClientTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
 import com.google.common.collect.ImmutableList;
 import io.netty.channel.ConnectTimeoutException;
 import io.opentelemetry.api.common.AttributeKey;
@@ -12,7 +14,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashSet;
@@ -158,7 +159,7 @@ abstract class AbstractRatpackHttpClientTest extends AbstractHttpClientTest<Void
 
   protected Set<AttributeKey<?>> getHttpAttributes(URI uri) {
     Set<AttributeKey<?>> attributes = new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-    attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+    attributes.remove(NETWORK_PROTOCOL_VERSION);
     return attributes;
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -9,6 +9,15 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 
@@ -20,7 +29,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -181,22 +189,17 @@ public abstract class AbstractReactorKafkaTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("producer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     String messageKey = record.key();
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     return assertions;
   }
@@ -206,15 +209,15 @@ public abstract class AbstractReactorKafkaTest {
     ArrayList<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, "receive"),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("consumer")),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
     if (Boolean.getBoolean("hasConsumerGroup")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     return assertions;
   }
@@ -225,20 +228,16 @@ public abstract class AbstractReactorKafkaTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
+                equalTo(MESSAGING_OPERATION, "process"),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("consumer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (Boolean.getBoolean("hasConsumerGroup")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     if (Boolean.getBoolean("otel.instrumentation.kafka.experimental-span-attributes")) {
       assertions.add(
@@ -246,15 +245,13 @@ public abstract class AbstractReactorKafkaTest {
     }
     String messageKey = record.key();
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     String messageValue = record.value();
     if (messageValue != null) {
       assertions.add(
           equalTo(
-              MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-              messageValue.getBytes(StandardCharsets.UTF_8).length));
+              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
     }
     return assertions;
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -23,7 +25,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ServerAttributes;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
@@ -126,8 +127,8 @@ abstract class AbstractReactorNettyHttpClientTest
 
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(ServerAttributes.SERVER_ADDRESS);
-          attributes.remove(ServerAttributes.SERVER_PORT);
+          attributes.remove(SERVER_ADDRESS);
+          attributes.remove(SERVER_PORT);
           return attributes;
         });
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.java
@@ -10,6 +10,12 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -18,8 +24,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -77,21 +81,19 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort())),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span -> span.hasName("GET").hasKind(CLIENT).hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(3))));
@@ -137,8 +139,8 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT)),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT)),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
@@ -146,16 +148,13 @@ class ReactorNettyConnectionSpanTest {
                         .hasStatus(StatusData.error())
                         .hasException(connectException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            satisfies(NETWORK_TYPE, val -> val.isIn(null, "ipv4")),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT),
+                            satisfies(NETWORK_PEER_ADDRESS, val -> val.isIn(null, "127.0.0.1")),
                             satisfies(
-                                NetworkAttributes.NETWORK_TYPE, val -> val.isIn(null, "ipv4")),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                val -> val.isIn(null, "127.0.0.1")),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
+                                NETWORK_PEER_PORT,
                                 val -> val.isIn(null, (long) PortUtils.UNUSABLE_PORT)))));
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
@@ -10,6 +10,12 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.netty.handler.codec.http.HttpMethod;
@@ -26,11 +32,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
@@ -136,13 +137,13 @@ abstract class AbstractReactorNettyHttpClientTest
     // unopened port or non routable address
     if ("http://localhost:61/".equals(uri.toString())
         || "https://192.0.2.1/".equals(uri.toString())) {
-      attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+      attributes.remove(NETWORK_PROTOCOL_VERSION);
     }
 
     if (uri.toString().contains("/read-timeout")) {
-      attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
-      attributes.remove(ServerAttributes.SERVER_ADDRESS);
-      attributes.remove(ServerAttributes.SERVER_PORT);
+      attributes.remove(NETWORK_PROTOCOL_VERSION);
+      attributes.remove(SERVER_ADDRESS);
+      attributes.remove(SERVER_PORT);
     }
     return attributes;
   }
@@ -310,11 +311,11 @@ abstract class AbstractReactorNettyHttpClientTest
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri.toString()),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "cancelled")),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(ERROR_TYPE, "cancelled")),
                 span ->
                     span.hasName("test-http-server")
                         .hasKind(SpanKind.SERVER)

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyBaseUrlOnlyTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyBaseUrlOnlyTest.java
@@ -11,6 +11,14 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.AbstractReactorNettyHttpClientTest.USER_AGENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -19,10 +27,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.test.server.http.RequestContextGetter;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpData;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
@@ -111,16 +115,14 @@ class ReactorNettyBaseUrlOnlyTest {
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri + "/"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri + "/"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(1))));
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.java
@@ -12,6 +12,20 @@ import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.Abstr
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.netty.handler.ssl.SslContextBuilder;
@@ -20,12 +34,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.ExceptionAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
@@ -94,33 +102,29 @@ class ReactorNettyClientSslTest {
                         // message
                         .hasEventsSatisfying(ReactorNettyClientSslTest::isSslHandshakeException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort()),
-                            equalTo(
-                                ErrorAttributes.ERROR_TYPE,
-                                SSLHandshakeException.class.getCanonicalName())),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort()),
+                            equalTo(ERROR_TYPE, SSLHandshakeException.class.getCanonicalName())),
                 span ->
                     span.hasName("RESOLVE")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort())),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("SSL handshake")
                         .hasKind(INTERNAL)
@@ -130,10 +134,10 @@ class ReactorNettyClientSslTest {
                         // message
                         .hasEventsSatisfying(ReactorNettyClientSslTest::isSslHandshakeException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, server.httpsPort()))));
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_PORT, server.httpsPort()))));
   }
 
   @Test
@@ -163,45 +167,41 @@ class ReactorNettyClientSslTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort())),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("SSL handshake")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, server.httpsPort())),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_PORT, server.httpsPort())),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpsPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpsPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(4))));
   }
@@ -227,10 +227,8 @@ class ReactorNettyClientSslTest {
             event ->
                 assertThat(event)
                     .hasAttributesSatisfyingExactly(
-                        equalTo(
-                            ExceptionAttributes.EXCEPTION_TYPE,
-                            SSLHandshakeException.class.getCanonicalName()),
-                        satisfies(ExceptionAttributes.EXCEPTION_MESSAGE, s -> s.isNotEmpty()),
-                        satisfies(ExceptionAttributes.EXCEPTION_STACKTRACE, s -> s.isNotEmpty())));
+                        equalTo(EXCEPTION_TYPE, SSLHandshakeException.class.getCanonicalName()),
+                        satisfies(EXCEPTION_MESSAGE, s -> s.isNotEmpty()),
+                        satisfies(EXCEPTION_STACKTRACE, s -> s.isNotEmpty())));
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.java
@@ -11,6 +11,17 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.AbstractReactorNettyHttpClientTest.USER_AGENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -19,11 +30,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,36 +88,32 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort())),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort())),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, server.httpPort()),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                AbstractLongAssert::isNotNegative)),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative)),
                 span ->
                     span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(3))));
   }
@@ -158,19 +160,18 @@ class ReactorNettyConnectionSpanTest {
                         .hasStatus(StatusData.error())
                         .hasException(connectException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT),
-                            equalTo(
-                                ErrorAttributes.ERROR_TYPE, connectException.getClass().getName())),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT),
+                            equalTo(ERROR_TYPE, connectException.getClass().getName())),
                 span ->
                     span.hasName("RESOLVE")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT)),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT)),
                 span ->
                     span.hasName("CONNECT")
                         .hasKind(INTERNAL)
@@ -178,10 +179,8 @@ class ReactorNettyConnectionSpanTest {
                         .hasStatus(StatusData.error())
                         .hasException(connectException)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, PortUtils.UNUSABLE_PORT),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
-                                val -> val.isIn(null, "127.0.0.1")))));
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT),
+                            satisfies(NETWORK_PEER_ADDRESS, val -> val.isIn(null, "127.0.0.1")))));
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientTest.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import io.netty.channel.ChannelOption;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpHeaderNames;
 import java.net.URI;
 import java.util.HashSet;
@@ -61,8 +63,8 @@ class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
       // net.peer.sock.* attributes
       Set<AttributeKey<?>> attributes =
           new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-      attributes.remove(ServerAttributes.SERVER_ADDRESS);
-      attributes.remove(ServerAttributes.SERVER_PORT);
+      attributes.remove(SERVER_ADDRESS);
+      attributes.remove(SERVER_PORT);
       return attributes;
     }
     return super.getHttpAttributes(uri);

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -10,6 +10,12 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.Span;
@@ -17,8 +23,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
@@ -117,18 +121,13 @@ public abstract class AbstractRedissonAsyncClientTest {
                     span.hasName("SET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SET foo ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SET"))));
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET foo ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))));
   }
 
   @Test
@@ -156,18 +155,13 @@ public abstract class AbstractRedissonAsyncClientTest {
                     span.hasName("SADD")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SADD set1 ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SADD"))
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SADD set1 ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SADD"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }
@@ -236,48 +230,36 @@ public abstract class AbstractRedissonAsyncClientTest {
                     span.hasName("DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SET batch2 ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SET"))
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET batch2 ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("EXEC")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "EXEC"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "EXEC"))
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "EXEC"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -11,6 +11,12 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -18,8 +24,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -120,36 +124,25 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("SET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SET foo ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SET"))),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET foo ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "GET foo"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "GET"))));
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "GET foo"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "GET"))));
   }
 
   @Test
@@ -170,13 +163,12 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "SET batch1 ?;SET batch2 ?"))));
   }
 
@@ -213,48 +205,36 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SET batch2 ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SET"))
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET batch2 ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("EXEC")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "EXEC"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "EXEC"))
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "EXEC"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0))));
   }
 
@@ -271,18 +251,14 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("RPUSH")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "RPUSH list1 ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "RPUSH"))
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "RPUSH"))
                         .hasNoParent()));
   }
 
@@ -302,36 +278,28 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("EVAL")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 String.format("EVAL %s 1 map1 ? ?", script)),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "EVAL"))),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("HGET")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "HGET map1 key1"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "HGET"))));
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "HGET"))));
   }
 
   @Test
@@ -347,18 +315,13 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("SADD")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
-                                "SADD set1 ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "SADD"))));
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SADD set1 ?"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SADD"))));
   }
 
   @Test
@@ -381,18 +344,14 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("ZADD")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "ZADD sort_set1 ? ? ? ? ? ?"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "ZADD"))));
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "ZADD"))));
   }
 
   private static void invokeAddAll(RScoredSortedSet<String> object, Map<String, Double> arg)
@@ -413,18 +372,14 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("INCR")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 "INCR AtomicLong"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "INCR"))));
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "INCR"))));
   }
 
   @Test
@@ -445,17 +400,13 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("EVAL")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "EVAL"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"),
                             satisfies(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 stringAssert -> stringAssert.startsWith("EVAL")))));
     traceAsserts.add(
         trace ->
@@ -464,17 +415,13 @@ public abstract class AbstractRedissonClientTest {
                     span.hasName("EVAL")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_OPERATION),
-                                "EVAL"),
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, (long) port),
+                            equalTo(DB_SYSTEM, "redis"),
+                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"),
                             satisfies(
-                                SemconvStabilityUtil.getAttributeKey(
-                                    DbIncubatingAttributes.DB_STATEMENT),
+                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                 stringAssert -> stringAssert.startsWith("EVAL")))));
     if (lockHas3Traces()) {
       traceAsserts.add(
@@ -484,17 +431,13 @@ public abstract class AbstractRedissonClientTest {
                       span.hasName("DEL")
                           .hasKind(CLIENT)
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                              equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
-                              equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_OPERATION),
-                                  "DEL"),
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(NETWORK_PEER_ADDRESS, ip),
+                              equalTo(NETWORK_PEER_PORT, (long) port),
+                              equalTo(DB_SYSTEM, "redis"),
+                              equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "DEL"),
                               satisfies(
-                                  SemconvStabilityUtil.getAttributeKey(
-                                      DbIncubatingAttributes.DB_STATEMENT),
+                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
                                   stringAssert -> stringAssert.startsWith("DEL")))));
     }
 

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.instrumentation.resources;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
@@ -68,9 +68,7 @@ class JarServiceNameDetectorTest {
 
     Resource resource = serviceNameProvider.createResource(config);
 
-    assertThat(resource.getAttributes())
-        .hasSize(1)
-        .containsEntry(ServiceAttributes.SERVICE_NAME, "my-service");
+    assertThat(resource.getAttributes()).hasSize(1).containsEntry(SERVICE_NAME, "my-service");
   }
 
   @Test
@@ -80,9 +78,7 @@ class JarServiceNameDetectorTest {
 
     Resource resource = serviceNameProvider.createResource(config);
 
-    assertThat(resource.getAttributes())
-        .hasSize(1)
-        .containsEntry(ServiceAttributes.SERVICE_NAME, "my-service");
+    assertThat(resource.getAttributes()).hasSize(1).containsEntry(SERVICE_NAME, "my-service");
   }
 
   static String[] getArgs(String jarName) {
@@ -102,9 +98,7 @@ class JarServiceNameDetectorTest {
 
     Resource resource = serviceNameProvider.createResource(config);
 
-    assertThat(resource.getAttributes())
-        .hasSize(1)
-        .containsEntry(ServiceAttributes.SERVICE_NAME, "my-service");
+    assertThat(resource.getAttributes()).hasSize(1).containsEntry(SERVICE_NAME, "my-service");
   }
 
   // regression test for

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,7 +69,7 @@ class ManifestResourceProviderTest {
                 null,
                 "0.0.1-SNAPSHOT",
                 openClasspathResource("MANIFEST.MF"),
-                Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "old"))))
+                Resource.create(Attributes.of(SERVICE_NAME, "old"))))
         .map(
             t ->
                 DynamicTest.dynamicTest(
@@ -92,9 +93,8 @@ class ManifestResourceProviderTest {
                       provider.shouldApply(config, t.existing);
 
                       Resource resource = provider.createResource(config);
-                      assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAME))
-                          .isEqualTo(t.expectedName);
-                      assertThat(resource.getAttribute(ServiceAttributes.SERVICE_VERSION))
+                      assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(t.expectedName);
+                      assertThat(resource.getAttribute(SERVICE_VERSION))
                           .isEqualTo(t.expectedVersion);
                     }))
         .collect(Collectors.toList());

--- a/instrumentation/rmi/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rmi/RmiTest.java
+++ b/instrumentation/rmi/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rmi/RmiTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.rmi;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import io.opentelemetry.api.trace.SpanId;
@@ -15,7 +18,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
@@ -149,13 +151,11 @@ class RmiTest {
                                             .hasName("exception")
                                             .hasAttributesSatisfyingExactly(
                                                 equalTo(
-                                                    ExceptionAttributes.EXCEPTION_TYPE,
+                                                    EXCEPTION_TYPE,
                                                     thrown.getClass().getCanonicalName()),
-                                                equalTo(
-                                                    ExceptionAttributes.EXCEPTION_MESSAGE,
-                                                    thrown.getMessage()),
+                                                equalTo(EXCEPTION_MESSAGE, thrown.getMessage()),
                                                 satisfies(
-                                                    ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                                    EXCEPTION_STACKTRACE,
                                                     AbstractAssert::isNotNull)))
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "java_rmi"),
@@ -171,13 +171,11 @@ class RmiTest {
                                             .hasName("exception")
                                             .hasAttributesSatisfyingExactly(
                                                 equalTo(
-                                                    ExceptionAttributes.EXCEPTION_TYPE,
+                                                    EXCEPTION_TYPE,
                                                     thrown.getClass().getCanonicalName()),
-                                                equalTo(
-                                                    ExceptionAttributes.EXCEPTION_MESSAGE,
-                                                    thrown.getMessage()),
+                                                equalTo(EXCEPTION_MESSAGE, thrown.getMessage()),
                                                 satisfies(
-                                                    ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                                    EXCEPTION_STACKTRACE,
                                                     AbstractAssert::isNotNull)))
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "java_rmi"),

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +23,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.rocketmqclient.v4_8.base.BaseConf;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -139,18 +144,12 @@ abstract class AbstractRocketMqClientTest {
                         span.hasName(sharedTopic + " publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),
@@ -162,21 +161,15 @@ abstract class AbstractRocketMqClientTest {
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                    MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),
@@ -215,18 +208,12 @@ abstract class AbstractRocketMqClientTest {
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),
@@ -238,21 +225,15 @@ abstract class AbstractRocketMqClientTest {
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                    MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),
@@ -304,14 +285,11 @@ abstract class AbstractRocketMqClientTest {
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  sharedTopic),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                              equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                              equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                              equalTo(MESSAGING_OPERATION, "publish"),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                  val -> val.isInstanceOf(String.class)),
+                                  MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                               satisfies(
                                   AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                   val -> val.isInstanceOf(String.class)),
@@ -333,30 +311,23 @@ abstract class AbstractRocketMqClientTest {
                         span.hasName("multiple_sources receive")
                             .hasKind(SpanKind.CONSUMER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive")),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_OPERATION, "receive")),
                     span ->
                         span.hasName(sharedTopic + " process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinksSatisfying(links(producerSpanContext.get()))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                    MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isNotEmpty()),
@@ -372,21 +343,15 @@ abstract class AbstractRocketMqClientTest {
                             .hasParent(trace.getSpan(0))
                             .hasLinksSatisfying(links(producerSpanContext.get()))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                    MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagB"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagB"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isNotEmpty()),
@@ -430,18 +395,12 @@ abstract class AbstractRocketMqClientTest {
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),
@@ -457,21 +416,15 @@ abstract class AbstractRocketMqClientTest {
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    sharedTopic),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
+                                    MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                    val -> val.isInstanceOf(String.class)),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG,
-                                    "TagA"),
+                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, "TagA"),
                                 satisfies(
                                     AttributeKey.stringKey("messaging.rocketmq.broker_address"),
                                     val -> val.isInstanceOf(String.class)),

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
@@ -123,9 +124,7 @@ public abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                                         MESSAGING_MESSAGE_ID,
                                         sendReceipt.getMessageId().toString()),
                                     equalTo(MESSAGING_DESTINATION_NAME, topic),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                        "publish")),
+                                    equalTo(MESSAGING_OPERATION, "publish")),
                         span ->
                             span.hasKind(SpanKind.CONSUMER)
                                 .hasName(topic + " process")
@@ -145,9 +144,7 @@ public abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                                         MESSAGING_MESSAGE_ID,
                                         sendReceipt.getMessageId().toString()),
                                     equalTo(MESSAGING_DESTINATION_NAME, topic),
-                                    equalTo(
-                                        MessagingIncubatingAttributes.MESSAGING_OPERATION,
-                                        "process")),
+                                    equalTo(MESSAGING_OPERATION, "process")),
                         span ->
                             span.hasName("child")
                                 .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
@@ -421,7 +423,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish")));
+                equalTo(MESSAGING_OPERATION, "publish")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
@@ -453,7 +455,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish")));
+                equalTo(MESSAGING_OPERATION, "publish")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
@@ -485,7 +487,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish")));
+                equalTo(MESSAGING_OPERATION, "publish")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
@@ -500,10 +502,10 @@ public abstract class AbstractRocketMqClientTest {
         .hasName(topic + " receive")
         .hasStatus(StatusData.unset())
         .hasAttributesSatisfyingExactly(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+            equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
             equalTo(MESSAGING_SYSTEM, "rocketmq"),
             equalTo(MESSAGING_DESTINATION_NAME, topic),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
+            equalTo(MESSAGING_OPERATION, "receive"),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
   }
 
@@ -520,15 +522,14 @@ public abstract class AbstractRocketMqClientTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(
-                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process")));
+                equalTo(MESSAGING_OPERATION, "process")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.CONSUMER)
@@ -553,8 +554,7 @@ public abstract class AbstractRocketMqClientTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(
-                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_GROUP, messageGroup),
@@ -562,7 +562,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process")));
+                equalTo(MESSAGING_OPERATION, "process")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.CONSUMER)
@@ -587,8 +587,7 @@ public abstract class AbstractRocketMqClientTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(
-                    MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP, deliveryTimestamp),
@@ -596,7 +595,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process")));
+                equalTo(MESSAGING_OPERATION, "process")));
     attributeAssertions.addAll(Arrays.asList(extraAttributes));
 
     return span.hasKind(SpanKind.CONSUMER)

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
@@ -8,13 +8,14 @@ package io.opentelemetry.instrumentation.runtimemetrics.java8;
 import static io.opentelemetry.instrumentation.runtimemetrics.java8.ScopeUtil.EXPECTED_SCOPE;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.JvmAttributes.JVM_THREAD_DAEMON;
+import static io.opentelemetry.semconv.JvmAttributes.JVM_THREAD_STATE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.JvmAttributes;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import org.junit.jupiter.api.Test;
@@ -66,14 +67,12 @@ class ThreadsStableSemconvTest {
                                             point
                                                 .hasValue(2)
                                                 .hasAttributesSatisfying(
-                                                    equalTo(JvmAttributes.JVM_THREAD_DAEMON, true)),
+                                                    equalTo(JVM_THREAD_DAEMON, true)),
                                         point ->
                                             point
                                                 .hasValue(5)
                                                 .hasAttributesSatisfying(
-                                                    equalTo(
-                                                        JvmAttributes.JVM_THREAD_DAEMON,
-                                                        false))))));
+                                                    equalTo(JVM_THREAD_DAEMON, false))))));
   }
 
   @Test
@@ -111,18 +110,14 @@ class ThreadsStableSemconvTest {
                                             point
                                                 .hasValue(1)
                                                 .hasAttributesSatisfying(
-                                                    equalTo(JvmAttributes.JVM_THREAD_DAEMON, false),
-                                                    equalTo(
-                                                        JvmAttributes.JVM_THREAD_STATE,
-                                                        "runnable")),
+                                                    equalTo(JVM_THREAD_DAEMON, false),
+                                                    equalTo(JVM_THREAD_STATE, "runnable")),
                                         point ->
                                             point
                                                 .hasValue(1)
                                                 .hasAttributesSatisfying(
-                                                    equalTo(JvmAttributes.JVM_THREAD_DAEMON, true),
-                                                    equalTo(
-                                                        JvmAttributes.JVM_THREAD_STATE,
-                                                        "waiting"))))));
+                                                    equalTo(JVM_THREAD_DAEMON, true),
+                                                    equalTo(JVM_THREAD_STATE, "waiting"))))));
   }
 
   static final class ThreadInfoAnswer implements Answer<Object> {

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServletHandlerTest.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/jetty/JettyServletHandlerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0.jetty;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -18,7 +19,6 @@ import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.AbstractServlet3T
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TestServlet3;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.HashSet;
@@ -45,7 +45,7 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
   }

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServletHandlerTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServletHandlerTest.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
-import io.opentelemetry.semconv.HttpAttributes;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -38,7 +39,7 @@ class JettyServletHandlerTest extends AbstractServlet5Test<Server, ServletHandle
         serverEndpoint -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(HttpAttributes.HTTP_ROUTE);
+          attributes.remove(HTTP_ROUTE);
           return attributes;
         });
   }

--- a/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkJavaBasedTest.java
+++ b/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkJavaBasedTest.java
@@ -7,6 +7,18 @@ package io.opentelemetry.javaagent.instrumentation.sparkjava;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -14,12 +26,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.testing.internal.armeria.client.WebClient;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import org.junit.jupiter.api.AfterAll;
@@ -62,21 +68,17 @@ public class SparkJavaBasedTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
-                            equalTo(UrlAttributes.URL_PATH, "/param/asdf1234"),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            satisfies(
-                                UserAgentAttributes.USER_AGENT_ORIGINAL,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/param/:param"),
-                            equalTo(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, port),
-                            equalTo(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)))));
+                            equalTo(URL_SCHEME, "http"),
+                            equalTo(URL_PATH, "/param/asdf1234"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
+                            equalTo(HTTP_ROUTE, "/param/:param"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)))));
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/r2dbc/R2DbcInstrumentationAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/r2dbc/R2DbcInstrumentationAutoConfigurationTest.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.r2dbc;
 
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -51,14 +52,12 @@ class R2DbcInstrumentationAutoConfigurationTest {
                   trace.hasSpansSatisfyingExactly(
                       span ->
                           span.hasAttribute(
-                              DbIncubatingAttributes.DB_STATEMENT,
+                              DB_STATEMENT,
                               "CREATE TABLE IF NOT EXISTS player(id INT NOT NULL AUTO_INCREMENT, name VARCHAR(?), age INT, PRIMARY KEY (id))")),
               trace ->
                   trace.hasSpansSatisfyingExactly(
                       span ->
-                          span.hasAttribute(
-                              DbIncubatingAttributes.DB_STATEMENT,
-                              "SELECT * FROM player WHERE id = ?")));
+                          span.hasAttribute(DB_STATEMENT, "SELECT * FROM player WHERE id = ?")));
         });
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/resources/SpringResourceProviderTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/resources/SpringResourceProviderTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.resources;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties;
@@ -15,7 +17,6 @@ import io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.testing.assertj.AttributesAssert;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.util.Collections;
 import java.util.Properties;
 import org.junit.jupiter.api.DisplayName;
@@ -42,8 +43,7 @@ public class SpringResourceProviderTest {
         .withPropertyValues("spring.application.name=myapp-backend")
         .run(
             context ->
-                assertResourceAttributes(context)
-                    .containsEntry(ServiceAttributes.SERVICE_NAME, "myapp-backend"));
+                assertResourceAttributes(context).containsEntry(SERVICE_NAME, "myapp-backend"));
   }
 
   @Test
@@ -58,8 +58,8 @@ public class SpringResourceProviderTest {
         .run(
             context ->
                 assertResourceAttributes(context)
-                    .containsEntry(ServiceAttributes.SERVICE_NAME, "demo")
-                    .containsEntry(ServiceAttributes.SERVICE_VERSION, "0.3"));
+                    .containsEntry(SERVICE_NAME, "demo")
+                    .containsEntry(SERVICE_VERSION, "0.3"));
   }
 
   private static AttributesAssert assertResourceAttributes(AssertableApplicationContext context) {

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceNameDetectorTest.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceNameDetectorTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.resources;
 
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +14,6 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
@@ -173,8 +173,7 @@ class SpringBootServiceNameDetectorTest {
   void shouldNotApplyWhenResourceHasServiceName() {
     SpringBootServiceNameDetector guesser = new SpringBootServiceNameDetector(system);
     Resource resource =
-        Resource.getDefault()
-            .merge(Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, "test-service")));
+        Resource.getDefault().merge(Resource.create(Attributes.of(SERVICE_NAME, "test-service")));
     assertThat(guesser.shouldApply(config, resource)).isFalse();
   }
 
@@ -189,12 +188,12 @@ class SpringBootServiceNameDetectorTest {
   void shouldNotApplyIfConfigHasServiceNameResourceAttribute() {
     SpringBootServiceNameDetector guesser = new SpringBootServiceNameDetector(system);
     when(config.getMap("otel.resource.attributes"))
-        .thenReturn(singletonMap(ServiceAttributes.SERVICE_NAME.getKey(), "test-service"));
+        .thenReturn(singletonMap(SERVICE_NAME.getKey(), "test-service"));
     assertThat(guesser.shouldApply(config, Resource.getDefault())).isFalse();
   }
 
   private static void expectServiceName(Resource result, String expected) {
-    assertThat(result.getAttribute(ServiceAttributes.SERVICE_NAME)).isEqualTo(expected);
+    assertThat(result.getAttribute(SERVICE_NAME)).isEqualTo(expected);
   }
 
   private static void writeString(Path path, String value) throws Exception {

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceVersionDetectorTest.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceVersionDetectorTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.spring.resources;
 
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ServiceAttributes;
 import java.io.InputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +33,7 @@ class SpringBootServiceVersionDetectorTest {
 
     SpringBootServiceVersionDetector guesser = new SpringBootServiceVersionDetector(system);
     Resource result = guesser.createResource(config);
-    assertThat(result.getAttribute(ServiceAttributes.SERVICE_VERSION)).isEqualTo("0.0.2");
+    assertThat(result.getAttribute(SERVICE_VERSION)).isEqualTo("0.0.2");
   }
 
   @Test

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/aws/AwsSqsTest.java
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/aws/AwsSqsTest.java
@@ -8,6 +8,15 @@ package io.opentelemetry.javaagent.instrumentation.spring.aws;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.awspring.cloud.sqs.operations.SqsTemplate;
@@ -16,8 +25,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.semconv.incubating.AwsIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
@@ -87,13 +94,12 @@ class AwsSqsTest {
                             equalTo(RpcIncubatingAttributes.RPC_METHOD, "GetQueueUrl"),
                             equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                             equalTo(
-                                HttpAttributes.HTTP_REQUEST_METHOD,
-                                HttpAttributes.HttpRequestMethodValues.POST),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, AwsSqsTestApplication.sqsPort),
+                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
                             satisfies(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
@@ -110,27 +116,22 @@ class AwsSqsTest {
                             equalTo(RpcIncubatingAttributes.RPC_METHOD, "SendMessage"),
                             equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                             equalTo(
-                                HttpAttributes.HTTP_REQUEST_METHOD,
-                                HttpAttributes.HttpRequestMethodValues.POST),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, AwsSqsTestApplication.sqsPort),
+                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
                             satisfies(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "test-queue"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "test-queue"),
                             equalTo(
                                 stringKey("aws.queue.url"),
                                 "http://localhost:"
@@ -148,27 +149,22 @@ class AwsSqsTest {
                             equalTo(RpcIncubatingAttributes.RPC_METHOD, "ReceiveMessage"),
                             equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                             equalTo(
-                                HttpAttributes.HTTP_REQUEST_METHOD,
-                                HttpAttributes.HttpRequestMethodValues.POST),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, AwsSqsTestApplication.sqsPort),
+                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
                             satisfies(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
                             equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
+                                MESSAGING_SYSTEM,
                                 MessagingIncubatingAttributes.MessagingSystemIncubatingValues
                                     .AWS_SQS),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "test-queue")),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "test-queue")),
                 span ->
                     span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(3)),
                 span ->
@@ -180,13 +176,12 @@ class AwsSqsTest {
                             equalTo(RpcIncubatingAttributes.RPC_METHOD, "DeleteMessageBatch"),
                             equalTo(RpcIncubatingAttributes.RPC_SERVICE, "Sqs"),
                             equalTo(
-                                HttpAttributes.HTTP_REQUEST_METHOD,
-                                HttpAttributes.HttpRequestMethodValues.POST),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, AwsSqsTestApplication.sqsPort),
+                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
                             satisfies(
-                                UrlAttributes.URL_FULL,
+                                URL_FULL,
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),

--- a/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/ReactiveSpringDataTest.java
+++ b/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/ReactiveSpringDataTest.java
@@ -49,7 +49,7 @@ class ReactiveSpringDataTest {
     applicationContext.close();
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testFindAll() {
     long count =

--- a/instrumentation/spring/spring-data/spring-data-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/AbstractSpringJpaTest.java
+++ b/instrumentation/spring/spring-data/spring-data-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/AbstractSpringJpaTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.spring.data;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,7 +27,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.List;
 import java.util.Optional;
 import org.hibernate.Version;
@@ -68,7 +74,7 @@ public abstract class AbstractSpringJpaTest<
                 span -> span.hasName("toString test").hasTotalAttributeCount(0)));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   static void assertHibernate4Trace(TraceAssert trace, String repoClassName) {
     trace.hasSpansSatisfyingExactly(
         span ->
@@ -82,17 +88,16 @@ public abstract class AbstractSpringJpaTest<
                 .hasKind(SpanKind.CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
-                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                    equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                    equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                    satisfies(
-                        DbIncubatingAttributes.DB_STATEMENT, val -> val.startsWith("insert ")),
-                    equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                    equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")));
+                    equalTo(DB_SYSTEM, "hsqldb"),
+                    equalTo(DB_NAME, "test"),
+                    equalTo(DB_USER, "sa"),
+                    equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                    satisfies(DB_STATEMENT, val -> val.startsWith("insert ")),
+                    equalTo(DB_OPERATION, "INSERT"),
+                    equalTo(DB_SQL_TABLE, "JpaCustomer")));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   static void assertHibernateTrace(TraceAssert trace, String repoClassName) {
     trace.hasSpansSatisfyingExactly(
         span ->
@@ -105,30 +110,27 @@ public abstract class AbstractSpringJpaTest<
             span.hasName("CALL test")
                 .hasKind(SpanKind.CLIENT)
                 .hasAttributesSatisfyingExactly(
-                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                    equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                    equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                    satisfies(
-                        DbIncubatingAttributes.DB_STATEMENT,
-                        val -> val.startsWith("call next value for ")),
-                    equalTo(DbIncubatingAttributes.DB_OPERATION, "CALL")),
+                    equalTo(DB_SYSTEM, "hsqldb"),
+                    equalTo(DB_NAME, "test"),
+                    equalTo(DB_USER, "sa"),
+                    equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                    satisfies(DB_STATEMENT, val -> val.startsWith("call next value for ")),
+                    equalTo(DB_OPERATION, "CALL")),
         span ->
             span.hasName("INSERT test.JpaCustomer")
                 .hasKind(SpanKind.CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
-                    equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                    equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                    equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                    equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                    satisfies(
-                        DbIncubatingAttributes.DB_STATEMENT, val -> val.startsWith("insert ")),
-                    equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                    equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")));
+                    equalTo(DB_SYSTEM, "hsqldb"),
+                    equalTo(DB_NAME, "test"),
+                    equalTo(DB_USER, "sa"),
+                    equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                    satisfies(DB_STATEMENT, val -> val.startsWith("insert ")),
+                    equalTo(DB_OPERATION, "INSERT"),
+                    equalTo(DB_SQL_TABLE, "JpaCustomer")));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testCrud() {
     boolean isHibernate4 = Version.getVersionString().startsWith("4.");
@@ -154,15 +156,13 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
     clearData();
 
     repo.save(customer);
@@ -192,29 +192,25 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer")),
                 span ->
                     span.hasName("UPDATE test.JpaCustomer")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("update ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "UPDATE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("update ")),
+                            equalTo(DB_OPERATION, "UPDATE"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
     clearData();
 
     customer = findByLastName(repo, "Anonymous").get(0);
@@ -232,15 +228,13 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
     clearData();
 
     repo.delete(customer);
@@ -258,32 +252,28 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer")),
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer")),
                 span ->
                     span.hasName("DELETE test.JpaCustomer")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("delete ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "DELETE"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("delete ")),
+                            equalTo(DB_OPERATION, "DELETE"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testCustomRepositoryMethod() {
     REPOSITORY repo = repository();
@@ -307,18 +297,16 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void testFailedRepositoryMethod() {
     // given
@@ -354,14 +342,12 @@ public abstract class AbstractSpringJpaTest<
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_SYSTEM, "hsqldb"),
-                            equalTo(DbIncubatingAttributes.DB_NAME, "test"),
-                            equalTo(DbIncubatingAttributes.DB_USER, "sa"),
-                            equalTo(DbIncubatingAttributes.DB_CONNECTION_STRING, "hsqldb:mem:"),
-                            satisfies(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                val -> val.startsWith("select ")),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "JpaCustomer"))));
+                            equalTo(DB_SYSTEM, "hsqldb"),
+                            equalTo(DB_NAME, "test"),
+                            equalTo(DB_USER, "sa"),
+                            equalTo(DB_CONNECTION_STRING, "hsqldb:mem:"),
+                            satisfies(DB_STATEMENT, val -> val.startsWith("select ")),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "JpaCustomer"))));
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
@@ -8,12 +8,19 @@ package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,14 +57,11 @@ class SpringIntegrationAndRabbitTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                NETWORK_PEER_ADDRESS,
                                 s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1", null)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                l -> l.isInstanceOf(Long.class)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq")),
+                            satisfies(NETWORK_PEER_PORT, l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
+                            equalTo(MESSAGING_SYSTEM, "rabbitmq")),
                 span -> span.hasName("queue.declare"),
                 span -> span.hasName("queue.bind"),
                 span ->
@@ -66,21 +70,14 @@ class SpringIntegrationAndRabbitTest {
                         .hasKind(SpanKind.PRODUCER)
                         .hasAttributesSatisfyingExactly(
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                NETWORK_PEER_ADDRESS,
                                 s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1", null)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                l -> l.isInstanceOf(Long.class)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_PEER_PORT, l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
+                            equalTo(MESSAGING_SYSTEM, "rabbitmq"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            satisfies(MESSAGING_MESSAGE_BODY_SIZE, l -> l.isInstanceOf(Long.class)),
                             satisfies(
                                 MessagingIncubatingAttributes
                                     .MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
@@ -98,21 +95,14 @@ class SpringIntegrationAndRabbitTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasAttributesSatisfyingExactly(
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                NETWORK_PEER_ADDRESS,
                                 s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1", null)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                l -> l.isInstanceOf(Long.class)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_PEER_PORT, l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
+                            equalTo(MESSAGING_SYSTEM, "rabbitmq"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            satisfies(MESSAGING_MESSAGE_BODY_SIZE, l -> l.isInstanceOf(Long.class)),
                             satisfies(
                                 MessagingIncubatingAttributes
                                     .MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
@@ -124,17 +114,12 @@ class SpringIntegrationAndRabbitTest {
                         .hasParent(trace.getSpan(6))
                         .hasKind(SpanKind.CONSUMER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_SYSTEM, "rabbitmq"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            satisfies(MESSAGING_MESSAGE_ID, s -> s.isInstanceOf(String.class)),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                s -> s.isInstanceOf(String.class)),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                l -> l.isInstanceOf(Long.class))),
+                                MESSAGING_MESSAGE_BODY_SIZE, l -> l.isInstanceOf(Long.class))),
                 span ->
                     span.hasName("consumer").hasParent(trace.getSpan(8)).hasTotalAttributeCount(0)),
         trace ->
@@ -144,13 +129,10 @@ class SpringIntegrationAndRabbitTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             satisfies(
-                                NetworkAttributes.NETWORK_PEER_ADDRESS,
+                                NETWORK_PEER_ADDRESS,
                                 s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1", null)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                l -> l.isInstanceOf(Long.class)),
-                            satisfies(
-                                NetworkAttributes.NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq"))));
+                            satisfies(NETWORK_PEER_PORT, l -> l.isInstanceOf(Long.class)),
+                            satisfies(NETWORK_TYPE, s -> s.isIn("ipv4", "ipv6", null)),
+                            equalTo(MESSAGING_SYSTEM, "rabbitmq"))));
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
@@ -10,13 +10,17 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,15 +43,12 @@ public abstract class AbstractJmsTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                    val -> val.isInstanceOf(String.class))));
+                equalTo(MESSAGING_SYSTEM, "jms"),
+                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                equalTo(MESSAGING_OPERATION, "publish"),
+                satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
     if (destinationName.equals("(temporary)")) {
-      attributeAssertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true));
+      attributeAssertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
     }
     if (testHeaders) {
       attributeAssertions.add(
@@ -89,20 +90,17 @@ public abstract class AbstractJmsTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, operation)));
+                equalTo(MESSAGING_SYSTEM, "jms"),
+                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
+                equalTo(MESSAGING_OPERATION, operation)));
     if (msgId != null) {
-      attributeAssertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, msgId));
+      attributeAssertions.add(equalTo(MESSAGING_MESSAGE_ID, msgId));
     } else {
       attributeAssertions.add(
-          satisfies(
-              MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-              val -> val.isInstanceOf(String.class)));
+          satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
     }
     if (destinationName.equals("(temporary)")) {
-      attributeAssertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true));
+      attributeAssertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
     }
     if (testHeaders) {
       attributeAssertions.add(

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -12,12 +12,15 @@ import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import jakarta.jms.ConnectionFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -47,14 +50,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "spring-jms-listener"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                              AbstractStringAssert::isNotBlank)));
+                          equalTo(MESSAGING_SYSTEM, "jms"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
+                          satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)));
 
           producerSpan.set(trace.getSpan(1));
         },
@@ -66,28 +65,20 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank)),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span ->
                     span.hasName("spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank)),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -133,14 +124,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
                                 singletonList("test")),
@@ -154,14 +141,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
                                 singletonList("test")),
@@ -173,14 +156,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.test_message_header"),
                                 singletonList("test")),

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
@@ -9,8 +9,11 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.assertj.core.api.AbstractStringAssert;
 
 class SpringListenerSuppressReceiveSpansTest extends AbstractSpringJmsListenerTest {
@@ -27,28 +30,20 @@ class SpringListenerSuppressReceiveSpansTest extends AbstractSpringJmsListenerTe
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank)),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "publish"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span ->
                     span.hasName("spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "jms"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "spring-jms-listener"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID,
-                                AbstractStringAssert::isNotBlank)),
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -9,6 +9,15 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -20,7 +29,6 @@ import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.opentelemetry.testing.AbstractSpringKafkaTest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,18 +82,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "testSingleTopic"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                              AbstractStringAssert::isNotEmpty),
+                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                              AbstractLongAssert::isNotNegative),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))));
@@ -99,44 +103,32 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testSingleTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testSingleListener"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1)),
+                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
                 span ->
                     span.hasName("testSingleTopic process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producer.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testSingleTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                            equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                AbstractLongAssert::isNotNegative),
+                                MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testSingleListener"),
+                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer")),
@@ -164,34 +156,23 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                 .hasKind(SpanKind.CONSUMER)
                 .hasNoParent()
                 .hasAttributesSatisfyingExactly(
-                    equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                    equalTo(
-                        MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                        "testSingleTopic"),
-                    equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                    equalTo(
-                        MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                        "testSingleListener"),
+                    equalTo(MESSAGING_SYSTEM, "kafka"),
+                    equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                    equalTo(MESSAGING_OPERATION, "receive"),
+                    equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
                     satisfies(
                         MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-                    equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+                    equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     List<AttributeAssertion> processAttributes =
         Arrays.asList(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                AbstractLongAssert::isNotNegative),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                AbstractStringAssert::isNotEmpty),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                AbstractLongAssert::isNotNegative),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+            equalTo(MESSAGING_OPERATION, "process"),
+            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
+            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
             satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
 
@@ -206,18 +187,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "testSingleTopic"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                              AbstractStringAssert::isNotEmpty),
+                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                              AbstractLongAssert::isNotNegative),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))));
@@ -280,18 +257,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "testBatchTopic"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                              AbstractStringAssert::isNotEmpty),
+                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                              AbstractLongAssert::isNotNegative),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))),
@@ -300,18 +273,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "testBatchTopic"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                              AbstractStringAssert::isNotEmpty),
+                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                              AbstractLongAssert::isNotNegative),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "20"),
+                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))));
@@ -326,19 +295,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testBatchTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testBatchListener"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                 span ->
                     span.hasName("testBatchTopic process")
                         .hasKind(SpanKind.CONSUMER)
@@ -347,19 +311,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             LinkData.create(producer1.get().getSpanContext()),
                             LinkData.create(producer2.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testBatchTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testBatchListener"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                            equalTo(MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("consumer")),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -387,18 +346,14 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                          equalTo(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                              "testBatchTopic"),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                          equalTo(MESSAGING_SYSTEM, "kafka"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                          equalTo(MESSAGING_OPERATION, "publish"),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                              AbstractStringAssert::isNotEmpty),
+                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                           satisfies(
-                              MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                              AbstractLongAssert::isNotNegative),
-                          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                           satisfies(
                               MESSAGING_CLIENT_ID,
                               stringAssert -> stringAssert.startsWith("producer"))));
@@ -447,13 +402,12 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         .hasKind(SpanKind.CONSUMER)
         .hasNoParent()
         .hasAttributesSatisfyingExactly(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "receive"),
-            equalTo(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+            equalTo(MESSAGING_OPERATION, "receive"),
+            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
   }
 
   private static void assertProcessSpan(
@@ -463,13 +417,12 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         .hasParent(trace.getSpan(0))
         .hasLinks(LinkData.create(producer.getSpanContext()))
         .hasAttributesSatisfyingExactly(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-            equalTo(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+            equalTo(MESSAGING_OPERATION, "process"),
+            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     if (failed) {
       span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
     }

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -9,6 +9,15 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -52,12 +61,9 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSingleTopic"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_SYSTEM, "kafka"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
                                     MESSAGING_CLIENT_ID,
                                     stringAssert -> stringAssert.startsWith("producer")),
@@ -66,38 +72,28 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                         .MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
                                     AbstractLongAssert::isNotNegative),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY,
-                                    "10")),
+                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
                     span ->
                         span.hasName("testSingleTopic process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSingleTopic"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_SYSTEM, "kafka"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                                equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                    AbstractLongAssert::isNotNegative),
+                                    MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                                 satisfies(
                                     MessagingIncubatingAttributes
                                         .MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
                                     AbstractLongAssert::isNotNegative),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY,
-                                    "10"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                    "testSingleListener"),
+                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
                                 satisfies(
                                     MESSAGING_CLIENT_ID,
                                     stringAssert -> stringAssert.startsWith("consumer"))),
@@ -119,21 +115,14 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
 
     List<AttributeAssertion> processAttributes =
         Arrays.asList(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                AbstractLongAssert::isNotNegative),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                AbstractStringAssert::isNotEmpty),
-            satisfies(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                AbstractLongAssert::isNotNegative),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+            equalTo(MESSAGING_OPERATION, "process"),
+            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
+            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")));
 
     testing()
@@ -146,12 +135,9 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testSingleTopic"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                                equalTo(MESSAGING_SYSTEM, "kafka"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
+                                equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
                                     MESSAGING_CLIENT_ID,
                                     stringAssert -> stringAssert.startsWith("producer")),
@@ -160,11 +146,9 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                         .MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
                                 satisfies(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
                                     AbstractLongAssert::isNotNegative),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY,
-                                    "10")),
+                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
                     span ->
                         span.hasName("testSingleTopic process")
                             .hasKind(SpanKind.CONSUMER)
@@ -211,44 +195,37 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  "testBatchTopic"),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                              equalTo(MESSAGING_SYSTEM, "kafka"),
+                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                              equalTo(MESSAGING_OPERATION, "publish"),
                               satisfies(
                                   MESSAGING_CLIENT_ID,
                                   stringAssert -> stringAssert.startsWith("producer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
                                   AbstractLongAssert::isNotNegative),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
                   span ->
                       span.hasName("testBatchTopic publish")
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  "testBatchTopic"),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                              equalTo(MESSAGING_SYSTEM, "kafka"),
+                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                              equalTo(MESSAGING_OPERATION, "publish"),
                               satisfies(
                                   MESSAGING_CLIENT_ID,
                                   stringAssert -> stringAssert.startsWith("producer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
                                   AbstractLongAssert::isNotNegative),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY,
-                                  "20")));
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20")));
 
               producer1.set(trace.getSpan(1));
               producer2.set(trace.getSpan(2));
@@ -264,21 +241,14 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                     producer1.get().getSpanContext(),
                                     producer2.get().getSpanContext()))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                    "testBatchTopic"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                    "testBatchListener"),
+                                equalTo(MESSAGING_SYSTEM, "kafka"),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                                equalTo(MESSAGING_OPERATION, "process"),
+                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
                                 satisfies(
                                     MESSAGING_CLIENT_ID,
                                     stringAssert -> stringAssert.startsWith("consumer")),
-                                equalTo(
-                                    MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-                                    2)),
+                                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
   }
 
@@ -299,13 +269,12 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
 
     List<AttributeAssertion> processAttributes =
         Arrays.asList(
-            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
-            equalTo(
-                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+            equalTo(MESSAGING_OPERATION, "process"),
+            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
-            equalTo(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
 
     testing()
         .waitAndAssertSortedTraces(
@@ -318,23 +287,19 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                  "testBatchTopic"),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                              equalTo(MESSAGING_SYSTEM, "kafka"),
+                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
+                              equalTo(MESSAGING_OPERATION, "publish"),
                               satisfies(
                                   MESSAGING_CLIENT_ID,
                                   stringAssert -> stringAssert.startsWith("producer")),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                  MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),
                               satisfies(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
+                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
                                   AbstractLongAssert::isNotNegative),
-                              equalTo(
-                                  MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY,
-                                  "10")));
+                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")));
 
               producer.set(trace.getSpan(1));
             },

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -7,6 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -18,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -105,25 +112,20 @@ public class SpringRabbitMqTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, destination),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                    AbstractLongAssert::isNotNegative)));
+                equalTo(MESSAGING_SYSTEM, "rabbitmq"),
+                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
     if (operation != null) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, operation));
+      assertions.add(equalTo(MESSAGING_OPERATION, operation));
     }
     if (peerAddress != null) {
-      assertions.add(equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"));
-      assertions.add(equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, peerAddress));
-      assertions.add(
-          satisfies(NetworkAttributes.NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative));
+      assertions.add(equalTo(NETWORK_TYPE, "ipv4"));
+      assertions.add(equalTo(NETWORK_PEER_ADDRESS, peerAddress));
+      assertions.add(satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative));
     }
     if (routingKey) {
       assertions.add(
-          satisfies(
-              MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
-              AbstractStringAssert::isNotBlank));
+          satisfies(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, AbstractStringAssert::isNotBlank));
     }
     if (testHeaders) {
       assertions.add(
@@ -213,12 +215,10 @@ public class SpringRabbitMqTest {
                       span.hasName("basic.ack")
                           .hasKind(SpanKind.CLIENT)
                           .hasAttributesSatisfyingExactly(
-                              equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"),
-                              equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip),
-                              satisfies(
-                                  NetworkAttributes.NETWORK_PEER_PORT,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "rabbitmq")));
+                              equalTo(NETWORK_TYPE, "ipv4"),
+                              equalTo(NETWORK_PEER_ADDRESS, ip),
+                              satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative),
+                              equalTo(MESSAGING_SYSTEM, "rabbitmq")));
             });
       }
     }

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiTest.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiTest.java
@@ -7,6 +7,9 @@ package io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -16,7 +19,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
@@ -199,14 +201,10 @@ class SpringRmiTest {
                               event
                                   .hasName("exception")
                                   .hasAttributesSatisfying(
-                                      equalTo(
-                                          ExceptionAttributes.EXCEPTION_TYPE,
-                                          error.getClass().getCanonicalName()),
-                                      equalTo(
-                                          ExceptionAttributes.EXCEPTION_MESSAGE,
-                                          error.getMessage()),
+                                      equalTo(EXCEPTION_TYPE, error.getClass().getCanonicalName()),
+                                      equalTo(EXCEPTION_MESSAGE, error.getMessage()),
                                       satisfies(
-                                          ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                          EXCEPTION_STACKTRACE,
                                           val -> val.isInstanceOf(String.class)))));
           assertions.add(
               span ->
@@ -219,14 +217,10 @@ class SpringRmiTest {
                               event
                                   .hasName("exception")
                                   .hasAttributesSatisfying(
-                                      equalTo(
-                                          ExceptionAttributes.EXCEPTION_TYPE,
-                                          error.getClass().getCanonicalName()),
-                                      equalTo(
-                                          ExceptionAttributes.EXCEPTION_MESSAGE,
-                                          error.getMessage()),
+                                      equalTo(EXCEPTION_TYPE, error.getClass().getCanonicalName()),
+                                      equalTo(EXCEPTION_MESSAGE, error.getMessage()),
                                       satisfies(
-                                          ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                          EXCEPTION_STACKTRACE,
                                           val -> val.isInstanceOf(String.class))))
                       .hasAttributesSatisfying(
                           equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "spring_rmi"),
@@ -247,13 +241,10 @@ class SpringRmiTest {
                                     .hasName("exception")
                                     .hasAttributesSatisfying(
                                         equalTo(
-                                            ExceptionAttributes.EXCEPTION_TYPE,
-                                            error.getClass().getCanonicalName()),
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_MESSAGE,
-                                            error.getMessage()),
+                                            EXCEPTION_TYPE, error.getClass().getCanonicalName()),
+                                        equalTo(EXCEPTION_MESSAGE, error.getMessage()),
                                         satisfies(
-                                            ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                            EXCEPTION_STACKTRACE,
                                             val -> val.isInstanceOf(String.class))))
                         .hasAttributesSatisfying(
                             equalTo(RpcIncubatingAttributes.RPC_SYSTEM, testSource.serverSystem),

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingTest.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
 import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
 
@@ -26,7 +29,6 @@ import io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1.spring.
 import io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1.spring.config.TriggerTaskConfig;
 import io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1.spring.service.LambdaTaskConfigurer;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ExceptionAttributes;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -166,11 +168,11 @@ class SpringSchedulingTest {
                                       .hasName("exception")
                                       .hasAttributesSatisfying(
                                           equalTo(
-                                              ExceptionAttributes.EXCEPTION_TYPE,
+                                              EXCEPTION_TYPE,
                                               IllegalStateException.class.getName()),
-                                          equalTo(ExceptionAttributes.EXCEPTION_MESSAGE, "failure"),
+                                          equalTo(EXCEPTION_MESSAGE, "failure"),
                                           satisfies(
-                                              ExceptionAttributes.EXCEPTION_STACKTRACE,
+                                              EXCEPTION_STACKTRACE,
                                               value -> value.isInstanceOf(String.class)))),
                   span -> span.hasName("error-handler").hasParent(trace.getSpan(0))));
     }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.web.v3_1;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -13,7 +14,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
@@ -105,7 +105,7 @@ public class SpringWebInstrumentationTest extends AbstractHttpClientTest<HttpEnt
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
@@ -17,9 +17,13 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
 import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static org.junit.jupiter.api.Named.named;
 
@@ -29,8 +33,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.EventDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.testing.internal.armeria.client.WebClient;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
@@ -112,17 +114,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, parameter.urlPath),
+                            equalTo(URL_PATH, parameter.urlPath),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables)),
                 span -> {
@@ -233,17 +233,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, parameter.urlPath),
+                            equalTo(URL_PATH, parameter.urlPath),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables)),
                 span -> {
@@ -341,17 +339,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, parameter.urlPath),
+                            equalTo(URL_PATH, parameter.urlPath),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables)),
                 span -> {
@@ -414,17 +410,15 @@ public class SpringWebfluxTest {
                         .hasStatus(StatusData.unset())
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, "/notfoundgreet"),
+                            equalTo(URL_PATH, "/notfoundgreet"),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 404),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/**")),
                 span ->
@@ -475,17 +469,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, "/echo"),
+                            equalTo(URL_PATH, "/echo"),
                             equalTo(HTTP_REQUEST_METHOD, "POST"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 202),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/echo")),
                 span ->
@@ -516,17 +508,15 @@ public class SpringWebfluxTest {
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, parameter.urlPath),
+                            equalTo(URL_PATH, parameter.urlPath),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 500),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             equalTo(ERROR_TYPE, "500")),
@@ -597,17 +587,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, "/double-greet-redirect"),
+                            equalTo(URL_PATH, "/double-greet-redirect"),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 307),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/double-greet-redirect")),
                 span ->
@@ -626,17 +614,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, "/double-greet"),
+                            equalTo(URL_PATH, "/double-greet"),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/double-greet")),
                 span -> {
@@ -678,17 +664,15 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, parameter.urlPath),
+                            equalTo(URL_PATH, parameter.urlPath),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables)),
                 span -> {
@@ -760,16 +744,14 @@ public class SpringWebfluxTest {
                         .hasStatus(StatusData.unset())
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(
-                                NetworkAttributes.NETWORK_PEER_PORT,
-                                val -> val.isInstanceOf(Long.class)),
+                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(UrlAttributes.URL_PATH, "/slow"),
+                            equalTo(URL_PATH, "/slow"),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_SCHEME, "http"),
+                            equalTo(URL_SCHEME, "http"),
                             satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/slow"),
                             equalTo(ERROR_TYPE, "_OTHER")),

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/AbstractSpringWebfluxClientInstrumentationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/AbstractSpringWebfluxClientInstrumentationTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.instrumentation.spring.webflux.client;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -17,11 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -89,7 +90,7 @@ public abstract class AbstractSpringWebfluxClientInstrumentationTest
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
           return attributes;
         });
 
@@ -184,11 +185,11 @@ public abstract class AbstractSpringWebfluxClientInstrumentationTest
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(UrlAttributes.URL_FULL, uri.toString()),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(ErrorAttributes.ERROR_TYPE, "cancelled")),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(ERROR_TYPE, "cancelled")),
                 span ->
                     span.hasName("test-http-server")
                         .hasKind(SpanKind.SERVER)

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedTest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedTest.java
@@ -12,6 +12,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY;
@@ -144,9 +146,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -166,9 +168,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "miss"))));
   }
 
@@ -201,9 +203,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(booleanKey("spymemcached.command.cancelled"), true))));
   }
 
@@ -256,9 +258,9 @@ class SpymemcachedTest {
                                             val -> val.isInstanceOf(String.class))))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"))));
+                            equalTo(DB_OPERATION, "get"))));
   }
 
   @Test
@@ -284,9 +286,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "getBulk"))));
+                            equalTo(DB_OPERATION, "getBulk"))));
   }
 
   @Test
@@ -308,9 +310,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "set"))));
+                            equalTo(DB_OPERATION, "set"))));
   }
 
   @Test
@@ -344,9 +346,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "set"),
+                            equalTo(DB_OPERATION, "set"),
                             equalTo(booleanKey("spymemcached.command.cancelled"), true))));
   }
 
@@ -370,18 +372,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "add")),
+                            equalTo(DB_OPERATION, "add")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -406,18 +408,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "add")),
+                            equalTo(DB_OPERATION, "add")),
                 span ->
                     span.hasName("add")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "add"))));
+                            equalTo(DB_OPERATION, "add"))));
   }
 
   @Test
@@ -440,18 +442,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "delete")),
+                            equalTo(DB_OPERATION, "delete")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "miss"))));
   }
 
@@ -474,9 +476,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "delete"))));
+                            equalTo(DB_OPERATION, "delete"))));
   }
 
   @Test
@@ -500,18 +502,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "replace")),
+                            equalTo(DB_OPERATION, "replace")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -538,9 +540,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "replace"))));
+                            equalTo(DB_OPERATION, "replace"))));
   }
 
   @Test
@@ -565,27 +567,27 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "gets")),
+                            equalTo(DB_OPERATION, "gets")),
                 span ->
                     span.hasName("append")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "append")),
+                            equalTo(DB_OPERATION, "append")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -611,27 +613,27 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "gets")),
+                            equalTo(DB_OPERATION, "gets")),
                 span ->
                     span.hasName("prepend")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "prepend")),
+                            equalTo(DB_OPERATION, "prepend")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -657,18 +659,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "gets")),
+                            equalTo(DB_OPERATION, "gets")),
                 span ->
                     span.hasName("cas")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "cas"))));
+                            equalTo(DB_OPERATION, "cas"))));
   }
 
   @Test
@@ -692,9 +694,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "cas"))));
+                            equalTo(DB_OPERATION, "cas"))));
   }
 
   @Test
@@ -716,9 +718,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "touch"))));
+                            equalTo(DB_OPERATION, "touch"))));
   }
 
   @Test
@@ -741,9 +743,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "touch"))));
+                            equalTo(DB_OPERATION, "touch"))));
   }
 
   @Test
@@ -766,9 +768,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "getAndTouch"))));
+                            equalTo(DB_OPERATION, "getAndTouch"))));
   }
 
   @Test
@@ -791,9 +793,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "getAndTouch"))));
+                            equalTo(DB_OPERATION, "getAndTouch"))));
   }
 
   @Test
@@ -820,18 +822,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "decr")),
+                            equalTo(DB_OPERATION, "decr")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -854,9 +856,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "decr"))));
+                            equalTo(DB_OPERATION, "decr"))));
   }
 
   @Test
@@ -877,9 +879,9 @@ class SpymemcachedTest {
                             new IllegalArgumentException("Key is too long (maxlen = 250)"))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "decr"))));
+                            equalTo(DB_OPERATION, "decr"))));
   }
 
   @Test
@@ -906,18 +908,18 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "incr")),
+                            equalTo(DB_OPERATION, "incr")),
                 span ->
                     span.hasName("get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "get"),
+                            equalTo(DB_OPERATION, "get"),
                             equalTo(stringKey("spymemcached.result"), "hit"))));
   }
 
@@ -940,9 +942,9 @@ class SpymemcachedTest {
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "incr"))));
+                            equalTo(DB_OPERATION, "incr"))));
   }
 
   @Test
@@ -963,9 +965,9 @@ class SpymemcachedTest {
                             new IllegalArgumentException("Key is too long (maxlen = 250)"))
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                DbIncubatingAttributes.DB_SYSTEM,
+                                DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.MEMCACHED),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "incr"))));
+                            equalTo(DB_OPERATION, "incr"))));
   }
 
   private static String key(String k) {

--- a/instrumentation/undertow-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowServerDispatchTest.java
+++ b/instrumentation/undertow-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowServerDispatchTest.java
@@ -11,13 +11,13 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 
 import com.google.common.collect.ImmutableSet;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.util.Headers;
@@ -130,6 +130,6 @@ class UndertowServerDispatchTest extends AbstractHttpServerTest<Undertow> {
     options.setTestException(false);
     options.setHasResponseCustomizer(endpoint -> true);
 
-    options.setHttpAttributes(endpoint -> ImmutableSet.of(NetworkAttributes.NETWORK_PEER_PORT));
+    options.setHttpAttributes(endpoint -> ImmutableSet.of(NETWORK_PEER_PORT));
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/VertxHttpClientTest.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/VertxHttpClientTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.v3_0.client;
 
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
 import client.VertxSingleConnection;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -13,8 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpClient;
@@ -90,9 +92,9 @@ class VertxHttpClientTest extends AbstractHttpClientTest<HttpClientRequest> {
         uri -> {
           Set<AttributeKey<?>> attributes =
               new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          attributes.remove(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
-          attributes.remove(ServerAttributes.SERVER_ADDRESS);
-          attributes.remove(ServerAttributes.SERVER_PORT);
+          attributes.remove(NETWORK_PROTOCOL_VERSION);
+          attributes.remove(SERVER_ADDRESS);
+          attributes.remove(SERVER_PORT);
           return attributes;
         });
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/v3_6/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/v3_6/AbstractVertxKafkaTest.java
@@ -7,13 +7,21 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka.v3_6;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -201,22 +209,17 @@ public abstract class AbstractVertxKafkaTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
+                equalTo(MESSAGING_OPERATION, "publish"),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("producer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     String messageKey = record.key();
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     return assertions;
   }
@@ -234,18 +237,16 @@ public abstract class AbstractVertxKafkaTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, operation),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, operation),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("consumer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT,
-                    AbstractLongAssert::isPositive)));
+                satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
     // consumer group is not available in version 0.11
     if (Boolean.getBoolean("testLatestDeps")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     return assertions;
   }
@@ -256,18 +257,14 @@ public abstract class AbstractVertxKafkaTest {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             Arrays.asList(
-                equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
+                equalTo(MESSAGING_OPERATION, "process"),
                 satisfies(
                     AttributeKey.stringKey("messaging.client_id"),
                     stringAssert -> stringAssert.startsWith("consumer")),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
-                    AbstractStringAssert::isNotEmpty),
-                satisfies(
-                    MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                    AbstractLongAssert::isNotNegative)));
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (Boolean.getBoolean("otel.instrumentation.kafka.experimental-span-attributes")) {
       assertions.add(
           satisfies(
@@ -276,19 +273,17 @@ public abstract class AbstractVertxKafkaTest {
     }
     // consumer group is not available in version 0.11
     if (Boolean.getBoolean("testLatestDeps")) {
-      assertions.add(equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
     }
     String messageKey = record.key();
     if (messageKey != null) {
-      assertions.add(
-          equalTo(MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
     }
     String messageValue = record.value();
     if (messageValue != null) {
       assertions.add(
           equalTo(
-              MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-              messageValue.getBytes(StandardCharsets.UTF_8).length));
+              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
     }
     return assertions;
   }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientTest.java
@@ -6,6 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.redis;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -14,9 +22,6 @@ import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.vertx.core.Vertx;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
@@ -206,25 +211,25 @@ class VertxRedisClientTest {
     // not testing database/dup
     if (SemconvStability.emitStableDatabaseSemconv()) {
       return new AttributeAssertion[] {
-        equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
+        equalTo(DB_SYSTEM, "redis"),
         equalTo(AttributeKey.stringKey("db.query.text"), statement),
         equalTo(AttributeKey.stringKey("db.operation.name"), operation),
         equalTo(AttributeKey.stringKey("db.namespace"), "1"),
-        equalTo(ServerAttributes.SERVER_ADDRESS, host),
-        equalTo(ServerAttributes.SERVER_PORT, port),
-        equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-        equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip)
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
+        equalTo(NETWORK_PEER_PORT, port),
+        equalTo(NETWORK_PEER_ADDRESS, ip)
       };
     } else {
       return new AttributeAssertion[] {
-        equalTo(DbIncubatingAttributes.DB_SYSTEM, "redis"),
-        equalTo(DbIncubatingAttributes.DB_STATEMENT, statement),
-        equalTo(DbIncubatingAttributes.DB_OPERATION, operation),
-        equalTo(DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX, 1),
-        equalTo(ServerAttributes.SERVER_ADDRESS, host),
-        equalTo(ServerAttributes.SERVER_PORT, port),
-        equalTo(NetworkAttributes.NETWORK_PEER_PORT, port),
-        equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, ip)
+        equalTo(DB_SYSTEM, "redis"),
+        equalTo(DB_STATEMENT, statement),
+        equalTo(DB_OPERATION, operation),
+        equalTo(DB_REDIS_DATABASE_INDEX, 1),
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
+        equalTo(NETWORK_PEER_PORT, port),
+        equalTo(NETWORK_PEER_ADDRESS, ip)
       };
     }
   }

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
@@ -12,6 +12,11 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -19,7 +24,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgException;
@@ -134,11 +138,11 @@ class VertxSqlClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "select * from test"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "test"),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
+                            equalTo(DB_STATEMENT, "select * from test"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "test"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port)),
                 span ->
@@ -190,9 +194,9 @@ class VertxSqlClientTest {
                                             EXCEPTION_STACKTRACE,
                                             val -> val.isInstanceOf(String.class))))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                            equalTo(DbIncubatingAttributes.DB_STATEMENT, "invalid"),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
+                            equalTo(DB_STATEMENT, "invalid"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port)),
                 span ->
@@ -224,13 +228,11 @@ class VertxSqlClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "select * from test where id = $1"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "test"),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
+                            equalTo(DB_STATEMENT, "select * from test where id = $1"),
+                            equalTo(DB_OPERATION, "SELECT"),
+                            equalTo(DB_SQL_TABLE, "test"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
   }
@@ -256,13 +258,11 @@ class VertxSqlClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                            equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                            equalTo(
-                                DbIncubatingAttributes.DB_STATEMENT,
-                                "insert into test values ($1, $2) returning *"),
-                            equalTo(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-                            equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "test"),
+                            equalTo(DB_NAME, DB),
+                            equalTo(DB_USER, USER_DB),
+                            equalTo(DB_STATEMENT, "insert into test values ($1, $2) returning *"),
+                            equalTo(DB_OPERATION, "INSERT"),
+                            equalTo(DB_SQL_TABLE, "test"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
   }
@@ -344,11 +344,11 @@ class VertxSqlClientTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                                equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                                equalTo(DbIncubatingAttributes.DB_STATEMENT, "select * from test"),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                                equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "test"),
+                                equalTo(DB_NAME, DB),
+                                equalTo(DB_USER, USER_DB),
+                                equalTo(DB_STATEMENT, "select * from test"),
+                                equalTo(DB_OPERATION, "SELECT"),
+                                equalTo(DB_SQL_TABLE, "test"),
                                 equalTo(SERVER_ADDRESS, host),
                                 equalTo(SERVER_PORT, port)),
                     span ->
@@ -409,13 +409,11 @@ class VertxSqlClientTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(DbIncubatingAttributes.DB_NAME, DB),
-                                equalTo(DbIncubatingAttributes.DB_USER, USER_DB),
-                                equalTo(
-                                    DbIncubatingAttributes.DB_STATEMENT,
-                                    "select * from test where id = $1"),
-                                equalTo(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-                                equalTo(DbIncubatingAttributes.DB_SQL_TABLE, "test"),
+                                equalTo(DB_NAME, DB),
+                                equalTo(DB_USER, USER_DB),
+                                equalTo(DB_STATEMENT, "select * from test where id = $1"),
+                                equalTo(DB_OPERATION, "SELECT"),
+                                equalTo(DB_SQL_TABLE, "test"),
                                 equalTo(SERVER_ADDRESS, host),
                                 equalTo(SERVER_PORT, port)),
                     span ->


### PR DESCRIPTION
automated via:

```
for file in $(find instrumentation -name '*Test.java'); do
  echo "Processing $file"

  # stable semconv

  negative_lookbehind='(?<!import static io.opentelemetry.semconv.)'

  for class in "ClientAttributes" "ErrorAttributes" "ExceptionAttributes" "HttpAttributes" "JvmAttributes" "NetworkAttributes" "OtelAttributes" "ServerAttributes" "ServiceAttributes" "TelemetryAttributes" "UrlAttributes" "UserAgentAttributes"; do
    for attr in $(grep -Po "$negative_lookbehind$class\.[A-Z][A-Z][A-Z_]*" $file | sort -u | sed "s/$class\.//"); do
      perl -i -pe "s/$negative_lookbehind$class\.$attr/$attr/" $file
      sed -i "0,/^import/{s/^import/import static io.opentelemetry.semconv.$class.$attr;\nimport/}" $file
    done
  done

  # incubating semconv

  negative_lookbehind='(?<!import static io.opentelemetry.semconv.incubating.)'

  for class in "DbIncubatingAttributes" "HttpIncubatingAttributes" "MessagingIncubatingAttributes"; do
    for attr in $(grep -Po "$negative_lookbehind$class\.[A-Z][A-Z][A-Z_]*" $file | sort -u | sed "s/$class\.//"); do
      perl -i -pe "s/$negative_lookbehind$class\.$attr/$attr/" $file
      sed -i "0,/^import/{s/^import/import static io.opentelemetry.semconv.incubating.$class.$attr;\nimport/}" $file
    done
  done
done

./gradlew spotlessApply
```

plus one manual rollback: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12575/commits/e308dbed86ad2bada0f4a240f782ac7147b63e06