### PR TITLE
[Spring Scheduling] Support Virtual Threads

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
@@ -24,6 +24,7 @@ public class TaskSchedulerInstrumentation implements TypeInstrumentation {
     return namedOneOf(
         "org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler",
         "org.springframework.scheduling.concurrent.ConcurrentTaskScheduler",
+        "org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler",
         "org.springframework.scheduling.commonj.TimerManagerTaskScheduler");
   }
 


### PR DESCRIPTION
Spring uses a different TaskScheduler when using virtual threads. See the `org.springframework.boot.autoconfigure.task.TaskSchedulerConfiguration` below:

```java
static class TaskSchedulerConfiguration {
        @Bean(name = "taskScheduler")
        @ConditionalOnThreading(Threading.VIRTUAL)
        SimpleAsyncTaskScheduler taskSchedulerVirtualThreads(SimpleAsyncTaskSchedulerBuilder builder) {
	        return builder.build();
        }
        
        @Bean
        @SuppressWarnings({ "deprecation", "removal" })
        @ConditionalOnThreading(Threading.PLATFORM)
        ThreadPoolTaskScheduler taskScheduler(org.springframework.boot.task.TaskSchedulerBuilder taskSchedulerBuilder,
		        ObjectProvider<ThreadPoolTaskSchedulerBuilder> threadPoolTaskSchedulerBuilderProvider) {
	        ThreadPoolTaskSchedulerBuilder threadPoolTaskSchedulerBuilder = threadPoolTaskSchedulerBuilderProvider
		        .getIfUnique();
	        if (threadPoolTaskSchedulerBuilder != null) {
		        return threadPoolTaskSchedulerBuilder.build();
	        }
	        return taskSchedulerBuilder.build();
        }
}
```

This Change adds the `SimpleAsyncTaskScheduler` to the instrumented classes