### PR TITLE
Temporarily increase stale days over end of year break

### DIFF
--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 7
+          # TODO (trask) update back to 7 days after end of year break
+          days-before-stale: 21
           days-before-close: 7
           only-labels: "needs author feedback"
           stale-issue-label: stale


### PR DESCRIPTION
While triaging, I'd like to label some of the issues as needing author feedback, but need to give more time for responses currently.