### PR TITLE
Fix gradle deprecation warnings

### DIFF
--- a/bom-alpha/build.gradle.kts
+++ b/bom-alpha/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   api(platform(project(":bom")))
 
   // Get the semconv version from :dependencyManagement
-  val semconvConstraint = project(":dependencyManagement").dependencyProject.configurations["api"].allDependencyConstraints
+  val semconvConstraint = project.project(project(":dependencyManagement").path).configurations["api"].allDependencyConstraints
     .find { it.group.equals("io.opentelemetry.semconv")
             && it.name.equals("opentelemetry-semconv") }
     ?: throw Exception("semconv constraint not found")

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -73,7 +73,7 @@ tasks.withType<Javadoc>().configureEach {
 configurations {
   named("errorprone") {
     dependencies.removeIf {
-      it is ProjectDependency && it.dependencyProject == project
+      it is ProjectDependency && it.group == project.group && it.name == project.name
     }
   }
 }


### PR DESCRIPTION
`dependencyProject` will be removed in gradle 9