### PR TITLE
Remove usage of grpc internal api

### DIFF
--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcInstrumentationModule.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcInstrumentationModule.java
@@ -22,6 +22,7 @@ public class ArmeriaGrpcInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new ArmeriaGrpcClientBuilderInstrumentation(),
-        new ArmeriaGrpcServiceBuilderInstrumentation());
+        new ArmeriaGrpcServiceBuilderInstrumentation(),
+        new ArmeriaServerCallInstrumentation());
   }
 }

--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaServerCallInstrumentation.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaServerCallInstrumentation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.armeria.grpc.v1_14;
 
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
-import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.grpc.ServerCall;
@@ -20,7 +20,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ArmeriaServerCallInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("com.linecorp.armeria.server.grpc.ArmeriaServerCall");
+    return namedOneOf(
+        "com.linecorp.armeria.server.grpc.ArmeriaServerCall",
+        "com.linecorp.armeria.internal.server.grpc.AbstractServerCall");
   }
 
   @Override

--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaServerCallInstrumentation.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaServerCallInstrumentation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.armeria.grpc.v1_14;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.grpc.ServerCall;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class ArmeriaServerCallInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.linecorp.armeria.server.grpc.ArmeriaServerCall");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor(), this.getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.This ServerCall<?, ?> serverCall,
+        @Advice.FieldValue("ctx") ServiceRequestContext ctx) {
+      String authority = ctx.request().headers().get(":authority");
+      if (authority != null) {
+        // ArmeriaServerCall does not implement getAuthority. We will store the value for authority
+        // header as virtual field, this field is read in grpc instrumentation in
+        // TracingServerInterceptor
+        VirtualField.find(ServerCall.class, String.class).set(serverCall, authority);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13504
This only works for the javaagent instrumentation. When our grpc library instrumentation is used with armeria then information derived from the `:authority` header (`server.address`, `server.port`) is lost. 