### PR TITLE
Add initial gen_ai instrumentation of bedrock InvokeModel

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
@@ -12,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 
 final class BedrockRuntimeAccess {
   private BedrockRuntimeAccess() {}
@@ -44,60 +45,86 @@ final class BedrockRuntimeAccess {
     return enabled && BedrockRuntimeImpl.isBedrockRuntimeResponse(response);
   }
 
-  @Nullable
   @NoMuzzle
-  static String getModelId(SdkRequest request) {
-    return enabled ? BedrockRuntimeImpl.getModelId(request) : null;
+  static void maybeParseInvokeModelRequest(
+      ExecutionAttributes executionAttributes, SdkRequest request) {
+    if (enabled) {
+      BedrockRuntimeImpl.maybeParseInvokeModelRequest(executionAttributes, request);
+    }
+  }
+
+  @NoMuzzle
+  static void maybeParseInvokeModelResponse(
+      ExecutionAttributes executionAttributes, SdkResponse response) {
+    if (enabled) {
+      BedrockRuntimeImpl.maybeParseInvokeModelResponse(executionAttributes, response);
+    }
   }
 
   @Nullable
   @NoMuzzle
-  static Long getMaxTokens(SdkRequest request) {
-    return enabled ? BedrockRuntimeImpl.getMaxTokens(request) : null;
+  static String getModelId(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getModelId(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Double getTemperature(SdkRequest request) {
-    return enabled ? BedrockRuntimeImpl.getTemperature(request) : null;
+  static String getOperationName(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getOperationName(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Double getTopP(SdkRequest request) {
-    return enabled ? BedrockRuntimeImpl.getTopP(request) : null;
+  static Long getMaxTokens(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getMaxTokens(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static List<String> getStopSequences(SdkRequest request) {
-    return enabled ? BedrockRuntimeImpl.getStopSequences(request) : null;
+  static Double getTemperature(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getTemperature(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static List<String> getStopReasons(Response response) {
-    return enabled ? BedrockRuntimeImpl.getStopReasons(response) : null;
+  static Double getTopP(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getTopP(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Long getUsageInputTokens(Response response) {
-    return enabled ? BedrockRuntimeImpl.getUsageInputTokens(response) : null;
+  static List<String> getStopSequences(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getStopSequences(executionAttributes) : null;
   }
 
   @Nullable
   @NoMuzzle
-  static Long getUsageOutputTokens(Response response) {
-    return enabled ? BedrockRuntimeImpl.getUsageOutputTokens(response) : null;
+  static List<String> getStopReasons(ExecutionAttributes executionAttributes, Response response) {
+    return enabled ? BedrockRuntimeImpl.getStopReasons(executionAttributes, response) : null;
+  }
+
+  @Nullable
+  @NoMuzzle
+  static Long getUsageInputTokens(ExecutionAttributes executionAttributes, Response response) {
+    return enabled ? BedrockRuntimeImpl.getUsageInputTokens(executionAttributes, response) : null;
+  }
+
+  @Nullable
+  @NoMuzzle
+  static Long getUsageOutputTokens(ExecutionAttributes executionAttributes, Response response) {
+    return enabled ? BedrockRuntimeImpl.getUsageOutputTokens(executionAttributes, response) : null;
   }
 
   @NoMuzzle
   static void recordRequestEvents(
-      Context otelContext, Logger eventLogger, SdkRequest request, boolean captureMessageContent) {
+      Context otelContext,
+      Logger eventLogger,
+      ExecutionAttributes executionAttributes,
+      SdkRequest request,
+      boolean captureMessageContent) {
     if (enabled) {
       BedrockRuntimeImpl.recordRequestEvents(
-          otelContext, eventLogger, request, captureMessageContent);
+          otelContext, eventLogger, executionAttributes, request, captureMessageContent);
     }
   }
 
@@ -105,11 +132,12 @@ final class BedrockRuntimeAccess {
   static void recordResponseEvents(
       Context otelContext,
       Logger eventLogger,
+      ExecutionAttributes executionAttributes,
       SdkResponse response,
       boolean captureMessageContent) {
     if (enabled) {
       BedrockRuntimeImpl.recordResponseEvents(
-          otelContext, eventLogger, response, captureMessageContent);
+          otelContext, eventLogger, executionAttributes, response, captureMessageContent);
     }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
-import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesGetter;
@@ -13,18 +12,10 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 
 enum BedrockRuntimeAttributesGetter
     implements GenAiAttributesGetter<ExecutionAttributes, Response> {
   INSTANCE;
-
-  // copied from GenAiIncubatingAttributes
-  private static final class GenAiOperationNameIncubatingValues {
-    static final String CHAT = "chat";
-
-    private GenAiOperationNameIncubatingValues() {}
-  }
 
   static final class GenAiSystemIncubatingValues {
     static final String AWS_BEDROCK = "aws.bedrock";
@@ -34,18 +25,7 @@ enum BedrockRuntimeAttributesGetter
 
   @Override
   public String getOperationName(ExecutionAttributes executionAttributes) {
-    String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
-    if (operation != null) {
-      switch (operation) {
-        case "Converse":
-        // fallthrough
-        case "ConverseStream":
-          return GenAiOperationNameIncubatingValues.CHAT;
-        default:
-          return null;
-      }
-    }
-    return null;
+    return BedrockRuntimeAccess.getOperationName(executionAttributes);
   }
 
   @Override
@@ -56,7 +36,7 @@ enum BedrockRuntimeAttributesGetter
   @Nullable
   @Override
   public String getRequestModel(ExecutionAttributes executionAttributes) {
-    return BedrockRuntimeAccess.getModelId(executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE));
+    return BedrockRuntimeAccess.getModelId(executionAttributes);
   }
 
   @Nullable
@@ -80,8 +60,7 @@ enum BedrockRuntimeAttributesGetter
   @Nullable
   @Override
   public Long getRequestMaxTokens(ExecutionAttributes executionAttributes) {
-    return BedrockRuntimeAccess.getMaxTokens(
-        executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE));
+    return BedrockRuntimeAccess.getMaxTokens(executionAttributes);
   }
 
   @Nullable
@@ -93,15 +72,13 @@ enum BedrockRuntimeAttributesGetter
   @Nullable
   @Override
   public List<String> getRequestStopSequences(ExecutionAttributes executionAttributes) {
-    return BedrockRuntimeAccess.getStopSequences(
-        executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE));
+    return BedrockRuntimeAccess.getStopSequences(executionAttributes);
   }
 
   @Nullable
   @Override
   public Double getRequestTemperature(ExecutionAttributes executionAttributes) {
-    return BedrockRuntimeAccess.getTemperature(
-        executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE));
+    return BedrockRuntimeAccess.getTemperature(executionAttributes);
   }
 
   @Nullable
@@ -113,7 +90,7 @@ enum BedrockRuntimeAttributesGetter
   @Nullable
   @Override
   public Double getRequestTopP(ExecutionAttributes executionAttributes) {
-    return BedrockRuntimeAccess.getTopP(executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE));
+    return BedrockRuntimeAccess.getTopP(executionAttributes);
   }
 
   @Override
@@ -122,7 +99,7 @@ enum BedrockRuntimeAttributesGetter
     if (response == null) {
       return emptyList();
     }
-    List<String> stopReasons = BedrockRuntimeAccess.getStopReasons(response);
+    List<String> stopReasons = BedrockRuntimeAccess.getStopReasons(executionAttributes, response);
     if (stopReasons == null) {
       return Collections.emptyList();
     }
@@ -148,7 +125,7 @@ enum BedrockRuntimeAttributesGetter
     if (response == null) {
       return null;
     }
-    return BedrockRuntimeAccess.getUsageInputTokens(response);
+    return BedrockRuntimeAccess.getUsageInputTokens(executionAttributes, response);
   }
 
   @Nullable
@@ -158,6 +135,6 @@ enum BedrockRuntimeAttributesGetter
     if (response == null) {
       return null;
     }
-    return BedrockRuntimeAccess.getUsageOutputTokens(response);
+    return BedrockRuntimeAccess.getUsageOutputTokens(executionAttributes, response);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
@@ -172,6 +172,8 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
       return request;
     }
 
+    BedrockRuntimeAccess.maybeParseInvokeModelRequest(executionAttributes, request);
+
     RequestSpanFinisher requestFinisher;
     io.opentelemetry.context.Context otelContext;
     Instant requestStart = Instant.now();
@@ -237,7 +239,7 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
 
     if (BedrockRuntimeAccess.isBedrockRuntimeRequest(request)) {
       BedrockRuntimeAccess.recordRequestEvents(
-          otelContext, eventLogger, request, genAiCaptureMessageContent);
+          otelContext, eventLogger, executionAttributes, request, genAiCaptureMessageContent);
     }
 
     // Insert other special handling here, following the same pattern as SQS and SNS.
@@ -366,6 +368,8 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
 
     io.opentelemetry.context.Context otelContext = getContext(executionAttributes);
     if (otelContext != null) {
+      BedrockRuntimeAccess.maybeParseInvokeModelResponse(executionAttributes, context.response());
+
       // http request has been changed
       executionAttributes.putAttribute(SDK_HTTP_REQUEST_ATTRIBUTE, context.httpRequest());
 
@@ -395,7 +399,7 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
     }
     if (BedrockRuntimeAccess.isBedrockRuntimeResponse(response)) {
       BedrockRuntimeAccess.recordResponseEvents(
-          otelContext, eventLogger, response, genAiCaptureMessageContent);
+          otelContext, eventLogger, executionAttributes, response, genAiCaptureMessageContent);
     }
     if (captureExperimentalSpanAttributes) {
       AwsSdkRequest sdkRequest = executionAttributes.getAttribute(AWS_SDK_REQUEST_ATTRIBUTE);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelamazonnova.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelamazonnova.yaml
@@ -1,0 +1,42 @@
+---
+id: 79b936f7-d7d1-437c-b41b-dc668fb0889f
+name: model_amazonnova-micro-v10_invoke
+request:
+  url: /model/amazon.nova-micro-v1%3A0/invoke
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "role" : "user",
+          "content" : [ {
+            "text" : "Say this is a test"
+          } ]
+        } ],
+        "inferenceConfig" : {
+          "max_new_tokens" : 10,
+          "temperature" : 0.8,
+          "topP" : 1,
+          "stopSequences" : [ "|" ]
+        }
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  body: "{\"output\":{\"message\":{\"content\":[{\"text\":\"It sounds like you're\
+    \ initiating a test or\"}],\"role\":\"assistant\"}},\"stopReason\":\"max_tokens\"\
+    ,\"usage\":{\"inputTokens\":5,\"outputTokens\":10,\"totalTokens\":15,\"cacheReadInputTokenCount\"\
+    :0,\"cacheWriteInputTokenCount\":0}}"
+  headers:
+    Date: "Wed, 19 Mar 2025 09:37:59 GMT"
+    Content-Type: application/json
+    x-amzn-RequestId: 5ef973ac-8020-4796-82ca-99e8e960a221
+    X-Amzn-Bedrock-Invocation-Latency: "174"
+    X-Amzn-Bedrock-Cache-Write-Input-Token-Count: "0"
+    X-Amzn-Bedrock-Cache-Read-Input-Token-Count: "0"
+    X-Amzn-Bedrock-Output-Token-Count: "10"
+    X-Amzn-Bedrock-Input-Token-Count: "5"
+uuid: 79b936f7-d7d1-437c-b41b-dc668fb0889f
+persistent: true
+insertionIndex: 24

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelamazontitan.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelamazontitan.yaml
@@ -1,0 +1,34 @@
+---
+id: dbcd468d-58ca-4d6f-87e9-7d377f1aae67
+name: model_amazontitan-text-lite-v1_invoke
+request:
+  url: /model/amazon.titan-text-lite-v1/invoke
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "inputText" : "Say this is a test",
+        "textGenerationConfig" : {
+          "maxTokenCount" : 10,
+          "temperature" : 0.8,
+          "topP" : 1,
+          "stopSequences" : [ "|" ]
+        }
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  body: "{\"inputTextTokenCount\":5,\"results\":[{\"tokenCount\":10,\"outputText\"\
+    :\"\\nHello! I am a computer program designed to\",\"completionReason\":\"LENGTH\"\
+    }]}"
+  headers:
+    Date: "Wed, 19 Mar 2025 05:44:06 GMT"
+    Content-Type: application/json
+    x-amzn-RequestId: 1c4e6b83-4da3-430c-b21f-34b0cb003f06
+    X-Amzn-Bedrock-Invocation-Latency: "658"
+    X-Amzn-Bedrock-Output-Token-Count: "10"
+    X-Amzn-Bedrock-Input-Token-Count: "5"
+uuid: dbcd468d-58ca-4d6f-87e9-7d377f1aae67
+persistent: true
+insertionIndex: 20

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelanthropicclaude.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.awssdk.v2_2.abstractaws2bedrockruntimetest.testinvokemodelanthropicclaude.yaml
@@ -1,0 +1,40 @@
+---
+id: 5b089fbd-8fb3-47ac-9ec3-6c3f62b5a8d7
+name: model_anthropicclaude-v2_invoke
+request:
+  url: /model/anthropic.claude-v2/invoke
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "role" : "user",
+          "content" : [ {
+            "text" : "Say this is a test",
+            "type" : "text"
+          } ]
+        } ],
+        "anthropic_version" : "bedrock-2023-05-31",
+        "max_tokens" : 10,
+        "temperature" : 0.8,
+        "top_p" : 1,
+        "stop_sequences" : [ "|" ]
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  body: "{\"id\":\"msg_bdrk_013qVdwsVMmWCPvoVQGAJwZB\",\"type\":\"message\",\"role\"\
+    :\"assistant\",\"model\":\"claude-2.0\",\"content\":[{\"type\":\"text\",\"text\"\
+    :\"Okay, I just said \\\"This is a test\"}],\"stop_reason\":\"max_tokens\",\"\
+    stop_sequence\":null,\"usage\":{\"input_tokens\":14,\"output_tokens\":10}}"
+  headers:
+    Date: "Wed, 19 Mar 2025 09:29:15 GMT"
+    Content-Type: application/json
+    x-amzn-RequestId: 8975185b-c163-4908-a344-8d986199cc2a
+    X-Amzn-Bedrock-Invocation-Latency: "1792"
+    X-Amzn-Bedrock-Output-Token-Count: "10"
+    X-Amzn-Bedrock-Input-Token-Count: "14"
+uuid: 5b089fbd-8fb3-47ac-9ec3-6c3f62b5a8d7
+persistent: true
+insertionIndex: 22


### PR DESCRIPTION
This adds instrumentation of InvokeModel for non-streaming and non-tools, will follow up with those.

Since the JSON body has to be parsed in the request/response to get the telemetry data, this takes the approach of parsing once into execution attributes for each. It meant some simple signature changes to the existing methods.

/cc @codefromthecrypt