### PR TITLE
Remove experimental methods out of (to-be-public) TelemetryBuilder classes

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
@@ -24,6 +24,11 @@ public final class ApacheHttpClientTelemetryBuilder {
   private final DefaultHttpClientInstrumenterBuilder<ApacheHttpClientRequest, HttpResponse> builder;
   private final OpenTelemetry openTelemetry;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
+  }
+
   ApacheHttpClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder =
         DefaultHttpClientInstrumenterBuilder.create(

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.apachehttpclient.v4_3.internal.Experimental;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -88,7 +89,11 @@ public final class ApacheHttpClientTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link
+   *     Experimental#setEmitExperimentalTelemetry(ApacheHttpClientTelemetryBuilder, boolean)}
+   *     instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public ApacheHttpClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<ApacheHttpClientTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       ApacheHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_3.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.apachehttpclient.v4_3.ApacheHttpClientTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<ApacheHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       ApacheHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          ApacheHttpClientTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<ApacheHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<ApacheHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<ApacheHttpClientTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       ApacheHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.apachehttpclient.v4_3.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.apachehttpclient.v4_3.ApacheHttpClientTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      ApacheHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          ApacheHttpClientTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/JavaHttpClientTelemetryBuilder.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/JavaHttpClientTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.httpclient.internal.Experimental;
 import io.opentelemetry.instrumentation.httpclient.internal.HttpHeadersSetter;
 import io.opentelemetry.instrumentation.httpclient.internal.JavaHttpClientInstrumenterBuilderFactory;
 import java.net.http.HttpRequest;
@@ -86,7 +87,11 @@ public final class JavaHttpClientTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link
+   *     Experimental#setEmitExperimentalTelemetry(JavaHttpClientTelemetryBuilder, boolean)}
+   *     instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public JavaHttpClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/JavaHttpClientTelemetryBuilder.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/JavaHttpClientTelemetryBuilder.java
@@ -25,6 +25,11 @@ public final class JavaHttpClientTelemetryBuilder {
   private final DefaultHttpClientInstrumenterBuilder<HttpRequest, HttpResponse<?>> builder;
   private final OpenTelemetry openTelemetry;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
+  }
+
   JavaHttpClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = JavaHttpClientInstrumenterBuilderFactory.create(openTelemetry);
     this.openTelemetry = openTelemetry;

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<JavaHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<JavaHttpClientTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JavaHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.httpclient.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      JavaHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          JavaHttpClientTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.httpclient.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<JavaHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JavaHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          JavaHttpClientTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<JavaHttpClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<JavaHttpClientTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       JavaHttpClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -27,6 +27,11 @@ public final class JettyClientTelemetryBuilder {
   private HttpClientTransport httpClientTransport;
   private SslContextFactory.Client sslContextFactory;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
+  }
+
   JettyClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = JettyHttpClientInstrumenterBuilderFactory.create(openTelemetry);
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.jetty.httpclient.v12_0.internal.Experimental;
 import io.opentelemetry.instrumentation.jetty.httpclient.v12_0.internal.JettyHttpClientInstrumenterBuilderFactory;
 import java.util.List;
 import java.util.Set;
@@ -101,7 +102,10 @@ public final class JettyClientTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(JettyClientTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<JettyClientTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<JettyClientTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jetty.httpclient.v12_0.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.jetty.httpclient.v12_0.JettyClientTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          JettyClientTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.jetty.httpclient.v12_0.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.jetty.httpclient.v12_0.JettyClientTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          JettyClientTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.Experimental;
 import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal.JettyHttpClientInstrumenterBuilderFactory;
 import java.util.List;
 import java.util.Set;
@@ -101,7 +102,10 @@ public final class JettyClientTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(JettyClientTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -28,6 +28,11 @@ public final class JettyClientTelemetryBuilder {
   private HttpClientTransport httpClientTransport;
   private SslContextFactory sslContextFactory;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
+  }
+
   JettyClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = JettyHttpClientInstrumenterBuilderFactory.create(openTelemetry);
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<JettyClientTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<JettyClientTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.JettyClientTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          JettyClientTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.jetty.httpclient.v9_2.JettyClientTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       JettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          JettyClientTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<JettyClientTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
@@ -25,7 +25,15 @@ import java.util.function.Function;
 public final class NettyClientTelemetryBuilder {
 
   private final DefaultHttpClientInstrumenterBuilder<HttpRequestAndChannel, HttpResponse> builder;
-  private boolean emitExperimentalTelemetry = false;
+  private boolean emitExperimentalHttpClientEvents = false;
+
+  static {
+    Experimental.setSetEmitExperimentalClientTelemetry(
+        (builder, emit) -> {
+          builder.builder.setEmitExperimentalHttpClientMetrics(emit);
+          builder.emitExperimentalHttpClientEvents = emit;
+        });
+  }
 
   NettyClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder =
@@ -39,8 +47,8 @@ public final class NettyClientTelemetryBuilder {
   @Deprecated
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setEmitExperimentalHttpClientEvents(
-      boolean emitExperimentalTelemetry) {
-    this.emitExperimentalTelemetry = emitExperimentalTelemetry;
+      boolean emitExperimentalHttpClientEvents) {
+    this.emitExperimentalHttpClientEvents = emitExperimentalHttpClientEvents;
     return this;
   }
 
@@ -101,17 +109,16 @@ public final class NettyClientTelemetryBuilder {
   /**
    * Configures the instrumentation to emit experimental HTTP client metrics.
    *
-   * @param emitExperimentalTelemetry {@code true} if the experimental HTTP client metrics are to be
-   *     emitted.
+   * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
+   *     are to be emitted.
    * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(NettyClientTelemetryBuilder,
    *     boolean)} instead.
    */
   @Deprecated
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
-      boolean emitExperimentalTelemetry) {
-    builder.setEmitExperimentalHttpClientMetrics(emitExperimentalTelemetry);
-    this.emitExperimentalTelemetry = emitExperimentalTelemetry;
+      boolean emitExperimentalHttpClientMetrics) {
+    builder.setEmitExperimentalHttpClientMetrics(emitExperimentalHttpClientMetrics);
     return this;
   }
 
@@ -134,6 +141,6 @@ public final class NettyClientTelemetryBuilder {
                 NettyConnectionInstrumentationFlag.DISABLED,
                 NettyConnectionInstrumentationFlag.DISABLED)
             .instrumenter(),
-        emitExperimentalTelemetry);
+        emitExperimentalHttpClientEvents);
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.client.NettyClientInstrumenterBuilderFactory;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.client.NettyClientInstrumenterFactory;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.client.NettyConnectionInstrumentationFlag;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.Experimental;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -24,17 +25,22 @@ import java.util.function.Function;
 public final class NettyClientTelemetryBuilder {
 
   private final DefaultHttpClientInstrumenterBuilder<HttpRequestAndChannel, HttpResponse> builder;
-  private boolean emitExperimentalHttpClientEvents = false;
+  private boolean emitExperimentalTelemetry = false;
 
   NettyClientTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder =
         NettyClientInstrumenterBuilderFactory.create("io.opentelemetry.netty-4.1", openTelemetry);
   }
 
+  /**
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(NettyClientTelemetryBuilder,
+   *     boolean)} instead.
+   */
+  @Deprecated
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setEmitExperimentalHttpClientEvents(
-      boolean emitExperimentalHttpClientEvents) {
-    this.emitExperimentalHttpClientEvents = emitExperimentalHttpClientEvents;
+      boolean emitExperimentalTelemetry) {
+    this.emitExperimentalTelemetry = emitExperimentalTelemetry;
     return this;
   }
 
@@ -95,13 +101,17 @@ public final class NettyClientTelemetryBuilder {
   /**
    * Configures the instrumentation to emit experimental HTTP client metrics.
    *
-   * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
-   *     are to be emitted.
+   * @param emitExperimentalTelemetry {@code true} if the experimental HTTP client metrics are to be
+   *     emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(NettyClientTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setEmitExperimentalHttpClientMetrics(
-      boolean emitExperimentalHttpClientMetrics) {
-    builder.setEmitExperimentalHttpClientMetrics(emitExperimentalHttpClientMetrics);
+      boolean emitExperimentalTelemetry) {
+    builder.setEmitExperimentalHttpClientMetrics(emitExperimentalTelemetry);
+    this.emitExperimentalTelemetry = emitExperimentalTelemetry;
     return this;
   }
 
@@ -124,6 +134,6 @@ public final class NettyClientTelemetryBuilder {
                 NettyConnectionInstrumentationFlag.DISABLED,
                 NettyConnectionInstrumentationFlag.DISABLED)
             .instrumenter(),
-        emitExperimentalHttpClientEvents);
+        emitExperimentalTelemetry);
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
@@ -29,6 +29,11 @@ public final class NettyServerTelemetryBuilder {
   static {
     NettyServerInstrumenterBuilderUtil.setBuilderExtractor(
         nettyServerTelemetryBuilder -> nettyServerTelemetryBuilder.builder);
+    Experimental.setSetEmitExperimentalServerTelemetry(
+        (builder, emit) -> {
+          builder.builder.setEmitExperimentalHttpServerMetrics(emit);
+          builder.emitExperimentalHttpServerEvents = emit;
+        });
   }
 
   NettyServerTelemetryBuilder(OpenTelemetry openTelemetry) {

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExt
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.server.HttpRequestHeadersGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.server.NettyHttpServerAttributesGetter;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.Experimental;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.ProtocolEventHandler;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.server.NettyServerInstrumenterBuilderUtil;
 import java.util.List;
@@ -99,7 +100,10 @@ public final class NettyServerTelemetryBuilder {
    *
    * @param emitExperimentalHttpServerMetrics {@code true} if the experimental HTTP server metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(NettyServerTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public NettyServerTelemetryBuilder setEmitExperimentalHttpServerMetrics(
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.netty.v4_1.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.netty.v4_1.NettyClientTelemetryBuilder;
+import io.opentelemetry.instrumentation.netty.v4_1.NettyServerTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalClientTelemetryMethod =
+      getEmitExperimentalClientTelemetryMethod();
+
+  @Nullable
+  private static final Method emitExperimentalServerTelemetryMethod =
+      getEmitExperimentalServerTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      NettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalClientTelemetryMethod != null) {
+      try {
+        emitExperimentalClientTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  public void setEmitExperimentalTelemetry(
+      NettyServerTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalServerTelemetryMethod != null) {
+      try {
+        emitExperimentalServerTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalClientTelemetryMethod() {
+    try {
+      Method method =
+          NettyClientTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalServerTelemetryMethod() {
+    try {
+      Method method =
+          NettyServerTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpServerMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
@@ -18,11 +18,11 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<NettyClientTelemetryBuilder, Boolean>
+  private static volatile BiConsumer<NettyClientTelemetryBuilder, Boolean>
       setEmitExperimentalClientTelemetry;
 
   @Nullable
-  private static BiConsumer<NettyServerTelemetryBuilder, Boolean>
+  private static volatile BiConsumer<NettyServerTelemetryBuilder, Boolean>
       setEmitExperimentalServerTelemetry;
 
   public void setEmitExperimentalTelemetry(

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
@@ -5,13 +5,9 @@
 
 package io.opentelemetry.instrumentation.netty.v4_1.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.netty.v4_1.NettyClientTelemetryBuilder;
 import io.opentelemetry.instrumentation.netty.v4_1.NettyServerTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -19,67 +15,39 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalClientTelemetryMethod =
-      getEmitExperimentalClientTelemetryMethod();
+  private static BiConsumer<NettyClientTelemetryBuilder, Boolean>
+      setEmitExperimentalClientTelemetry;
 
   @Nullable
-  private static final Method emitExperimentalServerTelemetryMethod =
-      getEmitExperimentalServerTelemetryMethod();
+  private static BiConsumer<NettyServerTelemetryBuilder, Boolean>
+      setEmitExperimentalServerTelemetry;
 
   public void setEmitExperimentalTelemetry(
       NettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalClientTelemetryMethod != null) {
-      try {
-        emitExperimentalClientTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalClientTelemetry != null) {
+      setEmitExperimentalClientTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
   public void setEmitExperimentalTelemetry(
       NettyServerTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalServerTelemetryMethod != null) {
-      try {
-        emitExperimentalServerTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalServerTelemetry != null) {
+      setEmitExperimentalServerTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalClientTelemetryMethod() {
-    try {
-      Method method =
-          NettyClientTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalClientTelemetry(
+      BiConsumer<NettyClientTelemetryBuilder, Boolean> setEmitExperimentalClientTelemetry) {
+    Experimental.setEmitExperimentalClientTelemetry = setEmitExperimentalClientTelemetry;
   }
 
-  @Nullable
-  private static Method getEmitExperimentalServerTelemetryMethod() {
-    try {
-      Method method =
-          NettyServerTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpServerMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalServerTelemetry(
+      BiConsumer<NettyServerTelemetryBuilder, Boolean> setEmitExperimentalServerTelemetry) {
+    Experimental.setEmitExperimentalServerTelemetry = setEmitExperimentalServerTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
@@ -15,11 +15,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/Experimental.java
@@ -25,14 +25,14 @@ public final class Experimental {
   private static volatile BiConsumer<NettyServerTelemetryBuilder, Boolean>
       setEmitExperimentalServerTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       NettyClientTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalClientTelemetry != null) {
       setEmitExperimentalClientTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       NettyServerTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalServerTelemetry != null) {
       setEmitExperimentalServerTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
@@ -25,6 +25,11 @@ public final class OkHttpTelemetryBuilder {
   private final DefaultHttpClientInstrumenterBuilder<Interceptor.Chain, Response> builder;
   private final OpenTelemetry openTelemetry;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
+  }
+
   OkHttpTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = OkHttpClientInstrumenterBuilderFactory.create(openTelemetry);
     this.openTelemetry = openTelemetry;

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.okhttp.v3_0.internal.Experimental;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpClientInstrumenterBuilderFactory;
 import java.util.List;
 import java.util.Set;
@@ -86,7 +87,10 @@ public final class OkHttpTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(OkHttpTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public OkHttpTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.okhttp.v3_0.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,21 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
+public final class Experimental {
 
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
-
-  @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  @Nullable private static BiConsumer<OkHttpTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       OkHttpTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          OkHttpTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<OkHttpTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
@@ -19,7 +19,7 @@ public final class Experimental {
   @Nullable
   private static volatile BiConsumer<OkHttpTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       OkHttpTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
@@ -16,7 +16,8 @@ import javax.annotation.Nullable;
  */
 public final class Experimental {
 
-  @Nullable private static BiConsumer<OkHttpTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  @Nullable
+  private static volatile BiConsumer<OkHttpTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       OkHttpTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.okhttp.v3_0.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      OkHttpTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          OkHttpTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.restlet.v1_1.internal.Experimental;
 import io.opentelemetry.instrumentation.restlet.v1_1.internal.RestletTelemetryBuilderFactory;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +85,10 @@ public final class RestletTelemetryBuilder {
    *
    * @param emitExperimentalHttpServerMetrics {@code true} if the experimental HTTP server metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(RestletTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setEmitExperimentalHttpServerMetrics(
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
@@ -24,6 +24,11 @@ public final class RestletTelemetryBuilder {
 
   private final DefaultHttpServerInstrumenterBuilder<Request, Response> builder;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpServerMetrics(emit));
+  }
+
   RestletTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = RestletTelemetryBuilderFactory.create(openTelemetry);
   }

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.restlet.v1_1.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.restlet.v1_1.RestletTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          RestletTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpServerMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.restlet.v1_1.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.restlet.v1_1.RestletTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          RestletTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpServerMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/Experimental.java
@@ -19,7 +19,7 @@ public final class Experimental {
   @Nullable
   private static volatile BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.restlet.v2_0.internal.Experimental;
 import io.opentelemetry.instrumentation.restlet.v2_0.internal.RestletTelemetryBuilderFactory;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +85,10 @@ public final class RestletTelemetryBuilder {
    *
    * @param emitExperimentalHttpServerMetrics {@code true} if the experimental HTTP server metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(RestletTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setEmitExperimentalHttpServerMetrics(
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
@@ -24,6 +24,11 @@ public final class RestletTelemetryBuilder {
 
   private final DefaultHttpServerInstrumenterBuilder<Request, Response> builder;
 
+  static {
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpServerMetrics(emit));
+  }
+
   RestletTelemetryBuilder(OpenTelemetry openTelemetry) {
     builder = RestletTelemetryBuilderFactory.create(openTelemetry);
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.restlet.v2_0.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.restlet.v2_0.RestletTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          RestletTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpServerMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.restlet.v2_0.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.restlet.v2_0.RestletTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          RestletTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpServerMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/Experimental.java
@@ -19,7 +19,7 @@ public final class Experimental {
   @Nullable
   private static volatile BiConsumer<RestletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       RestletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.spring.web.v3_1.internal.Experimental;
 import io.opentelemetry.instrumentation.spring.web.v3_1.internal.WebTelemetryUtil;
 import java.util.List;
 import java.util.Set;
@@ -108,7 +109,10 @@ public final class SpringWebTelemetryBuilder {
    *
    * @param emitExperimentalHttpClientMetrics {@code true} if the experimental HTTP client metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(SpringWebTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder setEmitExperimentalHttpClientMetrics(
       boolean emitExperimentalHttpClientMetrics) {

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -26,6 +26,8 @@ public final class SpringWebTelemetryBuilder {
 
   static {
     WebTelemetryUtil.setBuilderExtractor(SpringWebTelemetryBuilder::getBuilder);
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpClientMetrics(emit));
   }
 
   SpringWebTelemetryBuilder(OpenTelemetry openTelemetry) {

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.web.v3_1.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.spring.web.v3_1.SpringWebTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      SpringWebTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          SpringWebTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpClientMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.spring.web.v3_1.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.spring.web.v3_1.SpringWebTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<SpringWebTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          SpringWebTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpClientMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<SpringWebTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<SpringWebTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<SpringWebTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<SpringWebTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       SpringWebTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.spring.webmvc.v5_3.internal.Experimental;
 import io.opentelemetry.instrumentation.spring.webmvc.v5_3.internal.SpringMvcBuilderUtil;
 import java.util.List;
 import java.util.Set;
@@ -107,7 +108,10 @@ public final class SpringWebMvcTelemetryBuilder {
    *
    * @param emitExperimentalHttpServerMetrics {@code true} if the experimental HTTP server metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(SpringWebMvcTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setEmitExperimentalHttpServerMetrics(
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
@@ -29,6 +29,8 @@ public final class SpringWebMvcTelemetryBuilder {
 
   static {
     SpringMvcBuilderUtil.setBuilderExtractor(builder -> builder.builder);
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpServerMetrics(emit));
   }
 
   SpringWebMvcTelemetryBuilder(OpenTelemetry openTelemetry) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc.v5_3.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.spring.webmvc.v5_3.SpringWebMvcTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          SpringWebMvcTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpServerMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<SpringWebMvcTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.webmvc.v5_3.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.spring.webmvc.v5_3.SpringWebMvcTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          SpringWebMvcTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpServerMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<SpringWebMvcTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHt
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.spring.webmvc.v6_0.internal.Experimental;
 import io.opentelemetry.instrumentation.spring.webmvc.v6_0.internal.SpringMvcBuilderUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -106,7 +107,10 @@ public final class SpringWebMvcTelemetryBuilder {
    *
    * @param emitExperimentalHttpServerMetrics {@code true} if the experimental HTTP server metrics
    *     are to be emitted.
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(SpringWebMvcTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setEmitExperimentalHttpServerMetrics(
       boolean emitExperimentalHttpServerMetrics) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
@@ -28,6 +28,8 @@ public final class SpringWebMvcTelemetryBuilder {
 
   static {
     SpringMvcBuilderUtil.setBuilderExtractor(builder -> builder.builder);
+    Experimental.setSetEmitExperimentalTelemetry(
+        (builder, emit) -> builder.builder.setEmitExperimentalHttpServerMetrics(emit));
   }
 
   SpringWebMvcTelemetryBuilder(OpenTelemetry openTelemetry) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.webmvc.v6_0.internal;
+
+import static java.util.logging.Level.FINE;
+
+import io.opentelemetry.instrumentation.spring.webmvc.v6_0.SpringWebMvcTelemetryBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+// TODO (trask) update the above javadoc similar to
+//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
+public class Experimental {
+
+  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+
+  @Nullable
+  private static final Method emitExperimentalTelemetryMethod =
+      getEmitExperimentalTelemetryMethod();
+
+  public void setEmitExperimentalTelemetry(
+      SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
+
+    if (emitExperimentalTelemetryMethod != null) {
+      try {
+        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        logger.log(FINE, e.getMessage(), e);
+      }
+    }
+  }
+
+  @Nullable
+  private static Method getEmitExperimentalTelemetryMethod() {
+    try {
+      Method method =
+          SpringWebMvcTelemetryBuilder.class.getDeclaredMethod(
+              "setEmitExperimentalHttpServerMetrics", boolean.class);
+      method.setAccessible(true);
+      return method;
+    } catch (NoSuchMethodException e) {
+      logger.log(FINE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
@@ -14,11 +14,10 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * This class is internal and experimental. Its APIs are unstable and can change at any time. Its
+ * APIs (or a version of them) may be promoted to the public stable API in the future, but no
+ * guarantees are made.
  */
-// TODO (trask) update the above javadoc similar to
-//  https://github.com/open-telemetry/opentelemetry-java/pull/6886
 public class Experimental {
 
   private static final Logger logger = Logger.getLogger(Experimental.class.getName());

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
@@ -20,7 +20,7 @@ public final class Experimental {
   private static volatile BiConsumer<SpringWebMvcTelemetryBuilder, Boolean>
       setEmitExperimentalTelemetry;
 
-  public void setEmitExperimentalTelemetry(
+  public static void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
     if (setEmitExperimentalTelemetry != null) {
       setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
 public final class Experimental {
 
   @Nullable
-  private static BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
+  private static volatile BiConsumer<SpringWebMvcTelemetryBuilder, Boolean>
+      setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/internal/Experimental.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc.v6_0.internal;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.instrumentation.spring.webmvc.v6_0.SpringWebMvcTelemetryBuilder;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 /**
@@ -18,37 +14,22 @@ import javax.annotation.Nullable;
  * APIs (or a version of them) may be promoted to the public stable API in the future, but no
  * guarantees are made.
  */
-public class Experimental {
-
-  private static final Logger logger = Logger.getLogger(Experimental.class.getName());
+public final class Experimental {
 
   @Nullable
-  private static final Method emitExperimentalTelemetryMethod =
-      getEmitExperimentalTelemetryMethod();
+  private static BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry;
 
   public void setEmitExperimentalTelemetry(
       SpringWebMvcTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
-
-    if (emitExperimentalTelemetryMethod != null) {
-      try {
-        emitExperimentalTelemetryMethod.invoke(builder, emitExperimentalTelemetry);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        logger.log(FINE, e.getMessage(), e);
-      }
+    if (setEmitExperimentalTelemetry != null) {
+      setEmitExperimentalTelemetry.accept(builder, emitExperimentalTelemetry);
     }
   }
 
-  @Nullable
-  private static Method getEmitExperimentalTelemetryMethod() {
-    try {
-      Method method =
-          SpringWebMvcTelemetryBuilder.class.getDeclaredMethod(
-              "setEmitExperimentalHttpServerMetrics", boolean.class);
-      method.setAccessible(true);
-      return method;
-    } catch (NoSuchMethodException e) {
-      logger.log(FINE, e.getMessage(), e);
-      return null;
-    }
+  public static void setSetEmitExperimentalTelemetry(
+      BiConsumer<SpringWebMvcTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
+    Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
   }
+
+  private Experimental() {}
 }


### PR DESCRIPTION
`setEmitExperimental*` methods in `*TelemetryBuilder` classes have been deprecated and moved to internal/experimental classes, see Javadoc `@deprecated` for exact relocation

Part of #12846

* Ktor is done as part of #12855
* Apache HttpClient 5 is done as part of #12854
* Ratpack is done as part of #12853
* Webflux is done as part of #12852
* Armeria is done as part of #12851

See #12867 for change log migration notes entry