### PR TITLE
Ktor: support setting custom `spanNameExtractor` (#12842)

### DIFF
--- a/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/client/AbstractKtorClientTracingBuilder.kt
+++ b/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/client/AbstractKtorClientTracingBuilder.kt
@@ -13,7 +13,9 @@ import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
 import io.opentelemetry.instrumentation.ktor.internal.KtorBuilderUtil
+import java.util.function.Function
 
 abstract class AbstractKtorClientTracingBuilder(
   private val instrumentationName: String
@@ -168,5 +170,9 @@ abstract class AbstractKtorClientTracingBuilder(
 
   fun emitExperimentalHttpClientMetrics() {
     clientBuilder.setEmitExperimentalHttpClientMetrics(true)
+  }
+
+  fun spanNameExtractor(spanNameExtractorTransformer: Function<SpanNameExtractor<in HttpRequestData>, out SpanNameExtractor<in HttpRequestData>>) {
+    clientBuilder.setSpanNameExtractor(spanNameExtractorTransformer)
   }
 }

--- a/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/server/AbstractKtorServerTracingBuilder.kt
+++ b/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/server/AbstractKtorServerTracingBuilder.kt
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.ktor.server
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.opentelemetry.api.OpenTelemetry
@@ -16,9 +15,11 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpServerInstrumenterBuilder
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusBuilder
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor
 import io.opentelemetry.instrumentation.ktor.internal.KtorBuilderUtil
+import java.util.function.Function
 
 abstract class AbstractKtorServerTracingBuilder(private val instrumentationName: String) {
   companion object {
@@ -84,6 +85,10 @@ abstract class AbstractKtorServerTracingBuilder(private val instrumentationName:
         extract(request, prevExtractor)
       }
     }
+  }
+
+  fun spanNameExtractor(spanNameExtractorTransformer: Function<SpanNameExtractor<in ApplicationRequest>, out SpanNameExtractor<in ApplicationRequest>>) {
+    serverBuilder.setSpanNameExtractor(spanNameExtractorTransformer)
   }
 
   @Deprecated("Please use method `attributeExtractor`")


### PR DESCRIPTION
This PR adds support for custom `SpanNameExtractor`s in the Ktor instrumentation modules. It should support both Ktor 2 and 3.

See #12842 for more context.