### PR TITLE
Added `spring-scheduling.enabled` property to spring-configuration-metadata.json

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -489,6 +489,12 @@
       "defaultValue": true
     },
     {
+      "name": "otel.instrumentation.spring-scheduling.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Spring Scheduling instrumentation.",
+      "defaultValue": true
+    },
+    {
       "name": "otel.java.enabled.resource.providers",
       "type": "java.util.List<java.lang.String>",
       "description": "Enables one or more <code>ResourceProvider</code> types. If unset, all resource providers are enabled. Each entry is the fully qualified classname of a <code>ResourceProvider</code>."


### PR DESCRIPTION
When adding `spring-scheduling`, it seems that missed adding an activation condition property value to the `spring-configuration-metadata.json file` in the task.

If add it, it could be more helpful for developers during development, especially with features like auto-completion.



ref
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12438
- [ConditionalOnEnabledInstrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blame/4497fbf968c20becdcc998e8bacc849e2eeafc21/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/scheduling/SpringSchedulingInstrumentationAutoConfiguration.java#L25)