### PR TITLE
Use cncf-hosted oci gha runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       actions: read  # for github/codeql-action/init to get workflow details
       security-events: write  # for github/codeql-action/analyze to upload SARIF results
-    runs-on: otel-linux-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners in Oracle that we're wanting projects to use rather than the GitHub hosted ones, which are now incur a cost to use. This PR is currently a WIP to work through any tests that break or dependencies that may be missing. <3

Please direct any questions to myself, @krook and @RobertKielty