### PR TITLE
Fix flaky java http server tests

### DIFF
--- a/instrumentation/java-http-server/testing/src/main/java/io/opentelemetry/instrumentation/javahttpserver/AbstractJavaHttpServerTest.java
+++ b/instrumentation/java-http-server/testing/src/main/java/io/opentelemetry/instrumentation/javahttpserver/AbstractJavaHttpServerTest.java
@@ -58,8 +58,6 @@ public abstract class AbstractJavaHttpServerTest extends AbstractHttpServerTest<
       try (OutputStream os = exchange.getResponseBody()) {
         os.write(bytes);
       }
-    } else {
-      exchange.getResponseBody().close();
     }
   }
 


### PR DESCRIPTION
https://scans.gradle.com/s/6pr5nphlmr3yk/tests/task/:instrumentation:java-http-server:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.javahttpserver.JavaHttpServerTest/requestWithRedirect()?top-execution=1

When response does not have a body (content length is -1) then response is closed in `sendResponseHeaders`. Closing it again triggers an assertion error on jdk 11. This assertion error may be picked up by awaitility, that installs an uncaught exception handler, and retrhown on the main test thread.