### PR TITLE
Improve database semconv stability test formatting

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
@@ -22,7 +23,6 @@ import com.datastax.driver.core.Session;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -108,9 +108,7 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  "USE " + parameter.keyspace))),
+                              equalTo(maybeStable(DB_STATEMENT), "USE " + parameter.keyspace))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span ->
@@ -124,18 +122,10 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_NAME),
-                                  parameter.keyspace),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  parameter.expectedStatement),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                  parameter.operation),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                  parameter.table))));
+                              equalTo(maybeStable(DB_NAME), parameter.keyspace),
+                              equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     } else {
       testing.waitAndAssertTraces(
           trace ->
@@ -151,15 +141,9 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  parameter.expectedStatement),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                  parameter.operation),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                  parameter.table))));
+                              equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     }
 
     session.close();
@@ -196,9 +180,7 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  "USE " + parameter.keyspace))),
+                              equalTo(maybeStable(DB_STATEMENT), "USE " + parameter.keyspace))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
@@ -213,18 +195,10 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_NAME),
-                                  parameter.keyspace),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  parameter.expectedStatement),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                  parameter.operation),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                  parameter.table)),
+                              equalTo(maybeStable(DB_NAME), parameter.keyspace),
+                              equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
                           .hasKind(SpanKind.INTERNAL)
@@ -245,15 +219,9 @@ class CassandraClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM, "cassandra"),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                  parameter.expectedStatement),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                  parameter.operation),
-                              equalTo(
-                                  SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                  parameter.table)),
+                              equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
                           .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.cassandra.v4.common;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -33,7 +34,6 @@ import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -113,15 +113,9 @@ public abstract class AbstractCassandraTest {
                                 equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                                 equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
-                                    parameter.keyspace),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                    parameter.expectedStatement),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                    parameter.operation),
+                                equalTo(maybeStable(DB_NAME), parameter.keyspace),
+                                equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
                                 satisfies(
@@ -132,9 +126,7 @@ public abstract class AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                    parameter.table))));
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
 
     session.close();
   }
@@ -175,15 +167,9 @@ public abstract class AbstractCassandraTest {
                                 equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                                 equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
-                                    parameter.keyspace),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                    parameter.expectedStatement),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                    parameter.operation),
+                                equalTo(maybeStable(DB_NAME), parameter.keyspace),
+                                equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
                                 satisfies(
@@ -194,9 +180,7 @@ public abstract class AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                    parameter.table)),
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.testing.cassandra.v4_4;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -29,7 +30,6 @@ import static org.junit.jupiter.api.Named.named;
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.cassandra.v4.common.AbstractCassandraTest;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -73,15 +73,9 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                 equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                                 equalTo(NETWORK_PEER_PORT, cassandraPort),
                                 equalTo(DB_SYSTEM, "cassandra"),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_NAME),
-                                    parameter.keyspace),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                    parameter.expectedStatement),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                    parameter.operation),
+                                equalTo(maybeStable(DB_NAME), parameter.keyspace),
+                                equalTo(maybeStable(DB_STATEMENT), parameter.expectedStatement),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(DB_CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
                                 equalTo(DB_CASSANDRA_COORDINATOR_DC, "datacenter1"),
                                 satisfies(
@@ -92,9 +86,7 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(DB_CASSANDRA_PAGE_SIZE, 5000),
                                 equalTo(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0),
-                                equalTo(
-                                    SemconvStabilityUtil.getAttributeKey(DB_CASSANDRA_TABLE),
-                                    parameter.table)),
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.couchbase;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -23,7 +24,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -93,9 +93,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket")),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "ClusterManager.hasBucket")
                         .hasParent(trace.getSpan(0))));
@@ -136,9 +134,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket")),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "Bucket.upsert", bucketSettings.name())
                         .hasParent(trace.getSpan(1))));
@@ -186,9 +182,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket")),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(span, "Bucket.upsert", bucketSettings.name())
                         .hasParent(trace.getSpan(1)),
