### PR TITLE
Fixes and options for gRPC instrumentation

### DIFF
--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
@@ -98,7 +98,7 @@ class ArmeriaGrpcTest {
                                     .hasAttributesSatisfyingExactly(
                                         equalTo(
                                             MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                 span ->
                     span.hasName("example.Greeter/SayHello")
                         .hasKind(SpanKind.SERVER)
@@ -123,6 +123,6 @@ class ArmeriaGrpcTest {
                                     .hasName("message")
                                     .hasAttributesSatisfyingExactly(
                                         equalTo(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
   }
 }

--- a/instrumentation/grpc-1.6/README.md
+++ b/instrumentation/grpc-1.6/README.md
@@ -2,7 +2,7 @@
 
 | System property                                             | Type    | Default | Description                                                                                                                                                    |
 |-------------------------------------------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `otel.instrumentation.grpc.message-events`                  | Boolean | `true`  | Determines whether to add span event for each individual message received and sent. Set this to false in case of streaming large volumes of messages.          |
+| `otel.instrumentation.grpc.emit-message-events`             | Boolean | `true`  | Determines whether to emit span event for each individual message received and sent.                                                                           |
 | `otel.instrumentation.grpc.experimental-span-attributes`    | Boolean | `false` | Enable the capture of experimental span attributes.                                                                                                            |
 | `otel.instrumentation.grpc.capture-metadata.client.request` | String  |         | A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes. |
 | `otel.instrumentation.grpc.capture-metadata.server.request` | String  |         | A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes. |

--- a/instrumentation/grpc-1.6/README.md
+++ b/instrumentation/grpc-1.6/README.md
@@ -2,6 +2,7 @@
 
 | System property                                             | Type    | Default | Description                                                                                                                                                    |
 |-------------------------------------------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.grpc.message-events`                  | Boolean | `true`  | Determines whether to add span event for each individual message received and sent. Set this to false in case of streaming large volumes of messages.          |
 | `otel.instrumentation.grpc.experimental-span-attributes`    | Boolean | `false` | Enable the capture of experimental span attributes.                                                                                                            |
 | `otel.instrumentation.grpc.capture-metadata.client.request` | String  |         | A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes. |
 | `otel.instrumentation.grpc.capture-metadata.server.request` | String  |         | A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes. |

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -27,6 +27,10 @@ public final class GrpcSingletons {
   private static final AtomicReference<Context.Storage> STORAGE_REFERENCE = new AtomicReference<>();
 
   static {
+    boolean addMessageEvents =
+        AgentInstrumentationConfig.get()
+            .getBoolean("otel.instrumentation.grpc.message-events", true);
+
     boolean experimentalSpanAttributes =
         AgentInstrumentationConfig.get()
             .getBoolean("otel.instrumentation.grpc.experimental-span-attributes", false);
@@ -40,6 +44,7 @@ public final class GrpcSingletons {
 
     GrpcTelemetry telemetry =
         GrpcTelemetry.builder(GlobalOpenTelemetry.get())
+            .setAddMessageEvents(addMessageEvents)
             .setCaptureExperimentalSpanAttributes(experimentalSpanAttributes)
             .setCapturedClientRequestMetadata(clientRequestMetadata)
             .setCapturedServerRequestMetadata(serverRequestMetadata)

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -27,9 +27,9 @@ public final class GrpcSingletons {
   private static final AtomicReference<Context.Storage> STORAGE_REFERENCE = new AtomicReference<>();
 
   static {
-    boolean addMessageEvents =
+    boolean emitMessageEvents =
         AgentInstrumentationConfig.get()
-            .getBoolean("otel.instrumentation.grpc.message-events", true);
+            .getBoolean("otel.instrumentation.grpc.emit-message-events", true);
 
     boolean experimentalSpanAttributes =
         AgentInstrumentationConfig.get()
@@ -44,7 +44,7 @@ public final class GrpcSingletons {
 
     GrpcTelemetry telemetry =
         GrpcTelemetry.builder(GlobalOpenTelemetry.get())
-            .setAddMessageEvents(addMessageEvents)
+            .setEmitMessageEvents(emitMessageEvents)
             .setCaptureExperimentalSpanAttributes(experimentalSpanAttributes)
             .setCapturedClientRequestMetadata(clientRequestMetadata)
             .setCapturedServerRequestMetadata(serverRequestMetadata)

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetry.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetry.java
@@ -29,16 +29,19 @@ public final class GrpcTelemetry {
   private final Instrumenter<GrpcRequest, Status> clientInstrumenter;
   private final ContextPropagators propagators;
   private final boolean captureExperimentalSpanAttributes;
+  private final boolean addMessageEvents;
 
   GrpcTelemetry(
       Instrumenter<GrpcRequest, Status> serverInstrumenter,
       Instrumenter<GrpcRequest, Status> clientInstrumenter,
       ContextPropagators propagators,
-      boolean captureExperimentalSpanAttributes) {
+      boolean captureExperimentalSpanAttributes,
+      boolean addMessageEvents) {
     this.serverInstrumenter = serverInstrumenter;
     this.clientInstrumenter = clientInstrumenter;
     this.propagators = propagators;
     this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    this.addMessageEvents = addMessageEvents;
   }
 
   /**
@@ -46,7 +49,8 @@ public final class GrpcTelemetry {
    * io.grpc.ManagedChannelBuilder#intercept(ClientInterceptor...)}.
    */
   public ClientInterceptor newClientInterceptor() {
-    return new TracingClientInterceptor(clientInstrumenter, propagators);
+    return new TracingClientInterceptor(
+        clientInstrumenter, propagators, captureExperimentalSpanAttributes, addMessageEvents);
   }
 
   /**
@@ -54,6 +58,7 @@ public final class GrpcTelemetry {
    * io.grpc.ServerBuilder#intercept(ServerInterceptor)}.
    */
   public ServerInterceptor newServerInterceptor() {
-    return new TracingServerInterceptor(serverInstrumenter, captureExperimentalSpanAttributes);
+    return new TracingServerInterceptor(
+        serverInstrumenter, captureExperimentalSpanAttributes, addMessageEvents);
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetry.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetry.java
@@ -29,19 +29,19 @@ public final class GrpcTelemetry {
   private final Instrumenter<GrpcRequest, Status> clientInstrumenter;
   private final ContextPropagators propagators;
   private final boolean captureExperimentalSpanAttributes;
-  private final boolean addMessageEvents;
+  private final boolean emitMessageEvents;
 
   GrpcTelemetry(
       Instrumenter<GrpcRequest, Status> serverInstrumenter,
       Instrumenter<GrpcRequest, Status> clientInstrumenter,
       ContextPropagators propagators,
       boolean captureExperimentalSpanAttributes,
-      boolean addMessageEvents) {
+      boolean emitMessageEvents) {
     this.serverInstrumenter = serverInstrumenter;
     this.clientInstrumenter = clientInstrumenter;
     this.propagators = propagators;
     this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
-    this.addMessageEvents = addMessageEvents;
+    this.emitMessageEvents = emitMessageEvents;
   }
 
   /**
@@ -50,7 +50,7 @@ public final class GrpcTelemetry {
    */
   public ClientInterceptor newClientInterceptor() {
     return new TracingClientInterceptor(
-        clientInstrumenter, propagators, captureExperimentalSpanAttributes, addMessageEvents);
+        clientInstrumenter, propagators, captureExperimentalSpanAttributes, emitMessageEvents);
   }
 
   /**
@@ -59,6 +59,6 @@ public final class GrpcTelemetry {
    */
   public ServerInterceptor newServerInterceptor() {
     return new TracingServerInterceptor(
-        serverInstrumenter, captureExperimentalSpanAttributes, addMessageEvents);
+        serverInstrumenter, captureExperimentalSpanAttributes, emitMessageEvents);
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -49,7 +49,7 @@ public final class GrpcTelemetryBuilder {
       additionalServerExtractors = new ArrayList<>();
 
   private boolean captureExperimentalSpanAttributes;
-  private boolean addMessageEvents = true;
+  private boolean emitMessageEvents = true;
   private List<String> capturedClientRequestMetadata = Collections.emptyList();
   private List<String> capturedServerRequestMetadata = Collections.emptyList();
 
@@ -136,8 +136,8 @@ public final class GrpcTelemetryBuilder {
    * is true. Set this to false in case of streaming large volumes of messages.
    */
   @CanIgnoreReturnValue
-  public GrpcTelemetryBuilder setAddMessageEvents(boolean addMessageEvents) {
-    this.addMessageEvents = addMessageEvents;
+  public GrpcTelemetryBuilder setEmitMessageEvents(boolean emitMessageEvents) {
+    this.emitMessageEvents = emitMessageEvents;
     return this;
   }
 
@@ -223,6 +223,6 @@ public final class GrpcTelemetryBuilder {
         clientInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient()),
         openTelemetry.getPropagators(),
         captureExperimentalSpanAttributes,
-        addMessageEvents);
+        emitMessageEvents);
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -49,6 +49,7 @@ public final class GrpcTelemetryBuilder {
       additionalServerExtractors = new ArrayList<>();
 
   private boolean captureExperimentalSpanAttributes;
+  private boolean addMessageEvents = true;
   private List<String> capturedClientRequestMetadata = Collections.emptyList();
   private List<String> capturedServerRequestMetadata = Collections.emptyList();
 
@@ -127,6 +128,16 @@ public final class GrpcTelemetryBuilder {
   @CanIgnoreReturnValue
   public GrpcTelemetryBuilder setPeerService(String peerService) {
     this.peerService = peerService;
+    return this;
+  }
+
+  /**
+   * Determines whether to add span event for each individual message received and sent. The default
+   * is true. Set this to false in case of streaming large volumes of messages.
+   */
+  @CanIgnoreReturnValue
+  public GrpcTelemetryBuilder setAddMessageEvents(boolean addMessageEvents) {
+    this.addMessageEvents = addMessageEvents;
     return this;
   }
 
@@ -211,6 +222,7 @@ public final class GrpcTelemetryBuilder {
         // So we go ahead and inject manually in this instrumentation.
         clientInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient()),
         openTelemetry.getPropagators(),
-        captureExperimentalSpanAttributes);
+        captureExperimentalSpanAttributes,
+        addMessageEvents);
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -44,17 +44,17 @@ final class TracingClientInterceptor implements ClientInterceptor {
   private final Instrumenter<GrpcRequest, Status> instrumenter;
   private final ContextPropagators propagators;
   private final boolean captureExperimentalSpanAttributes;
-  private final boolean addMessageEvents;
+  private final boolean emitMessageEvents;
 
   TracingClientInterceptor(
       Instrumenter<GrpcRequest, Status> instrumenter,
       ContextPropagators propagators,
       boolean captureExperimentalSpanAttributes,
-      boolean addMessageEvents) {
+      boolean emitMessageEvents) {
     this.instrumenter = instrumenter;
     this.propagators = propagators;
     this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
-    this.addMessageEvents = addMessageEvents;
+    this.emitMessageEvents = emitMessageEvents;
   }
 
   @Override
@@ -129,7 +129,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
         throw e;
       }
       long messageId = SENT_MESSAGE_ID_UPDATER.incrementAndGet(this);
-      if (addMessageEvents) {
+      if (emitMessageEvents) {
         Attributes attributes = Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, messageId);
         Span.fromContext(context).addEvent("message", attributes);
       }
@@ -156,7 +156,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
       @Override
       public void onMessage(RESPONSE message) {
         long messageId = RECEIVED_MESSAGE_ID_UPDATER.incrementAndGet(TracingClientCall.this);
-        if (addMessageEvents) {
+        if (emitMessageEvents) {
           Attributes attributes = Attributes.of(MESSAGE_TYPE, RECEIVED, MESSAGE_ID, messageId);
           Span.fromContext(context).addEvent("message", attributes);
         }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -26,10 +26,10 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 final class TracingClientInterceptor implements ClientInterceptor {
 
-  private static final AttributeKey<Long> GRPC_MESSAGES_RECEIVED =
-      AttributeKey.longKey("grpc.messages.received");
-  private static final AttributeKey<Long> GRPC_MESSAGES_SENT =
-      AttributeKey.longKey("grpc.messages.sent");
+  private static final AttributeKey<Long> GRPC_RECEIVED_MESSAGE_COUNT =
+      AttributeKey.longKey("grpc.received.message_count");
+  private static final AttributeKey<Long> GRPC_SENT_MESSAGE_COUNT =
+      AttributeKey.longKey("grpc.sent.message_count");
   // copied from MessageIncubatingAttributes
   private static final AttributeKey<Long> MESSAGE_ID = AttributeKey.longKey("message.id");
   private static final AttributeKey<String> MESSAGE_TYPE = AttributeKey.stringKey("message.type");
@@ -175,9 +175,9 @@ final class TracingClientInterceptor implements ClientInterceptor {
         if (captureExperimentalSpanAttributes) {
           Span span = Span.fromContext(context);
           span.setAttribute(
-              GRPC_MESSAGES_RECEIVED, RECEIVED_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
+              GRPC_RECEIVED_MESSAGE_COUNT, RECEIVED_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
           span.setAttribute(
-              GRPC_MESSAGES_SENT, SENT_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
+              GRPC_SENT_MESSAGE_COUNT, SENT_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
         }
         instrumenter.end(context, request, status, status.getCause());
         try (Scope ignored = parentContext.makeCurrent()) {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -26,6 +26,10 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 final class TracingClientInterceptor implements ClientInterceptor {
 
+  private static final AttributeKey<Long> GRPC_MESSAGES_RECEIVED =
+      AttributeKey.longKey("grpc.messages.received");
+  private static final AttributeKey<Long> GRPC_MESSAGES_SENT =
+      AttributeKey.longKey("grpc.messages.sent");
   // copied from MessageIncubatingAttributes
   private static final AttributeKey<Long> MESSAGE_ID = AttributeKey.longKey("message.id");
   private static final AttributeKey<String> MESSAGE_TYPE = AttributeKey.stringKey("message.type");
@@ -171,9 +175,9 @@ final class TracingClientInterceptor implements ClientInterceptor {
         if (captureExperimentalSpanAttributes) {
           Span span = Span.fromContext(context);
           span.setAttribute(
-              "grpc.messages.received", RECEIVED_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
+              GRPC_MESSAGES_RECEIVED, RECEIVED_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
           span.setAttribute(
-              "grpc.messages.sent", SENT_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
+              GRPC_MESSAGES_SENT, SENT_MESSAGE_ID_UPDATER.get(TracingClientCall.this));
         }
         instrumenter.end(context, request, status, status.getCause());
         try (Scope ignored = parentContext.makeCurrent()) {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -25,6 +25,12 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 final class TracingServerInterceptor implements ServerInterceptor {
 
+  private static final AttributeKey<Boolean> GRPC_CANCELED =
+      AttributeKey.booleanKey("grpc.canceled");
+  private static final AttributeKey<Long> GRPC_MESSAGES_RECEIVED =
+      AttributeKey.longKey("grpc.messages.received");
+  private static final AttributeKey<Long> GRPC_MESSAGES_SENT =
+      AttributeKey.longKey("grpc.messages.sent");
   // copied from MessageIncubatingAttributes
   private static final AttributeKey<Long> MESSAGE_ID = AttributeKey.longKey("message.id");
   private static final AttributeKey<String> MESSAGE_TYPE = AttributeKey.stringKey("message.type");
@@ -151,11 +157,11 @@ final class TracingServerInterceptor implements ServerInterceptor {
         if (captureExperimentalSpanAttributes) {
           Span span = Span.fromContext(context);
           span.setAttribute(
-              "grpc.messages.received", RECEIVED_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
+              GRPC_MESSAGES_RECEIVED, RECEIVED_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
           span.setAttribute(
-              "grpc.messages.sent", SENT_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
+              GRPC_MESSAGES_SENT, SENT_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
           if (Status.CANCELLED.equals(status)) {
-            span.setAttribute("grpc.canceled", true);
+            span.setAttribute(GRPC_CANCELED, true);
           }
         }
         instrumenter.end(context, request, response, error);

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -27,10 +27,10 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
   private static final AttributeKey<Boolean> GRPC_CANCELED =
       AttributeKey.booleanKey("grpc.canceled");
-  private static final AttributeKey<Long> GRPC_MESSAGES_RECEIVED =
-      AttributeKey.longKey("grpc.messages.received");
-  private static final AttributeKey<Long> GRPC_MESSAGES_SENT =
-      AttributeKey.longKey("grpc.messages.sent");
+  private static final AttributeKey<Long> GRPC_RECEIVED_MESSAGE_COUNT =
+      AttributeKey.longKey("grpc.received.message_count");
+  private static final AttributeKey<Long> GRPC_SENT_MESSAGE_COUNT =
+      AttributeKey.longKey("grpc.sent.message_count");
   // copied from MessageIncubatingAttributes
   private static final AttributeKey<Long> MESSAGE_ID = AttributeKey.longKey("message.id");
   private static final AttributeKey<String> MESSAGE_TYPE = AttributeKey.stringKey("message.type");
@@ -157,9 +157,9 @@ final class TracingServerInterceptor implements ServerInterceptor {
         if (captureExperimentalSpanAttributes) {
           Span span = Span.fromContext(context);
           span.setAttribute(
-              GRPC_MESSAGES_RECEIVED, RECEIVED_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
+              GRPC_RECEIVED_MESSAGE_COUNT, RECEIVED_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
           span.setAttribute(
-              GRPC_MESSAGES_SENT, SENT_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
+              GRPC_SENT_MESSAGE_COUNT, SENT_MESSAGE_ID_UPDATER.get(TracingServerCall.this));
           if (Status.CANCELLED.equals(status)) {
             span.setAttribute(GRPC_CANCELED, true);
           }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingServerInterceptor.java
@@ -45,15 +45,15 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
   private final Instrumenter<GrpcRequest, Status> instrumenter;
   private final boolean captureExperimentalSpanAttributes;
-  private final boolean addMessageEvents;
+  private final boolean emitMessageEvents;
 
   TracingServerInterceptor(
       Instrumenter<GrpcRequest, Status> instrumenter,
       boolean captureExperimentalSpanAttributes,
-      boolean addMessageEvents) {
+      boolean emitMessageEvents) {
     this.instrumenter = instrumenter;
     this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
-    this.addMessageEvents = addMessageEvents;
+    this.emitMessageEvents = emitMessageEvents;
   }
 
   @Override
@@ -119,7 +119,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
         super.sendMessage(message);
       }
       long messageId = SENT_MESSAGE_ID_UPDATER.incrementAndGet(this);
-      if (addMessageEvents) {
+      if (emitMessageEvents) {
         Attributes attributes = Attributes.of(MESSAGE_TYPE, SENT, MESSAGE_ID, messageId);
         Span.fromContext(context).addEvent("message", attributes);
       }
@@ -164,7 +164,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
       @Override
       public void onMessage(REQUEST message) {
         long messageId = RECEIVED_MESSAGE_ID_UPDATER.incrementAndGet(TracingServerCall.this);
-        if (addMessageEvents) {
+        if (emitMessageEvents) {
           Attributes attributes = Attributes.of(MESSAGE_TYPE, RECEIVED, MESSAGE_ID, messageId);
           Span.fromContext(context).addEvent("message", attributes);
         }

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -163,7 +163,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -193,7 +193,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
     testing()
         .waitAndAssertMetrics(
             "io.opentelemetry.grpc-1.6",
@@ -316,7 +316,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -346,7 +346,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -481,7 +481,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -511,7 +511,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -993,7 +993,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -1023,7 +1023,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -1109,7 +1109,7 @@ public abstract class AbstractGrpcTest {
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(
                                               MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L));
+                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L));
                                   span.hasException(thrown);
                                 }),
                     span ->
@@ -1141,7 +1141,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -1225,7 +1225,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName(
                                 "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo")
@@ -1256,7 +1256,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -1327,7 +1327,7 @@ public abstract class AbstractGrpcTest {
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE,
                                                 "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L))),
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -1357,7 +1357,7 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(
                                                 MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 2L)))));
+                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
   }
 
   // Regression test for


### PR DESCRIPTION
- Fix for having message IDs for SENT and RECEIVED separately, as per https://opentelemetry.io/docs/specs/semconv/attributes-registry/rpc/
- Add new experimental properties `grpc.messages.received` and `grpc.messages.sent` for providing message counts.
- Add configuration option `otel.instrumentation.grpc.message-events` for disabling span events for idividual messages.

Closes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13368