### PR TITLE
Switch to new GitHub App Token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,11 +29,17 @@ jobs:
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh
 
+      - uses: actions/create-github-app-token@136412a57a7081aa63c935a2cc2918f76c34f514 # v1.11.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.OPENTELEMETRY_BASIC_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.OPENTELEMETRY_BASIC_AUTOMATION_PRIVATE_KEY }}
+
       - name: Create pull request
         env:
           NUMBER: ${{ github.event.inputs.number }}
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)


### PR DESCRIPTION
This is part of the Project Infrastructure SIG's work to lock down permissions more, related to

* https://github.com/open-telemetry/community/issues/1549
* https://github.com/open-telemetry/community/issues/2127

My plan is, after merging this, to test it with the backport automation first.

If that goes well, I'll extend it to the other automations in this repo.

If that goes well, I'll document it in https://github.com/open-telemetry/community/blob/main/assets.md and ask other repos to start transitioning away from @opentelemetrybot.

cc @austinlparker @adrielp