### PR TITLE
Add AgentForTestingTest.exportAndRetrieveLogRecords()

### DIFF
--- a/testing/agent-for-testing/src/test/java/io/opentelemetry/javaagent/testing/AgentForTestingTest.java
+++ b/testing/agent-for-testing/src/test/java/io/opentelemetry/javaagent/testing/AgentForTestingTest.java
@@ -8,7 +8,9 @@ package io.opentelemetry.javaagent.testing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.javaagent.testing.common.AgentTestingExporterAccess;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
@@ -43,5 +45,15 @@ class AgentForTestingTest {
     List<MetricData> metrics = AgentTestingExporterAccess.getExportedMetrics();
     assertEquals(1, metrics.size());
     assertEquals("test", metrics.get(0).getName());
+  }
+
+  @Test
+  void exportAndRetrieveLogRecords() {
+    Logger logger = GlobalOpenTelemetry.get().getLogsBridge().loggerBuilder("test").build();
+    logger.logRecordBuilder().setBody("testBody").emit();
+
+    List<LogRecordData> logRecords = AgentTestingExporterAccess.getExportedLogRecords();
+    assertEquals(1, logRecords.size());
+    assertEquals("testBody", logRecords.get(0).getBodyValue().getValue());
   }
 }


### PR DESCRIPTION
In the previous PR we added the metrics test: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13414
Now let's test that `javaagent.testing` works fine with logs.

It can cover issues like this: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13401