### PR TITLE
Better benchmark-overhead test logging

### DIFF
--- a/benchmark-overhead/build.gradle.kts
+++ b/benchmark-overhead/build.gradle.kts
@@ -33,5 +33,9 @@ dependencies {
 tasks {
   test {
     useJUnitPlatform()
+    testLogging {
+      exceptionFormat = TestExceptionFormat.FULL
+      showStandardStreams = true
+    }
   }
 }


### PR DESCRIPTION
Currently logs aren't very helpful to see why this is failing: #13388