### PR TITLE
Fix test failure with indy

### DIFF
--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
@@ -43,7 +43,7 @@ public class OpenTelemetryMeterRegistryAutoConfiguration {
 
   @Bean
   // static to avoid "is not eligible for getting processed by all BeanPostProcessors" warning
-  static BeanPostProcessor postProcessCompositeMeterRegistry() {
+  public static BeanPostProcessor postProcessCompositeMeterRegistry() {
     return new BeanPostProcessor() {
       @Override
       public Object postProcessAfterInitialization(Object bean, String beanName) {

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
@@ -43,6 +43,8 @@ public class OpenTelemetryMeterRegistryAutoConfiguration {
 
   @Bean
   // static to avoid "is not eligible for getting processed by all BeanPostProcessors" warning
+  // must be public because this class is injected as a proxy when using non-inlined advice and that
+  // proxy contains only public methods
   public static BeanPostProcessor postProcessCompositeMeterRegistry() {
     return new BeanPostProcessor() {
       @Override


### PR DESCRIPTION
https://scans.gradle.com/s/yav7egkq4lf4e/tests/task/:instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.spring.actuator.v2_0.ActuatorTest/shouldInjectOtelMeterRegistry()?expanded-stacktrace=WyIwIl0&top-execution=1

With indy `OpenTelemetryMeterRegistryAutoConfiguration` is injected into the app class loader as proxy. Didn't try to debug this but probably forwarding a package private method runs into some sort of access restriction or perhaps is excluded from the proxy, at least the original method doesn't get called. Verified that it is called when it is public.