### PR TITLE
Ensure muzzle collects VirtualFields from static initializers

### DIFF
--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
@@ -363,6 +363,20 @@ class ReferenceCollectorTest {
             entry(VirtualFieldTestClasses.Key1.class.getName(), State.class.getName()));
   }
 
+  @Test
+  public void shouldCollectVirtualFieldsFromStaticInitializers() {
+    ReferenceCollector collector = new ReferenceCollector(s -> s.endsWith("$Helper"));
+    collector.collectReferencesFromAdvice(
+        VirtualFieldTestClasses.VirtualFieldInStaticInitializerAdvice.class.getName());
+    collector.prune();
+
+    VirtualFieldMappings virtualFieldMappings = collector.getVirtualFieldMappings();
+    assertThat(virtualFieldMappings.entrySet())
+        .containsExactlyInAnyOrder(
+            entry(VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
+            entry(VirtualFieldTestClasses.Key2.class.getName(), Context.class.getName()));
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource
   public void shouldNotCollectVirtualFieldsForInvalidScenario(

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
@@ -26,7 +26,8 @@ public class VirtualFieldTestClasses {
     static final VirtualField<Key1, Context> FIELD_1 = VirtualField.find(Key1.class, Context.class);
 
     public static class Helper {
-      static final VirtualField<Key2, Context> FIELD_2 = VirtualField.find(Key2.class, Context.class);
+      static final VirtualField<Key2, Context> FIELD_2 =
+          VirtualField.find(Key2.class, Context.class);
 
       public static void foo() {}
     }

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
@@ -8,7 +8,7 @@ package io.opentelemetry.javaagent.tooling.muzzle;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 
-@SuppressWarnings({"ReturnValueIgnored", "unused"})
+@SuppressWarnings({"ReturnValueIgnored", "unused", "OtelPrivateConstructorForUtilityClass"})
 public class VirtualFieldTestClasses {
 
   public static class ValidAdvice {
@@ -18,6 +18,21 @@ public class VirtualFieldTestClasses {
       Key2.class.getName();
       Key1.class.getName();
       VirtualField.find(Key2.class, Context.class);
+    }
+  }
+
+  public static class VirtualFieldInStaticInitializerAdvice {
+
+    static final VirtualField<Key1, Context> FIELD_1 = VirtualField.find(Key1.class, Context.class);
+
+    public static class Helper {
+      static final VirtualField<Key2, Context> FIELD_2 = VirtualField.find(Key2.class, Context.class);
+
+      public static void foo() {}
+    }
+
+    public static void advice() {
+      Helper.foo();
     }
   }
 

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
@@ -8,7 +8,7 @@ package io.opentelemetry.javaagent.tooling.muzzle;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 
-@SuppressWarnings({"ReturnValueIgnored", "unused", "OtelPrivateConstructorForUtilityClass"})
+@SuppressWarnings({"ReturnValueIgnored", "unused"})
 public class VirtualFieldTestClasses {
 
   public static class ValidAdvice {
@@ -26,6 +26,8 @@ public class VirtualFieldTestClasses {
     static final VirtualField<Key1, Context> FIELD_1 = VirtualField.find(Key1.class, Context.class);
 
     public static class Helper {
+      private Helper() {}
+
       static final VirtualField<Key2, Context> FIELD_2 =
           VirtualField.find(Key2.class, Context.class);
 


### PR DESCRIPTION
As part of #13031, I wanted to adapt muzzle to also collect `VirtualFields` from static initializers, as this will be the recommended way of using them with indy-instrumentation.

Turns out, this already supported (yay). This PR just adds a test-case verifying this behaviour.