### PR TITLE
Demonstration of new getList() method on the TextMapGetter

### DIFF
--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
@@ -2,6 +2,18 @@ plugins {
   id("otel.library-instrumentation")
 }
 
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+configurations.all {
+  resolutionStrategy {
+    force("io.opentelemetry:opentelemetry-context:1.44.0-SNAPSHOT")
+    force("io.opentelemetry:opentelemetry-api:1.44.0-SNAPSHOT")
+  }
+}
+
 dependencies {
   compileOnly("org.springframework:spring-webmvc:6.0.0")
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/JakartaHttpServletRequestGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/JakartaHttpServletRequestGetter.java
@@ -7,7 +7,9 @@ package io.opentelemetry.instrumentation.spring.webmvc.v6_0;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
 import jakarta.servlet.http.HttpServletRequest;
+import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 
 enum JakartaHttpServletRequestGetter implements TextMapGetter<HttpServletRequest> {
   INSTANCE;
@@ -20,5 +22,10 @@ enum JakartaHttpServletRequestGetter implements TextMapGetter<HttpServletRequest
   @Override
   public String get(HttpServletRequest carrier, String key) {
     return carrier.getHeader(key);
+  }
+
+  @Override
+  public List<String> getList(@Nullable HttpServletRequest carrier, String key) {
+    return Collections.list(carrier.getHeaders(key));
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/NewBaggagePropagatorTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/NewBaggagePropagatorTest.java
@@ -1,0 +1,30 @@
+package io.opentelemetry.instrumentation.spring.webmvc.v6_0;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.context.Context;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NewBaggagePropagatorTest {
+  @Test
+  void testBaggageMultipleHeaders() {
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("baggage", "k1=v1");
+    request.addHeader("baggage", "k2=v2");
+
+    Context result =
+        propagator.extract(
+            Context.root(),
+            request,
+            JakartaHttpServletRequestGetter.INSTANCE);
+
+    Baggage expectedBaggage = Baggage.builder().put("k1", "v1").put("k2", "v2").build();
+    assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
+  }
+}
+


### PR DESCRIPTION
Demonstrates proposed spec changes

Implements getList() in the Spring Web MVC instrumentation's JakartaHttpServletRequestGetter.

Implements a test to demonstrate the new W3CBaggagePropagator working with multiple baggage headers (using a locally published version of opentelemetry-api and opentelemetry-context, which contains the changes to the textmapgetter interface and baggage propagator).

The TextMapGetter operates on a Jakarta servlet HttpServletRequest, a very common interface used in many servers. This demonstrates that using getList() should work in many area / servers.

The build will obviously not pass because it's relying on local SNAPSHOT changes that aren't merged to main in `opentelemetry-java`