### PR TITLE
Add an option to disable automatic kafka interceptor configuration in spring starter

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -358,6 +358,12 @@
       "defaultValue": false
     },
     {
+      "name": "otel.instrumentation.kafka.autoconfigure-interceptor",
+      "type": "java.lang.Boolean",
+      "description": "Enable automatic configuration of tracing interceptors on <code>ConcurrentKafkaListenerContainerFactory</code> using a <code>BeanPostProcessor</code>. You may disable this if you wish to manually configure these interceptors.",
+      "defaultValue": true
+    },
+    {
       "name": "otel.instrumentation.mongo.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable the Mongo client instrumentation.",


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11793
Based on https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11793#issuecomment-2228734206 by @zeitlinger Add an option to disable automatic configuration of interceptors and exposes `SpringKafkaTelemetry` as bean so that user could get access to the interceptors and manually add the interceptors. Also try to read the existing interceptors from `ConcurrentKafkaListenerContainerFactory` and wrap them instead of overwriting. Note that similarly to how we could end up overwriting user configured interceptors the user can also overwrite our interceptors.