### PR TITLE
Fix release branch builds

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -191,6 +191,8 @@ jobs:
         run: ./gradlew check spdxSbom -x javadoc -x spotlessCheck -PskipTests=true ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
 
       - name: Check for jApiCmp diffs
+        # The jApiCmp diff compares current to latest, which isn't appropriate for release branches
+        if: ${{ !startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/') }}
         run: |
           # need to "git add" in case any generated files did not already exist
           git add docs/apidiffs


### PR DESCRIPTION
core repo already has this check

https://github.com/open-telemetry/opentelemetry-java/blob/3e1d9536f80603ce00a421b8e1cbc4cd82126738/.github/workflows/build.yml#L85-L88

we don't need the windows check here since we only run this on linux already

and I'm not sure why the opentelemetrybot check would be needed so left that out