### PR TITLE
Source dd Trace from dd artifact and update sfx to last possible.

### DIFF
--- a/instrumentation/external-annotations/javaagent/build.gradle.kts
+++ b/instrumentation/external-annotations/javaagent/build.gradle.kts
@@ -18,7 +18,8 @@ dependencies {
   testImplementation("io.opentracing.contrib.dropwizard:dropwizard-opentracing:0.2.2") {
     isTransitive = false
   }
-  testImplementation("com.signalfx.public:signalfx-trace-api:0.48.0-sfx1")
+  testImplementation("com.datadoghq:dd-trace-api:1.43.0")
+  testImplementation("com.signalfx.public:signalfx-trace-api:0.48.0-sfx8")
   // Old and new versions of kamon use different packages for Trace annotation
   testImplementation("io.kamon:kamon-annotation_2.11:0.6.7") {
     isTransitive = false

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/SayTracedHello.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/SayTracedHello.java
@@ -24,7 +24,6 @@ public class SayTracedHello {
     return "hello!";
   }
 
-  // End of life -- never use this annotation in new development
   @com.signalfx.tracing.api.Trace
   public String signalfx() {
     Span.current().setAttribute("providerAttr", "SignalFx");

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/SayTracedHello.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/SayTracedHello.java
@@ -24,6 +24,7 @@ public class SayTracedHello {
     return "hello!";
   }
 
+  // End of life -- never use this annotation in new development
   @com.signalfx.tracing.api.Trace
   public String signalfx() {
     Span.current().setAttribute("providerAttr", "SignalFx");


### PR DESCRIPTION
This is pretty silly, but I noticed that the multi-annotations test was not using the latest version of the antiquated sfx library, so I updated it. I also noticed that the dd annotation was also being sourced from the sfx artifact (since it originated as a fork), so I added the direct dd test dependency before the sfx one, so that we are using a more contemporary source.