### PR TITLE
Renovate pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
   ],
   "ignorePaths": ["instrumentation/**"],
   // needed in order to get patch-only updates in package rules below


### PR DESCRIPTION
I _think_ this should make renovate pin docker and github actions that we haven't already pinned ourselves, e.g. https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13213/files#diff-494ad93a111989e335f16b3af92b63b59592f463bb9c01c74c09eda5a3fdebaaR1