### PR TITLE
CodeQL on every commit

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -1,9 +1,9 @@
-name: CodeQL (daily)
+name: CodeQL
 
 on:
-  schedule:
-    # daily at 1:30 UTC
-    - cron: "30 1 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
OSSF isn't detecting that we're running CodeQL, I suspect because we are running it once a day, instead of on push to main where it can link to it from the commit workflows.

related to #13157