### PR TITLE
Fix hang in lettuce async test

### DIFF
--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -108,7 +108,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
             new Utf8StringCodec(), new RedisURI(host, port, 3, TimeUnit.SECONDS));
     StatefulRedisConnection<String, String> connection1 = connectionFuture.get();
     cleanup.deferCleanup(connection1);
-    cleanup.deferCleanup(testConnectionClient::shutdown);
+    cleanup.deferCleanup(() -> shutdown(testConnectionClient));
 
     assertThat(connection1).isNotNull();
 


### PR DESCRIPTION
https://scans.gradle.com/s/cz4lh3d3rkvmu/failure
Same as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13569 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12927