### PR TITLE
Downgrade docker image used in couchbase 3.1 tests

### DIFF
--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseClient31Test.java
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseClient31Test.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v3_1;
 
-import static org.awaitility.Awaitility.await;
-
 import com.couchbase.client.core.env.TimeoutConfig;
 import com.couchbase.client.core.error.DocumentNotFoundException;
-import com.couchbase.client.core.error.UnambiguousTimeoutException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
@@ -44,20 +41,8 @@ class CouchbaseClient31Test {
 
   @BeforeAll
   static void setup() {
-    // wait and retry in the hope that it will help against test flakiness
-    await()
-        .atMost(Duration.ofMinutes(5))
-        .ignoreException(UnambiguousTimeoutException.class)
-        .until(
-            () -> {
-              startCouchbase();
-              return true;
-            });
-  }
-
-  private static void startCouchbase() {
     couchbase =
-        new CouchbaseContainer("couchbase/server:7.6.0")
+        new CouchbaseContainer("couchbase/server:6.5.1")
             .withExposedPorts(8091)
             .withEnabledServices(CouchbaseService.KV)
             .withBucket(new BucketDefinition("test"))


### PR DESCRIPTION
I think the test flakiness is caused by compatibility issues between client version 3.1.4 and server 7.6.0 (3.1.6 that is used in another test works fine). Running the test in a loop locally does not fail with timeouts on older server version while it fails with the newer server.