### PR TITLE
Add body to http server concurrency test response

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestAsyncWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestAsyncWebServer.scala
@@ -43,7 +43,7 @@ object AkkaHttpTestAsyncWebServer {
                     override def getParameter(name: String): String =
                       uri.query().get(name).orNull
                   })
-                  resp.withEntity("")
+                  resp.withEntity(endpoint.getBody)
                 case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
                 case REDIRECT =>
                   resp.withHeaders(headers.Location(endpoint.getBody))

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestSyncWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestSyncWebServer.scala
@@ -40,7 +40,7 @@ object AkkaHttpTestSyncWebServer {
                   override def getParameter(name: String): String =
                     uri.query().get(name).orNull
                 })
-                resp.withEntity("")
+                resp.withEntity(endpoint.getBody)
               case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
               case REDIRECT =>
                 resp.withHeaders(headers.Location(endpoint.getBody))

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestWebServer.scala
@@ -38,7 +38,7 @@ object AkkaHttpTestWebServer {
                 override def getParameter(name: String): String =
                   map.get(name).orNull
               })
-              ""
+              INDEXED_CHILD.getBody
             }
           }
           complete(AbstractHttpServerTest.controller(INDEXED_CHILD, supplier))

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
@@ -74,7 +74,7 @@ abstract class AbstractServerTest extends AbstractHttpServerTest<ListeningServer
                   name ->
                       new QueryStringDecoder(uri)
                           .parameters().get(name).stream().findFirst().orElse(""));
