### PR TITLE
Fill jvm.thread.state attribute for jvm.thread.count metric on jdk8

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
@@ -18,6 +18,9 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
@@ -156,6 +159,13 @@ class ThreadsStableSemconvTest {
                                                 .hasAttributesSatisfying(
                                                     equalTo(JVM_THREAD_DAEMON, true),
                                                     equalTo(JVM_THREAD_STATE, "waiting"))))));
+  }
+
+  @Test
+  void getThreads() {
+    Thread[] threads = Threads.getThreads();
+    Set<Thread> set = new HashSet<>(Arrays.asList(threads));
+    assertThat(set).contains(Thread.currentThread());
   }
 
   static final class ThreadInfoAnswer implements Answer<Object> {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -42,6 +43,7 @@ class ThreadsStableSemconvTest {
   @Mock private ThreadMXBean threadBean;
 
   @Test
+  @EnabledOnJre(JRE.JAVA_8)
   void registerObservers_Java8Jmx() {
     when(threadBean.getThreadCount()).thenReturn(7);
     when(threadBean.getDaemonThreadCount()).thenReturn(2);
@@ -77,7 +79,6 @@ class ThreadsStableSemconvTest {
   }
 
   @Test
-  @EnabledForJreRange(min = JRE.JAVA_9)
   void registerObservers_Java8Thread() {
     Thread threadInfo1 = mock(Thread.class, new ThreadInfoAnswer(false, Thread.State.RUNNABLE));
     Thread threadInfo2 = mock(Thread.class, new ThreadInfoAnswer(true, Thread.State.WAITING));


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/12614 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11980
Currently on jdk8 we don't fill `jvm.thread.state` attribute because through the jmx apis on jdk 8 we can't get `jvm.thread.state` and `jvm.thread.daemon` at the same time. This PR provides an alternative implementation based on `java.lang.Thread` that can fill both of these attributes on jdk8.