@@ -233,9 +227,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket")),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
                     assertCouchbaseSpan(
                             span,

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.couchbase;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -24,7 +25,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
@@ -112,9 +112,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket"))),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
@@ -150,9 +148,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(
                                 DB_SYSTEM,
                                 DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_OPERATION),
-                                "Cluster.openBucket"))),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.couchbase;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -23,7 +24,6 @@ import com.couchbase.mock.http.query.QueryServer;
 import com.couchbase.mock.httpio.HttpServer;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
@@ -127,15 +127,13 @@ public abstract class AbstractCouchbaseTest {
     List<AttributeAssertion> assertions = new ArrayList<>();
     assertions.add(equalTo(DB_SYSTEM, DbIncubatingAttributes.DbSystemIncubatingValues.COUCHBASE));
     if (operation != null) {
-      assertions.add(equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), operation));
+      assertions.add(equalTo(maybeStable(DB_OPERATION), operation));
     }
     if (bucketName != null) {
-      assertions.add(equalTo(SemconvStabilityUtil.getAttributeKey(DB_NAME), bucketName));
+      assertions.add(equalTo(maybeStable(DB_NAME), bucketName));
     }
     if (statement != null) {
-      assertions.add(
-          satisfies(
-              SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), s -> s.startsWith(statement)));
+      assertions.add(satisfies(maybeStable(DB_STATEMENT), s -> s.startsWith(statement)));
     }
     assertions.addAll(couchbaseAttributes());
 

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.redisson;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -22,7 +23,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
@@ -125,9 +125,8 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET foo ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))));
+                            equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"))));
   }
 
   @Test
@@ -159,9 +158,8 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SADD set1 ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SADD"))
+                            equalTo(maybeStable(DB_STATEMENT), "SADD set1 ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SADD"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }
@@ -234,9 +232,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "MULTI;SET batch1 ?"))
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")
@@ -246,9 +242,8 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))
+                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("EXEC")
@@ -258,8 +253,8 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "EXEC"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EXEC"))
+                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
+                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.redisson;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -22,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
@@ -128,9 +128,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET foo ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))),
+                            equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -141,8 +140,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "GET foo"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "GET"))));
+                            equalTo(maybeStable(DB_STATEMENT), "GET foo"),
+                            equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
   @Test
@@ -167,9 +166,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "SET batch1 ?;SET batch2 ?"))));
+                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
   }
 
   private static void invokeExecute(RBatch batch)
@@ -209,9 +206,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "MULTI;SET batch1 ?"))
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")
@@ -221,9 +216,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SET"))
+                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("EXEC")
@@ -233,8 +227,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "EXEC"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EXEC"))
+                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
+                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0))));
   }
 
@@ -255,10 +249,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "RPUSH list1 ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "RPUSH"))
+                            equalTo(maybeStable(DB_STATEMENT), "RPUSH list1 ?"),
+                            equalTo(maybeStable(DB_OPERATION), "RPUSH"))
                         .hasNoParent()));
   }
 
@@ -283,9 +275,9 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
                             equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
+                                maybeStable(DB_STATEMENT),
                                 String.format("EVAL %s 1 map1 ? ?", script)),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"))),
+                            equalTo(maybeStable(DB_OPERATION), "EVAL"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -296,10 +288,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "HGET map1 key1"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "HGET"))));
+                            equalTo(maybeStable(DB_STATEMENT), "HGET map1 key1"),
+                            equalTo(maybeStable(DB_OPERATION), "HGET"))));
   }
 
   @Test
@@ -319,9 +309,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT), "SADD set1 ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "SADD"))));
+                            equalTo(maybeStable(DB_STATEMENT), "SADD set1 ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SADD"))));
   }
 
   @Test
@@ -348,10 +337,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "ZADD sort_set1 ? ? ? ? ? ?"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "ZADD"))));
+                            equalTo(maybeStable(DB_STATEMENT), "ZADD sort_set1 ? ? ? ? ? ?"),
+                            equalTo(maybeStable(DB_OPERATION), "ZADD"))));
   }
 
   private static void invokeAddAll(RScoredSortedSet<String> object, Map<String, Double> arg)
@@ -376,10 +363,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
-                                "INCR AtomicLong"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "INCR"))));
+                            equalTo(maybeStable(DB_STATEMENT), "INCR AtomicLong"),
+                            equalTo(maybeStable(DB_OPERATION), "INCR"))));
   }
 
   @Test
