### PR TITLE
Remove spock and groovy from aws

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -26,7 +26,5 @@ dependencies {
 
   implementation("com.google.guava:guava")
 
-  implementation("org.apache.groovy:groovy")
   implementation("io.opentelemetry:opentelemetry-api")
-  implementation("org.spockframework:spock-core")
 }


### PR DESCRIPTION
I forgot to include this in #12949