-              response.content(Buf.Empty());
+              response.content(Buf.Utf8$.MODULE$.apply(endpoint.getBody()));
             } else if (QUERY_PARAM.equals(endpoint)) {
               response.content(Buf.Utf8$.MODULE$.apply(uri.getQuery()));
             } else if (REDIRECT.equals(endpoint)) {

--- a/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyTest.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyTest.java
@@ -20,7 +20,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import org.glassfish.grizzly.http.server.HttpHandler;
@@ -52,33 +51,18 @@ abstract class GrizzlyTest extends AbstractHttpServerTest<HttpServer> {
                 endpoint,
                 () -> {
                   if (endpoint.equals(SUCCESS)) {
-                    try {
-                      response.getWriter().write(endpoint.getBody());
-                    } catch (IOException e) {
-                      throw new RuntimeException(e);
-                    }
+                    response.getWriter().write(endpoint.getBody());
                   } else if (endpoint.equals(INDEXED_CHILD)) {
-                    response.setStatus(endpoint.getStatus());
                     endpoint.collectSpanAttributes(request::getParameter);
+                    response.setStatus(endpoint.getStatus());
+                    response.getWriter().write(endpoint.getBody());
                   } else if (endpoint.equals(QUERY_PARAM)) {
                     response.setStatus(endpoint.getStatus());
-                    try {
-                      response.getWriter().write(request.getQueryString());
-                    } catch (IOException e) {
-                      throw new RuntimeException(e);
-                    }
+                    response.getWriter().write(request.getQueryString());
                   } else if (endpoint.equals(REDIRECT)) {
-                    try {
-                      response.sendRedirect(endpoint.getBody());
-                    } catch (IOException e) {
-                      throw new RuntimeException(e);
-                    }
+                    response.sendRedirect(endpoint.getBody());
                   } else if (endpoint.equals(ERROR)) {
-                    try {
-                      response.sendError(endpoint.getStatus(), endpoint.getBody());
-                    } catch (IOException e) {
-                      throw new RuntimeException(e);
-                    }
+                    response.sendError(endpoint.getStatus(), endpoint.getBody());
                   } else if (endpoint.equals(NOT_FOUND)) {
                     response.setStatus(endpoint.getStatus());
                   } else if (endpoint.equals(EXCEPTION)) {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/java/io/opentelemetry/instrumentation/jaxrs/v2_0/test/JaxRsTestResource.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/java/io/opentelemetry/instrumentation/jaxrs/v2_0/test/JaxRsTestResource.java
@@ -105,7 +105,7 @@ public class JaxRsTestResource {
                 INDEXED_CHILD,
                 () -> {
                   INDEXED_CHILD.collectSpanAttributes(parameters::getFirst);
-                  response.resume("");
+                  response.resume(INDEXED_CHILD.getBody());
                 }));
   }
 

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-common/testing/src/main/java/io/opentelemetry/instrumentation/jaxrs/v3_0/test/JaxRsTestResource.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-common/testing/src/main/java/io/opentelemetry/instrumentation/jaxrs/v3_0/test/JaxRsTestResource.java
@@ -105,7 +105,7 @@ public class JaxRsTestResource {
                 INDEXED_CHILD,
                 () -> {
                   INDEXED_CHILD.collectSpanAttributes(parameters::getFirst);
-                  response.resume("");
+                  response.resume(INDEXED_CHILD.getBody());
                 }));
   }
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
@@ -127,7 +127,8 @@ class Netty38ServerTest extends AbstractHttpServerTest<ServerBootstrap> {
                                   HTTP_1_1, HttpResponseStatus.valueOf(endpoint.getStatus()));
                           response.setContent(responseContent);
                         } else if (INDEXED_CHILD.equals(endpoint)) {
-                          responseContent = ChannelBuffers.EMPTY_BUFFER;
+                          responseContent =
+                              ChannelBuffers.copiedBuffer(endpoint.getBody(), CharsetUtil.UTF_8);
                           endpoint.collectSpanAttributes(
                               name ->
                                   new QueryStringDecoder(uri)

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/Netty40ServerTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/Netty40ServerTest.java
@@ -106,7 +106,9 @@ class Netty40ServerTest extends AbstractHttpServerTest<EventLoopGroup> {
                                                 HttpResponseStatus.valueOf(endpoint.getStatus()),
                                                 content);
                                       } else if (endpoint.equals(INDEXED_CHILD)) {
-                                        content = Unpooled.EMPTY_BUFFER;
+                                        content =
+                                            Unpooled.copiedBuffer(
+                                                endpoint.getBody(), CharsetUtil.UTF_8);
                                         endpoint.collectSpanAttributes(
                                             it ->
                                                 new QueryStringDecoder(uri)

--- a/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ServerTest.java
+++ b/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ServerTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractNetty41ServerTest extends AbstractHttpServerTest<E
             new DefaultFullHttpResponse(
                 HTTP_1_1, HttpResponseStatus.valueOf(endpoint.getStatus()), content);
       } else if (INDEXED_CHILD.equals(endpoint)) {
-        content = Unpooled.EMPTY_BUFFER;
+        content = Unpooled.copiedBuffer(endpoint.getBody(), CharsetUtil.UTF_8);
         endpoint.collectSpanAttributes(
             name ->
                 new QueryStringDecoder(uri).parameters().get(name).stream().findFirst().orElse(""));

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestAsyncWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestAsyncWebServer.scala
@@ -41,7 +41,7 @@ object PekkoHttpTestAsyncWebServer {
                   override def getParameter(name: String): String =
                     uri.query().get(name).orNull
                 })
-                resp.withEntity("")
+                resp.withEntity(endpoint.getBody)
               case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
               case REDIRECT =>
                 resp.withHeaders(headers.Location(endpoint.getBody))

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
@@ -50,7 +50,7 @@ object PekkoHttpTestServerSourceWebServer {
                 override def getParameter(name: String): String =
                   map.get(name).orNull
               })
-              ""
+              INDEXED_CHILD.getBody
             }
           }
           complete(AbstractHttpServerTest.controller(INDEXED_CHILD, supplier))

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestSyncWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestSyncWebServer.scala
@@ -38,7 +38,7 @@ object PekkoHttpTestSyncWebServer {
                 override def getParameter(name: String): String =
                   uri.query().get(name).orNull
               })
-              resp.withEntity("")
+              resp.withEntity(endpoint.getBody)
             case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
             case REDIRECT =>
               resp.withHeaders(headers.Location(endpoint.getBody))

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
@@ -50,7 +50,7 @@ object PekkoHttpTestWebServer {
                 override def getParameter(name: String): String =
                   map.get(name).orNull
               })
-              ""
+              INDEXED_CHILD.getBody
             }
           }
           complete(AbstractHttpServerTest.controller(INDEXED_CHILD, supplier))

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayAsyncServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayAsyncServerTest.java
@@ -47,7 +47,8 @@ class PlayAsyncServerTest extends PlayServerTest {
                                       it ->
                                           play.mvc.Http.Context.Implicit.request()
                                               .getQueryString(it));