@@ -404,9 +389,9 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"),
+                            equalTo(maybeStable(DB_OPERATION), "EVAL"),
                             satisfies(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
+                                maybeStable(DB_STATEMENT),
                                 stringAssert -> stringAssert.startsWith("EVAL")))));
     traceAsserts.add(
         trace ->
@@ -419,9 +404,9 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(DB_SYSTEM, "redis"),
-                            equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "EVAL"),
+                            equalTo(maybeStable(DB_OPERATION), "EVAL"),
                             satisfies(
-                                SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
+                                maybeStable(DB_STATEMENT),
                                 stringAssert -> stringAssert.startsWith("EVAL")))));
     if (lockHas3Traces()) {
       traceAsserts.add(
@@ -435,9 +420,9 @@ public abstract class AbstractRedissonClientTest {
                               equalTo(NETWORK_PEER_ADDRESS, ip),
                               equalTo(NETWORK_PEER_PORT, (long) port),
                               equalTo(DB_SYSTEM, "redis"),
-                              equalTo(SemconvStabilityUtil.getAttributeKey(DB_OPERATION), "DEL"),
+                              equalTo(maybeStable(DB_OPERATION), "DEL"),
                               satisfies(
-                                  SemconvStabilityUtil.getAttributeKey(DB_STATEMENT),
+                                  maybeStable(DB_STATEMENT),
                                   stringAssert -> stringAssert.startsWith("DEL")))));
     }
 

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.redis;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
@@ -18,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -209,7 +209,7 @@ class VertxRedisClientTest {
   @SuppressWarnings("deprecation") // using deprecated semconv
   private static AttributeAssertion[] redisSpanAttributes(String operation, String statement) {
     // not testing database/dup
-    if (SemconvStability.emitStableDatabaseSemconv()) {
+    if (emitStableDatabaseSemconv()) {
       return new AttributeAssertion[] {
         equalTo(DB_SYSTEM, "redis"),
         equalTo(AttributeKey.stringKey("db.query.text"), statement),

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/SemconvStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/SemconvStabilityUtil.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.testing.junit.db;
 
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_COSMOSDB_CONTAINER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_MONGODB_COLLECTION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -39,14 +38,13 @@ public class SemconvStabilityUtil {
     map.put(DB_SQL_TABLE, DB_COLLECTION_NAME);
     map.put(DB_CASSANDRA_TABLE, DB_COLLECTION_NAME);
     map.put(DB_MONGODB_COLLECTION, DB_COLLECTION_NAME);
-    map.put(DB_COSMOSDB_CONTAINER, DB_COLLECTION_NAME);
     return map;
   }
 
   private SemconvStabilityUtil() {}
 
   @SuppressWarnings("unchecked")
-  public static <T> AttributeKey<T> getAttributeKey(AttributeKey<T> oldKey) {
+  public static <T> AttributeKey<T> maybeStable(AttributeKey<T> oldKey) {
     // not testing database/dup
     if (SemconvStability.emitStableDatabaseSemconv()) {
       return (AttributeKey<T>) oldToNewMap.get(oldKey);


### PR DESCRIPTION
Just a little renaming and static importing to improve the database semconv stability test formatting before I start adding a bunch more...

adding the script I used to static import so I can find and copy-paste-modify later when needed:

```
for file in $(find instrumentation -name '*Test.java'); do
  echo "Processing $file"

  # stable semconv

  negative_lookbehind='(?<!import static io.opentelemetry.instrumentation.testing.junit.db.)'

  if grep -Po "${negative_lookbehind}SemconvStabilityUtil.maybeStable" $file; then
    perl -i -pe "s/${negative_lookbehind}SemconvStabilityUtil.maybeStable/maybeStable/" $file
    sed -i "0,/^import/{s/^import/import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;\nimport/}" $file
  fi

  negative_lookbehind='(?<!import static io.opentelemetry.instrumentation.api.internal.)'

  if grep -Po "${negative_lookbehind}SemconvStability.emitStableDatabaseSemconv" $file; then
    perl -i -pe "s/${negative_lookbehind}SemconvStability.emitStableDatabaseSemconv/emitStableDatabaseSemconv/" $file
    sed -i "0,/^import/{s/^import/import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;\nimport/}" $file
  fi
done

./gradlew spotlessApply
```