### PR TITLE
Add debug logging to flaky apache async client tests

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
+    systemProperty("otel.instrumentation.pache-httpclient-5.debug", "true")
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
@@ -17,6 +17,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
-    systemProperty("otel.instrumentation.pache-httpclient-5.debug", "true")
+    systemProperty("otel.instrumentation.apache-httpclient-5.debug", "true")
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentationModule.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.Arrays;
@@ -20,6 +21,15 @@ public class ApacheHttpClientInstrumentationModule extends InstrumentationModule
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
+    boolean debug =
+        AgentInstrumentationConfig.get()
+            .getBoolean("otel.instrumentation.pache-httpclient-5.debug", false);
+    if (debug) {
+      return Arrays.asList(
+          new ApacheHttpClientInstrumentation(),
+          new ApacheHttpAsyncClientInstrumentation(),
+          new IoReactorInstrumentation());
+    }
     return Arrays.asList(
         new ApacheHttpClientInstrumentation(), new ApacheHttpAsyncClientInstrumentation());
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentationModule.java
@@ -23,12 +23,12 @@ public class ApacheHttpClientInstrumentationModule extends InstrumentationModule
   public List<TypeInstrumentation> typeInstrumentations() {
     boolean debug =
         AgentInstrumentationConfig.get()
-            .getBoolean("otel.instrumentation.pache-httpclient-5.debug", false);
+            .getBoolean("otel.instrumentation.apache-httpclient-5.debug", false);
     if (debug) {
       return Arrays.asList(
           new ApacheHttpClientInstrumentation(),
           new ApacheHttpAsyncClientInstrumentation(),
-          new IoReactorInstrumentation());
+          new IoReactorDebugInstrumentation());
     }
     return Arrays.asList(
         new ApacheHttpClientInstrumentation(), new ApacheHttpAsyncClientInstrumentation());

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/IoReactorDebugInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/IoReactorDebugInstrumentation.java
@@ -15,7 +15,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class IoReactorInstrumentation implements TypeInstrumentation {
+public class IoReactorDebugInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/IoReactorInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/IoReactorInstrumentation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class IoReactorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named("org.apache.hc.core5.reactor.IOReactor"));
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        namedOneOf("close", "initiateShutdown"), this.getClass().getName() + "$CloseAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class CloseAdvice {
+
+    @SuppressWarnings("SystemOut")
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void methodEnter(@Advice.This Object instance) {
+      System.err.println("closing i/o reactor " + instance);
+      new Exception().printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13453
https://scans.gradle.com/s/73ye46a66fxfy/tests/task/:instrumentation:apache-httpclient:apache-httpclient-5.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0.ApacheHttpAsyncClientTest$ApacheClientUriRequestTest?top-execution=1

The cause of the failure seems to be
```
2025-03-05T03:54:18.4862538Z     org.apache.hc.core5.reactor.IOReactorShutdownException: I/O reactor has been shut down
2025-03-05T03:54:18.4863513Z     	at org.apache.hc.core5.reactor.IOWorkers.validate(IOWorkers.java:51)
2025-03-05T03:54:18.4864287Z     	at org.apache.hc.core5.reactor.IOWorkers.access$000(IOWorkers.java:31)
2025-03-05T03:54:18.4865671Z     	at org.apache.hc.core5.reactor.IOWorkers$PowerOfTwoSelector.next(IOWorkers.java:67)
2025-03-05T03:54:18.4866916Z     	at org.apache.hc.core5.reactor.AbstractIOReactorBase.connect(AbstractIOReactorBase.java:53)
2025-03-05T03:54:18.4868342Z     	at org.apache.hc.client5.http.impl.nio.MultihomeIOSessionRequester$1.executeNext(MultihomeIOSessionRequester.java:105)
2025-03-05T03:54:18.4869926Z     	at org.apache.hc.client5.http.impl.nio.MultihomeIOSessionRequester$1$1.failed(MultihomeIOSessionRequester.java:141)
2025-03-05T03:54:18.4871268Z     	at org.apache.hc.core5.concurrent.BasicFuture.failed(BasicFuture.java:138)
2025-03-05T03:54:18.4872208Z     	at org.apache.hc.core5.reactor.IOSessionRequest.failed(IOSessionRequest.java:78)
2025-03-05T03:54:18.4873330Z     	at org.apache.hc.core5.reactor.InternalConnectChannel.onException(InternalConnectChannel.java:99)
2025-03-05T03:54:18.4874474Z     	at org.apache.hc.core5.reactor.InternalChannel.handleIOEvent(InternalChannel.java:55)
2025-03-05T03:54:18.4875812Z     	at org.apache.hc.core5.reactor.SingleCoreIOReactor.processEvents(SingleCoreIOReactor.java:179)
2025-03-05T03:54:18.4877245Z     	at org.apache.hc.core5.reactor.SingleCoreIOReactor.doExecute(SingleCoreIOReactor.java:128)
2025-03-05T03:54:18.4878894Z     	at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute(AbstractSingleCoreIOReactor.java:82)
2025-03-05T03:54:18.4880476Z     	at org.apache.hc.core5.reactor.IOReactorWorker.run(IOReactorWorker.java:44)
2025-03-05T03:54:18.4881664Z     	at java.base/java.lang.Thread.run(Thread.java:829)
```
we need to figure out what shuts it down. Probably has something to do with `connectionErrorUnopenedPort` test.