### PR TITLE
Rename "db.client.connections.usage" to "db.client.connection.count"

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -56,8 +57,10 @@ public final class DbConnectionPoolMetrics {
   }
 
   public ObservableLongMeasurement connections() {
+    String metricName =
+        emitStableDatabaseSemconv() ? "db.client.connection.count" : "db.client.connections.usage";
     return meter
-        .upDownCounterBuilder("db.client.connection.count")
+        .upDownCounterBuilder(metricName)
         .setUnit("{connections}")
         .setDescription(
             "The number of connections that are currently in state described by the state attribute.")

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
@@ -57,7 +57,7 @@ public final class DbConnectionPoolMetrics {
 
   public ObservableLongMeasurement connections() {
     return meter
-        .upDownCounterBuilder("db.client.connections.usage")
+        .upDownCounterBuilder("db.client.connection.count")
         .setUnit("{connections}")
         .setDescription(
             "The number of connections that are currently in state described by the state attribute.")

--- a/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
+++ b/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractDruidInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connections.usage",
+                "db.client.connection.count",
                 "db.client.connections.idle.min",
                 "db.client.connections.idle.max",
                 "db.client.connections.max",

--- a/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
+++ b/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.alibabadruid;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.alibaba.druid.pool.DruidDataSource;
@@ -73,7 +74,9 @@ public abstract class AbstractDruidInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connection.count",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.count"
+                    : "db.client.connections.usage",
                 "db.client.connections.idle.min",
                 "db.client.connections.idle.max",
                 "db.client.connections.max",

--- a/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
+++ b/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.apachedbcp;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -75,7 +76,9 @@ public abstract class AbstractApacheDbcpInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connection.count",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.count"
+                    : "db.client.connections.usage",
                 "db.client.connections.idle.min",
                 "db.client.connections.idle.max",
                 "db.client.connections.max"));

--- a/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
+++ b/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractApacheDbcpInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connections.usage",
+                "db.client.connection.count",
                 "db.client.connections.idle.min",
                 "db.client.connections.idle.max",
                 "db.client.connections.max"));

--- a/instrumentation/c3p0-0.9/testing/src/main/java/io/opentelemetry/instrumentation/c3p0/AbstractC3p0InstrumentationTest.java
+++ b/instrumentation/c3p0-0.9/testing/src/main/java/io/opentelemetry/instrumentation/c3p0/AbstractC3p0InstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.c3p0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
@@ -66,7 +67,11 @@ public abstract class AbstractC3p0InstrumentationTest {
     // then
     Set<String> metricNames =
         new HashSet<>(
-            Arrays.asList("db.client.connection.count", "db.client.connections.pending_requests"));
+            Arrays.asList(
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.count"
+                    : "db.client.connections.usage",
+                "db.client.connections.pending_requests"));
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->

--- a/instrumentation/c3p0-0.9/testing/src/main/java/io/opentelemetry/instrumentation/c3p0/AbstractC3p0InstrumentationTest.java
+++ b/instrumentation/c3p0-0.9/testing/src/main/java/io/opentelemetry/instrumentation/c3p0/AbstractC3p0InstrumentationTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractC3p0InstrumentationTest {
     // then
     Set<String> metricNames =
         new HashSet<>(
-            Arrays.asList("db.client.connections.usage", "db.client.connections.pending_requests"));
+            Arrays.asList("db.client.connection.count", "db.client.connections.pending_requests"));
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->

--- a/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
+++ b/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.hikaricp;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -81,7 +82,9 @@ public abstract class AbstractHikariInstrumentationTest {
     testing()
         .waitAndAssertMetrics(
             "io.opentelemetry.hikaricp-3.0",
-            "db.client.connection.count",
+            emitStableDatabaseSemconv()
+                ? "db.client.connection.count"
+                : "db.client.connections.usage",
             AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(

--- a/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
+++ b/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractHikariInstrumentationTest {
     testing()
         .waitAndAssertMetrics(
             "io.opentelemetry.hikaricp-3.0",
-            "db.client.connections.usage",
+            "db.client.connection.count",
             AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(

--- a/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
+++ b/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractOracleUcpInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connections.usage",
+                "db.client.connection.count",
                 "db.client.connections.max",
                 "db.client.connections.pending_requests"));
     assertThat(testing().metrics())

--- a/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
+++ b/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.oracleucp;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -117,7 +118,9 @@ public abstract class AbstractOracleUcpInstrumentationTest {
     Set<String> metricNames =
         new HashSet<>(
             Arrays.asList(
-                "db.client.connection.count",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.count"
+                    : "db.client.connections.usage",
                 "db.client.connections.max",
                 "db.client.connections.pending_requests"));
     assertThat(testing().metrics())

--- a/instrumentation/tomcat/tomcat-jdbc/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/TomcatJdbcInstrumentationTest.java
+++ b/instrumentation/tomcat/tomcat-jdbc/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/TomcatJdbcInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.jdbc;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -77,7 +78,7 @@ class TomcatJdbcInstrumentationTest {
   private static void assertNoConnectionPoolMetrics() {
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connection.count",
+        emitStableDatabaseSemconv() ? "db.client.connection.count" : "db.client.connections.usage",
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",

--- a/instrumentation/tomcat/tomcat-jdbc/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/TomcatJdbcInstrumentationTest.java
+++ b/instrumentation/tomcat/tomcat-jdbc/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/TomcatJdbcInstrumentationTest.java
@@ -77,7 +77,7 @@ class TomcatJdbcInstrumentationTest {
   private static void assertNoConnectionPoolMetrics() {
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connections.usage",
+        "db.client.connection.count",
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",

--- a/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractViburInstrumentationTest {
     // then
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME, "db.client.connections.usage", AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME, "db.client.connection.count", AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME, "db.client.connections.max", AbstractIterableAssert::isEmpty);

--- a/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.viburdbcp;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -72,9 +73,11 @@ public abstract class AbstractViburInstrumentationTest {
     Thread.sleep(100);
 
     // then
+    String countMetricName =
+        emitStableDatabaseSemconv() ? "db.client.connection.count" : "db.client.connections.usage";
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME, "db.client.connection.count", AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME, countMetricName, AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME, "db.client.connections.max", AbstractIterableAssert::isEmpty);

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/DbConnectionPoolMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/DbConnectionPoolMetricsAssertions.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.testing.junit.db;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 
@@ -126,7 +127,7 @@ public final class DbConnectionPoolMetricsAssertions {
   private void verifyConnectionUsage() {
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "db.client.connection.count",
+        emitStableDatabaseSemconv() ? "db.client.connection.count" : "db.client.connections.usage",
         metrics -> metrics.anySatisfy(this::verifyUsageMetric));
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/DbConnectionPoolMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/DbConnectionPoolMetricsAssertions.java
@@ -126,7 +126,7 @@ public final class DbConnectionPoolMetricsAssertions {
   private void verifyConnectionUsage() {
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "db.client.connections.usage",
+        "db.client.connection.count",
         metrics -> metrics.anySatisfy(this::verifyUsageMetric));
   }
 


### PR DESCRIPTION
Related to #12608.

Was our continued use of the older [semconv](https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/#database-client-connection-count) name intentional?