### PR TITLE
Improve flaky test reporting

### DIFF
--- a/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
+++ b/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
@@ -108,6 +108,7 @@ public class FlakyTestReporter {
     if (testExecuted != null && reportModified.isAfter(testExecuted)) {
       System.err.println(
           "Ignoring " + testReport + " since it appears to be restored from gradle build cache");
+      return;
     }
 
     class TestCase {

--- a/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
+++ b/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
@@ -71,6 +71,7 @@ public class FlakyTestReporter {
     }
   }
 
+  @SuppressWarnings("JavaTimeDefaultTimeZone")
   private void scanTestFile(Path testReport) {
     Document doc = parse(testReport);
     doc.getDocumentElement().normalize();

--- a/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
+++ b/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
@@ -24,6 +24,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,6 +85,28 @@ public class FlakyTestReporter {
     // there are no flaky tests if there are no failures, skip it
     if (failures == 0 && errors == 0) {
       return;
+    }
+
+    // google sheets don't automatically recognize dates with time zone, here we reformat the date
+    // so that it wouldn't have the time zone
+    TemporalAccessor ta =
+        DateTimeFormatter.ISO_DATE_TIME.parseBest(
+            timestamp, ZonedDateTime::from, LocalDateTime::from);
+    timestamp = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(ta);
+
+    // when test result file was modified more than 20 minutes after the time in the results file
+    // then the test results were restored from gradle cache and the test wasn't actually executed
+    Instant reportModified = Instant.ofEpochMilli(testReport.toFile().lastModified());
+    reportModified = reportModified.minus(20, ChronoUnit.MINUTES);
+    Instant testExecuted = null;
+    if (ta instanceof ZonedDateTime) {
+      testExecuted = ((ZonedDateTime) ta).toInstant();
+    } else if (ta instanceof LocalDateTime) {
+      testExecuted = ((LocalDateTime) ta).toInstant(OffsetDateTime.now().getOffset());
+    }
+    if (testExecuted != null && reportModified.isAfter(testExecuted)) {
+      System.err.println(
+          "Ignoring " + testReport + " since it appears to be restored from gradle build cache");
     }
 
     class TestCase {


### PR DESCRIPTION
Apparently recently the timestamp in junit test reports contain a time zone like in `2025-03-08T05:04:57.500Z` Google sheets doesn't seem to be able to automatically parse this as a data. To overcome this we'll strip the time zone.
This PR also adds detection for when test report is restored from gradle build cache and ignores flaky tests for these.