### PR TITLE
Fix scope leak in aws sdk instrumentation

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
@@ -142,6 +142,11 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
     io.opentelemetry.context.Context parentOtelContext = io.opentelemetry.context.Context.current();
     SdkRequest request = context.request();
 
+    // the request has already been modified, duplicate interceptor?
+    if (executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE) != null) {
+      return request;
+    }
+
     // Ignore presign request. These requests don't run all interceptor methods and the span created
     // here would never be ended and scope closed.
     if (executionAttributes.getAttribute(AwsSignerExecutionAttribute.PRESIGNER_EXPIRATION)
@@ -229,6 +234,11 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void afterMarshalling(
       Context.AfterMarshalling context, ExecutionAttributes executionAttributes) {
+    // the request has already been modified, duplicate interceptor?
+    if (executionAttributes.getAttribute(SCOPE_ATTRIBUTE) != null) {
+      return;
+    }
+
     io.opentelemetry.context.Context otelContext = getContext(executionAttributes);
     if (otelContext != null
         && executionAttributes


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13124
When exception is thrown during marshalling we end up leaking the scope. This PR moves opening the scope after marshalling as it was before https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8405