### PR TITLE
Allow manually running ossf scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -6,6 +6,7 @@ on:
       - main
   schedule:
     - cron: "43 6 * * 5" # weekly at 06:43 (UTC) on Friday
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
I suspect the Branch-Protection rule is failing because of something related to the repo settings, so would be helpful to be able to make setting changes and re-run manually for testing.