### PR TITLE
Remove latest dep restriction from cxf client test

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/build.gradle.kts
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   latestDepTestLibrary("org.glassfish.jersey.inject:jersey-hk2:2.+")
   latestDepTestLibrary("org.glassfish.jersey.core:jersey-client:2.+")
   latestDepTestLibrary("org.jboss.resteasy:resteasy-client:3.0.26.Final")
-  latestDepTestLibrary("org.apache.cxf:cxf-rt-rs-client:3.6.5")
+  latestDepTestLibrary("org.apache.cxf:cxf-rt-rs-client:3.+")
 }
 
 // Requires old Guava. Can't use enforcedPlatform since predates BOM


### PR DESCRIPTION
reverts https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13467