### PR TITLE
Disable exporters for tests in the javaagent module

### DIFF
--- a/benchmark-overhead-jmh/build.gradle.kts
+++ b/benchmark-overhead-jmh/build.gradle.kts
@@ -53,6 +53,7 @@ tasks {
       "-javaagent:${shadowTask.archiveFile.get()}",
       "-Dotel.traces.exporter=none",
       "-Dotel.metrics.exporter=none",
+      "-Dotel.logs.exporter=none",
       // avoid instrumenting HttpURLConnection for now since it is used to make the requests
       // and this benchmark is focused on servlet overhead for now
       "-Dotel.instrumentation.http-url-connection.enabled=false",

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -253,6 +253,9 @@ tasks {
     dependsOn(shadowJar)
 
     jvmArgs("-Dotel.javaagent.debug=true")
+    jvmArgs("-Dotel.traces.exporter=none")
+    jvmArgs("-Dotel.metrics.exporter=none")
+    jvmArgs("-Dotel.logs.exporter=none")
 
     jvmArgumentProviders.add(JavaagentProvider(shadowJar.flatMap { it.archiveFile }))
 


### PR DESCRIPTION
Tests in the `javaagent` module run with the agent but without our testing extension. All export attempts fail and pollute output.