### PR TITLE
Pin npm and pypi modules and one docker module

### DIFF
--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -30,7 +30,7 @@ jobs:
         run: git checkout -b opentelemetrybot/cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }}
 
       - run: sudo apt-get install jq python3-pip
-      - run: pip install yq
+      - run: pip install yq==3.4.2
 
       - name: update index.yml
         run: |

--- a/.github/workflows/reusable-markdown-lint-check.yml
+++ b/.github/workflows/reusable-markdown-lint-check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install mardkdownlint
-        run: npm install -g markdownlint-cli
+        run: npm install -g markdownlint-cli@0.43.0
 
       - name: Run markdownlint
         run: |

--- a/benchmark-overhead/Dockerfile-petclinic-base
+++ b/benchmark-overhead/Dockerfile-petclinic-base
@@ -13,7 +13,7 @@ RUN git checkout 8aa4d49
 RUN ./mvnw package -Dmaven.test.skip=true
 RUN cp target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
 
-FROM bellsoft/liberica-openjdk-alpine:21.0.6
+FROM bellsoft/liberica-openjdk-alpine:21.0.5@sha256:45083bf56e4cf13c34c6ec04356deec655638c8aa8443f9dcab7a90fb4db8fb6
 COPY --from=app-build /app/spring-petclinic-rest.jar /app/spring-petclinic-rest.jar
 WORKDIR /app
 EXPOSE 9966


### PR DESCRIPTION
(these are the only npm and pypi modules detected by ossf)

Intentionally not pinning the latest in order to check that renovate detects/updates them