### PR TITLE
Fix failing javadoc

### DIFF
--- a/javaagent-tooling/javaagent-tooling-java9/src/main/java/io/opentelemetry/javaagent/tooling/Java9LambdaTransformer.java
+++ b/javaagent-tooling/javaagent-tooling-java9/src/main/java/io/opentelemetry/javaagent/tooling/Java9LambdaTransformer.java
@@ -9,7 +9,7 @@ import io.opentelemetry.javaagent.bootstrap.LambdaTransformer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 
-/** lambda transformer with java9 jpms module compatibility */
+/** Lambda transformer for java 9 and later with jpms module compatibility. */
 public class Java9LambdaTransformer implements LambdaTransformer {
 
   private final ClassFileTransformer delegate;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Java8LambdaTransformer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Java8LambdaTransformer.java
@@ -9,7 +9,7 @@ import io.opentelemetry.javaagent.bootstrap.LambdaTransformer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 
-/** lambda transformer for java < 9 without jpms modules support */
+/** Lambda transformer for java versions before 9 without jpms modules support. */
 public class Java8LambdaTransformer implements LambdaTransformer {
 
   private final ClassFileTransformer delegate;


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/13085859698/job/36517703128
Apparently `&lt;`should be used instead of  `<`.