### PR TITLE
Try to fix flaky apache async http client 5 tests

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
@@ -12,6 +12,8 @@ muzzle {
 
 dependencies {
   library("org.apache.httpcomponents.client5:httpclient5:5.0")
+  // https://issues.apache.org/jira/browse/HTTPCORE-653
+  library("org.apache.httpcomponents.core5:httpcore5:5.0.3")
 }
 
 tasks {


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13460
Hopefully https://issues.apache.org/jira/browse/HTTPCORE-653 is the issue that makes the apache async http client 5 test flaky for us.