### PR TITLE
Make the OTel starter work with GraalVM native 22 and 23

### DIFF
--- a/.github/workflows/reusable-native-tests.yml
+++ b/.github/workflows/reusable-native-tests.yml
@@ -17,6 +17,11 @@ jobs:
   graalvm-native-tests:
     if: "!inputs.skip-native-tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-java-version:
+          - 22
+          - 23
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: read-java
@@ -24,7 +29,7 @@ jobs:
       - uses: graalvm/setup-graalvm@01ed653ac833fe80569f1ef9f25585ba2811baab # v1.3.3.1
         with:
           version: "latest"
-          java-version: "${{ steps.read-java.outputs.version }}"
+          java-version: ${{ matrix.test-java-version }}
           components: "native-image"
       - name: Running test
         env:

--- a/instrumentation-api/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/native-image.properties
+++ b/instrumentation-api/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/native-image.properties
@@ -1,4 +1,0 @@
-Args=\
-  --initialize-at-build-time=io.opentelemetry.instrumentation.api.internal.cache.concurrentlinkedhashmap.ConcurrentLinkedHashMap \
-  --initialize-at-build-time=io.opentelemetry.instrumentation.api.internal.cache.MapBackedCache \
-  --initialize-at-build-time=io.opentelemetry.api.internal.InternalAttributeKeyImpl

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0/native-image.properties
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0/native-image.properties
@@ -1,2 +1,0 @@
-Args=\
-  --initialize-at-build-time=io.opentelemetry.instrumentation.logback.appender.v1_0.internal.LoggingEventMapper

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -217,6 +217,7 @@ class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest 
         new ArrayList<>(Arrays.asList("jvm.thread.count", "jvm.memory.used", "jvm.memory.init"));
 
     double javaVersion = Double.parseDouble(System.getProperty("java.specification.version"));
+    // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13503
     if (javaVersion < 23) {
       jmxMetrics.add("jvm.system.cpu.load_1m");
     }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -214,12 +214,12 @@ class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest 
 
     // JMX based metrics - test one per JMX bean
     List<String> jmxMetrics =
-        new ArrayList<>(
-            Arrays.asList(
-                "jvm.thread.count",
-                "jvm.memory.used",
-                "jvm.system.cpu.load_1m",
-                "jvm.memory.init"));
+        new ArrayList<>(Arrays.asList("jvm.thread.count", "jvm.memory.used", "jvm.memory.init"));
+
+    double javaVersion = Double.parseDouble(System.getProperty("java.specification.version"));
+    if (javaVersion < 23) {
+      jmxMetrics.add("jvm.system.cpu.load_1m");
+    }
 
     boolean noNative = System.getProperty("org.graalvm.nativeimage.imagecode") == null;
     if (noNative) {


### PR DESCRIPTION
GraalVM native is supported by Spring Boot for version 22 or above: https://docs.spring.io/spring-boot/system-requirements.html#getting-started.system-requirements.graal

So, this PR executes the GraalVM native tests for 22 and 23.