-                                  return Results.status(INDEXED_CHILD.getStatus());
+                                  return Results.status(
+                                      INDEXED_CHILD.getStatus(), INDEXED_CHILD.getBody());
                                 })))
             .GET(QUERY_PARAM.getPath())
             .routeAsync(

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -55,7 +55,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
                         () -> {
                           INDEXED_CHILD.collectSpanAttributes(
                               it -> play.mvc.Http.Context.Implicit.request().getQueryString(it));
-                          return Results.status(INDEXED_CHILD.getStatus());
+                          return Results.status(INDEXED_CHILD.getStatus(), INDEXED_CHILD.getBody());
                         }))
             .GET(QUERY_PARAM.getPath())
             .routeTo(

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -52,7 +52,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
                         () -> {
                           INDEXED_CHILD.collectSpanAttributes(
                               it -> play.mvc.Http.Context.Implicit.request().getQueryString(it));
-                          return Results.status(INDEXED_CHILD.getStatus());
+                          return Results.status(INDEXED_CHILD.getStatus(), INDEXED_CHILD.getBody());
                         }))
             .GET(QUERY_PARAM.getPath())
             .routeTo(

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/java/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/java/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractRatpackHttpServerTest extends AbstractHttpServerTe
                                               context
                                                   .getResponse()
                                                   .status(endpoint.getStatus())
-                                                  .send();
+                                                  .send(endpoint.getBody());
                                             }))));
 
                 handlerChain.prefix(

--- a/instrumentation/restlet/restlet-1.1/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/AbstractRestletServerTest.java
+++ b/instrumentation/restlet/restlet-1.1/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/AbstractRestletServerTest.java
@@ -186,6 +186,7 @@ public class AbstractRestletServerTest extends AbstractHttpServerTest<Component>
                 () -> {
                   INDEXED_CHILD.collectSpanAttributes(
                       name -> request.getOriginalRef().getQueryAsForm().getFirst(name).getValue());
+                  response.setEntity(INDEXED_CHILD.getBody(), MediaType.TEXT_PLAIN);
                   response.setStatus(Status.valueOf(INDEXED_CHILD.getStatus()));
                 });
           }

--- a/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.java
+++ b/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.java
@@ -208,7 +208,8 @@ public class AbstractRestletServerTest extends AbstractHttpServerTest<Component>
                 () -> {
                   INDEXED_CHILD.collectSpanAttributes(
                       name -> request.getOriginalRef().getQueryAsForm().getFirstValue(name));
-                  response.setStatus(Status.valueOf(INDEXED_CHILD.getStatus()));
+                  response.setStatus(
+                      Status.valueOf(INDEXED_CHILD.getStatus()), INDEXED_CHILD.getBody());
                 });
           }
         });

--- a/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.java
+++ b/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.java
@@ -208,6 +208,7 @@ public class AbstractRestletServerTest extends AbstractHttpServerTest<Component>
                 () -> {
                   INDEXED_CHILD.collectSpanAttributes(
                       name -> request.getOriginalRef().getQueryAsForm().getFirstValue(name));
+                  response.setEntity(INDEXED_CHILD.getBody(), MediaType.TEXT_PLAIN);
                   response.setStatus(
                       Status.valueOf(INDEXED_CHILD.getStatus()), INDEXED_CHILD.getBody());
                 });

--- a/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletAppTestBase.java
+++ b/instrumentation/restlet/restlet-2.0/testing/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletAppTestBase.java
@@ -154,9 +154,7 @@ class RestletAppTestBase {
           () -> {
             INDEXED_CHILD.collectSpanAttributes(
                 name -> getRequest().getOriginalRef().getQueryAsForm().getFirstValue(name));
-            // INDEXED_CHILD.getBody() returns an empty string, in which case Restlet sets status to
-            // 204
-            return "child";
+            return INDEXED_CHILD.getBody();
           });
     }
   }

