### PR TITLE
Add code attributes to play mvc controller spans

### DIFF
--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionCodeAttributesGetter.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionCodeAttributesGetter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.play.v2_4;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesGetter;
+import javax.annotation.Nullable;
+
+public class ActionCodeAttributesGetter implements CodeAttributesGetter<ActionData> {
+  @Nullable
+  @Override
+  public Class<?> getCodeClass(ActionData actionData) {
+    return actionData.codeClass();
+  }
+
+  @Nullable
+  @Override
+  public String getMethodName(ActionData actionData) {
+    return actionData.methodName();
+  }
+}

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionData.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionData.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.play.v2_4;
+
+import java.lang.reflect.Method;
+
+public class ActionData {
+  private final Class<?> target;
+  private final Method method;
+
+  public ActionData(Class<?> target, Method method) {
+    this.target = target;
+    this.method = method;
+  }
+
+  public Class<?> codeClass() {
+    return target;
+  }
+
+  public String methodName() {
+    return method.getName();
+  }
+}

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionScope.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/ActionScope.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.play.v2_4;
+
+import static io.opentelemetry.javaagent.instrumentation.play.v2_4.Play24Singletons.instrumenter;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+/** Container used to carry state between enter and exit advices */
+public final class ActionScope {
+
+  private final ActionData actionData;
+  private final Context context;
+  private final Scope scope;
+
+  public ActionScope(Context context, Scope scope, ActionData actionData) {
+    this.actionData = actionData;
+    this.context = context;
+    this.scope = scope;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public Scope getScope() {
+    return scope;
+  }
+
+  public static ActionScope start(Context parentContext, ActionData actionData) {
+    if (!instrumenter().shouldStart(parentContext, actionData)) {
+      return null;
+    }
+
+    Context context = instrumenter().start(parentContext, actionData);
+    return new ActionScope(context, context.makeCurrent(), actionData);
+  }
+
+  public void closeScope() {
+    if (scope != null) {
+      scope.close();
+    }
+  }
+
+  public void end(Throwable throwable) {
+    closeScope();
+    instrumenter().end(context, actionData, null, throwable);
+  }
+}

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/Play24Singletons.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/Play24Singletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.play.v2_4;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
@@ -16,15 +17,20 @@ import play.api.mvc.Request;
 import scala.Option;
 
 public final class Play24Singletons {
-
   private static final String SPAN_NAME = "play.request";
-  private static final Instrumenter<Void, Void> INSTRUMENTER =
-      Instrumenter.<Void, Void>builder(
-              GlobalOpenTelemetry.get(), "io.opentelemetry.play-mvc-2.4", s -> SPAN_NAME)
-          .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-          .buildInstrumenter();
+  private static final Instrumenter<ActionData, Void> INSTRUMENTER;
 
-  public static Instrumenter<Void, Void> instrumenter() {
+  static {
+    INSTRUMENTER =
+        Instrumenter.<ActionData, Void>builder(
+                GlobalOpenTelemetry.get(), "io.opentelemetry.play-mvc-2.4", s -> SPAN_NAME)
+            .addAttributesExtractor(
+                CodeAttributesExtractor.create(new ActionCodeAttributesGetter()))
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
+            .buildInstrumenter();
+  }
+
+  public static Instrumenter<ActionData, Void> instrumenter() {
     return INSTRUMENTER;
   }
 

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -13,7 +13,10 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -112,9 +115,15 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
   }
 
   @Override
+  @SuppressWarnings("deprecation") // uses deprecated semconv
   public SpanDataAssert assertHandlerSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint) {
-    span.hasName("play.request").hasKind(INTERNAL);
+    span.hasName("play.request")
+        .hasKind(INTERNAL)
+        .hasAttributesSatisfyingExactly(
+            equalTo(CODE_NAMESPACE, "play.api.mvc.ActionBuilder$$anon$2"),
+            equalTo(CODE_FUNCTION, "apply"));
+
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
       span.hasException(new IllegalArgumentException(EXCEPTION.getBody()));


### PR DESCRIPTION
Related to #7345 

I know there are still discussions ([here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12984#discussion_r1900602815) and [here](https://github.com/open-telemetry/semantic-conventions/issues/1677)) around these conventions, but figured another example might help us continue to validate

Is this the right approach?