### PR TITLE
Unify aws lambda flush handling

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/README.md
@@ -1,0 +1,5 @@
+# Settings for the AWS Lambda Instrumentation
+
+| System property                                 | Type    | Default | Description                    |
+|-------------------------------------------------|---------|---------|--------------------------------|
+| `otel.instrumentation.aws-lambda.flush-timeout` | Integer | 10000   | Flush timeout in milliseconds. |

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaInstrumentationHelper.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaInstrumentationHelper.java
@@ -8,14 +8,27 @@ package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenter;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenterFactory;
+import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrapperConfiguration;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
+import java.time.Duration;
 
 public final class AwsLambdaInstrumentationHelper {
 
   private static final AwsLambdaFunctionInstrumenter FUNCTION_INSTRUMENTER =
       AwsLambdaFunctionInstrumenterFactory.createInstrumenter(GlobalOpenTelemetry.get());
+  private static final Duration FLUSH_TIMEOUT =
+      Duration.ofMillis(
+          AgentInstrumentationConfig.get()
+              .getLong(
+                  "otel.instrumentation.aws-lambda.flush-timeout",
+                  WrapperConfiguration.OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT.toMillis()));
 
   public static AwsLambdaFunctionInstrumenter functionInstrumenter() {
     return FUNCTION_INSTRUMENTER;
+  }
+
+  public static Duration flushTimeout() {
+    return FLUSH_TIMEOUT;
   }
 
   private AwsLambdaInstrumentationHelper() {}

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.flushTimeout;
 import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.functionInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -90,7 +91,7 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
         functionInstrumenter().end(functionContext, input, null, throwable);
       }
 
-      OpenTelemetrySdkAccess.forceFlush(1, TimeUnit.SECONDS);
+      OpenTelemetrySdkAccess.forceFlush(flushTimeout().toNanos(), TimeUnit.NANOSECONDS);
     }
   }
 }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
@@ -7,7 +7,7 @@ This package contains libraries to help instrument AWS lambda functions in your 
 To use the instrumentation, configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
-In order to configure a span flush timeout (default is set to 10 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
+In order to configure a span flush timeout (default is set to 10 seconds), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
 
 Available wrappers:
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
@@ -7,7 +7,7 @@ This package contains libraries to help instrument AWS lambda functions in your 
 To use the instrumentation, configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
-In order to configure a span flush timeout (default is set to 1 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in seconds.
+In order to configure a span flush timeout (default is set to 10 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
 
 Available wrappers:
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/README.md
@@ -1,0 +1,5 @@
+# Settings for the AWS Lambda Instrumentation
+
+| System property                                 | Type    | Default | Description                    |
+|-------------------------------------------------|---------|---------|--------------------------------|
+| `otel.instrumentation.aws-lambda.flush-timeout` | Integer | 10000   | Flush timeout in milliseconds. |

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaInstrumentationHelper.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaInstrumentationHelper.java
@@ -8,29 +8,38 @@ package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenter;
+import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrapperConfiguration;
 import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaEventsInstrumenterFactory;
 import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaSqsInstrumenterFactory;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
+import java.time.Duration;
 
 public final class AwsLambdaInstrumentationHelper {
 
-  private static final io.opentelemetry.instrumentation.awslambdacore.v1_0.internal
-          .AwsLambdaFunctionInstrumenter
-      FUNCTION_INSTRUMENTER =
-          AwsLambdaEventsInstrumenterFactory.createInstrumenter(
-              GlobalOpenTelemetry.get(), AgentCommonConfig.get().getKnownHttpRequestMethods());
+  private static final AwsLambdaFunctionInstrumenter FUNCTION_INSTRUMENTER =
+      AwsLambdaEventsInstrumenterFactory.createInstrumenter(
+          GlobalOpenTelemetry.get(), AgentCommonConfig.get().getKnownHttpRequestMethods());
+  private static final Instrumenter<SQSEvent, Void> MESSAGE_TRACER =
+      AwsLambdaSqsInstrumenterFactory.forEvent(GlobalOpenTelemetry.get());
+  private static final Duration FLUSH_TIMEOUT =
+      Duration.ofMillis(
+          AgentInstrumentationConfig.get()
+              .getLong(
+                  "otel.instrumentation.aws-lambda.flush-timeout",
+                  WrapperConfiguration.OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT.toMillis()));
 
-  public static io.opentelemetry.instrumentation.awslambdacore.v1_0.internal
-          .AwsLambdaFunctionInstrumenter
-      functionInstrumenter() {
+  public static AwsLambdaFunctionInstrumenter functionInstrumenter() {
     return FUNCTION_INSTRUMENTER;
   }
 
-  private static final Instrumenter<SQSEvent, Void> MESSAGE_TRACER =
-      AwsLambdaSqsInstrumenterFactory.forEvent(GlobalOpenTelemetry.get());
-
   public static Instrumenter<SQSEvent, Void> messageInstrumenter() {
     return MESSAGE_TRACER;
+  }
+
+  public static Duration flushTimeout() {
+    return FLUSH_TIMEOUT;
   }
 
   private AwsLambdaInstrumentationHelper() {}

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaRequestHandlerInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2.AwsLambdaInstrumentationHelper.flushTimeout;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -114,7 +115,7 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
             .end(functionContext, input, result, throwable);
       }
 
-      OpenTelemetrySdkAccess.forceFlush(1, TimeUnit.SECONDS);
+      OpenTelemetrySdkAccess.forceFlush(flushTimeout().toNanos(), TimeUnit.NANOSECONDS);
     }
   }
 }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/README.md
@@ -7,7 +7,7 @@ This package contains libraries to help instrument AWS lambda functions in your 
 To use the instrumentation, configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
-In order to configure a span flush timeout (default is set to 10 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
+In order to configure a span flush timeout (default is set to 10 seconds), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
 
 Available wrappers:
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/README.md
@@ -7,7 +7,7 @@ This package contains libraries to help instrument AWS lambda functions in your 
 To use the instrumentation, configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
-In order to configure a span flush timeout (default is set to 1 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in seconds.
+In order to configure a span flush timeout (default is set to 10 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in milliseconds.
 
 Available wrappers:
 

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/OpenTelemetrySdkAccess.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/OpenTelemetrySdkAccess.java
@@ -22,13 +22,13 @@ public final class OpenTelemetrySdkAccess {
    */
   public interface ForceFlusher {
     /** Executes force flush. */
-    void run(int timeout, TimeUnit unit);
+    void run(long timeout, TimeUnit unit);
   }
 
   private static volatile ForceFlusher forceFlush;
 
   /** Forces flushing of pending spans. */
-  public static void forceFlush(int timeout, TimeUnit unit) {
+  public static void forceFlush(long timeout, TimeUnit unit) {
     forceFlush.run(timeout, unit);
   }
 

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/OpenTelemetrySdkAccess.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/OpenTelemetrySdkAccess.java
@@ -27,7 +27,13 @@ public final class OpenTelemetrySdkAccess {
 
   private static volatile ForceFlusher forceFlush;
 
-  /** Forces flushing of pending spans. */
+  /** Forces flushing of pending telemetry. */
+  @Deprecated
+  public static void forceFlush(int timeout, TimeUnit unit) {
+    forceFlush((long) timeout, unit);
+  }
+
+  /** Forces flushing of pending telemetry. */
   public static void forceFlush(long timeout, TimeUnit unit) {
     forceFlush.run(timeout, unit);
   }


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12375
Set default flush timeout for agent instrumentation to 10s as it is for the wrapper used in the library configuration. 