### PR TITLE
Change oshi test library logic for arm mac

### DIFF
--- a/instrumentation/oshi/javaagent/build.gradle.kts
+++ b/instrumentation/oshi/javaagent/build.gradle.kts
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group.set("com.github.oshi")
     module.set("oshi-core")
-    versions.set("[5.3.1,)")
+    versions.set("[5.5.0,)")
     // Could not parse POM https://repo.maven.apache.org/maven2/com/github/oshi/oshi-core/6.1.1/oshi-core-6.1.1.pom
     skip("6.1.1")
   }
@@ -17,7 +17,7 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
-  library("com.github.oshi:oshi-core:5.3.1")
+  library("com.github.oshi:oshi-core:5.5.0")
 
   testImplementation(project(":instrumentation:oshi:testing"))
 }

--- a/instrumentation/oshi/javaagent/build.gradle.kts
+++ b/instrumentation/oshi/javaagent/build.gradle.kts
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group.set("com.github.oshi")
     module.set("oshi-core")
-    versions.set("[5.5.0,)")
+    versions.set("[5.3.1,)")
     // Could not parse POM https://repo.maven.apache.org/maven2/com/github/oshi/oshi-core/6.1.1/oshi-core-6.1.1.pom
     skip("6.1.1")
   }
@@ -17,7 +17,7 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
-  library("com.github.oshi:oshi-core:5.5.0")
+  library("com.github.oshi:oshi-core:5.3.1")
 
   testImplementation(project(":instrumentation:oshi:testing"))
 }

--- a/instrumentation/oshi/library/build.gradle.kts
+++ b/instrumentation/oshi/library/build.gradle.kts
@@ -4,8 +4,12 @@ plugins {
 }
 
 dependencies {
-  // 5.5.0 is the first version that works on arm mac
-  library("com.github.oshi:oshi-core:5.5.0")
+  library("com.github.oshi:oshi-core:5.3.1")
+
+  if (osdetector.os == "osx" && osdetector.arch == "aarch_64" && !(findProperty("testLatestDeps") as Boolean)) {
+    // 5.5.0 is the first version that works on arm mac
+    configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.github.oshi:oshi-core:5.5.0")
+  }
 
   testImplementation(project(":instrumentation:oshi:testing"))
 }

--- a/instrumentation/oshi/library/build.gradle.kts
+++ b/instrumentation/oshi/library/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 dependencies {
   library("com.github.oshi:oshi-core:5.3.1")
 
-  if (osdetector.os == "osx" && osdetector.arch == "aarch_64" && !(findProperty("testLatestDeps") as Boolean)) {
-    // 5.5.0 is the first version that works on arm mac
-    configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.github.oshi:oshi-core:5.5.0")
-  }
-
   testImplementation(project(":instrumentation:oshi:testing"))
+}
+
+if (osdetector.os == "osx" && osdetector.arch == "aarch_64" && !(findProperty("testLatestDeps") as Boolean)) {
+  // 5.5.0 is the first version that works on arm mac
+  configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.github.oshi:oshi-core:5.5.0")
 }

--- a/instrumentation/oshi/library/build.gradle.kts
+++ b/instrumentation/oshi/library/build.gradle.kts
@@ -3,11 +3,9 @@ plugins {
   id("com.google.osdetector")
 }
 
-// 5.5.0 is the first version that works on arm mac
-val oshiVersion = if (osdetector.os == "osx" && osdetector.arch == "aarch_64") "5.5.0" else "5.3.1"
-
 dependencies {
-  library("com.github.oshi:oshi-core:$oshiVersion")
+  // 5.5.0 is the first version that works on arm mac
+  library("com.github.oshi:oshi-core:5.5.0")
 
   testImplementation(project(":instrumentation:oshi:testing"))
 }


### PR DESCRIPTION
Discussed [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13449#discussion_r1983696935)

~bumping the oshi minimum version to 5.5.0 and getting rid of the conditional for arm mac~

removing variable from declaration and handling the override in a different way

