### PR TITLE
Fix jfr tests on openj9

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/javaagent/src/test/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/java17/JfrRuntimeMetricsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/javaagent/src/test/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/java17/JfrRuntimeMetricsTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.javaagent.runtimemetrics.java17;
 
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import jdk.jfr.FlightRecorder;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,11 @@ class JfrRuntimeMetricsTest {
   @BeforeAll
   static void setUp() {
     try {
-      Class.forName("jdk.jfr.consumer.RecordingStream");
+      Class.forName("jdk.jfr.FlightRecorder");
     } catch (ClassNotFoundException exception) {
       Assumptions.abort("JFR not present");
     }
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetrics.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetrics.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import jdk.jfr.EventSettings;
+import jdk.jfr.FlightRecorder;
 import jdk.jfr.consumer.RecordingStream;
 
 /** The entry point class for runtime metrics support using JFR and JMX. */
@@ -107,7 +108,7 @@ public final class RuntimeMetrics implements Closeable {
 
     static JfrRuntimeMetrics build(
         OpenTelemetry openTelemetry, Predicate<JfrFeature> featurePredicate) {
-      if (!hasJfrRecordingStream()) {
+      if (!isJfrAvailable()) {
         return null;
       }
       return new JfrRuntimeMetrics(openTelemetry, featurePredicate);
@@ -134,13 +135,14 @@ public final class RuntimeMetrics implements Closeable {
       return startUpLatch;
     }
 
-    private static boolean hasJfrRecordingStream() {
+    private static boolean isJfrAvailable() {
       try {
-        Class.forName("jdk.jfr.consumer.RecordingStream");
-        return true;
+        Class.forName("jdk.jfr.FlightRecorder");
       } catch (ClassNotFoundException e) {
         return false;
       }
+
+      return FlightRecorder.isAvailable();
     }
   }
 }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrExtension.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrExtension.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import jdk.jfr.FlightRecorder;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -36,10 +37,11 @@ public class JfrExtension implements BeforeEachCallback, AfterEachCallback {
   @Override
   public void beforeEach(ExtensionContext context) throws InterruptedException {
     try {
-      Class.forName("jdk.jfr.consumer.RecordingStream");
+      Class.forName("jdk.jfr.FlightRecorder");
     } catch (ClassNotFoundException exception) {
       Assumptions.abort("JFR not present");
     }
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
 
     metricReader = InMemoryMetricReader.create();
     meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.OpenTelemetry;
 import java.util.Arrays;
 import java.util.HashMap;
+import jdk.jfr.FlightRecorder;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -19,10 +20,11 @@ class RuntimeMetricsBuilderTest {
   @BeforeAll
   static void setup() {
     try {
-      Class.forName("jdk.jfr.consumer.RecordingStream");
+      Class.forName("jdk.jfr.FlightRecorder");
     } catch (ClassNotFoundException exception) {
       Assumptions.abort("JFR not present");
     }
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.concurrent.atomic.AtomicBoolean;
+import jdk.jfr.FlightRecorder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,10 +29,11 @@ class RuntimeMetricsTest {
   @BeforeEach
   void setup() {
     try {
-      Class.forName("jdk.jfr.consumer.RecordingStream");
+      Class.forName("jdk.jfr.FlightRecorder");
     } catch (ClassNotFoundException exception) {
       Assumptions.abort("JFR not present");
     }
+    Assumptions.assumeTrue(FlightRecorder.isAvailable(), "JFR not available");
 
     reader = InMemoryMetricReader.createDelta();
     sdk =


### PR DESCRIPTION
https://scans.gradle.com/s/ernv5ktl4bcui/tests/task/:instrumentation:runtime-telemetry:runtime-telemetry-java17:library:test/details/io.opentelemetry.instrumentation.runtimemetrics.java17.BufferMetricTest/shouldHaveJfrLoadedClassesCountEvents()?expanded-stacktrace=WyIwIl0&top-execution=1

wasn't able to repro on mac, but it looks like jfr apis are now present in openj9 jvms used in the ci