### PR TITLE
Hopefully fix lettuce tests hanging

### DIFF
--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -85,7 +85,7 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
 
     StatefulRedisConnection<String, String> testConnection = testConnectionClient.connect();
     cleanup.deferCleanup(testConnection);
-    cleanup.deferCleanup(testConnectionClient::shutdown);
+    cleanup.deferCleanup(() -> shutdown(testConnectionClient));
 
     testing.waitAndAssertTraces(
         trace ->


### PR DESCRIPTION
https://scans.gradle.com/s/i6diwf2z5ick6/console-log/task/:instrumentation:lettuce:lettuce-5.0:javaagent:testStableSemconv?page=2#L1938
Same as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12927