--- a/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TestServlet3.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TestServlet3.java
@@ -53,6 +53,7 @@ public class TestServlet3 {
             } else if (INDEXED_CHILD.equals(endpoint)) {
               endpoint.collectSpanAttributes(req::getParameter);
               resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(endpoint.getBody());
             } else if (QUERY_PARAM.equals(endpoint)) {
               resp.setStatus(endpoint.getStatus());
               resp.getWriter().print(req.getQueryString());
@@ -118,6 +119,7 @@ public class TestServlet3 {
                     } else if (INDEXED_CHILD.equals(endpoint)) {
                       endpoint.collectSpanAttributes(req::getParameter);
                       resp.setStatus(endpoint.getStatus());
+                      resp.getWriter().print(endpoint.getBody());
                       context.complete();
                     } else if (QUERY_PARAM.equals(endpoint)) {
                       resp.setStatus(endpoint.getStatus());
@@ -206,6 +208,7 @@ public class TestServlet3 {
               } else if (INDEXED_CHILD.equals(endpoint)) {
                 endpoint.collectSpanAttributes(req::getParameter);
                 resp.setStatus(endpoint.getStatus());
+                resp.getWriter().print(endpoint.getBody());
               } else if (QUERY_PARAM.equals(endpoint)) {
                 resp.setStatus(endpoint.getStatus());
                 resp.getWriter().print(req.getQueryString());

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
@@ -53,6 +53,7 @@ public class TestServlet5 {
             } else if (INDEXED_CHILD.equals(endpoint)) {
               endpoint.collectSpanAttributes(req::getParameter);
               resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(endpoint.getBody());
             } else if (QUERY_PARAM.equals(endpoint)) {
               resp.setStatus(endpoint.getStatus());
               resp.getWriter().print(req.getQueryString());
@@ -118,6 +119,7 @@ public class TestServlet5 {
                     } else if (INDEXED_CHILD.equals(endpoint)) {
                       endpoint.collectSpanAttributes(req::getParameter);
                       resp.setStatus(endpoint.getStatus());
+                      resp.getWriter().print(endpoint.getBody());
                       context.complete();
                     } else if (QUERY_PARAM.equals(endpoint)) {
                       resp.setStatus(endpoint.getStatus());
@@ -206,6 +208,7 @@ public class TestServlet5 {
               } else if (INDEXED_CHILD.equals(endpoint)) {
                 endpoint.collectSpanAttributes(req::getParameter);
                 resp.setStatus(endpoint.getStatus());
+                resp.getWriter().print(endpoint.getBody());
               } else if (QUERY_PARAM.equals(endpoint)) {
                 resp.setStatus(endpoint.getStatus());
                 resp.getWriter().print(req.getQueryString());

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/base/ServerTestController.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/base/ServerTestController.java
@@ -99,7 +99,7 @@ public abstract class ServerTestController {
         () -> {
           endpoint.collectSpanAttributes(it -> request.getQueryParams().getFirst(it));
           setStatus(response, endpoint);
-          return "";
+          return endpoint.getBody();
         });
   }
 

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.java
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.java
@@ -45,8 +45,9 @@ class AsyncServlet extends HttpServlet {
                     resp.setStatus(endpoint.getStatus());
                     resp.getWriter().print(endpoint.getBody());
                   } else if (endpoint.equals(INDEXED_CHILD)) {
-                    endpoint.collectSpanAttributes(x -> req.getParameter(x));
+                    endpoint.collectSpanAttributes(req::getParameter);
                     resp.setStatus(endpoint.getStatus());
+                    resp.getWriter().print(endpoint.getBody());
                   } else if (endpoint.equals(QUERY_PARAM)) {
                     resp.setStatus(endpoint.getStatus());
                     resp.getWriter().print(req.getQueryString());

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.java
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.java
@@ -44,8 +44,9 @@ class AsyncServlet extends HttpServlet {
                     resp.setStatus(endpoint.getStatus());
                     resp.getWriter().print(endpoint.getBody());
                   } else if (endpoint.equals(INDEXED_CHILD)) {
-                    endpoint.collectSpanAttributes(x -> req.getParameter(x));
+                    endpoint.collectSpanAttributes(req::getParameter);
                     resp.setStatus(endpoint.getStatus());
+                    resp.getWriter().print(endpoint.getBody());
                   } else if (endpoint.equals(QUERY_PARAM)) {
                     resp.setStatus(endpoint.getStatus());
                     resp.getWriter().print(req.getQueryString());

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
@@ -43,7 +43,9 @@ abstract class AbstractVertxRxVerticle extends AbstractVerticle {
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(
                           parameter -> ctx.request().params().get(parameter));
-                      ctx.response().setStatusCode(INDEXED_CHILD.getStatus()).end(INDEXED_CHILD.getBody());
+                      ctx.response()
+                          .setStatusCode(INDEXED_CHILD.getStatus())
+                          .end(INDEXED_CHILD.getBody());
                     }));
 
     router

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
@@ -43,7 +43,7 @@ abstract class AbstractVertxRxVerticle extends AbstractVerticle {
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(
                           parameter -> ctx.request().params().get(parameter));
-                      ctx.response().setStatusCode(INDEXED_CHILD.getStatus()).end();
+                      ctx.response().setStatusCode(INDEXED_CHILD.getStatus()).end(INDEXED_CHILD.getBody());
                     }));
 
     router

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/server/AbstractVertxRxVerticle.java
@@ -43,7 +43,9 @@ abstract class AbstractVertxRxVerticle extends AbstractVerticle {
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(
                           parameter -> ctx.request().params().get(parameter));
-                      ctx.response().setStatusCode(INDEXED_CHILD.getStatus()).end();
+                      ctx.response()
+                          .setStatusCode(INDEXED_CHILD.getStatus())
+                          .end(INDEXED_CHILD.getBody());
                     }));
 
     router

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/AbstractVertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/AbstractVertxWebServer.java
@@ -58,7 +58,9 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                     INDEXED_CHILD,
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(it -> ctx.request().getParam(it));
-                      end(ctx.response().setStatusCode(INDEXED_CHILD.getStatus()), INDEXED_CHILD.getBody());
+                      end(
+                          ctx.response().setStatusCode(INDEXED_CHILD.getStatus()),
+                          INDEXED_CHILD.getBody());
                       return null;
                     }));
     router

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/AbstractVertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/AbstractVertxWebServer.java
@@ -58,7 +58,7 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                     INDEXED_CHILD,
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(it -> ctx.request().getParam(it));
-                      end(ctx.response().setStatusCode(INDEXED_CHILD.getStatus()));
+                      end(ctx.response().setStatusCode(INDEXED_CHILD.getStatus()), INDEXED_CHILD.getBody());
                       return null;
                     }));
     router

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -403,6 +403,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
     TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
     TextMapSetter<HttpRequestBuilder> setter = HttpRequestBuilder::header;
 
