### PR TITLE
Add support for ConverseStream to bedrock instrumentation

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -103,6 +103,11 @@ dependencies {
   library("software.amazon.awssdk:aws-core:2.2.0")
   library("software.amazon.awssdk:sqs:2.2.0")
 
+  // Don't use library to make sure base test is run with the floor version.
+  // bedrock runtime is tested separately in testBedrockRuntime.
+  // First release with Converse API
+  compileOnly("software.amazon.awssdk:bedrockruntime:2.25.63")
+
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
   testImplementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/BedrockRuntimeInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/BedrockRuntimeInstrumentationModule.java
@@ -11,7 +11,10 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.BedrockRuntimeAdviceBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.ArrayList;
+import java.util.List;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -25,6 +28,13 @@ public class BedrockRuntimeInstrumentationModule extends AbstractAwsSdkInstrumen
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassesNamed("software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    List<TypeInstrumentation> instrumentations = new ArrayList<>(super.typeInstrumentations());
+    instrumentations.add(new DefaultBedrockRuntimeAsyncClientBuilderInstrumentation());
+    return instrumentations;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/DefaultBedrockRuntimeAsyncClientBuilderInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/DefaultBedrockRuntimeAsyncClientBuilderInstrumentation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.instrumentation.awssdk.v2_2.autoconfigure.AwsSdkSingletons;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+
+public class DefaultBedrockRuntimeAsyncClientBuilderInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named(
+        "software.amazon.awssdk.services.bedrockruntime.DefaultBedrockRuntimeAsyncClientBuilder");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("buildClient"), this.getClass().getName() + "$BuildClientAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class BuildClientAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void methodExit(
+        @Advice.Return(readOnly = false) BedrockRuntimeAsyncClient client) {
+      client = AwsSdkSingletons.telemetry().wrapBedrockRuntimeClient(client);
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 
 class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
   @RegisterExtension
@@ -23,5 +24,11 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
   @Override
   protected ClientOverrideConfiguration.Builder createOverrideConfigurationBuilder() {
     return ClientOverrideConfiguration.builder();
+  }
+
+  @Override
+  protected BedrockRuntimeAsyncClient configureBedrockRuntimeClient(
+      BedrockRuntimeAsyncClient client) {
+    return client;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetry.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetry.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkInstrumenterFactory;
+import io.opentelemetry.instrumentation.awssdk.v2_2.internal.BedrockRuntimeImpl;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.Response;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.SqsImpl;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.SqsProcessRequest;
@@ -20,6 +21,7 @@ import javax.annotation.Nullable;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
@@ -27,6 +29,14 @@ import software.amazon.awssdk.services.sqs.SqsClient;
  * Entrypoint to OpenTelemetry instrumentation of the AWS SDK. Register the {@link
  * ExecutionInterceptor} returned by {@link #newExecutionInterceptor()} with an SDK client to have
  * all requests traced.
+ *
+ * <p>Certain services additionally require wrapping the SDK client itself:
+ *
+ * <ul>
+ *   <li>SQSClient - {@link #wrap(SqsClient)}
+ *   <li>SQSAsyncClient - {@link #wrap(SqsAsyncClient)}
+ *   <li>BedrockRuntimeAsyncClient - {@link #wrapBedrockRuntimeClient(BedrockRuntimeAsyncClient)}
+ * </ul>
  *
  * <pre>{@code
  * DynamoDbClient dynamoDb = DynamoDbClient.builder()
@@ -125,5 +135,15 @@ public class AwsSdkTelemetry {
   @NoMuzzle
   public SqsAsyncClient wrap(SqsAsyncClient sqsClient) {
     return SqsImpl.wrap(sqsClient);
+  }
+
+  /**
+   * Construct a new tracing-enabled {@link BedrockRuntimeAsyncClient} using the provided {@link
+   * BedrockRuntimeAsyncClient} instance.
+   */
+  @NoMuzzle
+  public BedrockRuntimeAsyncClient wrapBedrockRuntimeClient(
+      BedrockRuntimeAsyncClient bedrockClient) {
+    return BedrockRuntimeImpl.wrap(bedrockClient);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
@@ -9,7 +9,6 @@ import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
 import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
-import software.amazon.awssdk.core.SdkResponse;
 
 final class BedrockRuntimeAccess {
   private BedrockRuntimeAccess() {}
@@ -69,19 +68,19 @@ final class BedrockRuntimeAccess {
 
   @Nullable
   @NoMuzzle
-  static String getStopReason(SdkResponse response) {
-    return enabled ? BedrockRuntimeImpl.getStopReason(response) : null;
+  static List<String> getStopReasons(Response response) {
+    return enabled ? BedrockRuntimeImpl.getStopReasons(response) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Long getUsageInputTokens(SdkResponse response) {
+  static Long getUsageInputTokens(Response response) {
     return enabled ? BedrockRuntimeImpl.getUsageInputTokens(response) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Long getUsageOutputTokens(SdkResponse response) {
+  static Long getUsageOutputTokens(Response response) {
     return enabled ? BedrockRuntimeImpl.getUsageOutputTokens(response) : null;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesGetter;
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -37,6 +36,8 @@ enum BedrockRuntimeAttributesGetter
     if (operation != null) {
       switch (operation) {
         case "Converse":
+        // fallthrough
+        case "ConverseStream":
           return GenAiOperationNameIncubatingValues.CHAT;
         default:
           return null;
@@ -117,11 +118,11 @@ enum BedrockRuntimeAttributesGetter
   @Override
   public List<String> getResponseFinishReasons(
       ExecutionAttributes executionAttributes, Response response) {
-    String stopReason = BedrockRuntimeAccess.getStopReason(response.getSdkResponse());
-    if (stopReason == null) {
+    List<String> stopReasons = BedrockRuntimeAccess.getStopReasons(response);
+    if (stopReasons == null) {
       return null;
     }
-    return Arrays.asList(stopReason);
+    return stopReasons;
   }
 
   @Nullable
@@ -139,12 +140,12 @@ enum BedrockRuntimeAttributesGetter
   @Nullable
   @Override
   public Long getUsageInputTokens(ExecutionAttributes executionAttributes, Response response) {
-    return BedrockRuntimeAccess.getUsageInputTokens(response.getSdkResponse());
+    return BedrockRuntimeAccess.getUsageInputTokens(response);
   }
 
   @Nullable
   @Override
   public Long getUsageOutputTokens(ExecutionAttributes executionAttributes, Response response) {
-    return BedrockRuntimeAccess.getUsageOutputTokens(response.getSdkResponse());
+    return BedrockRuntimeAccess.getUsageOutputTokens(response);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
@@ -5,21 +5,45 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.ImplicitContextKeyed;
+import io.opentelemetry.context.Scope;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
 import software.amazon.awssdk.services.bedrockruntime.model.InferenceConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
 import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 
-final class BedrockRuntimeImpl {
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class BedrockRuntimeImpl {
   private BedrockRuntimeImpl() {}
 
   static boolean isBedrockRuntimeRequest(SdkRequest request) {
     if (request instanceof ConverseRequest) {
+      return true;
+    }
+    if (request instanceof ConverseStreamRequest) {
       return true;
     }
     return false;
@@ -30,82 +54,121 @@ final class BedrockRuntimeImpl {
     if (request instanceof ConverseRequest) {
       return ((ConverseRequest) request).modelId();
     }
+    if (request instanceof ConverseStreamRequest) {
+      return ((ConverseStreamRequest) request).modelId();
+    }
     return null;
   }
 
   @Nullable
   static Long getMaxTokens(SdkRequest request) {
+    InferenceConfiguration config = null;
     if (request instanceof ConverseRequest) {
-      InferenceConfiguration config = ((ConverseRequest) request).inferenceConfig();
-      if (config != null) {
-        return integerToLong(config.maxTokens());
-      }
+      config = ((ConverseRequest) request).inferenceConfig();
+    }
+    if (request instanceof ConverseStreamRequest) {
+      config = ((ConverseStreamRequest) request).inferenceConfig();
+    }
+    if (config != null) {
+      return integerToLong(config.maxTokens());
     }
     return null;
   }
 
   @Nullable
   static Double getTemperature(SdkRequest request) {
+    InferenceConfiguration config = null;
     if (request instanceof ConverseRequest) {
-      InferenceConfiguration config = ((ConverseRequest) request).inferenceConfig();
-      if (config != null) {
-        return floatToDouble(config.temperature());
-      }
+      config = ((ConverseRequest) request).inferenceConfig();
+    }
+    if (request instanceof ConverseStreamRequest) {
+      config = ((ConverseStreamRequest) request).inferenceConfig();
+    }
+    if (config != null) {
+      return floatToDouble(config.temperature());
     }
     return null;
   }
 
   @Nullable
   static Double getTopP(SdkRequest request) {
+    InferenceConfiguration config = null;
     if (request instanceof ConverseRequest) {
-      InferenceConfiguration config = ((ConverseRequest) request).inferenceConfig();
-      if (config != null) {
-        return floatToDouble(config.topP());
-      }
+      config = ((ConverseRequest) request).inferenceConfig();
+    }
+    if (request instanceof ConverseStreamRequest) {
+      config = ((ConverseStreamRequest) request).inferenceConfig();
+    }
+    if (config != null) {
+      return floatToDouble(config.topP());
     }
     return null;
   }
 
   @Nullable
   static List<String> getStopSequences(SdkRequest request) {
+    InferenceConfiguration config = null;
     if (request instanceof ConverseRequest) {
-      InferenceConfiguration config = ((ConverseRequest) request).inferenceConfig();
-      if (config != null) {
-        return config.stopSequences();
-      }
+      config = ((ConverseRequest) request).inferenceConfig();
+    }
+    if (request instanceof ConverseStreamRequest) {
+      config = ((ConverseStreamRequest) request).inferenceConfig();
+    }
+    if (config != null) {
+      return config.stopSequences();
     }
     return null;
   }
 
   @Nullable
-  static String getStopReason(SdkResponse response) {
-    if (response instanceof ConverseResponse) {
-      StopReason reason = ((ConverseResponse) response).stopReason();
+  static List<String> getStopReasons(Response response) {
+    SdkResponse sdkResponse = response.getSdkResponse();
+    if (sdkResponse instanceof ConverseResponse) {
+      StopReason reason = ((ConverseResponse) sdkResponse).stopReason();
       if (reason != null) {
-        return reason.toString();
+        return Collections.singletonList(reason.toString());
       }
+    }
+    TracingConverseStreamResponseHandler streamHandler =
+        TracingConverseStreamResponseHandler.fromContext(response.otelContext());
+    if (streamHandler != null) {
+      return streamHandler.stopReasons;
     }
     return null;
   }
 
   @Nullable
-  static Long getUsageInputTokens(SdkResponse response) {
-    if (response instanceof ConverseResponse) {
-      TokenUsage usage = ((ConverseResponse) response).usage();
-      if (usage != null) {
-        return integerToLong(usage.inputTokens());
-      }
+  static Long getUsageInputTokens(Response response) {
+    SdkResponse sdkResponse = response.getSdkResponse();
+    TokenUsage usage = null;
+    if (sdkResponse instanceof ConverseResponse) {
+      usage = ((ConverseResponse) sdkResponse).usage();
+    }
+    TracingConverseStreamResponseHandler streamHandler =
+        TracingConverseStreamResponseHandler.fromContext(response.otelContext());
+    if (streamHandler != null) {
+      usage = streamHandler.usage;
+    }
+    if (usage != null) {
+      return integerToLong(usage.inputTokens());
     }
     return null;
   }
 
   @Nullable
-  static Long getUsageOutputTokens(SdkResponse response) {
-    if (response instanceof ConverseResponse) {
-      TokenUsage usage = ((ConverseResponse) response).usage();
-      if (usage != null) {
-        return integerToLong(usage.outputTokens());
-      }
+  static Long getUsageOutputTokens(Response response) {
+    SdkResponse sdkResponse = response.getSdkResponse();
+    TokenUsage usage = null;
+    if (sdkResponse instanceof ConverseResponse) {
+      usage = ((ConverseResponse) sdkResponse).usage();
+    }
+    TracingConverseStreamResponseHandler streamHandler =
+        TracingConverseStreamResponseHandler.fromContext(response.otelContext());
+    if (streamHandler != null) {
+      usage = streamHandler.usage;
+    }
+    if (usage != null) {
+      return integerToLong(usage.outputTokens());
     }
     return null;
   }
@@ -124,5 +187,100 @@ final class BedrockRuntimeImpl {
       return null;
     }
     return Double.valueOf(value);
+  }
+
+  public static BedrockRuntimeAsyncClient wrap(BedrockRuntimeAsyncClient asyncClient) {
+    // proxy BedrockRuntimeAsyncClient so we can wrap the subscriber to converseStream to capture
+    // events.
+    return (BedrockRuntimeAsyncClient)
+        Proxy.newProxyInstance(
+            asyncClient.getClass().getClassLoader(),
+            new Class<?>[] {BedrockRuntimeAsyncClient.class},
+            (proxy, method, args) -> {
+              if (method.getName().equals("converseStream")
+                  && args.length >= 2
+                  && args[1] instanceof ConverseStreamResponseHandler) {
+                TracingConverseStreamResponseHandler wrapped =
+                    new TracingConverseStreamResponseHandler(
+                        (ConverseStreamResponseHandler) args[1]);
+                args[1] = wrapped;
+                try (Scope ignored = wrapped.makeCurrent()) {
+                  return invokeProxyMethod(method, asyncClient, args);
+                }
+              }
+              return invokeProxyMethod(method, asyncClient, args);
+            });
+  }
+
+  private static Object invokeProxyMethod(Method method, Object target, Object[] args)
+      throws Throwable {
+    try {
+      return method.invoke(target, args);
+    } catch (InvocationTargetException exception) {
+      throw exception.getCause();
+    }
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class TracingConverseStreamResponseHandler
+      implements ConverseStreamResponseHandler, ImplicitContextKeyed {
+
+    @Nullable
+    public static TracingConverseStreamResponseHandler fromContext(Context context) {
+      return context.get(KEY);
+    }
+
+    private static final ContextKey<TracingConverseStreamResponseHandler> KEY =
+        ContextKey.named("bedrock-runtime-converse-stream-response-handler");
+
+    private final ConverseStreamResponseHandler delegate;
+
+    List<String> stopReasons;
+    TokenUsage usage;
+
+    TracingConverseStreamResponseHandler(ConverseStreamResponseHandler delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void responseReceived(ConverseStreamResponse converseStreamResponse) {
+      delegate.responseReceived(converseStreamResponse);
+    }
+
+    @Override
+    public void onEventStream(SdkPublisher<ConverseStreamOutput> sdkPublisher) {
+      delegate.onEventStream(
+          sdkPublisher.map(
+              event -> {
+                if (event instanceof MessageStopEvent) {
+                  if (stopReasons == null) {
+                    stopReasons = new ArrayList<>();
+                  }
+                  stopReasons.add(((MessageStopEvent) event).stopReasonAsString());
+                }
+                if (event instanceof ConverseStreamMetadataEvent) {
+                  usage = ((ConverseStreamMetadataEvent) event).usage();
+                }
+                return event;
+              }));
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable throwable) {
+      delegate.exceptionOccurred(throwable);
+    }
+
+    @Override
+    public void complete() {
+      delegate.complete();
+    }
+
+    @Override
+    public Context storeInContext(Context context) {
+      return context.with(KEY, this);
+    }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Response.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Response.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import io.opentelemetry.context.Context;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
@@ -15,14 +16,20 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 public final class Response {
   private final SdkHttpResponse sdkHttpResponse;
   private final SdkResponse sdkResponse;
+  private final Context otelContext;
 
   Response(SdkHttpResponse sdkHttpResponse) {
     this(sdkHttpResponse, null);
   }
 
   Response(SdkHttpResponse sdkHttpResponse, SdkResponse sdkResponse) {
+    this(sdkHttpResponse, sdkResponse, null);
+  }
+
+  Response(SdkHttpResponse sdkHttpResponse, SdkResponse sdkResponse, Context otelContext) {
     this.sdkHttpResponse = sdkHttpResponse;
     this.sdkResponse = sdkResponse;
+    this.otelContext = otelContext;
   }
 
   public SdkHttpResponse getSdkHttpResponse() {
@@ -31,5 +38,9 @@ public final class Response {
 
   public SdkResponse getSdkResponse() {
     return sdkResponse;
+  }
+
+  public Context otelContext() {
+    return otelContext;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
@@ -366,7 +366,10 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
           executionAttributes, otelContext, Span.fromContext(otelContext), httpResponse);
       RequestSpanFinisher finisher = executionAttributes.getAttribute(REQUEST_FINISHER_ATTRIBUTE);
       finisher.finish(
-          otelContext, executionAttributes, new Response(httpResponse, context.response()), null);
+          otelContext,
+          executionAttributes,
+          new Response(httpResponse, context.response(), otelContext),
+          null);
     }
     clearAttributes(executionAttributes);
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 
 class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
 
@@ -35,5 +36,11 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
   protected ClientOverrideConfiguration.Builder createOverrideConfigurationBuilder() {
     return ClientOverrideConfiguration.builder()
         .addExecutionInterceptor(telemetry.newExecutionInterceptor());
+  }
+
+  @Override
+  protected BedrockRuntimeAsyncClient configureBedrockRuntimeClient(
+      BedrockRuntimeAsyncClient client) {
+    return telemetry.wrapBedrockRuntimeClient(client);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testconversestream.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testconversestream.yaml
@@ -1,0 +1,56 @@
+---
+id: 56110546-3b1d-4466-aebd-369edf2293a1
+name: model_amazontitan-text-lite-v1_converse-stream
+request:
+  url: /model/amazon.titan-text-lite-v1/converse-stream
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "role" : "user",
+          "content" : [ {
+            "text" : "Say this is a test"
+          } ]
+        } ]
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  base64Body: AAAArAAAAFJVkJ0mCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVIiwicm9sZSI6ImFzc2lzdGFudCJ9mBqgYwAAAPIAAABXotkYAws6ZXZlbnQtdHlwZQcAEWNvbnRlbnRCbG9ja0RlbHRhDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiY29udGVudEJsb2NrSW5kZXgiOjAsImRlbHRhIjp7InRleHQiOiJIZWxsbyEgSSdtIHNvcnJ5LCBidXQgSSdtIG5vdCBzdXJlIHdoYXQgeW91IG1lYW4uIENhbiB5b3UgcGxlYXNlIGNsYXJpZnkgeW91ciBxdWVzdGlvbj8ifSwicCI6ImFiIn149OkZAAAAsQAAAFbKjQoMCzpldmVudC10eXBlBwAQY29udGVudEJsb2NrU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTIn1DzHT/AAAAhQAAAFEASIHpCzpldmVudC10eXBlBwALbWVzc2FnZVN0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJwIjoiYWJjZCIsInN0b3BSZWFzb24iOiJlbmRfdHVybiJ9HPrdBQAAAOUAAABOFHL7UQs6ZXZlbnQtdHlwZQcACG1ldGFkYXRhDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsibWV0cmljcyI6eyJsYXRlbmN5TXMiOjEyNzF9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKSyIsInVzYWdlIjp7ImlucHV0VG9rZW5zIjo4LCJvdXRwdXRUb2tlbnMiOjI2LCJ0b3RhbFRva2VucyI6MzR9fS4T3UI=
+  headers:
+    Date: "Thu, 27 Feb 2025 03:57:58 GMT"
+    Content-Type: application/vnd.amazon.eventstream
+    x-amzn-RequestId: afce5691-7115-4abb-87a0-8dff8ed025f1
+uuid: 56110546-3b1d-4466-aebd-369edf2293a1
+persistent: true
+insertionIndex: 6
+---
+id: 82987a12-fd54-4e35-a1d5-c19780fa69a5
+name: model_amazontitan-text-lite-v1_converse-stream
+request:
+  url: /model/amazon.titan-text-lite-v1/converse-stream
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "role" : "user",
+          "content" : [ {
+            "text" : "Say this is a test"
+          } ]
+        } ]
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  base64Body: AAAAiwAAAFImcW4yCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1uIiwicm9sZSI6ImFzc2lzdGFudCJ9uwonDAAAAK4AAABXXzo6yQs6ZXZlbnQtdHlwZQcAEWNvbnRlbnRCbG9ja0RlbHRhDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiY29udGVudEJsb2NrSW5kZXgiOjAsImRlbHRhIjp7InRleHQiOiJcIlRlc3QsIHRlc3RcIiJ9LCJwIjoiYWJjZGVmZyJ9t6q0lwAAALUAAABWPw2szAs6ZXZlbnQtdHlwZQcAEGNvbnRlbnRCbG9ja1N0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVlcifY0Un70AAACNAAAAUTA4yigLOmV2ZW50LXR5cGUHAAttZXNzYWdlU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7InAiOiJhYmNkZWZnaGlqa2wiLCJzdG9wUmVhc29uIjoiZW5kX3R1cm4ifS7bVN0AAADbAAAATgpj/bYLOmV2ZW50LXR5cGUHAAhtZXRhZGF0YQ06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7Im1ldHJpY3MiOnsibGF0ZW5jeU1zIjo2MjV9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQiIsInVzYWdlIjp7ImlucHV0VG9rZW5zIjo4LCJvdXRwdXRUb2tlbnMiOjEwLCJ0b3RhbFRva2VucyI6MTh9fSqyy9o=
+  headers:
+    Date: "Thu, 27 Feb 2025 03:58:37 GMT"
+    Content-Type: application/vnd.amazon.eventstream
+    x-amzn-RequestId: 5308774f-01a7-40f3-bf88-fc1d00338db9
+uuid: 82987a12-fd54-4e35-a1d5-c19780fa69a5
+persistent: true
+insertionIndex: 8

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testconversestreamoptions.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testconversestreamoptions.yaml
@@ -1,0 +1,34 @@
+---
+id: 172ed60a-ae31-47f3-a114-3e7e54e5bc91
+name: model_amazontitan-text-lite-v1_converse-stream
+request:
+  url: /model/amazon.titan-text-lite-v1/converse-stream
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "role" : "user",
+          "content" : [ {
+            "text" : "Say this is a test"
+          } ]
+        } ],
+        "inferenceConfig" : {
+          "maxTokens" : 5,
+          "temperature" : 0.8,
+          "topP" : 1,
+          "stopSequences" : [ "|" ]
+        }
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  base64Body: AAAAkwAAAFJ24bJxCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXYiLCJyb2xlIjoiYXNzaXN0YW50In2AaQZuAAAA3gAAAFem6NoGCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsidGV4dCI6IlRoaXMgbW9kZWwifSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2In2KDkuVAAAAiQAAAFZb3PlLCzpldmVudC10eXBlBwAQY29udGVudEJsb2NrU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJwIjoiYWJjZGUifecc8K8AAACyAAAAURNJ5X8LOmV2ZW50LXR5cGUHAAttZXNzYWdlU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7InAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVSIsInN0b3BSZWFzb24iOiJtYXhfdG9rZW5zIn2F/hMnAAAAyAAAAE4tIxDkCzpldmVudC10eXBlBwAIbWV0YWRhdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6NTE1fSwicCI6ImFiY2RlZmdoaWoiLCJ1c2FnZSI6eyJpbnB1dFRva2VucyI6OCwib3V0cHV0VG9rZW5zIjo1LCJ0b3RhbFRva2VucyI6MTN9fQQQoFU=
+  headers:
+    Date: "Thu, 27 Feb 2025 06:04:08 GMT"
+    Content-Type: application/vnd.amazon.eventstream
+    x-amzn-RequestId: 79e23cf6-ec23-4055-bf94-e6b8ca4555db
+uuid: 172ed60a-ae31-47f3-a114-3e7e54e5bc91
+persistent: true
+insertionIndex: 10


### PR DESCRIPTION
Unfortunately needed to add a client wrapper for library instrumentation users to be able to intercept the response stream, otherwise main difference from non-streaming instrumentation is to propagate that interceptor's data through `Context`.

/cc @codefromthecrypt