### PR TITLE
Remove unnecessary AgentInstrumentationSpecification extend

### DIFF
--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
@@ -19,7 +19,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
@@ -34,7 +33,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
+abstract class AbstractHibernateTest {
 
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();

--- a/instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/mdc/v1_1/JbossLogmanagerMdcTest.java
+++ b/instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/mdc/v1_1/JbossLogmanagerMdcTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.jbosslogmanager.mdc.v1_1;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.lang.reflect.InvocationTargetException;
@@ -25,7 +24,7 @@ import org.jboss.logmanager.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JbossLogmanagerMdcTest extends AgentInstrumentationSpecification {
+public class JbossLogmanagerMdcTest {
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();


### PR DESCRIPTION
These are groovy test conventions that were inadvertently added during test conversions but are not needed in these java tests