### PR TITLE
Hibernate 6: don't record NoResultException

### DIFF
--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/QueryInstrumentation.java
@@ -45,13 +45,14 @@ public class QueryInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         isMethod()
             .and(
+                // not instrumenting getSingleResult as it calls list that is instrumented and
+                // we don't want to record the NoResultException that it throws
                 namedOneOf(
                     "list",
                     "getResultList",
                     "stream",
                     "getResultStream",
                     "uniqueResult",
-                    "getSingleResult",
                     "getSingleResultOrNull",
                     "uniqueResultOptional",
                     "executeUpdate",

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/AbstractHibernateTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractHibernateTest {
     // Pre-populate the DB, so delete/update can be tested.
     Session writer = sessionFactory.openSession();
     writer.beginTransaction();
-    prepopulated = new ArrayList<Value>();
+    prepopulated = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       prepopulated.add(new Value("Hello :) " + i));
       writer.persist(prepopulated.get(i));


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/12863
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/12125
Hibernate 4 instrumentation does not record this exception or mark the span as failed.