### PR TITLE
Make OSSF scorecard happy

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -42,6 +42,7 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
   - Require status checks to pass
     - EasyCLA
     - `required-status-check`
+    - `gradle-wrapper-validation`
   - Block force pushes: CHECKED
 
 ### `cloudfoundry` branch

--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -42,7 +42,6 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
   - Require status checks to pass
     - EasyCLA
     - `required-status-check`
-    - `gradle-wrapper-validation`
   - Block force pushes: CHECKED
 
 ### `cloudfoundry` branch

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -71,7 +71,6 @@ jobs:
     # only the "common" checks are required for release branch PRs in order to avoid any unnecessary
     # release branch maintenance (especially for patches)
     needs:
-      - gradle-wrapper-validation
       - common
       - muzzle
       - shell-script-check

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -16,14 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  gradle-wrapper-validation:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      # this needs to be in the top-level workflow in order to make OSSF scorecard happy
-      - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
-
   common:
     uses: ./.github/workflows/build-common.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  gradle-wrapper-validation:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      # this needs to be in the top-level workflow in order to make OSSF scorecard happy
-      - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
-
   common:
     uses: ./.github/workflows/build-common.yml
     secrets:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,14 @@
+name: "Validate Gradle Wrappers"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # this needs to be in its own workflow in order to make OSSF scorecard happy
+      - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0


### PR DESCRIPTION
This didn't work: #13164

Trying a more conventional setup.

(OSSF scorecard is supposed to look for a successful run of this and then not warn on binary gradle wrappers)

After merging, I'll update the required status checks.