### PR TITLE
Ignore classes in java.lang.invoke in early instrumentations

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -56,7 +56,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -227,8 +226,11 @@ public class AgentInstaller {
     AgentBuilder.Identified.Extendable extendableAgentBuilder =
         agentBuilder
             .ignore(
-                target -> instrumentationInstalled, // turn off after instrumentation is installed
-                Objects::nonNull)
+                target ->
+                    // turn off after instrumentation is installed, exclude classes in
+                    // java.lang.invoke to avoid circularity when bootstrapping indy instrumentation
+                    instrumentationInstalled
+                        || target.getTypeName().startsWith("java.lang.invoke."))
             .type(none())
             .transform(
                 (builder, typeDescription, classLoader, module, protectionDomain) -> builder);


### PR DESCRIPTION
Fixes indy test failures in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13590
These failures are caused by circularity for classes in `java.lang.invoke`. Ignoring that package shouldn't be an issue because the purpose of the early instrumentations is to set up virtual field transforms for executors instrumentation as early as possible. Since virtual field instrumentation does structural modifications to classes it can not be applied to already loaded classes. The classes that we wish to apply these transforms to aren't in the `java.lang.invoke` package.