### PR TITLE
feat: ignore Byteman classes

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -40,7 +40,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
         .ignoreClass("com.nr.agent.")
         .ignoreClass("com.singularity.")
         .ignoreClass("com.jinspired.")
-        .ignoreClass("org.jinspired.");
+        .ignoreClass("org.jinspired.")
+        .ignoreClass("org.jboss.byteman.");
 
     // allow JDK HttpClient
     builder.allowClass("jdk.internal.net.http.");


### PR DESCRIPTION
Recently, I was testing an [exception injection using Chaos Mesh](https://chaos-mesh.org/docs/simulate-jvm-application-chaos/) in a Java application instrumented with OpenTelemetry, and I found that the injection failed when the Otel agent was running. Chaos Mesh uses [Byteman](https://byteman.jboss.org/) for exception injection; I saw the Byteman classes are not ignored. This PR adds the package `org.jboss.byteman.` to the ignored classes.