### PR TITLE
Fix route handling when local root span wasn't created by instrumentation api

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -190,7 +190,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
       context = contextCustomizer.onStart(context, request, attributes);
     }
 
-    boolean localRoot = LocalRootSpan.isLocalRoot(context);
+    boolean localRoot = LocalRootSpan.fromContextOrNull(context) == null;
 
     spanBuilder.setAllAttributes(attributes);
     Span span = spanBuilder.setParent(context).startSpan();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -190,7 +190,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
       context = contextCustomizer.onStart(context, request, attributes);
     }
 
-    boolean localRoot = LocalRootSpan.fromContextOrNull(context) == null;
+    boolean localRoot = LocalRootSpan.isLocalRoot(parentContext);
+    boolean hasLocalRoot = LocalRootSpan.fromContextOrNull(context) != null;
 
     spanBuilder.setAllAttributes(attributes);
     Span span = spanBuilder.setParent(context).startSpan();
@@ -216,9 +217,9 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     if (localRoot) {
       context = LocalRootSpan.store(context, span);
-      if (spanKind == SpanKind.SERVER) {
-        HttpRouteState.updateSpan(context, span);
-      }
+    }
+    if (!hasLocalRoot && spanKind == SpanKind.SERVER) {
+      HttpRouteState.updateSpan(context, span);
     }
 
     return spanSuppressor.storeInContext(context, spanKind, span);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpRouteState.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpRouteState.java
@@ -27,7 +27,7 @@ public final class HttpRouteState implements ImplicitContextKeyed {
 
   public static void updateSpan(Context context, Span span) {
     HttpRouteState state = fromContextOrNull(context);
-    if (state != null) {
+    if (state != null && state.span == null) {
       state.span = span;
     }
   }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -371,7 +371,7 @@ class InstrumenterTest {
 
     assertThat(spanContext.isValid()).isTrue();
     assertThat(request).containsKey("traceparent");
-    assertThat(LocalRootSpan.fromContextOrNull(context)).isNull();
+    assertThat(LocalRootSpan.fromContextOrNull(context)).isNotNull();
 
     instrumenter.end(context, request, RESPONSE, new IllegalStateException("test"));
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -371,7 +371,7 @@ class InstrumenterTest {
 
     assertThat(spanContext.isValid()).isTrue();
     assertThat(request).containsKey("traceparent");
-    assertThat(LocalRootSpan.fromContextOrNull(context)).isNotNull();
+    assertThat(LocalRootSpan.fromContextOrNull(context)).isNull();
 
     instrumenter.end(context, request, RESPONSE, new IllegalStateException("test"));
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerRouteTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerRouteTest.java
@@ -44,7 +44,7 @@ class HttpServerRouteTest {
   }
 
   @Test
-  void noLocalRootSpan() {
+  void nonInstrumenerParentLocalRootSpan() {
     Span parentSpan =
         testing.getOpenTelemetry().getTracer("test").spanBuilder("parent").startSpan();
     parentSpan.end();
@@ -56,10 +56,11 @@ class HttpServerRouteTest {
 
     instrumenter.end(context, "test", null, null);
 
-    assertNull(HttpServerRoute.get(context));
+    assertEquals("/get/:id", HttpServerRoute.get(context));
     assertThat(testing.getSpans())
         .satisfiesExactly(
-            span -> assertThat(span).hasName("parent"), span -> assertThat(span).hasName("test"));
+            span -> assertThat(span).hasName("parent"),
+            span -> assertThat(span).hasName("HTTP /get/:id"));
   }
 
   @Test


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13583
Currently instrumentation api sets local root only when parent span is either invalid or remote. If the parent span is not created by instrumentation api then the local root span will remain unset and the server span won't be set in http route state.  Ideally if the server span is created outside of the instrumentation api we'd like to suppress our server span, but one of the side-effects of having spans that are not created with instrumentation api is that span suppression won't work since we rely on context keys set by instrumentation api to determine whether there already is a server span. ~~I'm not completely convinced that this is the right thing to do but route not being updated when there is a non instrumentation api parent is unexpected. Another option we could try is that instead of setting the local root span we could just update the server span in the http route state and leave the local root unset. @trask WDYT?~~ This PR fixes updating the route state when the root span wasn't created by instrumentation api.