### PR TITLE
Update postgres driver in r2dbc tests

### DIFF
--- a/instrumentation/r2dbc-1.0/testing/build.gradle.kts
+++ b/instrumentation/r2dbc-1.0/testing/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 
   runtimeOnly("dev.miku:r2dbc-mysql:0.8.2.RELEASE")
   runtimeOnly("org.mariadb:r2dbc-mariadb:1.1.3")
-  runtimeOnly("org.postgresql:r2dbc-postgresql:1.0.1.RELEASE")
+  runtimeOnly("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
 }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
@@ -141,6 +142,7 @@ public abstract class AbstractR2dbcStatementTest {
                 .option(USER, USER_DB)
                 .option(PASSWORD, PW_DB)
                 .option(DATABASE, DB)
+                .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
                 .build());
 
     getTesting()


### PR DESCRIPTION
https://scans.gradle.com/s/dlxnycgjzg354/tests/task/:instrumentation:r2dbc-1.0:library:testStableSemconv/details/io.opentelemetry.instrumentation.r2dbc.v1_0.R2dbcStatementTest/testQueries(Parameter)%5B6%5D?top-execution=1

r2dbc postgres tests are currently the most flaky test we have, update the driver in hope that it solves the issue. Also add connection timeout, perhaps that will reveal whether it is establishing the connection or something else that causes the timeout.