### PR TITLE
Add experimental http client url.template attribute

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.CommonConfig;
+import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientExperimentalAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientExperimentalMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientPeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimentalAttributesExtractor;
@@ -218,6 +219,13 @@ public final class DefaultHttpClientInstrumenterBuilder<REQUEST, RESPONSE> {
   }
 
   public Instrumenter<REQUEST, RESPONSE> build() {
+    if (emitExperimentalHttpClientTelemetry
+        && attributesGetter instanceof HttpClientExperimentalAttributesGetter) {
+      HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE> experimentalAttributesGetter =
+          (HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE>) attributesGetter;
+      Experimental.setUrlTemplateExtractor(
+          httpSpanNameExtractorBuilder, experimentalAttributesGetter::getUrlTemplate);
+    }
     SpanNameExtractor<? super REQUEST> spanNameExtractor =
         spanNameExtractorTransformer.apply(httpSpanNameExtractorBuilder.build());
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalAttributesGetter.java
@@ -8,9 +8,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import javax.annotation.Nullable;
 
-/**
- * An interface for getting experimental HTTP client attributes.
- */
+/** An interface for getting experimental HTTP client attributes. */
 public interface HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE>
     extends HttpClientAttributesGetter<REQUEST, RESPONSE> {
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalAttributesGetter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.http;
+
+import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import javax.annotation.Nullable;
+
+/**
+ * An interface for getting experimental HTTP client attributes.
+ */
+public interface HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE>
+    extends HttpClientAttributesGetter<REQUEST, RESPONSE> {
+
+  /**
+   * Returns the template used by the http client framework to build the request URL.
+   *
+   * <p>Examples: {@code /users/:userID?}, {@code {controller}/{action}/{id?}}
+   */
+  @Nullable
+  String getUrlTemplate(REQUEST request);
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractor.java
@@ -26,6 +26,9 @@ public final class HttpExperimentalAttributesExtractor<REQUEST, RESPONSE>
   static final AttributeKey<Long> HTTP_RESPONSE_BODY_SIZE =
       AttributeKey.longKey("http.response.body.size");
 
+  // copied from UrlIncubatingAttributes
+  private static final AttributeKey<String> URL_TEMPLATE = AttributeKey.stringKey("url.template");
+
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpClientAttributesGetter<REQUEST, RESPONSE> getter) {
     return new HttpExperimentalAttributesExtractor<>(getter);
@@ -60,6 +63,12 @@ public final class HttpExperimentalAttributesExtractor<REQUEST, RESPONSE>
     if (response != null) {
       Long responseBodySize = responseBodySize(request, response);
       internalSet(attributes, HTTP_RESPONSE_BODY_SIZE, responseBodySize);
+    }
+
+    if (getter instanceof HttpClientExperimentalAttributesGetter) {
+      HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE> experimentalGetter =
+          (HttpClientExperimentalAttributesGetter<REQUEST, RESPONSE>) getter;
+      internalSet(attributes, URL_TEMPLATE, experimentalGetter.getUrlTemplate(request));
     }
   }
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractorTest.java
@@ -7,17 +7,20 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.UrlIncubatingAttributes;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,22 +29,30 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class HttpExperimentalAttributesExtractorTest {
 
-  @Mock HttpClientAttributesGetter<String, String> clientGetter;
+  @Mock HttpClientExperimentalAttributesGetter<String, String> clientGetter;
   @Mock HttpServerAttributesGetter<String, String> serverGetter;
 
   @Test
   void shouldExtractRequestAndResponseSizes_client() {
-    runTest(clientGetter, HttpExperimentalAttributesExtractor.create(clientGetter));
+    when(clientGetter.getUrlTemplate("request")).thenReturn("template");
+    runTest(
+        clientGetter,
+        HttpExperimentalAttributesExtractor.create(clientGetter),
+        Collections.singletonMap(UrlIncubatingAttributes.URL_TEMPLATE, "template"));
   }
 
   @Test
   void shouldExtractRequestAndResponseSizes_server() {
-    runTest(serverGetter, HttpExperimentalAttributesExtractor.create(serverGetter));
+    runTest(
+        serverGetter,
+        HttpExperimentalAttributesExtractor.create(serverGetter),
+        Collections.emptyMap());
   }
 
   void runTest(
       HttpCommonAttributesGetter<String, String> getter,
-      AttributesExtractor<String, String> extractor) {
+      AttributesExtractor<String, String> extractor,
+      Map<AttributeKey<?>, ?> expected) {
 
     when(getter.getHttpRequestHeader("request", "content-length")).thenReturn(singletonList("123"));
     when(getter.getHttpResponseHeader("request", "response", "content-length"))
@@ -52,9 +63,9 @@ class HttpExperimentalAttributesExtractorTest {
     assertThat(attributes.build()).isEmpty();
 
     extractor.onEnd(attributes, Context.root(), "request", "response", null);
-    assertThat(attributes.build())
-        .containsOnly(
-            entry(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, 123L),
-            entry(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, 42L));
+    Map<AttributeKey<?>, Object> expectedAttributes = new HashMap<>(expected);
+    expectedAttributes.put(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, 123L);
+    expectedAttributes.put(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, 42L);
+    assertThat(attributes.build().asMap()).containsExactlyInAnyOrderEntriesOf(expectedAttributes);
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.instrumentation.api.internal;
 
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractorBuilder;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBuilder;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /**
@@ -18,6 +20,10 @@ public final class Experimental {
   @Nullable
   private static volatile BiConsumer<HttpClientAttributesExtractorBuilder<?, ?>, Boolean>
       redactHttpClientQueryParameters;
+
+  @Nullable
+  private static volatile BiConsumer<HttpSpanNameExtractorBuilder<?>, Function<?, String>>
+      urlTemplateExtractorSetter;
 
   private Experimental() {}
 
@@ -32,5 +38,20 @@ public final class Experimental {
       BiConsumer<HttpClientAttributesExtractorBuilder<?, ?>, Boolean>
           redactHttpClientQueryParameters) {
     Experimental.redactHttpClientQueryParameters = redactHttpClientQueryParameters;
+  }
+
+  public static <REQUEST> void setUrlTemplateExtractor(
+      HttpSpanNameExtractorBuilder<REQUEST> builder,
+      Function<REQUEST, String> urlTemplateExtractor) {
+    if (urlTemplateExtractorSetter != null) {
+      urlTemplateExtractorSetter.accept(builder, urlTemplateExtractor);
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static <REQUEST> void internalSetUrlTemplateExtractor(
+      BiConsumer<HttpSpanNameExtractorBuilder<REQUEST>, Function<REQUEST, String>>
+          urlTemplateExtractorSetter) {
+    Experimental.urlTemplateExtractorSetter = (BiConsumer) urlTemplateExtractorSetter;
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Extractor of the <a
@@ -61,19 +62,28 @@ public final class HttpSpanNameExtractor {
 
     private final HttpClientAttributesGetter<REQUEST, ?> getter;
     private final Set<String> knownMethods;
+    private final Function<REQUEST, String> urlTemplateExtractor;
 
-    Client(HttpClientAttributesGetter<REQUEST, ?> getter, Set<String> knownMethods) {
+    Client(
+        HttpClientAttributesGetter<REQUEST, ?> getter,
+        Set<String> knownMethods,
+        Function<REQUEST, String> urlTemplateExtractor) {
       this.getter = getter;
       this.knownMethods = knownMethods;
+      this.urlTemplateExtractor = urlTemplateExtractor;
     }
 
     @Override
     public String extract(REQUEST request) {
       String method = getter.getHttpRequestMethod(request);
-      if (method == null || !knownMethods.contains(method)) {
+      String template = urlTemplateExtractor.apply(request);
+      if (method == null) {
         return "HTTP";
       }
-      return method;
+      if (!knownMethods.contains(method)) {
+        method = "HTTP";
+      }
+      return template == null ? method : method + " " + template;
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpSpanNameExtractor.java
@@ -76,13 +76,13 @@ public final class HttpSpanNameExtractor {
     @Override
     public String extract(REQUEST request) {
       String method = getter.getHttpRequestMethod(request);
-      String template = urlTemplateExtractor.apply(request);
       if (method == null) {
         return "HTTP";
       }
       if (!knownMethods.contains(method)) {
         method = "HTTP";
       }
+      String template = urlTemplateExtractor.apply(request);
       return template == null ? method : method + " " + template;
     }
   }
@@ -100,13 +100,13 @@ public final class HttpSpanNameExtractor {
     @Override
     public String extract(REQUEST request) {
       String method = getter.getHttpRequestMethod(request);
-      String route = getter.getHttpRoute(request);
       if (method == null) {
         return "HTTP";
       }
       if (!knownMethods.contains(method)) {
         method = "HTTP";
       }
+      String route = getter.getHttpRoute(request);
       return route == null ? method : method + " " + route;
     }
   }


### PR DESCRIPTION
Add filling `url.template` to `HttpExperimentalAttributesExtractor`. Also modify `HttpSpanNameExtractor` to use the url template in http client span name.