### PR TITLE
Enable transform safe logging for tests in the javaagent module

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -421,5 +421,6 @@ class JavaagentProvider(
 ) : CommandLineArgumentProvider {
   override fun asArguments(): Iterable<String> = listOf(
     "-javaagent:${file(agentJar).absolutePath}",
+    "-Dotel.javaagent.testing.transform-safe-logging.enabled=true"
   )
 }


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12582