### PR TITLE
Remove forcing dynamic typing from advice

### DIFF
--- a/instrumentation/netty/netty-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/NettyFutureInstrumentation.java
+++ b/instrumentation/netty/netty-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/NettyFutureInstrumentation.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4.common;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static net.bytebuddy.matcher.ElementMatchers.isArray;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -43,7 +42,9 @@ public class NettyFutureInstrumentation implements TypeInstrumentation {
             .and(takesArgument(0, named("io.netty.util.concurrent.GenericFutureListener"))),
         NettyFutureInstrumentation.class.getName() + "$AddListenerAdvice");
     transformer.applyAdviceToMethod(
-        isMethod().and(named("addListeners")).and(takesArgument(0, isArray())),
+        isMethod()
+            .and(named("addListeners"))
+            .and(takesArgument(0, named("io.netty.util.concurrent.GenericFutureListener[]"))),
         NettyFutureInstrumentation.class.getName() + "$AddListenersAdvice");
     transformer.applyAdviceToMethod(
         isMethod()
@@ -51,7 +52,9 @@ public class NettyFutureInstrumentation implements TypeInstrumentation {
             .and(takesArgument(0, named("io.netty.util.concurrent.GenericFutureListener"))),
         NettyFutureInstrumentation.class.getName() + "$RemoveListenerAdvice");
     transformer.applyAdviceToMethod(
-        isMethod().and(named("removeListeners")).and(takesArgument(0, isArray())),
+        isMethod()
+            .and(named("removeListeners"))
+            .and(takesArgument(0, named("io.netty.util.concurrent.GenericFutureListener[]"))),
         NettyFutureInstrumentation.class.getName() + "$RemoveListenersAdvice");
   }
 
@@ -81,7 +84,7 @@ public class NettyFutureInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter
     @Advice.AssignReturned.AsScalar
     @Advice.AssignReturned.ToArguments(@ToArgument(0))
-    public static Object[] wrapListener(
+    public static GenericFutureListener<?>[] wrapListener(
         @Advice.Argument(value = 0) GenericFutureListener<? extends Future<?>>[] listeners) {
 
       Context context = Java8BytecodeBridge.currentContext();
@@ -119,7 +122,7 @@ public class NettyFutureInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter
     @Advice.AssignReturned.AsScalar
     @Advice.AssignReturned.ToArguments(@ToArgument(0))
-    public static Object[] wrapListener(
+    public static GenericFutureListener<?>[] wrapListener(
         @Advice.Argument(value = 0) GenericFutureListener<? extends Future<?>>[] listeners) {
 
       @SuppressWarnings({"unchecked", "rawtypes"})

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/client/HttpExtClientInstrumentation.java
@@ -18,6 +18,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.pekko.http.scaladsl.HttpExt;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
@@ -40,7 +41,8 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
 
   @SuppressWarnings("unused")
   public static class SingleRequestAdvice {
-    @Advice.AssignReturned.ToArguments(@ToArgument(value = 0, index = 0))
+    @Advice.AssignReturned.ToArguments(
+        @ToArgument(value = 0, index = 0, typing = Assigner.Typing.DYNAMIC))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(@Advice.Argument(value = 0) HttpRequest request) {
       Context parentContext = currentContext();

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/DefaultExecControllerInstrumentation.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/DefaultExecControllerInstrumentation.java
@@ -81,10 +81,10 @@ public class DefaultExecControllerInstrumentation implements TypeInstrumentation
       @ToField(value = "initializers", index = 0),
       @ToField(value = "interceptors", index = 1)
     })
-    public static Object[] exit(
+    public static ImmutableList<?>[] exit(
         @Advice.FieldValue("initializers") ImmutableList<? extends ExecInitializer> initializers,
         @Advice.FieldValue("interceptors") ImmutableList<? extends ExecInterceptor> interceptors) {
-      return new Object[] {
+      return new ImmutableList<?>[] {
         ImmutableList.of(OpenTelemetryExecInitializer.INSTANCE),
         ImmutableList.of(OpenTelemetryExecInterceptor.INSTANCE)
       };

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
@@ -63,7 +63,7 @@ public class RequestActionSupportInstrumentation implements TypeInstrumentation 
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     @Advice.AssignReturned.ToArguments(@ToArgument(0))
-    public static Object wrapDownstream(@Advice.Argument(0) Downstream<?> downstream) {
+    public static Downstream<?> wrapDownstream(@Advice.Argument(0) Downstream<?> downstream) {
       // Propagate the current context to downstream
       // since that is the subsequent code chained to the http client call
       return DownstreamWrapper.wrapIfNeeded(downstream);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.tooling.instrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
-import io.opentelemetry.javaagent.tooling.instrumentation.indy.ForceDynamicallyTypedAssignReturnedFactory;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -22,9 +21,7 @@ final class TypeTransformerImpl implements TypeTransformer {
     this.agentBuilder = agentBuilder;
     adviceMapping =
         Advice.withCustomMapping()
-            .with(
-                new ForceDynamicallyTypedAssignReturnedFactory(
-                    new Advice.AssignReturned.Factory().withSuppressed(Throwable.class)));
+            .with(new Advice.AssignReturned.Factory().withSuppressed(Throwable.class));
   }
 
   @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
@@ -32,7 +32,9 @@ public final class IndyTypeTransformerImpl implements TypeTransformer {
     this.instrumentationModule = module;
     this.adviceMapping =
         Advice.withCustomMapping()
-            .with(new Advice.AssignReturned.Factory().withSuppressed(Throwable.class))
+            .with(
+                new ForceDynamicallyTypedAssignReturnedFactory(
+                    new Advice.AssignReturned.Factory().withSuppressed(Throwable.class)))
             .bootstrap(
                 IndyBootstrap.getIndyBootstrapMethod(),
                 IndyBootstrap.getAdviceBootstrapArguments(instrumentationModule),

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
@@ -32,9 +32,7 @@ public final class IndyTypeTransformerImpl implements TypeTransformer {
     this.instrumentationModule = module;
     this.adviceMapping =
         Advice.withCustomMapping()
-            .with(
-                new ForceDynamicallyTypedAssignReturnedFactory(
-                    new Advice.AssignReturned.Factory().withSuppressed(Throwable.class)))
+            .with(new Advice.AssignReturned.Factory().withSuppressed(Throwable.class))
             .bootstrap(
                 IndyBootstrap.getIndyBootstrapMethod(),
                 IndyBootstrap.getAdviceBootstrapArguments(instrumentationModule),


### PR DESCRIPTION
Remove forcing dynamic typing from inline advice. As far as I understand non-inline advice needs dynamic typing because we replace all types with Object in the caller of the advice. We do that to make using advice more convenient. Caller of the advice does not see types in the instrumentation loader, erasing the type lets us use our own classes in advice method signature. With inline advice advice code does not run in an isolated class loaders, so all types are visible to application code.