### PR TITLE
Insert OpenTelemetry phase before Setup

### DIFF
--- a/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/internal/KtorServerTelemetryUtil.kt
@@ -33,7 +33,7 @@ object KtorServerTelemetryUtil {
     val tracer = KtorServerTracer(instrumenter)
     val startPhase = PipelinePhase("OpenTelemetry")
 
-    application.insertPhaseBefore(ApplicationCallPipeline.Monitoring, startPhase)
+    application.insertPhaseBefore(ApplicationCallPipeline.Setup, startPhase)
     application.intercept(startPhase) {
       val context = tracer.start(call)
 

--- a/instrumentation/ktor/ktor-3.0/library/README.md
+++ b/instrumentation/ktor/ktor-3.0/library/README.md
@@ -32,7 +32,7 @@ implementation("io.opentelemetry.instrumentation:opentelemetry-ktor-3.0:OPENTELE
 
 ## Initializing server instrumentation
 
-Initialize instrumentation by installing the `KtorServerTelemetry` feature. Make sure that no other 
+Initialize instrumentation by installing the `KtorServerTelemetry` feature. Make sure that no other
 logging plugin is installed before this.
 You must set the `OpenTelemetry` to use with the feature.
 

--- a/instrumentation/ktor/ktor-3.0/library/README.md
+++ b/instrumentation/ktor/ktor-3.0/library/README.md
@@ -32,7 +32,8 @@ implementation("io.opentelemetry.instrumentation:opentelemetry-ktor-3.0:OPENTELE
 
 ## Initializing server instrumentation
 
-Initialize instrumentation by installing the `KtorServerTelemetry` feature.
+Initialize instrumentation by installing the `KtorServerTelemetry` feature. Make sure that no other 
+logging plugin is installed before this.
 You must set the `OpenTelemetry` to use with the feature.
 
 ```kotlin

--- a/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpServerTest.kt
@@ -5,9 +5,13 @@
 
 package io.opentelemetry.instrumentation.ktor.v3_0
 
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
+import io.ktor.server.application.hooks.CallFailed
+import io.ktor.server.response.respondText
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class KtorHttpServerTest : AbstractKtorHttpServerTest() {
@@ -27,6 +31,12 @@ class KtorHttpServerTest : AbstractKtorHttpServerTest() {
         capturedRequestHeaders(TEST_REQUEST_HEADER)
         capturedResponseHeaders(TEST_RESPONSE_HEADER)
       }
+
+      install(createRouteScopedPlugin("Failure handler, that can mask exceptions if exception handling is in the wrong phase", ServerEndpoint.EXCEPTION.path, {}) {
+        on(CallFailed) { call, cause ->
+          call.respondText("failure: ${cause.message}", status = HttpStatusCode.InternalServerError)
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
Fixes #13237 

The root cause of the issue is that the tracing context is applied too late in the pipeline (`Monitoring` phase). I moved it before the `Setup` phase so that the tracing setup becomes the first thing that happens during processing.

The `Monitoring` phase is still important because it allows us to check if the call finished without errors. If this got moved to the `Setup` phase along with the tracing setup, it'd mean that exception handling in `CallFailed` hooks would mask the error, and it wouldn't be reported.