### PR TITLE
Restrict GITHUB_TOKEN default permission

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -18,6 +18,11 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
   (To reduce friction for new contributors,
   as the default is "Require approval for first-time contributors")
 
+- Workflow permissions
+  - Default permissions granted to the `GITHUB_TOKEN` when running workflows in this repository:
+    Read repository contents and packages permissions
+  - Allow GitHub Actions to create and approve pull requests: UNCHECKED
+
 ## Branch protections
 
 The order of branch protection rules

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -8,8 +8,14 @@ on:
   # because repository write permission is needed to assign reviewers
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   assign-reviewers:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: trask/component-owners@02dfde3c03025c064cc6961975e28a42e81c394a # main


### PR DESCRIPTION
All the workflows now have explicit permissions set, so I don't think we're relying on the default permissions anywhere.