### PR TITLE
fix semconv naming for 'jvm.buffer.memory.used' metric

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/README.md
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/README.md
@@ -37,7 +37,7 @@ default, and the telemetry each produces:
 
 | JfrFeature                | Default Enabled | Metrics                                                                                                           |
 |---------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------|
-| BUFFER_METRICS            | `false`         | `jvm.buffer.count`, `jvm.buffer.memory.limit`, `jvm.buffer.memory.usage`                                          |
+| BUFFER_METRICS            | `false`         | `jvm.buffer.count`, `jvm.buffer.memory.limit`, `jvm.buffer.memory.used`                                           |
 | CLASS_LOAD_METRICS        | `false`         | `jvm.class.count`, `jvm.class.loaded`, `jvm.class.unloaded`                                                       |
 | CONTEXT_SWITCH_METRICS    | `true`          | `jvm.cpu.context_switch`                                                                                          |
 | CPU_COUNT_METRICS         | `true`          | `jvm.cpu.limit`                                                                                                   |

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/buffer/DirectBufferStatisticsHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/buffer/DirectBufferStatisticsHandler.java
@@ -22,7 +22,7 @@ import jdk.jfr.consumer.RecordedEvent;
  * any time.
  */
 public final class DirectBufferStatisticsHandler implements RecordedEventHandler {
-  private static final String METRIC_NAME_USAGE = "jvm.buffer.memory.usage";
+  private static final String METRIC_NAME_USAGE = "jvm.buffer.memory.used";
   private static final String METRIC_NAME_LIMIT = "jvm.buffer.memory.limit";
   private static final String METRIC_NAME_COUNT = "jvm.buffer.count";
   private static final String METRIC_DESCRIPTION_USAGE = "Measure of memory used by buffers.";

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/BufferMetricTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/BufferMetricTest.java
@@ -72,7 +72,7 @@ class BufferMetricTest {
                                     }))),
         metric ->
             metric
-                .hasName("jvm.buffer.memory.usage")
+                .hasName("jvm.buffer.memory.used")
                 .hasDescription("Measure of memory used by buffers.")
                 .hasUnit(BYTES)
                 .hasLongSumSatisfying(

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPools.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPools.java
@@ -45,7 +45,7 @@ public final class ExperimentalBufferPools {
     Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
     observables.add(
         meter
-            .upDownCounterBuilder("jvm.buffer.memory.usage")
+            .upDownCounterBuilder("jvm.buffer.memory.used")
             .setDescription("Measure of memory used by buffers.")
             .setUnit("By")
             .buildWithCallback(callback(bufferBeans, BufferPoolMXBean::getMemoryUsed)));

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPoolsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPoolsTest.java
@@ -56,7 +56,7 @@ class ExperimentalBufferPoolsTest {
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",
-        "jvm.buffer.memory.usage",
+        "jvm.buffer.memory.used",
         metrics ->
             metrics.anySatisfy(
                 metricData ->


### PR DESCRIPTION
When the stable and experimental JVM metrics were introduced with [release 2.0.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md#version-200-2024-01-12), the `jvm.buffer.memory.usage` metric was not properly renamed to `jvm.buffer.memory.used` and thus does not fit the [expected semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmbuffermemoryused).

This PR renames the metric to fit the definition in semantic conventions.

This is still an experimental metric, and while there hasn't had any bug report of this inconsistency in about a year, it's technically a breaking change.