### PR TITLE
Update K6 image used by benchmark overhead tests

### DIFF
--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
@@ -35,7 +35,7 @@ public class K6Container {
 
   public GenericContainer<?> build() {
     String k6OutputFile = namingConventions.container.k6Results(agent);
-    return new GenericContainer<>(DockerImageName.parse("loadimpact/k6"))
+    return new GenericContainer<>(DockerImageName.parse("grafana/k6"))
         .withNetwork(network)
         .withNetworkAliases("k6")
         .withLogConsumer(new Slf4jLogConsumer(logger))


### PR DESCRIPTION
Update K6 image used by benchmark overhead tests because loadimact/k6 is out of support a year ago.

```
+------------------------------------------------------------------------------+
| WARNING: The loadimpact/k6 Docker image has been replaced by grafana/k6.     |
|          THIS IMAGE IS DEPRECATED and its support will be discontinued after |
|          Dec 31, 2023. Please update your scripts to use grafana/k6 to       |
|          continue using the latest version of k6.                            |
+------------------------------------------------------------------------------+
```