### PR TITLE
add `url.template` to client spans

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of opentelemetry-instrumentation-api-2.15.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.14.0.jar
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === REQUEST:java.lang.Object, === RESPONSE:java.lang.Object
+	+++  NEW INTERFACE: io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === REQUEST:java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getUrlTemplate(java.lang.Object)
+		+++  NEW ANNOTATION: javax.annotation.Nullable

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesGetter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.semconv.http;
 
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
@@ -21,7 +22,8 @@ import javax.annotation.Nullable;
 public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
     extends HttpCommonAttributesGetter<REQUEST, RESPONSE>,
         NetworkAttributesGetter<REQUEST, RESPONSE>,
-        ServerAttributesGetter<REQUEST> {
+        ServerAttributesGetter<REQUEST>,
+        UrlAttributesGetter<REQUEST> {
 
   /**
    * Returns the absolute URL describing a network resource according to <a

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
@@ -70,10 +70,11 @@ public final class HttpSpanNameExtractor {
     @Override
     public String extract(REQUEST request) {
       String method = getter.getHttpRequestMethod(request);
+      String template = getter.getUrlTemplate(request);
       if (method == null || !knownMethods.contains(method)) {
         return "HTTP";
       }
-      return method;
+      return template == null ? method : method + " " + template;
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
@@ -70,10 +70,10 @@ public final class HttpSpanNameExtractor {
     @Override
     public String extract(REQUEST request) {
       String method = getter.getHttpRequestMethod(request);
-      String template = getter.getUrlTemplate(request);
       if (method == null || !knownMethods.contains(method)) {
         return "HTTP";
       }
+      String template = getter.getUrlTemplate(request);
       return template == null ? method : method + " " + template;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/UrlAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/UrlAttributesGetter.java
@@ -50,4 +50,14 @@ public interface UrlAttributesGetter<REQUEST> {
   default String getUrlQuery(REQUEST request) {
     return null;
   }
+
+  /**
+   * Returns the template used to build the full URL (if available)
+   *
+   * <p>Examples: {@code /users/{id}}; {@code /users?q={query}}</p>
+   */
+  @Nullable
+  default String getUrlTemplate(REQUEST request) {
+    return null;
+  }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/UrlAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/UrlAttributesGetter.java
@@ -54,7 +54,7 @@ public interface UrlAttributesGetter<REQUEST> {
   /**
    * Returns the template used to build the full URL (if available)
    *
-   * <p>Examples: {@code /users/{id}}; {@code /users?q={query}}</p>
+   * <p>Examples: {@code /users/{id}}; {@code /users?q={query}}
    */
   @Nullable
   default String getUrlTemplate(REQUEST request) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/InternalUrlAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/InternalUrlAttributesExtractor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.semconv.url.internal;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.semconv.url.UrlAttributesGetter;
 import io.opentelemetry.semconv.UrlAttributes;
@@ -31,10 +32,12 @@ public final class InternalUrlAttributesExtractor<REQUEST> {
     String urlScheme = getUrlScheme(request);
     String urlPath = getter.getUrlPath(request);
     String urlQuery = getter.getUrlQuery(request);
+    String urlTemplate = getter.getUrlTemplate(request);
 
     internalSet(attributes, UrlAttributes.URL_SCHEME, urlScheme);
     internalSet(attributes, UrlAttributes.URL_PATH, urlPath);
     internalSet(attributes, UrlAttributes.URL_QUERY, urlQuery);
+    internalSet(attributes, AttributeKey.stringKey("url.template"), urlTemplate);
   }
 
   private String getUrlScheme(REQUEST request) {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractorTest.java
@@ -51,6 +51,7 @@ class HttpSpanNameExtractorTest {
   void templateAndMethod() {
     when(clientGetter.getUrlTemplate(anyMap())).thenReturn("/cats/{id}");
     when(clientGetter.getHttpRequestMethod(anyMap())).thenReturn("GET");
-    assertThat(HttpSpanNameExtractor.create(clientGetter).extract(Collections.emptyMap())).isEqualTo("GET /cats/{id}");
+    assertThat(HttpSpanNameExtractor.create(clientGetter).extract(Collections.emptyMap()))
+        .isEqualTo("GET /cats/{id}");
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractorTest.java
@@ -46,4 +46,11 @@ class HttpSpanNameExtractorTest {
     assertThat(HttpSpanNameExtractor.create(clientGetter).extract(Collections.emptyMap()))
         .isEqualTo("HTTP");
   }
+
+  @Test
+  void templateAndMethod() {
+    when(clientGetter.getUrlTemplate(anyMap())).thenReturn("/cats/{id}");
+    when(clientGetter.getHttpRequestMethod(anyMap())).thenReturn("GET");
+    assertThat(HttpSpanNameExtractor.create(clientGetter).extract(Collections.emptyMap())).isEqualTo("GET /cats/{id}");
+  }
 }

--- a/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/KtorHttpClientAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/KtorHttpClientAttributesGetter.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.ktor.v2_0.common
 
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.util.AttributeKey
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter
 
 internal object KtorHttpClientAttributesGetter : HttpClientAttributesGetter<HttpRequestData, HttpResponse> {
@@ -34,4 +35,7 @@ internal object KtorHttpClientAttributesGetter : HttpClientAttributesGetter<Http
   override fun getServerAddress(request: HttpRequestData) = request.url.host
 
   override fun getServerPort(request: HttpRequestData) = request.url.port
+
+  private val urlTemplateAttributeKey = AttributeKey<String>("URL_TEMPLATE")
+  override fun getUrlTemplate(request: HttpRequestData): String? = request.attributes.getOrNull(urlTemplateAttributeKey)
 }


### PR DESCRIPTION
Added support for url.template (plus KTOR integration)

if https://github.com/ktorio/ktor/pull/4747 gets merged in. Fixes #13570.
If it does not get merged, allows applications to set the attribute.

`url.template` is currently hard coded as it's not in the semantics package yet. 

I imagine this is due to stability stuff. I'm unsure if this makes this PR unmergable. 