### PR TITLE
Implementation for the latest Messaging Semantic conventions.

### DIFF
--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -42,11 +42,11 @@ tasks {
   }
 
   val testStableSemconv by registering(Test::class) {
-    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database,messaging")
   }
 
   val testBothSemconv by registering(Test::class) {
-    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,messaging/dup")
   }
 
   check {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -13,16 +13,33 @@ import java.util.Locale;
  * that may be used in a messaging system.
  */
 public enum MessageOperation {
+  @Deprecated
   PUBLISH,
+
   RECEIVE,
-  PROCESS;
+  PROCESS,
+  CREATE,
+  SEND,
+  SETTLE;
 
   /**
    * Returns the operation name as defined in <a
    * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">the
    * specification</a>.
+   *
+   * @deprecated Use {@link #operationType} instead.
    */
+  @Deprecated
   String operationName() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Returns the operation type as defined in <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-types">the
+   * specification</a>.
+   */
+  String operationType() {
     return name().toLowerCase(Locale.ROOT);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -189,6 +189,7 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
    * any time.
    */
   @Override
+  @SuppressWarnings("deprecation") // using deprecated semconv
   public SpanKey internalGetSpanKey() {
     if (operation == null) {
       return null;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
@@ -19,21 +19,61 @@ import javax.annotation.Nullable;
  */
 public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
 
-  @Nullable
   String getSystem(REQUEST request);
+
+  @Nullable
+  default Long getBatchMessageCount(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  @Nullable
+  default String getConsumerGroupName(REQUEST request) {
+    return null;
+  }
+
+  boolean isAnonymousDestination(REQUEST request);
 
   @Nullable
   String getDestination(REQUEST request);
 
   @Nullable
-  String getDestinationTemplate(REQUEST request);
+  default String getDestinationSubscriptionName(REQUEST request) {
+    return null;
+  }
+
+  @Nullable
+  default String getDestinationTemplate(REQUEST request) {
+    return null;
+  }
 
   boolean isTemporaryDestination(REQUEST request);
 
-  boolean isAnonymousDestination(REQUEST request);
+  @Nullable
+  default String getOperationName(REQUEST request) {
+    return null;
+  }
 
   @Nullable
-  String getConversationId(REQUEST request);
+  String getClientId(REQUEST request);
+
+  @Nullable
+  default String getDestinationPartitionId(REQUEST request) {
+    return null;
+  }
+
+  @Nullable
+  default String getConversationId(REQUEST request) {
+    return null;
+  }
+
+  @Nullable
+  String getMessageId(REQUEST request, @Nullable RESPONSE response);
+
+  @Nullable
+  Long getMessageBodySize(REQUEST request);
+
+  @Nullable
+  Long getMessageEnvelopeSize(REQUEST request);
 
   @Nullable
   @Deprecated
@@ -44,26 +84,6 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
   @Nullable
   @Deprecated
   default Long getMessagePayloadCompressedSize(REQUEST request) {
-    return null;
-  }
-
-  @Nullable
-  Long getMessageBodySize(REQUEST request);
-
-  @Nullable
-  Long getMessageEnvelopeSize(REQUEST request);
-
-  @Nullable
-  String getMessageId(REQUEST request, @Nullable RESPONSE response);
-
-  @Nullable
-  String getClientId(REQUEST request);
-
-  @Nullable
-  Long getBatchMessageCount(REQUEST request, @Nullable RESPONSE response);
-
-  @Nullable
-  default String getDestinationPartitionId(REQUEST request) {
     return null;
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingNetworkAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingNetworkAttributesExtractor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import javax.annotation.Nullable;
+
+public final class MessagingNetworkAttributesExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  /**
+   * Creates the network attributes extractor.
+   *
+   * @see InstrumenterBuilder#addAttributesExtractor(AttributesExtractor)
+   */
+  public static <REQUEST, RESPONSE> MessagingNetworkAttributesExtractor<REQUEST, RESPONSE> create(
+      MessagingNetworkAttributesGetter<REQUEST, RESPONSE> getter) {
+    return new MessagingNetworkAttributesExtractor<>(getter);
+  }
+
+  private final MessagingNetworkAttributesGetter<REQUEST, RESPONSE> getter;
+
+  MessagingNetworkAttributesExtractor(MessagingNetworkAttributesGetter<REQUEST, RESPONSE> getter) {
+    this.getter = getter;
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    attributes.put(NETWORK_PEER_ADDRESS, getter.getNetworkPeerAddress(request, null));
+    attributes.put(NETWORK_PEER_PORT, getter.getNetworkPeerPort(request, null));
+
+    attributes.put(SERVER_ADDRESS, getter.getServerAddress(request));
+    attributes.put(SERVER_PORT, getter.getServerPort(request));
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingNetworkAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingNetworkAttributesGetter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.semconv.network.internal.InetSocketAddressUtil;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+public interface MessagingNetworkAttributesGetter<REQUEST, RESPONSE>
+    extends ServerAttributesGetter<REQUEST> {
+
+  @Nullable
+  default InetSocketAddress getNetworkPeerInetSocketAddress(
+      REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  @Nullable
+  default String getNetworkPeerAddress(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getIpAddress(getNetworkPeerInetSocketAddress(request, response));
+  }
+
+  @Nullable
+  default Integer getNetworkPeerPort(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getPort(getNetworkPeerInetSocketAddress(request, response));
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
+import javax.annotation.Nullable;
 
 public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtractor<REQUEST> {
 
@@ -19,21 +22,35 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
    * @see MessageOperation used to extract {@code <operation name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
-      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
-    return new MessagingSpanNameExtractor<>(getter, operation);
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessageOperation operation,
+      ServerAttributesGetter<REQUEST> serverAttributesGetter) {
+    return new MessagingSpanNameExtractor<>(getter, operation, serverAttributesGetter);
   }
 
   private final MessagingAttributesGetter<REQUEST, ?> getter;
+  private final ServerAttributesGetter<REQUEST> serverAttributesGetter;
   private final MessageOperation operation;
 
   private MessagingSpanNameExtractor(
-      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessageOperation operation,
+      ServerAttributesGetter<REQUEST> serverAttributesGetter) {
     this.getter = getter;
+    this.serverAttributesGetter = serverAttributesGetter;
     this.operation = operation;
   }
 
   @Override
+  @SuppressWarnings("deprecation") // using deprecated semconv
   public String extract(REQUEST request) {
+    if (SemconvStability.emitStableMessagingSemconv()) {
+      String destination = getDestination(request);
+      if (destination == null) {
+        return getter.getOperationName(request);
+      }
+      return getter.getOperationName(request) + " " + destination;
+    }
     String destinationName =
         getter.isTemporaryDestination(request)
             ? MessagingAttributesExtractor.TEMP_DESTINATION_NAME
@@ -43,5 +60,28 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
     }
 
     return destinationName + " " + operation.operationName();
+  }
+
+  @Nullable
+  private String getDestination(REQUEST request) {
+    String destination = null;
+    if (getter.getDestinationTemplate(request) != null) {
+      destination = getter.getDestinationTemplate(request);
+    } else if (getter.isTemporaryDestination(request)) {
+      destination = MessagingAttributesExtractor.TEMP_DESTINATION_NAME;
+    } else if (getter.isAnonymousDestination(request)) {
+      destination = MessagingAttributesExtractor.ANONYMOUS_DESTINATION_NAME;
+    } else if (getter.getDestination(request) != null) {
+      destination = getter.getDestination(request);
+    } else {
+      if (serverAttributesGetter.getServerAddress(request) != null
+          && serverAttributesGetter.getServerPort(request) != null) {
+        destination =
+            serverAttributesGetter.getServerAddress(request)
+                + ":"
+                + serverAttributesGetter.getServerPort(request);
+      }
+    }
+    return destination;
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -15,11 +15,13 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
   /**
    * Returns a {@link SpanNameExtractor} that constructs the span name according to <a
    * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#span-name">
-   * messaging semantic conventions</a>: {@code <destination name> <operation name>}.
+   * messaging semantic conventions</a>: {@code <operation name> <destination name> }.
    *
-   * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <destination
-   *     name>}.
-   * @see MessageOperation used to extract {@code <operation name>}.
+   * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <operation name>}
+   *     and {@code <destination name>}.
+   * @see MessageOperation used to extract {@code <operation name>} (backwards compatibility with
+   *     old conventions).
+   * @see ServerAttributesGetter used to extract data for {@code <destination name>}
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter,

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/package-info.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -6,9 +6,12 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,25 +24,37 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
+  @Mock ServerAttributesGetter<Message> serverAttributesGetter;
 
   @ParameterizedTest
   @MethodSource("spanNameParams")
   void shouldExtractSpanName(
       boolean isTemporaryQueue,
+      boolean isAnonymous,
       String destinationName,
+      String destinationTemplate,
       MessageOperation operation,
       String expectedSpanName) {
     // given
     Message message = new Message();
 
-    if (isTemporaryQueue) {
-      when(getter.isTemporaryDestination(message)).thenReturn(true);
-    } else {
-      when(getter.getDestination(message)).thenReturn(destinationName);
+    when(getter.getDestinationTemplate(message)).thenReturn(destinationTemplate);
+    if (isAnonymous) {
+      lenient().when(getter.isAnonymousDestination(message)).thenReturn(true);
     }
 
+    if (isTemporaryQueue) {
+      lenient().when(getter.isTemporaryDestination(message)).thenReturn(true);
+    } else {
+      lenient().when(getter.getDestination(message)).thenReturn(destinationName);
+    }
+    when(getter.getOperationName(message)).thenReturn(operation.operationType());
+
+    lenient().when(serverAttributesGetter.getServerPort(message)).thenReturn(1234);
+    lenient().when(serverAttributesGetter.getServerAddress(message)).thenReturn("127.0.0.1");
+
     SpanNameExtractor<Message> underTest =
-        MessagingSpanNameExtractor.create(getter, operation, null);
+        MessagingSpanNameExtractor.create(getter, operation, serverAttributesGetter);
 
     // when
     String spanName = underTest.extract(message);
@@ -50,10 +65,41 @@ class MessagingSpanNameExtractorTest {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   static Stream<Arguments> spanNameParams() {
+    if (SemconvStability.emitStableMessagingSemconv()) {
+      return Stream.of(
+          Arguments.of(
+              false,
+              false,
+              "destination/1",
+              "destination/{}",
+              MessageOperation.PUBLISH,
+              "publish destination/{}"),
+          Arguments.of(
+              false,
+              false,
+              "destination/1",
+              null,
+              MessageOperation.PUBLISH,
+              "publish destination/1"),
+          Arguments.of(true, false, null, "temp", MessageOperation.PROCESS, "process temp"),
+          Arguments.of(true, false, null, null, MessageOperation.PROCESS, "process (temporary)"),
+          Arguments.of(false, true, null, "anon", MessageOperation.PROCESS, "process anon"),
+          Arguments.of(false, true, null, null, MessageOperation.PROCESS, "process (anonymous)"),
+          Arguments.of(true, true, null, null, MessageOperation.PROCESS, "process (temporary)"),
+          Arguments.of(
+              false, false, null, null, MessageOperation.RECEIVE, "receive 127.0.0.1:1234"));
+    }
     return Stream.of(
-        Arguments.of(false, "destination", MessageOperation.PUBLISH, "destination publish"),
-        Arguments.of(true, null, MessageOperation.PROCESS, "(temporary) process"),
-        Arguments.of(false, null, MessageOperation.RECEIVE, "unknown receive"));
+        Arguments.of(
+            false,
+            false,
+            "destination",
+            "not used",
+            MessageOperation.PUBLISH,
+            "destination publish"),
+        Arguments.of(
+            true, false, null, "not used", MessageOperation.PROCESS, "(temporary) process"),
+        Arguments.of(false, false, null, "not used", MessageOperation.RECEIVE, "unknown receive"));
   }
 
   static class Message {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -38,7 +38,8 @@ class MessagingSpanNameExtractorTest {
       when(getter.getDestination(message)).thenReturn(destinationName);
     }
 
-    SpanNameExtractor<Message> underTest = MessagingSpanNameExtractor.create(getter, operation);
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.create(getter, operation, null);
 
     // when
     String spanName = underTest.extract(message);
@@ -47,6 +48,7 @@ class MessagingSpanNameExtractorTest {
     assertEquals(expectedSpanName, spanName);
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   static Stream<Arguments> spanNameParams() {
     return Stream.of(
         Arguments.of(false, "destination", MessageOperation.PUBLISH, "destination publish"),

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -18,12 +18,17 @@ public final class SemconvStability {
 
   private static final boolean emitOldDatabaseSemconv;
   private static final boolean emitStableDatabaseSemconv;
+  private static final boolean emitOldMessagingSemconv;
+  private static final boolean emitStableMessagingSemconv;
 
   static {
     boolean oldDatabase = true;
     boolean stableDatabase = false;
+    boolean oldMessaging = true;
+    boolean stableMessaging = false;
 
     String value = ConfigPropertiesUtil.getString("otel.semconv-stability.opt-in");
+    System.out.println(value);
     if (value != null) {
       Set<String> values = new HashSet<>(asList(value.split(",")));
       if (values.contains("database")) {
@@ -36,10 +41,23 @@ public final class SemconvStability {
         oldDatabase = true;
         stableDatabase = true;
       }
+      if (values.contains("messaging")) {
+        oldMessaging = false;
+        stableMessaging = true;
+      }
+      // no else -- technically it's possible to set "messaging,messaging/dup", in which case we
+      // should emit both sets of attributes
+      // and messaging/dup has higher precedence than messaging in case both values are present
+      if (values.contains("messaging/dup")) {
+        oldMessaging = true;
+        stableMessaging = true;
+      }
     }
 
     emitOldDatabaseSemconv = oldDatabase;
     emitStableDatabaseSemconv = stableDatabase;
+    emitOldMessagingSemconv = oldMessaging;
+    emitStableMessagingSemconv = stableMessaging;
   }
 
   public static boolean emitOldDatabaseSemconv() {
@@ -48,6 +66,14 @@ public final class SemconvStability {
 
   public static boolean emitStableDatabaseSemconv() {
     return emitStableDatabaseSemconv;
+  }
+
+  public static boolean emitOldMessagingSemconv() {
+    return emitOldMessagingSemconv;
+  }
+
+  public static boolean emitStableMessagingSemconv() {
+    return emitStableMessagingSemconv;
   }
 
   private SemconvStability() {}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
@@ -49,6 +49,8 @@ public final class SpanKey {
       ContextKey.named("opentelemetry-traces-span-key-consumer-receive");
   private static final ContextKey<Span> CONSUMER_PROCESS_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-process");
+  private static final ContextKey<Span> CONSUMER_SETTLE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-consumer-settle");
 
   /* Span keys */
 
@@ -69,6 +71,7 @@ public final class SpanKey {
   public static final SpanKey PRODUCER = new SpanKey(PRODUCER_KEY);
   public static final SpanKey CONSUMER_RECEIVE = new SpanKey(CONSUMER_RECEIVE_KEY);
   public static final SpanKey CONSUMER_PROCESS = new SpanKey(CONSUMER_PROCESS_KEY);
+  public static final SpanKey CONSUMER_SETTLE = new SpanKey(CONSUMER_SETTLE_KEY);
 
   private final ContextKey<Span> key;
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsAttributesGetter.java
@@ -8,11 +8,15 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
-enum SqsAttributesGetter implements MessagingAttributesGetter<Request<?>, Response<?>> {
+enum SqsAttributesGetter
+    implements
+        MessagingAttributesGetter<Request<?>, Response<?>>,
+        MessagingNetworkAttributesGetter<Request<?>, Response<?>> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsProcessRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsProcessRequestAttributesGetter.java
@@ -7,12 +7,15 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import com.amazonaws.Response;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 enum SqsProcessRequestAttributesGetter
-    implements MessagingAttributesGetter<SqsProcessRequest, Response<?>> {
+    implements
+        MessagingAttributesGetter<SqsProcessRequest, Response<?>>,
+        MessagingNetworkAttributesGetter<SqsProcessRequest, Response<?>> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsReceiveRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsReceiveRequestAttributesGetter.java
@@ -7,13 +7,16 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import com.amazonaws.Response;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 enum SqsReceiveRequestAttributesGetter
-    implements MessagingAttributesGetter<SqsReceiveRequest, Response<?>> {
+    implements
+        MessagingAttributesGetter<SqsReceiveRequest, Response<?>>,
+        MessagingNetworkAttributesGetter<SqsReceiveRequest, Response<?>> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -16,6 +17,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -23,6 +25,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +54,10 @@ public final class AwsSdkInstrumenterFactory {
       httpClientSuppressionAttributesExtractor =
           new AwsSdkHttpClientSuppressionAttributesExtractor();
 
+  private static final MessagingNetworkAttributesExtractor<ExecutionAttributes, Response>
+      messagingNetworkAttributesExtractor =
+          MessagingNetworkAttributesExtractor.create(SqsAttributesGetter.INSTANCE);
+
   private static final List<AttributesExtractor<ExecutionAttributes, Response>>
       defaultAttributesExtractors =
           Arrays.asList(rpcAttributesExtractor, httpClientSuppressionAttributesExtractor);
@@ -60,7 +67,8 @@ public final class AwsSdkInstrumenterFactory {
           Arrays.asList(
               rpcAttributesExtractor,
               experimentalAttributesExtractor,
-              httpClientSuppressionAttributesExtractor);
+              httpClientSuppressionAttributesExtractor,
+              messagingNetworkAttributesExtractor);
 
   private static final List<AttributesExtractor<ExecutionAttributes, Response>>
       defaultConsumerAttributesExtractors =
@@ -130,11 +138,11 @@ public final class AwsSdkInstrumenterFactory {
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
+        MessagingSpanNameExtractor.create(getter, operation, getter),
         SpanKindExtractor.alwaysConsumer(),
         toSqsRequestExtractors(consumerAttributesExtractors()),
         singletonList(messagingAttributeExtractor),
-        messagingReceiveInstrumentationEnabled);
+        messagingReceiveInstrumentationEnabled || SemconvStability.emitStableMessagingSemconv());
   }
 
   public Instrumenter<SqsProcessRequest, Response> consumerProcessInstrumenter() {
@@ -145,11 +153,11 @@ public final class AwsSdkInstrumenterFactory {
         Instrumenter.<SqsProcessRequest, Response>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operation, getter))
             .addAttributesExtractors(toSqsRequestExtractors(consumerAttributesExtractors()))
             .addAttributesExtractor(messagingAttributesExtractor(getter, operation));
 
-    if (messagingReceiveInstrumentationEnabled) {
+    if (messagingReceiveInstrumentationEnabled || SemconvStability.emitStableMessagingSemconv()) {
       builder.addSpanLinksExtractor(
           (spanLinks, parentContext, request) -> {
             Context extracted =
@@ -189,15 +197,17 @@ public final class AwsSdkInstrumenterFactory {
     return result;
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   public Instrumenter<ExecutionAttributes, Response> producerInstrumenter() {
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessageOperation operation =
+        emitStableMessagingSemconv() ? MessageOperation.SEND : MessageOperation.PUBLISH;
     SqsAttributesGetter getter = SqsAttributesGetter.INSTANCE;
     AttributesExtractor<ExecutionAttributes, Response> messagingAttributeExtractor =
         messagingAttributesExtractor(getter, operation);
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
+        MessagingSpanNameExtractor.create(getter, operation, getter),
         SpanKindExtractor.alwaysProducer(),
         attributesExtractors(),
         singletonList(messagingAttributeExtractor),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -13,7 +14,10 @@ import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 
-enum SqsAttributesGetter implements MessagingAttributesGetter<ExecutionAttributes, Response> {
+enum SqsAttributesGetter
+    implements
+        MessagingAttributesGetter<ExecutionAttributes, Response>,
+        MessagingNetworkAttributesGetter<ExecutionAttributes, Response> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsProcessRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsProcessRequestAttributesGetter.java
@@ -6,13 +6,16 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
 
 enum SqsProcessRequestAttributesGetter
-    implements MessagingAttributesGetter<SqsProcessRequest, Response> {
+    implements
+        MessagingAttributesGetter<SqsProcessRequest, Response>,
+        MessagingNetworkAttributesGetter<SqsProcessRequest, Response> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsReceiveRequestAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsReceiveRequestAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -13,7 +14,9 @@ import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
 
 enum SqsReceiveRequestAttributesGetter
-    implements MessagingAttributesGetter<SqsReceiveRequest, Response> {
+    implements
+        MessagingAttributesGetter<SqsReceiveRequest, Response>,
+        MessagingNetworkAttributesGetter<SqsReceiveRequest, Response> {
   INSTANCE;
 
   // copied from MessagingIncubatingAttributes.MessagingSystemIncubatingValues

--- a/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
+++ b/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.jms;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWithDestination, Void> {
+enum JmsMessageAttributesGetter
+    implements
+        MessagingAttributesGetter<MessageWithDestination, Void>,
+        MessagingNetworkAttributesGetter<MessageWithDestination, Void> {
   INSTANCE;
 
   private static final Logger logger = Logger.getLogger(JmsMessageAttributesGetter.class.getName());

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaConsumerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaConsumerAttributesGetter.java
@@ -6,13 +6,17 @@
 package io.opentelemetry.instrumentation.kafka.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
-enum KafkaConsumerAttributesGetter implements MessagingAttributesGetter<KafkaProcessRequest, Void> {
+enum KafkaConsumerAttributesGetter
+    implements
+        MessagingAttributesGetter<KafkaProcessRequest, Void>,
+        MessagingNetworkAttributesGetter<KafkaProcessRequest, Void> {
   INSTANCE;
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaProducerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaProducerAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.kafka.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +19,9 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  * any time.
  */
 enum KafkaProducerAttributesGetter
-    implements MessagingAttributesGetter<KafkaProducerRequest, RecordMetadata> {
+    implements
+        MessagingAttributesGetter<KafkaProducerRequest, RecordMetadata>,
+        MessagingNetworkAttributesGetter<KafkaProducerRequest, RecordMetadata> {
   INSTANCE;
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.kafka.internal;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
@@ -14,7 +15,10 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.kafka.common.TopicPartition;
 
-enum KafkaReceiveAttributesGetter implements MessagingAttributesGetter<KafkaReceiveRequest, Void> {
+enum KafkaReceiveAttributesGetter
+    implements
+        MessagingAttributesGetter<KafkaReceiveRequest, Void>,
+        MessagingNetworkAttributesGetter<KafkaReceiveRequest, Void> {
   INSTANCE;
 
   @Override

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -75,6 +75,7 @@ public final class AgentSpanTestingInstrumenter {
       SpanKey.PRODUCER,
       SpanKey.CONSUMER_RECEIVE,
       SpanKey.CONSUMER_PROCESS,
+      SpanKey.CONSUMER_SETTLE,
     };
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -14,7 +16,9 @@ import javax.annotation.Nullable;
 import org.apache.pulsar.common.naming.TopicName;
 
 enum PulsarBatchMessagingAttributesGetter
-    implements MessagingAttributesGetter<PulsarBatchRequest, Void> {
+    implements
+        MessagingAttributesGetter<PulsarBatchRequest, Void>,
+        MessagingNetworkAttributesGetter<PulsarBatchRequest, Void> {
   INSTANCE;
 
   @Override
@@ -98,5 +102,31 @@ enum PulsarBatchMessagingAttributesGetter
         .map(message -> message.getProperty(name))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  @Nullable
+  @Override
+  public Integer getServerPort(PulsarBatchRequest pulsarRequest) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getServerPort(pulsarRequest);
+  }
+
+  @Nullable
+  @Override
+  public String getServerAddress(PulsarBatchRequest pulsarRequest) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getServerAddress(pulsarRequest);
+  }
+
+  @Nullable
+  @Override
+  public InetSocketAddress getNetworkPeerInetSocketAddress(
+      PulsarBatchRequest pulsarRequest, @Nullable Void unused) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getNetworkPeerInetSocketAddress(
+        pulsarRequest, null);
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(PulsarBatchRequest pulsarRequest, @Nullable Void unused) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getNetworkPeerPort(pulsarRequest, null);
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
@@ -9,12 +9,17 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
+import java.net.InetSocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.naming.TopicName;
 
-enum PulsarMessagingAttributesGetter implements MessagingAttributesGetter<PulsarRequest, Void> {
+enum PulsarMessagingAttributesGetter
+    implements
+        MessagingAttributesGetter<PulsarRequest, Void>,
+        MessagingNetworkAttributesGetter<PulsarRequest, Void> {
   INSTANCE;
 
   @Override
@@ -98,5 +103,31 @@ enum PulsarMessagingAttributesGetter implements MessagingAttributesGetter<Pulsar
   public List<String> getMessageHeader(PulsarRequest request, String name) {
     String value = request.getMessage().getProperty(name);
     return value != null ? singletonList(value) : emptyList();
+  }
+
+  @Nullable
+  @Override
+  public Integer getServerPort(PulsarRequest pulsarRequest) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getServerPort(pulsarRequest);
+  }
+
+  @Nullable
+  @Override
+  public String getServerAddress(PulsarRequest pulsarRequest) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getServerAddress(pulsarRequest);
+  }
+
+  @Nullable
+  @Override
+  public InetSocketAddress getNetworkPeerInetSocketAddress(
+      PulsarRequest pulsarRequest, @Nullable Void unused) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getNetworkPeerInetSocketAddress(
+        pulsarRequest, null);
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(PulsarRequest pulsarRequest, @Nullable Void unused) {
+    return PulsarNetClientAttributesGetter.INSTANCE.getNetworkPeerPort(pulsarRequest, null);
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
-import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import javax.annotation.Nullable;
 
-public final class PulsarNetClientAttributesGetter
-    implements ServerAttributesGetter<BasePulsarRequest> {
+public enum PulsarNetClientAttributesGetter
+    implements MessagingNetworkAttributesGetter<BasePulsarRequest, Void> {
+  INSTANCE;
 
   @Nullable
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
@@ -56,6 +56,7 @@ public final class RabbitSingletons {
     return deliverInstrumenter;
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   private static Instrumenter<ChannelAndMethod, Void> createChannelInstrumenter(boolean publish) {
     return Instrumenter.<ChannelAndMethod, Void>builder(
             GlobalOpenTelemetry.get(), instrumentationName, ChannelAndMethod::getMethod)

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
@@ -6,12 +6,16 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.common.message.MessageExt;
 
-enum RocketMqConsumerAttributeGetter implements MessagingAttributesGetter<MessageExt, Void> {
+enum RocketMqConsumerAttributeGetter
+    implements
+        MessagingAttributesGetter<MessageExt, Void>,
+        MessagingNetworkAttributesGetter<MessageExt, Void> {
   INSTANCE;
 
   @Override

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -14,7 +15,9 @@ import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.common.message.Message;
 
 enum RocketMqProducerAttributeGetter
-    implements MessagingAttributesGetter<SendMessageContext, Void> {
+    implements
+        MessagingAttributesGetter<SendMessageContext, Void>,
+        MessagingNetworkAttributesGetter<SendMessageContext, Void> {
   INSTANCE;
 
   @Override

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -13,7 +14,9 @@ import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.message.MessageView;
 
 enum RocketMqConsumerProcessAttributeGetter
-    implements MessagingAttributesGetter<MessageView, ConsumeResult> {
+    implements
+        MessagingAttributesGetter<MessageView, ConsumeResult>,
+        MessagingNetworkAttributesGetter<MessageView, ConsumeResult> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
@@ -7,12 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.client.apis.message.MessageView;
 
 enum RocketMqConsumerReceiveAttributeGetter
-    implements MessagingAttributesGetter<ReceiveMessageRequest, List<MessageView>> {
+    implements
+        MessagingAttributesGetter<ReceiveMessageRequest, List<MessageView>>,
+        MessagingNetworkAttributesGetter<ReceiveMessageRequest, List<MessageView>> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -13,7 +14,9 @@ import org.apache.rocketmq.client.java.impl.producer.SendReceiptImpl;
 import org.apache.rocketmq.client.java.message.PublishingMessageImpl;
 
 enum RocketMqProducerAttributeGetter
-    implements MessagingAttributesGetter<PublishingMessageImpl, SendReceiptImpl> {
+    implements
+        MessagingAttributesGetter<PublishingMessageImpl, SendReceiptImpl>,
+        MessagingNetworkAttributesGetter<PublishingMessageImpl, SendReceiptImpl> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -79,6 +80,7 @@ public final class SpringIntegrationTelemetryBuilder {
    * Returns a new {@link SpringIntegrationTelemetry} with the settings of this {@link
    * SpringIntegrationTelemetryBuilder}.
    */
+  @SuppressWarnings("deprecation") // using deprecated semconv
   public SpringIntegrationTelemetry build() {
     Instrumenter<MessageWithChannel, Void> consumerInstrumenter =
         Instrumenter.<MessageWithChannel, Void>builder(
@@ -102,7 +104,9 @@ public final class SpringIntegrationTelemetryBuilder {
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
                     SpringMessagingAttributesGetter.INSTANCE,
-                    MessageOperation.PUBLISH,
+                    emitStableMessagingSemconv()
+                        ? MessageOperation.CREATE
+                        : MessageOperation.PUBLISH,
                     capturedHeaders))
             .buildInstrumenter(SpanKindExtractor.alwaysProducer());
     return new SpringIntegrationTelemetry(

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
@@ -6,12 +6,15 @@
 package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesGetter;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.amqp.core.Message;
 
-enum SpringRabbitMessageAttributesGetter implements MessagingAttributesGetter<Message, Void> {
+enum SpringRabbitMessageAttributesGetter
+    implements
+        MessagingAttributesGetter<Message, Void>, MessagingNetworkAttributesGetter<Message, Void> {
   INSTANCE;
 
   @Override

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -27,11 +28,12 @@ public final class SpringRabbitSingletons {
         Instrumenter.<Message, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operation, getter))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(getter, operation)
                     .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build())
+            .addAttributesExtractor(MessagingNetworkAttributesExtractor.create(getter))
             .buildConsumerInstrumenter(MessageHeaderGetter.INSTANCE);
   }
 


### PR DESCRIPTION
Update Messaging span with the latest semantic conventions.
https://github.com/open-telemetry/semantic-conventions/blob/v1.30.0/docs/messaging/messaging-spans.md

By default nothing changes, it adheres to this:

> * SHOULD introduce an environment variable `OTEL_SEMCONV_STABILITY_OPT_IN`
>   in the existing major version which is a comma-separated list of values.
>   The list of values includes:
>   * `messaging` - emit the new, stable messaging conventions,
>     and stop emitting the old experimental messaging conventions
>     that the instrumentation emitted previously.
>   * `messaging/dup` - emit both the old and the stable messaging conventions,
>     allowing for a seamless transition.
>   * The default behavior (in the absence of one of these values) is to continue
>     emitting whatever version of the old experimental messaging conventions
>     the instrumentation was emitting previously.
>   * Note: `messaging/dup` has higher precedence than `messaging` in case both values are present

