### PR TITLE
Fix another release workflow step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,8 @@ jobs:
                        --base main
 
   update-apidiff-baseline-to-released-version:
+    permissions:
+      contents: write # for git push to PR branch
     runs-on: ubuntu-latest
     needs:
       - release


### PR DESCRIPTION
(will do the apidiff step manually for v2.13.0)