+    List<String> responses = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       int index = i;
       HttpRequestBuilder request =
@@ -419,10 +420,22 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
             client
                 .execute(request.build())
                 .aggregate()
-                .whenComplete((result, throwable) -> latch.countDown());
+                .whenComplete(
+                    (result, throwable) -> {
+                      latch.countDown();
+                      if (throwable != null) {
+                        responses.add(throwable.toString());
+                      } else {
+                        responses.add(result.status().code() + " " + result.contentUtf8());
+                      }
+                    });
           });
     }
     latch.await();
+    assertThat(responses)
+        .allSatisfy(
+            response ->
+                assertThat(response).isEqualTo(endpoint.getStatus() + " " + endpoint.getBody()));
 
     assertHighConcurrency(count);
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -422,12 +422,12 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
                 .aggregate()
                 .whenComplete(
                     (result, throwable) -> {
-                      latch.countDown();
                       if (throwable != null) {
                         responses.add(throwable.toString());
                       } else {
                         responses.add(result.status().code() + " " + result.contentUtf8());
                       }
+                      latch.countDown();
                     });
           });
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
@@ -47,7 +47,7 @@ public class ServerEndpoint {
   public static final ServerEndpoint AUTH_ERROR =
       new ServerEndpoint("AUTH_ERROR", "basicsecured/endpoint", 401, null);
   public static final ServerEndpoint INDEXED_CHILD =
-      new ServerEndpoint("INDEXED_CHILD", "child", 200, "");
+      new ServerEndpoint("INDEXED_CHILD", "child", 200, "success");
 
   public static final String ID_ATTRIBUTE_NAME = "test.request.id";
   public static final String ID_PARAMETER_NAME = "id";


### PR DESCRIPTION
Java http server concurrency tests is falky on jdk < 21 https://scans.gradle.com/s/e7bczrryr4vec/tests/task/:instrumentation:java-http-server:library:test/details/io.opentelemetry.instrumentation.javahttpserver.JavaHttpServerTest/highConcurrency()?top-execution=1 Adding body to the response seems to help.