### PR TITLE
Fix flaky @WithSpan test

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.test.annotation;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
@@ -112,7 +113,8 @@ class WithSpanInstrumentationTest {
   void multipleSpansWithoutParent() {
     new TracedWithSpan().consumer();
 
-    testing.waitAndAssertTraces(
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("TracedWithSpan.consumer", "TracedWithSpan.withoutParent"),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/annotations/InstrumentationWithSpanAspectTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/annotations/InstrumentationWithSpanAspectTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumen
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
 import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
@@ -189,7 +190,8 @@ class InstrumentationWithSpanAspectTest {
     testing.runWithSpan("parent", withSpanTester::testWithoutParentSpan);
 
     // then
-    testing.waitAndAssertTraces(
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("parent", unproxiedTesterSimpleClassName + ".testWithoutParentSpan"),
         trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("parent").hasKind(INTERNAL)),
         trace ->
             trace.hasSpansSatisfyingExactly(


### PR DESCRIPTION
https://scans.gradle.com/s/xks2yrj4u6lsa/tests/task/:instrumentation:opentelemetry-instrumentation-annotations-1.16:javaagent:test/details/io.opentelemetry.test.annotation.WithSpanInstrumentationTest/multipleSpansWithoutParent()?expanded-stacktrace=WyIwIl0&top-execution=1
https://scans.gradle.com/s/fnzhv4rbiip7i/tests/task/:instrumentation:spring:spring-boot-autoconfigure:test/details/io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.annotations.InstrumentationWithSpanAspectTest/withSpanWithoutParent()?top-execution=1
On jdk8 the traces can be in the wrong order because they have the same start time.