### PR TITLE
Fix compilation errors due to declarative config breaking changes

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 // this line is managed by .github/scripts/update-sdk-version.sh
-val otelSdkVersion = "1.47.0"
+val otelSdkVersion = "1.48.0-SNAPSHOT"
 val otelContribVersion = "1.44.0-alpha"
 val otelSdkAlphaVersion = otelSdkVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 

--- a/instrumentation/resources/library/build.gradle.kts
+++ b/instrumentation/resources/library/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-common")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator")
 
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service-annotations")

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/internal/ResourceComponentProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/internal/ResourceComponentProvider.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.instrumentation.resources.internal;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.function.Supplier;
 
@@ -31,7 +31,7 @@ abstract class ResourceComponentProvider implements ComponentProvider<Resource> 
   }
 
   @Override
-  public Resource create(StructuredConfigProperties structuredConfigProperties) {
+  public Resource create(DeclarativeConfigProperties declarativeConfigProperties) {
     return supplier.get();
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/DeclarativeConfigTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/DeclarativeConfigTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +33,7 @@ class DeclarativeConfigTest {
 
     boolean java8 = "1.8".equals(System.getProperty("java.specification.version"));
     OpenTelemetrySdk openTelemetrySdk =
-        FileConfiguration.parseAndCreate(
+        DeclarativeConfiguration.parseAndCreate(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
     assertThat(openTelemetrySdk.getSdkTracerProvider())
         .extracting("sharedState.resource", as(InstanceOfAssertFactories.type(Resource.class)))

--- a/javaagent-extension-api/build.gradle.kts
+++ b/javaagent-extension-api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   api("net.bytebuddy:byte-buddy-dep")
 
+  implementation("io.opentelemetry:opentelemetry-api-incubator")
   implementation(project(":instrumentation-api"))
   implementation(project(":instrumentation-api-incubator"))
 

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/AgentListener.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/AgentListener.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.extension;
 
+import io.opentelemetry.api.incubator.config.ConfigProvider;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 import java.lang.instrument.Instrumentation;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
@@ -37,13 +38,16 @@ public interface AgentListener extends Ordered {
     if (sdkConfigProperties != null) {
       return sdkConfigProperties;
     }
-    StructuredConfigProperties structuredConfigProperties =
-        AutoConfigureUtil.getStructuredConfig(autoConfiguredOpenTelemetrySdk);
-    if (structuredConfigProperties != null) {
-      return new StructuredConfigPropertiesBridge(structuredConfigProperties);
+    ConfigProvider configProvider =
+        AutoConfigureUtil.getConfigProvider(autoConfiguredOpenTelemetrySdk);
+    if (configProvider != null) {
+      DeclarativeConfigProperties instrumentationConfig = configProvider.getInstrumentationConfig();
+      if (instrumentationConfig != null) {
+        return new DeclarativeConfigPropertiesBridge(instrumentationConfig);
+      }
     }
     // Should never happen
     throw new IllegalStateException(
-        "AutoConfiguredOpenTelemetrySdk does not have ConfigProperties or StructuredConfigProperties. This is likely a programming error in opentelemetry-java");
+        "AutoConfiguredOpenTelemetrySdk does not have ConfigProperties or DeclarativeConfigProperties. This is likely a programming error in opentelemetry-java");
   }
 }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/DeclarativeConfigPropertiesBridge.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/DeclarativeConfigPropertiesBridge.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.extension;
 
-import static io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties.empty;
+import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,7 +18,8 @@ import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 
 /**
- * A {@link ConfigProperties} which resolves properties based on {@link StructuredConfigProperties}.
+ * A {@link ConfigProperties} which resolves properties based on {@link
+ * DeclarativeConfigProperties}.
  *
  * <p>Only properties starting with "otel.instrumentation." are resolved. Others return null (or
  * default value if provided).
@@ -30,9 +31,9 @@ import javax.annotation.Nullable;
  *   <li>The portion of the property after "otel.instrumentation." is split into segments based on
  *       ".".
  *   <li>For each N-1 segment, we walk down the tree to find the relevant leaf {@link
- *       StructuredConfigProperties}.
- *   <li>We extract the property from the resolved {@link StructuredConfigProperties} using the last
- *       segment as the property key.
+ *       DeclarativeConfigProperties}.
+ *   <li>We extract the property from the resolved {@link DeclarativeConfigProperties} using the
+ *       last segment as the property key.
  * </ul>
  *
  * <p>For example, given the following YAML, asking for {@code
@@ -45,54 +46,51 @@ import javax.annotation.Nullable;
  *         string_key: value
  * </pre>
  */
-final class StructuredConfigPropertiesBridge implements ConfigProperties {
+final class DeclarativeConfigPropertiesBridge implements ConfigProperties {
 
   private static final String OTEL_INSTRUMENTATION_PREFIX = "otel.instrumentation.";
 
   // The node at .instrumentation.java
-  private final StructuredConfigProperties instrumentationJavaNode;
+  private final DeclarativeConfigProperties instrumentationJavaNode;
 
-  StructuredConfigPropertiesBridge(StructuredConfigProperties rootStructuredConfigProperties) {
-    instrumentationJavaNode =
-        rootStructuredConfigProperties
-            .getStructured("instrumentation", empty())
-            .getStructured("java", empty());
+  DeclarativeConfigPropertiesBridge(DeclarativeConfigProperties instrumentationConfigProperties) {
+    instrumentationJavaNode = instrumentationConfigProperties.getStructured("java", empty());
   }
 
   @Nullable
   @Override
   public String getString(String propertyName) {
-    return getPropertyValue(propertyName, StructuredConfigProperties::getString);
+    return getPropertyValue(propertyName, DeclarativeConfigProperties::getString);
   }
 
   @Nullable
   @Override
   public Boolean getBoolean(String propertyName) {
-    return getPropertyValue(propertyName, StructuredConfigProperties::getBoolean);
+    return getPropertyValue(propertyName, DeclarativeConfigProperties::getBoolean);
   }
 
   @Nullable
   @Override
   public Integer getInt(String propertyName) {
-    return getPropertyValue(propertyName, StructuredConfigProperties::getInt);
+    return getPropertyValue(propertyName, DeclarativeConfigProperties::getInt);
   }
 
   @Nullable
   @Override
   public Long getLong(String propertyName) {
-    return getPropertyValue(propertyName, StructuredConfigProperties::getLong);
+    return getPropertyValue(propertyName, DeclarativeConfigProperties::getLong);
   }
 
   @Nullable
   @Override
   public Double getDouble(String propertyName) {
-    return getPropertyValue(propertyName, StructuredConfigProperties::getDouble);
+    return getPropertyValue(propertyName, DeclarativeConfigProperties::getDouble);
   }
 
   @Nullable
   @Override
   public Duration getDuration(String propertyName) {
-    Long millis = getPropertyValue(propertyName, StructuredConfigProperties::getLong);
+    Long millis = getPropertyValue(propertyName, DeclarativeConfigProperties::getLong);
     if (millis == null) {
       return null;
     }
@@ -110,8 +108,8 @@ final class StructuredConfigPropertiesBridge implements ConfigProperties {
 
   @Override
   public Map<String, String> getMap(String propertyName) {
-    StructuredConfigProperties propertyValue =
-        getPropertyValue(propertyName, StructuredConfigProperties::getStructured);
+    DeclarativeConfigProperties propertyValue =
+        getPropertyValue(propertyName, DeclarativeConfigProperties::getStructured);
     if (propertyValue == null) {
       return Collections.emptyMap();
     }
@@ -131,7 +129,7 @@ final class StructuredConfigPropertiesBridge implements ConfigProperties {
 
   @Nullable
   private <T> T getPropertyValue(
-      String property, BiFunction<StructuredConfigProperties, String, T> extractor) {
+      String property, BiFunction<DeclarativeConfigProperties, String, T> extractor) {
     if (!property.startsWith(OTEL_INSTRUMENTATION_PREFIX)) {
       return null;
     }
@@ -141,7 +139,7 @@ final class StructuredConfigPropertiesBridge implements ConfigProperties {
     if (segments.length == 0) {
       return null;
     }
-    StructuredConfigProperties target = instrumentationJavaNode;
+    DeclarativeConfigProperties target = instrumentationJavaNode;
     if (segments.length > 1) {
       for (int i = 0; i < segments.length - 1; i++) {
         target = target.getStructured(segments[i], empty());

--- a/javaagent-extension-api/src/test/java/io/opentelemetry/javaagent/extension/DeclarativeConfigPropertiesBridgeTest.java
+++ b/javaagent-extension-api/src/test/java/io/opentelemetry/javaagent/extension/DeclarativeConfigPropertiesBridgeTest.java
@@ -8,17 +8,21 @@ package io.opentelemetry.javaagent.extension;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.SdkConfigProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.InstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class StructuredConfigPropertiesBridgeTest {
+class DeclarativeConfigPropertiesBridgeTest {
 
   private static final String YAML =
       "file_format: 0.3\n"
@@ -42,15 +46,26 @@ class StructuredConfigPropertiesBridgeTest {
           + "        string_key2: value2\n"
           + "        bool_key: true\n";
 
-  private final StructuredConfigProperties structuredConfigProperties =
-      FileConfiguration.toConfigProperties(
-          new ByteArrayInputStream(YAML.getBytes(StandardCharsets.UTF_8)));
-  private final ConfigProperties bridge =
-      new StructuredConfigPropertiesBridge(structuredConfigProperties);
-  private final ConfigProperties emptyBridge =
-      new StructuredConfigPropertiesBridge(
-          FileConfiguration.toConfigProperties(
-              new ByteArrayInputStream("file_format: 0.3\n".getBytes(StandardCharsets.UTF_8))));
+  private ConfigProperties bridge;
+  private ConfigProperties emptyBridge;
+
+  @BeforeEach
+  void setup() {
+    OpenTelemetryConfigurationModel model =
+        DeclarativeConfiguration.parse(
+            new ByteArrayInputStream(YAML.getBytes(StandardCharsets.UTF_8)));
+    SdkConfigProvider configProvider = SdkConfigProvider.create(model);
+    bridge =
+        new DeclarativeConfigPropertiesBridge(
+            Objects.requireNonNull(configProvider.getInstrumentationConfig()));
+
+    OpenTelemetryConfigurationModel emptyModel =
+        new OpenTelemetryConfigurationModel().withInstrumentation(new InstrumentationModel());
+    SdkConfigProvider emptyConfigProvider = SdkConfigProvider.create(emptyModel);
+    emptyBridge =
+        new DeclarativeConfigPropertiesBridge(
+            Objects.requireNonNull(emptyConfigProvider.getInstrumentationConfig()));
+  }
 
   @Test
   void getProperties() {


### PR DESCRIPTION
Fix breaking changes from moving / renaming of certain declarative config classes in: https://github.com/open-telemetry/opentelemetry-java/pull/6549

**NOTE:** Depends on `opentelemetry-java` 1.48.0 release, scheduled for 3/6/25.