### PR TITLE
Akka/pekko http: set read timeout only for read timeout test

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationTest.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationTest.scala
@@ -66,22 +66,23 @@ class AkkaHttpClientInstrumentationTest
       uri: URI,
       headers: util.Map[String, String]
   ): Int = {
-    val settings = ConnectionPoolSettings(system)
-      .withConnectionSettings(
-        ClientConnectionSettings(system)
-          .withConnectingTimeout(
-            FiniteDuration(
-              AbstractHttpClientTest.CONNECTION_TIMEOUT.toMillis,
-              MILLISECONDS
-            )
-          )
-          .withIdleTimeout(
-            FiniteDuration(
-              AbstractHttpClientTest.READ_TIMEOUT.toMillis,
-              MILLISECONDS
-            )
-          )
+    var clientConnectionSettings = ClientConnectionSettings(system)
+      .withConnectingTimeout(
+        FiniteDuration(
+          AbstractHttpClientTest.CONNECTION_TIMEOUT.toMillis,
+          MILLISECONDS
+        )
       )
+    if (uri.toString.contains("/read-timeout")) {
+      clientConnectionSettings = clientConnectionSettings.withIdleTimeout(
+        FiniteDuration(
+          AbstractHttpClientTest.READ_TIMEOUT.toMillis,
+          MILLISECONDS
+        )
+      )
+    }
+    val settings = ConnectionPoolSettings(system)
+      .withConnectionSettings(clientConnectionSettings)
     val response = Await.result(
       Http.get(system).singleRequest(request, settings = settings),
       10 seconds

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpClientInstrumentationTest.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpClientInstrumentationTest.scala
@@ -65,22 +65,23 @@ class PekkoHttpClientInstrumentationTest
       uri: URI,
       headers: util.Map[String, String]
   ): Int = {
-    val settings = ConnectionPoolSettings(system)
-      .withConnectionSettings(
-        ClientConnectionSettings(system)
-          .withConnectingTimeout(
-            FiniteDuration(
-              AbstractHttpClientTest.CONNECTION_TIMEOUT.toMillis,
-              MILLISECONDS
-            )
-          )
-          .withIdleTimeout(
-            FiniteDuration(
-              AbstractHttpClientTest.READ_TIMEOUT.toMillis,
-              MILLISECONDS
-            )
-          )
+    var clientConnectionSettings = ClientConnectionSettings(system)
+      .withConnectingTimeout(
+        FiniteDuration(
+          AbstractHttpClientTest.CONNECTION_TIMEOUT.toMillis,
+          MILLISECONDS
+        )
       )
+    if (uri.toString.contains("/read-timeout")) {
+      clientConnectionSettings = clientConnectionSettings.withIdleTimeout(
+        FiniteDuration(
+          AbstractHttpClientTest.READ_TIMEOUT.toMillis,
+          MILLISECONDS
+        )
+      )
+    }
+    val settings = ConnectionPoolSettings(system)
+      .withConnectionSettings(clientConnectionSettings)
     val response = Await.result(
       Http.get(system).singleRequest(request, settings = settings),
       10 seconds


### PR DESCRIPTION
https://scans.gradle.com/s/d7ypki764ea7s/tests/task/:instrumentation:akka:akka-http-10.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpClientInstrumentationTest/httpsRequest()?top-execution=1

Hopefully helps agains timeouts when tests run a bit slow.