### PR TITLE
Revert "Remove (hopefully) unnecessary workflow lines"

### DIFF
--- a/.github/workflows/build-daily-no-build-cache.yml
+++ b/.github/workflows/build-daily-no-build-cache.yml
@@ -39,6 +39,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - common

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -42,6 +42,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - common

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   analyze:
     permissions:
+      contents: read
       actions: read  # for github/codeql-action/init to get workflow details
       security-events: write  # for github/codeql-action/analyze to upload SARIF results
     runs-on: otel-linux-latest-8-cores

--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   issue_comment:
     permissions:
+      contents: read
       issues: write
     if: >
       contains(github.event.issue.labels.*.name, 'needs author feedback') &&

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   stale:
     permissions:
+      contents: read
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,6 +8,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/native-tests-daily.yml
+++ b/.github/workflows/native-tests-daily.yml
@@ -17,6 +17,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - graalvm-native-tests

--- a/.github/workflows/overhead-benchmark-daily.yml
+++ b/.github/workflows/overhead-benchmark-daily.yml
@@ -56,6 +56,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - run-overhead-tests

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -44,6 +44,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - analyze

--- a/.github/workflows/publish-petclinic-benchmark-image.yml
+++ b/.github/workflows/publish-petclinic-benchmark-image.yml
@@ -14,6 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-smoke-test-early-jdk8-images.yml
+++ b/.github/workflows/publish-smoke-test-early-jdk8-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +48,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publishLinux:
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +48,7 @@ jobs:
 
   publishWindows:
     permissions:
+      contents: read
       packages: write
     runs-on: windows-latest
     defaults:
@@ -82,6 +84,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publishLinux

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/reusable-publish-smoke-test-images.yml
     with:
@@ -22,6 +23,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/reusable-publish-smoke-test-images.yml
     with:
@@ -22,6 +23,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/reusable-publish-smoke-test-images.yml
     with:
@@ -25,6 +26,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-security-manager-images.yml
+++ b/.github/workflows/publish-smoke-test-security-manager-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/reusable-publish-smoke-test-images.yml
     with:
@@ -22,6 +23,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -24,6 +24,7 @@ jobs:
 
   publish:
     permissions:
+      contents: read
       packages: write
     needs: prepare
     runs-on: ${{ matrix.os }}
@@ -87,6 +88,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish:
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/reusable-publish-smoke-test-images.yml
     with:
@@ -22,6 +23,7 @@ jobs:
 
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     needs:
       - publish

--- a/.github/workflows/reusable-publish-smoke-test-images.yml
+++ b/.github/workflows/reusable-publish-smoke-test-images.yml
@@ -36,6 +36,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   workflow-notification:
     permissions:
+      contents: read
       issues: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java-instrumentation#13241

It was a good try, but these are needed when calling a reusable workflow, so may as well keep them all for consistency.

> [Invalid workflow file: .github/workflows/publish-smoke-test-servlet-images.yml#L88](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/13201868570/workflow)
The workflow is not valid. .github/workflows/publish-smoke-test-servlet-images.yml (Line: 88, Col: 3): Error calling workflow 'open-telemetry/opentelemetry-java-instrumentation/.github/workflows/reusable-workflow-notification.yml@1aea4554cebfcfa15500ed77ae8b4c013dce1d15'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.

this is my understanding of the issue:

* the non-presence of a permission on the job removes the workflow-level permission (as opposed to being additive)
* since our repos are public, normally you don't need to specify `contents: read` anyways
* when calling reusable workflows though there appears to be some validation that fails if you haven't specified `contents: read` on the job that is calling the reusable workflow