### PR TITLE
Rework shutdown in lettuce 5.0 tests

### DIFF
--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -93,7 +93,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
   @AfterAll
   static void cleanUp() {
     connection.close();
-    redisClient.shutdown();
+    shutdown(redisClient);
     redisServer.stop();
   }
 

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
@@ -63,7 +63,7 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
   @AfterAll
   static void cleanUp() {
     connection.close();
-    redisClient.shutdown();
+    shutdown(redisClient);
     redisServer.stop();
   }
 

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -74,7 +74,7 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
   @AfterAll
   static void cleanUp() {
     connection.close();
-    redisClient.shutdown();
+    shutdown(redisClient);
     redisServer.stop();
   }
 


### PR DESCRIPTION
https://scans.gradle.com/s/5ivplxzd53vuw/console-log/task/:instrumentation:lettuce:lettuce-5.0:javaagent:test?anchor=1526&page=2

lettuce `shutdown` seems to have a bug that can cause the shutdown to hang. Try to work around it by using `shutdownAsync(..).get(15, TimeUnit.SECONDS)` (`shutdown` internally uses `shutdownAsync(..).get()` and the `get` hangs)