### PR TITLE
Hopefully fix flaky logback async test

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -112,8 +112,9 @@ testing {
         } else {
           implementation("ch.qos.logback:logback-classic") {
             version {
-              // first version that has ch.qos.logback.classic.AsyncAppender
-              strictly("1.0.4")
+              // 1.0.4 is the first version that has ch.qos.logback.classic.AsyncAppender
+              // we are using 1.0.7 because of https://jira.qos.ch/browse/LOGBACK-720
+              strictly("1.0.7")
             }
           }
           implementation("org.slf4j:slf4j-api") {


### PR DESCRIPTION
https://scans.gradle.com/s/kzn5f3zht6f36/tests/task/:instrumentation:logback:logback-appender-1.0:library:asyncAppenderTest/details/io.opentelemetry.instrumentation.logback.appender.v1_0.AsyncOpenTelemetryAppenderTest/captureLogMessage()
I guess we are running into the race described in https://jira.qos.ch/browse/LOGBACK-720