### PR TITLE
Remove test runtime hints

### DIFF
--- a/smoke-tests-otel-starter/spring-boot-3.2/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
+++ b/smoke-tests-otel-starter/spring-boot-3.2/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.spring.smoketest;
 
-import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import org.springframework.aot.hint.TypeReference;
 
 // Necessary for GraalVM native test
 public class RuntimeHints implements RuntimeHintsRegistrar {
@@ -16,16 +14,5 @@ public class RuntimeHints implements RuntimeHintsRegistrar {
   public void registerHints(
       org.springframework.aot.hint.RuntimeHints hints, ClassLoader classLoader) {
     hints.resources().registerResourceBundle("org.apache.commons.dbcp2.LocalStrings");
-
-    // To avoid Spring native issue with MongoDB: java.lang.ClassNotFoundException:
-    // org.springframework.data.mongodb.core.aggregation.AggregationOperation
-    hints
-        .reflection()
-        .registerType(
-            TypeReference.of(
-                "org.springframework.data.mongodb.core.aggregation.AggregationOperation"),
-            hint -> {
-              hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
-            });
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-3/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
+++ b/smoke-tests-otel-starter/spring-boot-3/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.spring.smoketest;
 
-import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import org.springframework.aot.hint.TypeReference;
 
 // Necessary for GraalVM native test
 public class RuntimeHints implements RuntimeHintsRegistrar {
@@ -16,14 +14,5 @@ public class RuntimeHints implements RuntimeHintsRegistrar {
   public void registerHints(
       org.springframework.aot.hint.RuntimeHints hints, ClassLoader classLoader) {
     hints.resources().registerResourceBundle("org.apache.commons.dbcp2.LocalStrings");
-
-    // To avoid Spring native issue with MongoDB: java.lang.ClassNotFoundException:
-    // org.springframework.data.mongodb.core.aggregation.AggregationOperation
-    hints
-        .reflection()
-        .registerType(
-            TypeReference.of(
-                "org.springframework.data.mongodb.core.aggregation.AggregationOperation"),
-            hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS));
   }
 }


### PR DESCRIPTION
The runtime hint was added in _tests_ because of a Spring limitation with GraalVM native execution.

This limitation seems to have been addressed on Spring side.