### PR TITLE
Fix warning about setting VirtualField supplier twice

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -224,7 +224,7 @@ public class AgentInstaller {
                 (builder, typeDescription, classLoader, module, protectionDomain) -> builder);
 
     VirtualFieldImplementationInstallerFactory virtualFieldInstallerFactory =
-        new VirtualFieldImplementationInstallerFactory();
+        VirtualFieldImplementationInstallerFactory.getInstance();
     for (EarlyInstrumentationModule earlyInstrumentationModule :
         loadOrdered(EarlyInstrumentationModule.class, Utils.getExtensionsClassLoader())) {
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationInstallerFactory.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationInstallerFactory.java
@@ -18,9 +18,15 @@ public final class VirtualFieldImplementationInstallerFactory {
 
   private static final TransformSafeLogger logger =
       TransformSafeLogger.getLogger(VirtualFieldImplementationInstallerFactory.class);
+  private static final VirtualFieldImplementationInstallerFactory INSTANCE =
+      new VirtualFieldImplementationInstallerFactory();
 
-  public VirtualFieldImplementationInstallerFactory() {
+  private VirtualFieldImplementationInstallerFactory() {
     RuntimeVirtualFieldSupplier.set(new RuntimeFieldBasedImplementationSupplier());
+  }
+
+  public static VirtualFieldImplementationInstallerFactory getInstance() {
+    return INSTANCE;
   }
 
   public VirtualFieldImplementationInstaller create(InstrumentationModule instrumentationModule) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -54,7 +54,7 @@ public final class InstrumentationModuleInstaller {
 
   private final Instrumentation instrumentation;
   private final VirtualFieldImplementationInstallerFactory virtualFieldInstallerFactory =
-      new VirtualFieldImplementationInstallerFactory();
+      VirtualFieldImplementationInstallerFactory.getInstance();
 
   public InstrumentationModuleInstaller(Instrumentation instrumentation) {
     this.instrumentation = instrumentation;


### PR DESCRIPTION
[otel.javaagent 2024-11-07 14:15:47:169 +0200] [main] WARN io.opentelemetry.javaagent.shaded.instrumentation.api.internal.RuntimeVirtualFieldSupplier - Runtime VirtualField supplier has already been set up, further set() calls are ignored