### PR TITLE
Be consistent about using snake case in metadata yaml

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -5,8 +5,8 @@
 activej:
   instrumentations:
   - name: activej-http-6.0
-    srcPath: instrumentation/activej-http-6.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/activej-http-6.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.activej-http-6.0
     target_versions:
@@ -15,7 +15,7 @@ activej:
 akka:
   instrumentations:
   - name: akka-http-10.0
-    srcPath: instrumentation/akka/akka-http-10.0
+    source_path: instrumentation/akka/akka-http-10.0
     scope:
       name: io.opentelemetry.akka-http-10.0
     target_versions:
@@ -24,7 +24,7 @@ akka:
       - com.typesafe.akka:akka-http_2.13:[10,)
       - com.typesafe.akka:akka-http_2.11:[10,)
   - name: akka-actor-fork-join-2.5
-    srcPath: instrumentation/akka/akka-actor-fork-join-2.5
+    source_path: instrumentation/akka/akka-actor-fork-join-2.5
     scope:
       name: io.opentelemetry.akka-actor-fork-join-2.5
     target_versions:
@@ -33,7 +33,7 @@ akka:
       - com.typesafe.akka:akka-actor_2.13:[2.5.23,2.6)
       - com.typesafe.akka:akka-actor_2.11:[2.5,)
   - name: akka-actor-2.3
-    srcPath: instrumentation/akka/akka-actor-2.3
+    source_path: instrumentation/akka/akka-actor-2.3
     scope:
       name: io.opentelemetry.akka-actor-2.3
     target_versions:
@@ -44,7 +44,7 @@ akka:
 alibaba:
   instrumentations:
   - name: alibaba-druid-1.0
-    srcPath: instrumentation/alibaba-druid-1.0
+    source_path: instrumentation/alibaba-druid-1.0
     scope:
       name: io.opentelemetry.alibaba-druid-1.0
     target_versions:
@@ -55,35 +55,35 @@ alibaba:
 apache:
   instrumentations:
   - name: apache-shenyu-2.4
-    srcPath: instrumentation/apache-shenyu-2.4
+    source_path: instrumentation/apache-shenyu-2.4
     scope:
       name: io.opentelemetry.apache-shenyu-2.4
     target_versions:
       javaagent:
       - org.apache.shenyu:shenyu-web:[2.4.0,)
   - name: apache-httpclient-2.0
-    srcPath: instrumentation/apache-httpclient/apache-httpclient-2.0
+    source_path: instrumentation/apache-httpclient/apache-httpclient-2.0
     scope:
       name: io.opentelemetry.apache-httpclient-2.0
     target_versions:
       javaagent:
       - commons-httpclient:commons-httpclient:[2.0,4.0)
   - name: apache-httpasyncclient-4.1
-    srcPath: instrumentation/apache-httpasyncclient-4.1
+    source_path: instrumentation/apache-httpasyncclient-4.1
     scope:
       name: io.opentelemetry.apache-httpasyncclient-4.1
     target_versions:
       javaagent:
       - org.apache.httpcomponents:httpasyncclient:[4.1,)
   - name: apache-httpclient-4.3
-    srcPath: instrumentation/apache-httpclient/apache-httpclient-4.3
+    source_path: instrumentation/apache-httpclient/apache-httpclient-4.3
     scope:
       name: io.opentelemetry.apache-httpclient-4.3
     target_versions:
       library:
       - org.apache.httpcomponents:httpclient:[4.3,4.+)
   - name: apache-httpclient-4.0
-    srcPath: instrumentation/apache-httpclient/apache-httpclient-4.0
+    source_path: instrumentation/apache-httpclient/apache-httpclient-4.0
     scope:
       name: io.opentelemetry.apache-httpclient-4.0
     target_versions:
@@ -91,28 +91,28 @@ apache:
       - io.dropwizard:dropwizard-client:(,3.0.0)
       - org.apache.httpcomponents:httpclient:[4.0,)
   - name: apache-dubbo-2.7
-    srcPath: instrumentation/apache-dubbo-2.7
+    source_path: instrumentation/apache-dubbo-2.7
     scope:
       name: io.opentelemetry.apache-dubbo-2.7
     target_versions:
       javaagent:
       - org.apache.dubbo:dubbo:[2.7,)
   - name: apache-httpclient-5.2
-    srcPath: instrumentation/apache-httpclient/apache-httpclient-5.2
+    source_path: instrumentation/apache-httpclient/apache-httpclient-5.2
     scope:
       name: io.opentelemetry.apache-httpclient-5.2
     target_versions:
       library:
       - org.apache.httpcomponents.client5:httpclient5:5.2.1
   - name: apache-httpclient-5.0
-    srcPath: instrumentation/apache-httpclient/apache-httpclient-5.0
+    source_path: instrumentation/apache-httpclient/apache-httpclient-5.0
     scope:
       name: io.opentelemetry.apache-httpclient-5.0
     target_versions:
       javaagent:
       - org.apache.httpcomponents.client5:httpclient5:[5.0,)
   - name: apache-dbcp-2.0
-    srcPath: instrumentation/apache-dbcp-2.0
+    source_path: instrumentation/apache-dbcp-2.0
     scope:
       name: io.opentelemetry.apache-dbcp-2.0
     target_versions:
@@ -123,7 +123,7 @@ apache:
 armeria:
   instrumentations:
   - name: armeria-1.3
-    srcPath: instrumentation/armeria/armeria-1.3
+    source_path: instrumentation/armeria/armeria-1.3
     scope:
       name: io.opentelemetry.armeria-1.3
     target_versions:
@@ -132,7 +132,7 @@ armeria:
       library:
       - com.linecorp.armeria:armeria:1.3.0
   - name: armeria-grpc-1.14
-    srcPath: instrumentation/armeria/armeria-grpc-1.14
+    source_path: instrumentation/armeria/armeria-grpc-1.14
     scope:
       name: io.opentelemetry.armeria-grpc-1.14
     target_versions:
@@ -141,14 +141,14 @@ armeria:
 async:
   instrumentations:
   - name: async-http-client-1.9
-    srcPath: instrumentation/async-http-client/async-http-client-1.9
+    source_path: instrumentation/async-http-client/async-http-client-1.9
     scope:
       name: io.opentelemetry.async-http-client-1.9
     target_versions:
       javaagent:
       - com.ning:async-http-client:[1.9.0,)
   - name: async-http-client-2.0
-    srcPath: instrumentation/async-http-client/async-http-client-2.0
+    source_path: instrumentation/async-http-client/async-http-client-2.0
     scope:
       name: io.opentelemetry.async-http-client-2.0
     target_versions:
@@ -157,7 +157,7 @@ async:
 aws:
   instrumentations:
   - name: aws-lambda-events-2.2
-    srcPath: instrumentation/aws-lambda/aws-lambda-events-2.2
+    source_path: instrumentation/aws-lambda/aws-lambda-events-2.2
     scope:
       name: io.opentelemetry.aws-lambda-events-2.2
     target_versions:
@@ -167,7 +167,7 @@ aws:
       - com.amazonaws:aws-lambda-java-events:2.2.1
       - com.amazonaws:aws-lambda-java-core:1.0.0
   - name: aws-lambda-core-1.0
-    srcPath: instrumentation/aws-lambda/aws-lambda-core-1.0
+    source_path: instrumentation/aws-lambda/aws-lambda-core-1.0
     scope:
       name: io.opentelemetry.aws-lambda-core-1.0
     target_versions:
@@ -176,7 +176,7 @@ aws:
       library:
       - com.amazonaws:aws-lambda-java-core:1.0.0
   - name: aws-sdk-1.11
-    srcPath: instrumentation/aws-sdk/aws-sdk-1.11
+    source_path: instrumentation/aws-sdk/aws-sdk-1.11
     scope:
       name: io.opentelemetry.aws-sdk-1.11
     target_versions:
@@ -187,7 +187,7 @@ aws:
       - com.amazonaws:aws-java-sdk-sqs:[1.11.106,1.12.583)
       - com.amazonaws:aws-java-sdk-core:1.11.0
   - name: aws-sdk-2.2
-    srcPath: instrumentation/aws-sdk/aws-sdk-2.2
+    source_path: instrumentation/aws-sdk/aws-sdk-2.2
     scope:
       name: io.opentelemetry.aws-sdk-2.2
     target_versions:
@@ -206,21 +206,21 @@ aws:
 azure:
   instrumentations:
   - name: azure-core-1.36
-    srcPath: instrumentation/azure-core/azure-core-1.36
+    source_path: instrumentation/azure-core/azure-core-1.36
     scope:
       name: io.opentelemetry.azure-core-1.36
     target_versions:
       javaagent:
       - com.azure:azure-core:[1.36.0,)
   - name: azure-core-1.19
-    srcPath: instrumentation/azure-core/azure-core-1.19
+    source_path: instrumentation/azure-core/azure-core-1.19
     scope:
       name: io.opentelemetry.azure-core-1.19
     target_versions:
       javaagent:
       - com.azure:azure-core:[1.19.0,1.36.0)
   - name: azure-core-1.14
-    srcPath: instrumentation/azure-core/azure-core-1.14
+    source_path: instrumentation/azure-core/azure-core-1.14
     scope:
       name: io.opentelemetry.azure-core-1.14
     target_versions:
@@ -229,7 +229,7 @@ azure:
 c3p0:
   instrumentations:
   - name: c3p0-0.9
-    srcPath: instrumentation/c3p0-0.9
+    source_path: instrumentation/c3p0-0.9
     scope:
       name: io.opentelemetry.c3p0-0.9
     target_versions:
@@ -240,7 +240,7 @@ c3p0:
 camel:
   instrumentations:
   - name: camel-2.20
-    srcPath: instrumentation/camel-2.20
+    source_path: instrumentation/camel-2.20
     scope:
       name: io.opentelemetry.camel-2.20
     target_versions:
@@ -249,14 +249,14 @@ camel:
 cassandra:
   instrumentations:
   - name: cassandra-4.0
-    srcPath: instrumentation/cassandra/cassandra-4.0
+    source_path: instrumentation/cassandra/cassandra-4.0
     scope:
       name: io.opentelemetry.cassandra-4.0
     target_versions:
       javaagent:
       - com.datastax.oss:java-driver-core:[4.0,4.4)
   - name: cassandra-4.4
-    srcPath: instrumentation/cassandra/cassandra-4.4
+    source_path: instrumentation/cassandra/cassandra-4.4
     scope:
       name: io.opentelemetry.cassandra-4.4
     target_versions:
@@ -265,7 +265,7 @@ cassandra:
       library:
       - com.datastax.oss:java-driver-core:4.4.0
   - name: cassandra-3.0
-    srcPath: instrumentation/cassandra/cassandra-3.0
+    source_path: instrumentation/cassandra/cassandra-3.0
     scope:
       name: io.opentelemetry.cassandra-3.0
     target_versions:
@@ -276,7 +276,7 @@ clickhouse:
   - name: clickhouse-client-0.5
     description: Instruments the V1 ClickHouseClient, providing database client spans
       and metrics.
-    srcPath: instrumentation/clickhouse-client-0.5
+    source_path: instrumentation/clickhouse-client-0.5
     scope:
       name: io.opentelemetry.clickhouse-client-0.5
     target_versions:
@@ -285,35 +285,35 @@ clickhouse:
 couchbase:
   instrumentations:
   - name: couchbase-3.1.6
-    srcPath: instrumentation/couchbase/couchbase-3.1.6
+    source_path: instrumentation/couchbase/couchbase-3.1.6
     scope:
       name: io.opentelemetry.couchbase-3.1.6
     target_versions:
       javaagent:
       - com.couchbase.client:java-client:[3.1.6,3.2.0)
   - name: couchbase-2.6
-    srcPath: instrumentation/couchbase/couchbase-2.6
+    source_path: instrumentation/couchbase/couchbase-2.6
     scope:
       name: io.opentelemetry.couchbase-2.6
     target_versions:
       javaagent:
       - com.couchbase.client:java-client:[2.6.0,3)
   - name: couchbase-2.0
-    srcPath: instrumentation/couchbase/couchbase-2.0
+    source_path: instrumentation/couchbase/couchbase-2.0
     scope:
       name: io.opentelemetry.couchbase-2.0
     target_versions:
       javaagent:
       - com.couchbase.client:java-client:[2,3)
   - name: couchbase-3.2
-    srcPath: instrumentation/couchbase/couchbase-3.2
+    source_path: instrumentation/couchbase/couchbase-3.2
     scope:
       name: io.opentelemetry.couchbase-3.2
     target_versions:
       javaagent:
       - com.couchbase.client:java-client:[3.2.0,)
   - name: couchbase-3.1
-    srcPath: instrumentation/couchbase/couchbase-3.1
+    source_path: instrumentation/couchbase/couchbase-3.1
     scope:
       name: io.opentelemetry.couchbase-3.1
     target_versions:
@@ -322,15 +322,15 @@ couchbase:
 dropwizard:
   instrumentations:
   - name: dropwizard-metrics-4.0
-    disabledByDefault: true
-    srcPath: instrumentation/dropwizard/dropwizard-metrics-4.0
+    disabled_by_default: true
+    source_path: instrumentation/dropwizard/dropwizard-metrics-4.0
     scope:
       name: io.opentelemetry.dropwizard-metrics-4.0
     target_versions:
       javaagent:
       - io.dropwizard.metrics:metrics-core:[4.0.0,)
   - name: dropwizard-views-0.7
-    srcPath: instrumentation/dropwizard/dropwizard-views-0.7
+    source_path: instrumentation/dropwizard/dropwizard-views-0.7
     scope:
       name: io.opentelemetry.dropwizard-views-0.7
     target_versions:
@@ -339,14 +339,14 @@ dropwizard:
 elasticsearch:
   instrumentations:
   - name: elasticsearch-rest-6.4
-    srcPath: instrumentation/elasticsearch/elasticsearch-rest-6.4
+    source_path: instrumentation/elasticsearch/elasticsearch-rest-6.4
     scope:
       name: io.opentelemetry.elasticsearch-rest-6.4
     target_versions:
       javaagent:
       - org.elasticsearch.client:elasticsearch-rest-client:[6.4,7.0)
   - name: elasticsearch-api-client-7.16
-    srcPath: instrumentation/elasticsearch/elasticsearch-api-client-7.16
+    source_path: instrumentation/elasticsearch/elasticsearch-api-client-7.16
     scope:
       name: io.opentelemetry.elasticsearch-api-client-7.16
     target_versions:
@@ -354,7 +354,7 @@ elasticsearch:
       - co.elastic.clients:elasticsearch-java:[7.16,7.17.20)
       - co.elastic.clients:elasticsearch-java:[8.0.0,8.10)
   - name: elasticsearch-rest-5.0
-    srcPath: instrumentation/elasticsearch/elasticsearch-rest-5.0
+    source_path: instrumentation/elasticsearch/elasticsearch-rest-5.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-5.0
     target_versions:
@@ -362,7 +362,7 @@ elasticsearch:
       - org.elasticsearch.client:rest:[5.0,6.4)
       - org.elasticsearch.client:elasticsearch-rest-client:[5.0,6.4)
   - name: elasticsearch-rest-7.0
-    srcPath: instrumentation/elasticsearch/elasticsearch-rest-7.0
+    source_path: instrumentation/elasticsearch/elasticsearch-rest-7.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-7.0
     target_versions:
@@ -371,7 +371,7 @@ elasticsearch:
       library:
       - org.elasticsearch.client:elasticsearch-rest-client:7.0.0
   - name: elasticsearch-transport-6.0
-    srcPath: instrumentation/elasticsearch/elasticsearch-transport-6.0
+    source_path: instrumentation/elasticsearch/elasticsearch-transport-6.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-6.0
     target_versions:
@@ -379,7 +379,7 @@ elasticsearch:
       - org.elasticsearch:elasticsearch:[6.0.0,8.0.0)
       - org.elasticsearch.client:transport:[6.0.0,)
   - name: elasticsearch-transport-5.0
-    srcPath: instrumentation/elasticsearch/elasticsearch-transport-5.0
+    source_path: instrumentation/elasticsearch/elasticsearch-transport-5.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.0
     target_versions:
@@ -387,7 +387,7 @@ elasticsearch:
       - org.elasticsearch.client:transport:[5.0.0,5.3.0)
       - org.elasticsearch:elasticsearch:[5.0.0,5.3.0)
   - name: elasticsearch-transport-5.3
-    srcPath: instrumentation/elasticsearch/elasticsearch-transport-5.3
+    source_path: instrumentation/elasticsearch/elasticsearch-transport-5.3
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.3
     target_versions:
@@ -397,7 +397,7 @@ elasticsearch:
 executors:
   instrumentations:
   - name: executors
-    srcPath: instrumentation/executors
+    source_path: instrumentation/executors
     scope:
       name: io.opentelemetry.executors
     target_versions:
@@ -406,7 +406,7 @@ executors:
 finagle:
   instrumentations:
   - name: finagle-http-23.11
-    srcPath: instrumentation/finagle-http-23.11
+    source_path: instrumentation/finagle-http-23.11
     scope:
       name: io.opentelemetry.finagle-http-23.11
     target_versions:
@@ -416,7 +416,7 @@ finagle:
 finatra:
   instrumentations:
   - name: finatra-2.9
-    srcPath: instrumentation/finatra-2.9
+    source_path: instrumentation/finatra-2.9
     scope:
       name: io.opentelemetry.finatra-2.9
     target_versions:
@@ -426,7 +426,7 @@ finatra:
 geode:
   instrumentations:
   - name: geode-1.4
-    srcPath: instrumentation/geode-1.4
+    source_path: instrumentation/geode-1.4
     scope:
       name: io.opentelemetry.geode-1.4
     target_versions:
@@ -435,7 +435,7 @@ geode:
 google:
   instrumentations:
   - name: google-http-client-1.19
-    srcPath: instrumentation/google-http-client-1.19
+    source_path: instrumentation/google-http-client-1.19
     scope:
       name: io.opentelemetry.google-http-client-1.19
     target_versions:
@@ -444,7 +444,7 @@ google:
 grails:
   instrumentations:
   - name: grails-3.0
-    srcPath: instrumentation/grails-3.0
+    source_path: instrumentation/grails-3.0
     scope:
       name: io.opentelemetry.grails-3.0
     target_versions:
@@ -453,7 +453,7 @@ grails:
 graphql:
   instrumentations:
   - name: graphql-java-12.0
-    srcPath: instrumentation/graphql-java/graphql-java-12.0
+    source_path: instrumentation/graphql-java/graphql-java-12.0
     scope:
       name: io.opentelemetry.graphql-java-12.0
     target_versions:
@@ -462,8 +462,8 @@ graphql:
       library:
       - com.graphql-java:graphql-java:[12.0,19.+)
   - name: graphql-java-20.0
-    srcPath: instrumentation/graphql-java/graphql-java-20.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/graphql-java/graphql-java-20.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.graphql-java-20.0
     target_versions:
@@ -474,7 +474,7 @@ graphql:
 grizzly:
   instrumentations:
   - name: grizzly-2.3
-    srcPath: instrumentation/grizzly-2.3
+    source_path: instrumentation/grizzly-2.3
     scope:
       name: io.opentelemetry.grizzly-2.3
     target_versions:
@@ -483,7 +483,7 @@ grizzly:
 grpc:
   instrumentations:
   - name: grpc-1.6
-    srcPath: instrumentation/grpc-1.6
+    source_path: instrumentation/grpc-1.6
     scope:
       name: io.opentelemetry.grpc-1.6
     target_versions:
@@ -494,7 +494,7 @@ grpc:
 guava:
   instrumentations:
   - name: guava-10.0
-    srcPath: instrumentation/guava-10.0
+    source_path: instrumentation/guava-10.0
     scope:
       name: io.opentelemetry.guava-10.0
     target_versions:
@@ -505,7 +505,7 @@ guava:
 gwt:
   instrumentations:
   - name: gwt-2.0
-    srcPath: instrumentation/gwt-2.0
+    source_path: instrumentation/gwt-2.0
     scope:
       name: io.opentelemetry.gwt-2.0
     target_versions:
@@ -515,36 +515,36 @@ gwt:
 hibernate:
   instrumentations:
   - name: hibernate-4.0
-    srcPath: instrumentation/hibernate/hibernate-4.0
+    source_path: instrumentation/hibernate/hibernate-4.0
     scope:
       name: io.opentelemetry.hibernate-4.0
     target_versions:
       javaagent:
       - org.hibernate:hibernate-core:[4.0.0.Final,6)
   - name: hibernate-procedure-call-4.3
-    srcPath: instrumentation/hibernate/hibernate-procedure-call-4.3
+    source_path: instrumentation/hibernate/hibernate-procedure-call-4.3
     scope:
       name: io.opentelemetry.hibernate-procedure-call-4.3
     target_versions:
       javaagent:
       - org.hibernate:hibernate-core:[4.3.0.Final,)
   - name: hibernate-3.3
-    srcPath: instrumentation/hibernate/hibernate-3.3
+    source_path: instrumentation/hibernate/hibernate-3.3
     scope:
       name: io.opentelemetry.hibernate-3.3
     target_versions:
       javaagent:
       - org.hibernate:hibernate-core:[3.3.0.GA,4.0.0.Final)
   - name: hibernate-6.0
-    srcPath: instrumentation/hibernate/hibernate-6.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/hibernate/hibernate-6.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.hibernate-6.0
     target_versions:
       javaagent:
       - org.hibernate:hibernate-core:[6.0.0.Final,)
   - name: hibernate-reactive-1.0
-    srcPath: instrumentation/hibernate/hibernate-reactive-1.0
+    source_path: instrumentation/hibernate/hibernate-reactive-1.0
     scope:
       name: io.opentelemetry.hibernate-reactive-1.0
     target_versions:
@@ -553,7 +553,7 @@ hibernate:
 hikaricp:
   instrumentations:
   - name: hikaricp-3.0
-    srcPath: instrumentation/hikaricp-3.0
+    source_path: instrumentation/hikaricp-3.0
     scope:
       name: io.opentelemetry.hikaricp-3.0
     target_versions:
@@ -564,7 +564,7 @@ hikaricp:
 http:
   instrumentations:
   - name: http-url-connection
-    srcPath: instrumentation/http-url-connection
+    source_path: instrumentation/http-url-connection
     scope:
       name: io.opentelemetry.http-url-connection
     target_versions:
@@ -573,7 +573,7 @@ http:
 hystrix:
   instrumentations:
   - name: hystrix-1.4
-    srcPath: instrumentation/hystrix-1.4
+    source_path: instrumentation/hystrix-1.4
     scope:
       name: io.opentelemetry.hystrix-1.4
     target_versions:
@@ -582,7 +582,7 @@ hystrix:
 influxdb:
   instrumentations:
   - name: influxdb-2.4
-    srcPath: instrumentation/influxdb-2.4
+    source_path: instrumentation/influxdb-2.4
     scope:
       name: io.opentelemetry.influxdb-2.4
     target_versions:
@@ -591,15 +591,15 @@ influxdb:
 java:
   instrumentations:
   - name: java-http-server
-    srcPath: instrumentation/java-http-server
+    source_path: instrumentation/java-http-server
     scope:
       name: io.opentelemetry.java-http-server
     target_versions:
       javaagent:
       - Java 8+
   - name: java-http-client
-    srcPath: instrumentation/java-http-client
-    minimumJavaVersion: 11
+    source_path: instrumentation/java-http-client
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.java-http-client
     target_versions:
@@ -608,8 +608,8 @@ java:
 javalin:
   instrumentations:
   - name: javalin-5.0
-    srcPath: instrumentation/javalin-5.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/javalin-5.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.javalin-5.0
     target_versions:
@@ -618,7 +618,7 @@ javalin:
 jaxrs:
   instrumentations:
   - name: jaxrs-2.0-cxf-3.2
-    srcPath: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2
+    source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2
     scope:
       name: io.opentelemetry.jaxrs-2.0-cxf-3.2
     target_versions:
@@ -626,14 +626,14 @@ jaxrs:
       - org.apache.tomee:openejb-cxf-rs:(8,)
       - org.apache.cxf:cxf-rt-frontend-jaxrs:[3.2,4)
   - name: jaxrs-3.0-annotations
-    srcPath: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations
+    source_path: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations
     scope:
       name: io.opentelemetry.jaxrs-3.0-annotations
     target_versions:
       javaagent:
       - jakarta.ws.rs:jakarta.ws.rs-api:[3.0.0,)
   - name: jaxrs-2.0-jersey-2.0
-    srcPath: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0
+    source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0
     scope:
       name: io.opentelemetry.jaxrs-2.0-jersey-2.0
     target_versions:
@@ -641,15 +641,15 @@ jaxrs:
       - org.glassfish.jersey.core:jersey-server:[2.0,3.0.0)
       - org.glassfish.jersey.containers:jersey-container-servlet:[2.0,3.0.0)
   - name: jaxrs-3.0-jersey-3.0
-    srcPath: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jaxrs-3.0-jersey-3.0
     target_versions:
       javaagent:
       - org.glassfish.jersey.core:jersey-server:[3.0.0,)
   - name: jaxrs-2.0-resteasy-3.1
-    srcPath: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1
+    source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1
     scope:
       name: io.opentelemetry.jaxrs-2.0-resteasy-3.1
     target_versions:
@@ -657,7 +657,7 @@ jaxrs:
       - org.jboss.resteasy:resteasy-jaxrs:[3.1.0.Final,3.5.0.Final)
       - org.jboss.resteasy:resteasy-core:[4.0.0.Final,6)
   - name: jaxrs-2.0-resteasy-3.0
-    srcPath: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0
+    source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0
     scope:
       name: io.opentelemetry.jaxrs-2.0-resteasy-3.0
     target_versions:
@@ -665,28 +665,28 @@ jaxrs:
       - org.jboss.resteasy:resteasy-jaxrs:[3.0.0.Final,3.1.0.Final)
       - org.jboss.resteasy:resteasy-jaxrs:[3.5.0.Final,4)
   - name: jaxrs-2.0-annotations
-    srcPath: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations
+    source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations
     scope:
       name: io.opentelemetry.jaxrs-2.0-annotations
     target_versions:
       javaagent:
       - javax.ws.rs:javax.ws.rs-api:[,]
   - name: jaxrs-client-1.1
-    srcPath: instrumentation/jaxrs-client/jaxrs-client-1.1
+    source_path: instrumentation/jaxrs-client/jaxrs-client-1.1
     scope:
       name: io.opentelemetry.jaxrs-client-1.1
     target_versions: {}
   - name: jaxrs-3.0-resteasy-6.0
-    srcPath: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jaxrs-3.0-resteasy-6.0
     target_versions:
       javaagent:
       - org.jboss.resteasy:resteasy-core:[6.0.0.Final,)
   - name: jaxrs-1.0
-    disabledByDefault: true
-    srcPath: instrumentation/jaxrs/jaxrs-1.0
+    disabled_by_default: true
+    source_path: instrumentation/jaxrs/jaxrs-1.0
     scope:
       name: io.opentelemetry.jaxrs-1.0
     target_versions:
@@ -695,46 +695,46 @@ jaxrs:
 jaxws:
   instrumentations:
   - name: jaxws-jws-api-1.1
-    disabledByDefault: true
-    srcPath: instrumentation/jaxws/jaxws-jws-api-1.1
+    disabled_by_default: true
+    source_path: instrumentation/jaxws/jaxws-jws-api-1.1
     scope:
       name: io.opentelemetry.jaxws-jws-api-1.1
     target_versions:
       javaagent:
       - javax.jws:javax.jws-api:[1.1,]
   - name: jaxws-2.0
-    srcPath: instrumentation/jaxws/jaxws-2.0
+    source_path: instrumentation/jaxws/jaxws-2.0
     scope:
       name: io.opentelemetry.jaxws-2.0
     target_versions:
       javaagent:
       - javax.xml.ws:jaxws-api:[2.0,]
   - name: jaxws-2.0-metro-2.2
-    srcPath: instrumentation/jaxws/jaxws-2.0-metro-2.2
+    source_path: instrumentation/jaxws/jaxws-2.0-metro-2.2
     scope:
       name: io.opentelemetry.jaxws-2.0-metro-2.2
     target_versions: {}
   - name: jaxws-cxf-3.0
-    srcPath: instrumentation/jaxws/jaxws-cxf-3.0
+    source_path: instrumentation/jaxws/jaxws-cxf-3.0
     scope:
       name: io.opentelemetry.jaxws-cxf-3.0
     target_versions:
       javaagent:
       - org.apache.cxf:cxf-rt-frontend-jaxws:[3.0.0,)
   - name: jaxws-2.0-axis2-1.6
-    srcPath: instrumentation/jaxws/jaxws-2.0-axis2-1.6
+    source_path: instrumentation/jaxws/jaxws-2.0-axis2-1.6
     scope:
       name: io.opentelemetry.jaxws-2.0-axis2-1.6
     target_versions:
       javaagent:
       - org.apache.axis2:axis2-jaxws:[1.6.0,)
   - name: jaxws-2.0-cxf-3.0
-    srcPath: instrumentation/jaxws/jaxws-2.0-cxf-3.0
+    source_path: instrumentation/jaxws/jaxws-2.0-cxf-3.0
     scope:
       name: io.opentelemetry.jaxws-2.0-cxf-3.0
     target_versions: {}
   - name: jaxws-metro-2.2
-    srcPath: instrumentation/jaxws/jaxws-metro-2.2
+    source_path: instrumentation/jaxws/jaxws-metro-2.2
     scope:
       name: io.opentelemetry.jaxws-metro-2.2
     target_versions:
@@ -743,14 +743,14 @@ jaxws:
 jboss:
   instrumentations:
   - name: jboss-logmanager-appender-1.1
-    srcPath: instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1
+    source_path: instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1
     scope:
       name: io.opentelemetry.jboss-logmanager-appender-1.1
     target_versions:
       javaagent:
       - org.jboss.logmanager:jboss-logmanager:[1.1.0.GA,)
   - name: jboss-logmanager-mdc-1.1
-    srcPath: instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1
+    source_path: instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1
     scope:
       name: io.opentelemetry.jboss-logmanager-mdc-1.1
     target_versions:
@@ -759,8 +759,8 @@ jboss:
 jdbc:
   instrumentations:
   - name: jdbc
-    disabledByDefault: true
-    srcPath: instrumentation/jdbc
+    disabled_by_default: true
+    source_path: instrumentation/jdbc
     scope:
       name: io.opentelemetry.jdbc
     target_versions:
@@ -769,21 +769,21 @@ jdbc:
 jedis:
   instrumentations:
   - name: jedis-1.4
-    srcPath: instrumentation/jedis/jedis-1.4
+    source_path: instrumentation/jedis/jedis-1.4
     scope:
       name: io.opentelemetry.jedis-1.4
     target_versions:
       javaagent:
       - redis.clients:jedis:[1.4.0,3.0.0)
   - name: jedis-4.0
-    srcPath: instrumentation/jedis/jedis-4.0
+    source_path: instrumentation/jedis/jedis-4.0
     scope:
       name: io.opentelemetry.jedis-4.0
     target_versions:
       javaagent:
       - redis.clients:jedis:[4.0.0-beta1,)
   - name: jedis-3.0
-    srcPath: instrumentation/jedis/jedis-3.0
+    source_path: instrumentation/jedis/jedis-3.0
     scope:
       name: io.opentelemetry.jedis-3.0
     target_versions:
@@ -792,8 +792,8 @@ jedis:
 jetty:
   instrumentations:
   - name: jetty-httpclient-12.0
-    srcPath: instrumentation/jetty-httpclient/jetty-httpclient-12.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/jetty-httpclient/jetty-httpclient-12.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.jetty-httpclient-12.0
     target_versions:
@@ -802,22 +802,22 @@ jetty:
       library:
       - org.eclipse.jetty:jetty-client:12.0.0
   - name: jetty-12.0
-    srcPath: instrumentation/jetty/jetty-12.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/jetty/jetty-12.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.jetty-12.0
     target_versions:
       javaagent:
       - org.eclipse.jetty:jetty-server:[12,)
   - name: jetty-8.0
-    srcPath: instrumentation/jetty/jetty-8.0
+    source_path: instrumentation/jetty/jetty-8.0
     scope:
       name: io.opentelemetry.jetty-8.0
     target_versions:
       javaagent:
       - org.eclipse.jetty:jetty-server:[8.0.0.v20110901,11)
   - name: jetty-httpclient-9.2
-    srcPath: instrumentation/jetty-httpclient/jetty-httpclient-9.2
+    source_path: instrumentation/jetty-httpclient/jetty-httpclient-9.2
     scope:
       name: io.opentelemetry.jetty-httpclient-9.2
     target_versions:
@@ -826,8 +826,8 @@ jetty:
       library:
       - org.eclipse.jetty:jetty-client:[9.2.0.v20140526,9.+)
   - name: jetty-11.0
-    srcPath: instrumentation/jetty/jetty-11.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jetty/jetty-11.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jetty-11.0
     target_versions:
@@ -836,15 +836,15 @@ jetty:
 jms:
   instrumentations:
   - name: jms-3.0
-    srcPath: instrumentation/jms/jms-3.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jms/jms-3.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jms-3.0
     target_versions:
       javaagent:
       - jakarta.jms:jakarta.jms-api:[3.0.0,)
   - name: jms-1.1
-    srcPath: instrumentation/jms/jms-1.1
+    source_path: instrumentation/jms/jms-1.1
     scope:
       name: io.opentelemetry.jms-1.1
     target_versions:
@@ -855,7 +855,7 @@ jms:
 jodd:
   instrumentations:
   - name: jodd-http-4.2
-    srcPath: instrumentation/jodd-http-4.2
+    source_path: instrumentation/jodd-http-4.2
     scope:
       name: io.opentelemetry.jodd-http-4.2
     target_versions:
@@ -864,30 +864,30 @@ jodd:
 jsf:
   instrumentations:
   - name: jsf-myfaces-3.0
-    srcPath: instrumentation/jsf/jsf-myfaces-3.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jsf/jsf-myfaces-3.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jsf-myfaces-3.0
     target_versions:
       javaagent:
       - org.apache.myfaces.core:myfaces-impl:[3,)
   - name: jsf-mojarra-3.0
-    srcPath: instrumentation/jsf/jsf-mojarra-3.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/jsf/jsf-mojarra-3.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.jsf-mojarra-3.0
     target_versions:
       javaagent:
       - org.glassfish:jakarta.faces:[3,)
   - name: jsf-myfaces-1.2
-    srcPath: instrumentation/jsf/jsf-myfaces-1.2
+    source_path: instrumentation/jsf/jsf-myfaces-1.2
     scope:
       name: io.opentelemetry.jsf-myfaces-1.2
     target_versions:
       javaagent:
       - org.apache.myfaces.core:myfaces-impl:[1.2,3)
   - name: jsf-mojarra-1.2
-    srcPath: instrumentation/jsf/jsf-mojarra-1.2
+    source_path: instrumentation/jsf/jsf-mojarra-1.2
     scope:
       name: io.opentelemetry.jsf-mojarra-1.2
     target_versions:
@@ -900,7 +900,7 @@ jsf:
 jsp:
   instrumentations:
   - name: jsp-2.3
-    srcPath: instrumentation/jsp-2.3
+    source_path: instrumentation/jsp-2.3
     scope:
       name: io.opentelemetry.jsp-2.3
     target_versions:
@@ -909,21 +909,21 @@ jsp:
 kafka:
   instrumentations:
   - name: kafka-streams-0.11
-    srcPath: instrumentation/kafka/kafka-streams-0.11
+    source_path: instrumentation/kafka/kafka-streams-0.11
     scope:
       name: io.opentelemetry.kafka-streams-0.11
     target_versions:
       javaagent:
       - org.apache.kafka:kafka-streams:[0.11.0.0,)
   - name: kafka-clients-2.6
-    srcPath: instrumentation/kafka/kafka-clients/kafka-clients-2.6
+    source_path: instrumentation/kafka/kafka-clients/kafka-clients-2.6
     scope:
       name: io.opentelemetry.kafka-clients-2.6
     target_versions:
       library:
       - org.apache.kafka:kafka-clients:2.6.0
   - name: kafka-clients-0.11
-    srcPath: instrumentation/kafka/kafka-clients/kafka-clients-0.11
+    source_path: instrumentation/kafka/kafka-clients/kafka-clients-0.11
     scope:
       name: io.opentelemetry.kafka-clients-0.11
     target_versions:
@@ -932,7 +932,7 @@ kafka:
 kotlinx:
   instrumentations:
   - name: kotlinx-coroutines
-    srcPath: instrumentation/kotlinx-coroutines
+    source_path: instrumentation/kotlinx-coroutines
     scope:
       name: io.opentelemetry.kotlinx-coroutines
     target_versions:
@@ -941,7 +941,7 @@ kotlinx:
       - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:[1.3.9,)
       - org.jetbrains.kotlinx:kotlinx-coroutines-core:[1.0.0,1.3.8)
   - name: kotlinx-coroutines-1.0
-    srcPath: instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0
+    source_path: instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0
     scope:
       name: io.opentelemetry.kotlinx-coroutines-1.0
     target_versions:
@@ -949,7 +949,7 @@ kotlinx:
       - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:[1.3.9,)
       - org.jetbrains.kotlinx:kotlinx-coroutines-core:[1.0.0,1.3.8)
   - name: kotlinx-coroutines-flow-1.3
-    srcPath: instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3
+    source_path: instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3
     scope:
       name: io.opentelemetry.kotlinx-coroutines-flow-1.3
     target_versions:
@@ -959,7 +959,7 @@ kotlinx:
 ktor:
   instrumentations:
   - name: ktor-2.0
-    srcPath: instrumentation/ktor/ktor-2.0
+    source_path: instrumentation/ktor/ktor-2.0
     scope:
       name: io.opentelemetry.ktor-2.0
     target_versions:
@@ -970,7 +970,7 @@ ktor:
       - io.ktor:ktor-client-core:[2.0.0,2.+)
       - io.ktor:ktor-server-core:[2.0.0,2.+)
   - name: ktor-3.0
-    srcPath: instrumentation/ktor/ktor-3.0
+    source_path: instrumentation/ktor/ktor-3.0
     scope:
       name: io.opentelemetry.ktor-3.0
     target_versions:
@@ -981,7 +981,7 @@ ktor:
       - io.ktor:ktor-server-core:3.0.0
       - io.ktor:ktor-client-core:3.0.0
   - name: ktor-1.0
-    srcPath: instrumentation/ktor/ktor-1.0
+    source_path: instrumentation/ktor/ktor-1.0
     scope:
       name: io.opentelemetry.ktor-1.0
     target_versions:
@@ -990,7 +990,7 @@ ktor:
 kubernetes:
   instrumentations:
   - name: kubernetes-client-7.0
-    srcPath: instrumentation/kubernetes-client-7.0
+    source_path: instrumentation/kubernetes-client-7.0
     scope:
       name: io.opentelemetry.kubernetes-client-7.0
     target_versions:
@@ -999,7 +999,7 @@ kubernetes:
 lettuce:
   instrumentations:
   - name: lettuce-5.1
-    srcPath: instrumentation/lettuce/lettuce-5.1
+    source_path: instrumentation/lettuce/lettuce-5.1
     scope:
       name: io.opentelemetry.lettuce-5.1
     target_versions:
@@ -1008,14 +1008,14 @@ lettuce:
       library:
       - io.lettuce:lettuce-core:5.1.0.RELEASE
   - name: lettuce-5.0
-    srcPath: instrumentation/lettuce/lettuce-5.0
+    source_path: instrumentation/lettuce/lettuce-5.0
     scope:
       name: io.opentelemetry.lettuce-5.0
     target_versions:
       javaagent:
       - io.lettuce:lettuce-core:[5.0.0.RELEASE,5.1.0.RELEASE)
   - name: lettuce-4.0
-    srcPath: instrumentation/lettuce/lettuce-4.0
+    source_path: instrumentation/lettuce/lettuce-4.0
     scope:
       name: io.opentelemetry.lettuce-4.0
     target_versions:
@@ -1024,26 +1024,26 @@ lettuce:
 liberty:
   instrumentations:
   - name: liberty-dispatcher-20.0
-    srcPath: instrumentation/liberty/liberty-dispatcher-20.0
+    source_path: instrumentation/liberty/liberty-dispatcher-20.0
     scope:
       name: io.opentelemetry.liberty-dispatcher-20.0
     target_versions: {}
   - name: liberty-20.0
-    srcPath: instrumentation/liberty/liberty-20.0
+    source_path: instrumentation/liberty/liberty-20.0
     scope:
       name: io.opentelemetry.liberty-20.0
     target_versions: {}
 log4j:
   instrumentations:
   - name: log4j-context-data-2.7
-    srcPath: instrumentation/log4j/log4j-context-data/log4j-context-data-2.7
+    source_path: instrumentation/log4j/log4j-context-data/log4j-context-data-2.7
     scope:
       name: io.opentelemetry.log4j-context-data-2.7
     target_versions:
       javaagent:
       - org.apache.logging.log4j:log4j-core:[2.7,2.17.0)
   - name: log4j-appender-2.17
-    srcPath: instrumentation/log4j/log4j-appender-2.17
+    source_path: instrumentation/log4j/log4j-appender-2.17
     scope:
       name: io.opentelemetry.log4j-appender-2.17
     target_versions:
@@ -1052,21 +1052,21 @@ log4j:
       library:
       - org.apache.logging.log4j:log4j-core:2.17.0
   - name: log4j-appender-1.2
-    srcPath: instrumentation/log4j/log4j-appender-1.2
+    source_path: instrumentation/log4j/log4j-appender-1.2
     scope:
       name: io.opentelemetry.log4j-appender-1.2
     target_versions:
       javaagent:
       - log4j:log4j:[1.2,)
   - name: log4j-mdc-1.2
-    srcPath: instrumentation/log4j/log4j-mdc-1.2
+    source_path: instrumentation/log4j/log4j-mdc-1.2
     scope:
       name: io.opentelemetry.log4j-mdc-1.2
     target_versions:
       javaagent:
       - log4j:log4j:[1.2,)
   - name: log4j-context-data-2.17
-    srcPath: instrumentation/log4j/log4j-context-data/log4j-context-data-2.17
+    source_path: instrumentation/log4j/log4j-context-data/log4j-context-data-2.17
     scope:
       name: io.opentelemetry.log4j-context-data-2.17
     target_versions:
@@ -1075,7 +1075,7 @@ log4j:
 logback:
   instrumentations:
   - name: logback-mdc-1.0
-    srcPath: instrumentation/logback/logback-mdc-1.0
+    source_path: instrumentation/logback/logback-mdc-1.0
     scope:
       name: io.opentelemetry.logback-mdc-1.0
     target_versions:
@@ -1085,7 +1085,7 @@ logback:
       - ch.qos.logback:logback-classic:1.0.0
       - org.slf4j:slf4j-api:1.6.4
   - name: logback-appender-1.0
-    srcPath: instrumentation/logback/logback-appender-1.0
+    source_path: instrumentation/logback/logback-appender-1.0
     scope:
       name: io.opentelemetry.logback-appender-1.0
     target_versions:
@@ -1098,8 +1098,8 @@ logback:
 micrometer:
   instrumentations:
   - name: micrometer-1.5
-    disabledByDefault: true
-    srcPath: instrumentation/micrometer/micrometer-1.5
+    disabled_by_default: true
+    source_path: instrumentation/micrometer/micrometer-1.5
     scope:
       name: io.opentelemetry.micrometer-1.5
     target_versions:
@@ -1110,14 +1110,14 @@ micrometer:
 mongo:
   instrumentations:
   - name: mongo-4.0
-    srcPath: instrumentation/mongo/mongo-4.0
+    source_path: instrumentation/mongo/mongo-4.0
     scope:
       name: io.opentelemetry.mongo-4.0
     target_versions:
       javaagent:
       - org.mongodb:mongodb-driver-core:[4.0,)
   - name: mongo-3.1
-    srcPath: instrumentation/mongo/mongo-3.1
+    source_path: instrumentation/mongo/mongo-3.1
     scope:
       name: io.opentelemetry.mongo-3.1
     target_versions:
@@ -1126,7 +1126,7 @@ mongo:
       library:
       - org.mongodb:mongo-java-driver:3.1.0
   - name: mongo-3.7
-    srcPath: instrumentation/mongo/mongo-3.7
+    source_path: instrumentation/mongo/mongo-3.7
     scope:
       name: io.opentelemetry.mongo-3.7
     target_versions:
@@ -1134,7 +1134,7 @@ mongo:
       - org.mongodb:mongodb-driver-core:[3.7, 4.0)
       - org.mongodb:mongo-java-driver:[3.7, 4.0)
   - name: mongo-async-3.3
-    srcPath: instrumentation/mongo/mongo-async-3.3
+    source_path: instrumentation/mongo/mongo-async-3.3
     scope:
       name: io.opentelemetry.mongo-async-3.3
     target_versions:
@@ -1143,8 +1143,8 @@ mongo:
 mybatis:
   instrumentations:
   - name: mybatis-3.2
-    disabledByDefault: true
-    srcPath: instrumentation/mybatis-3.2
+    disabled_by_default: true
+    source_path: instrumentation/mybatis-3.2
     scope:
       name: io.opentelemetry.mybatis-3.2
     target_versions:
@@ -1153,14 +1153,14 @@ mybatis:
 netty:
   instrumentations:
   - name: netty-3.8
-    srcPath: instrumentation/netty/netty-3.8
+    source_path: instrumentation/netty/netty-3.8
     scope:
       name: io.opentelemetry.netty-3.8
     target_versions:
       javaagent:
       - io.netty:netty:[3.8.0.Final,4)
   - name: netty-4.0
-    srcPath: instrumentation/netty/netty-4.0
+    source_path: instrumentation/netty/netty-4.0
     scope:
       name: io.opentelemetry.netty-4.0
     target_versions:
@@ -1168,7 +1168,7 @@ netty:
       - io.netty:netty-all:[4.0.0.Final,4.1.0.Final)
       - io.netty:netty-codec-http:[4.0.0.Final,4.1.0.Final)
   - name: netty-4.1
-    srcPath: instrumentation/netty/netty-4.1
+    source_path: instrumentation/netty/netty-4.1
     scope:
       name: io.opentelemetry.netty-4.1
     target_versions:
@@ -1180,7 +1180,7 @@ netty:
 okhttp:
   instrumentations:
   - name: okhttp-3.0
-    srcPath: instrumentation/okhttp/okhttp-3.0
+    source_path: instrumentation/okhttp/okhttp-3.0
     scope:
       name: io.opentelemetry.okhttp-3.0
     target_versions:
@@ -1189,7 +1189,7 @@ okhttp:
       library:
       - com.squareup.okhttp3:okhttp:3.0.0
   - name: okhttp-2.2
-    srcPath: instrumentation/okhttp/okhttp-2.2
+    source_path: instrumentation/okhttp/okhttp-2.2
     scope:
       name: io.opentelemetry.okhttp-2.2
     target_versions:
@@ -1198,8 +1198,8 @@ okhttp:
 opensearch:
   instrumentations:
   - name: opensearch-rest-1.0
-    srcPath: instrumentation/opensearch/opensearch-rest-1.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/opensearch/opensearch-rest-1.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.opensearch-rest-1.0
     target_versions:
@@ -1208,7 +1208,7 @@ opensearch:
 oracle:
   instrumentations:
   - name: oracle-ucp-11.2
-    srcPath: instrumentation/oracle-ucp-11.2
+    source_path: instrumentation/oracle-ucp-11.2
     scope:
       name: io.opentelemetry.oracle-ucp-11.2
     target_versions:
@@ -1220,7 +1220,7 @@ oracle:
 oshi:
   instrumentations:
   - name: oshi
-    srcPath: instrumentation/oshi
+    source_path: instrumentation/oshi
     scope:
       name: io.opentelemetry.oshi
     target_versions:
@@ -1231,14 +1231,14 @@ oshi:
 payara:
   instrumentations:
   - name: payara
-    srcPath: instrumentation/payara
+    source_path: instrumentation/payara
     scope:
       name: io.opentelemetry.payara
     target_versions: {}
 pekko:
   instrumentations:
   - name: pekko-actor-1.0
-    srcPath: instrumentation/pekko/pekko-actor-1.0
+    source_path: instrumentation/pekko/pekko-actor-1.0
     scope:
       name: io.opentelemetry.pekko-actor-1.0
     target_versions:
@@ -1247,7 +1247,7 @@ pekko:
       - org.apache.pekko:pekko-actor_2.12:[1.0,)
       - org.apache.pekko:pekko-actor_2.13:[1.0,)
   - name: pekko-http-1.0
-    srcPath: instrumentation/pekko/pekko-http-1.0
+    source_path: instrumentation/pekko/pekko-http-1.0
     scope:
       name: io.opentelemetry.pekko-http-1.0
     target_versions:
@@ -1261,7 +1261,7 @@ pekko:
 play:
   instrumentations:
   - name: play-ws-1.0
-    srcPath: instrumentation/play/play-ws/play-ws-1.0
+    source_path: instrumentation/play/play-ws/play-ws-1.0
     scope:
       name: io.opentelemetry.play-ws-1.0
     target_versions:
@@ -1269,7 +1269,7 @@ play:
       - com.typesafe.play:play-ahc-ws-standalone_2.12:[1.0.0,2.0.0)
       - com.typesafe.play:play-ahc-ws-standalone_2.11:[1.0.0,2.0.0)
   - name: play-mvc-2.6
-    srcPath: instrumentation/play/play-mvc/play-mvc-2.6
+    source_path: instrumentation/play/play-mvc/play-mvc-2.6
     scope:
       name: io.opentelemetry.play-mvc-2.6
     target_versions:
@@ -1278,14 +1278,14 @@ play:
       - com.typesafe.play:play_2.12:[2.6.0,)
       - com.typesafe.play:play_2.13:[2.6.0,)
   - name: play-mvc-2.4
-    srcPath: instrumentation/play/play-mvc/play-mvc-2.4
+    source_path: instrumentation/play/play-mvc/play-mvc-2.4
     scope:
       name: io.opentelemetry.play-mvc-2.4
     target_versions:
       javaagent:
       - com.typesafe.play:play_2.11:[2.4.0,2.6)
   - name: play-ws-2.0
-    srcPath: instrumentation/play/play-ws/play-ws-2.0
+    source_path: instrumentation/play/play-ws/play-ws-2.0
     scope:
       name: io.opentelemetry.play-ws-2.0
     target_versions:
@@ -1294,7 +1294,7 @@ play:
       - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.0.6,2.1.0)
       - com.typesafe.play:play-ahc-ws-standalone_2.11:[2.0.0,]
   - name: play-ws-2.1
-    srcPath: instrumentation/play/play-ws/play-ws-2.1
+    source_path: instrumentation/play/play-ws/play-ws-2.1
     scope:
       name: io.opentelemetry.play-ws-2.1
     target_versions:
@@ -1304,7 +1304,7 @@ play:
 powerjob:
   instrumentations:
   - name: powerjob-4.0
-    srcPath: instrumentation/powerjob-4.0
+    source_path: instrumentation/powerjob-4.0
     scope:
       name: io.opentelemetry.powerjob-4.0
     target_versions:
@@ -1313,7 +1313,7 @@ powerjob:
 pulsar:
   instrumentations:
   - name: pulsar-2.8
-    srcPath: instrumentation/pulsar/pulsar-2.8
+    source_path: instrumentation/pulsar/pulsar-2.8
     scope:
       name: io.opentelemetry.pulsar-2.8
     target_versions:
@@ -1322,7 +1322,7 @@ pulsar:
 quarkus:
   instrumentations:
   - name: quarkus-resteasy-reactive
-    srcPath: instrumentation/quarkus-resteasy-reactive
+    source_path: instrumentation/quarkus-resteasy-reactive
     scope:
       name: io.opentelemetry.quarkus-resteasy-reactive
     target_versions:
@@ -1331,7 +1331,7 @@ quarkus:
 quartz:
   instrumentations:
   - name: quartz-2.0
-    srcPath: instrumentation/quartz-2.0
+    source_path: instrumentation/quartz-2.0
     scope:
       name: io.opentelemetry.quartz-2.0
     target_versions:
@@ -1342,7 +1342,7 @@ quartz:
 r2dbc:
   instrumentations:
   - name: r2dbc-1.0
-    srcPath: instrumentation/r2dbc-1.0
+    source_path: instrumentation/r2dbc-1.0
     scope:
       name: io.opentelemetry.r2dbc-1.0
     target_versions:
@@ -1353,7 +1353,7 @@ r2dbc:
 rabbitmq:
   instrumentations:
   - name: rabbitmq-2.7
-    srcPath: instrumentation/rabbitmq-2.7
+    source_path: instrumentation/rabbitmq-2.7
     scope:
       name: io.opentelemetry.rabbitmq-2.7
     target_versions:
@@ -1362,14 +1362,14 @@ rabbitmq:
 ratpack:
   instrumentations:
   - name: ratpack-1.4
-    srcPath: instrumentation/ratpack/ratpack-1.4
+    source_path: instrumentation/ratpack/ratpack-1.4
     scope:
       name: io.opentelemetry.ratpack-1.4
     target_versions:
       javaagent:
       - io.ratpack:ratpack-core:[1.4.0,)
   - name: ratpack-1.7
-    srcPath: instrumentation/ratpack/ratpack-1.7
+    source_path: instrumentation/ratpack/ratpack-1.7
     scope:
       name: io.opentelemetry.ratpack-1.7
     target_versions:
@@ -1380,35 +1380,35 @@ ratpack:
 reactor:
   instrumentations:
   - name: reactor-kafka-1.0
-    srcPath: instrumentation/reactor/reactor-kafka-1.0
+    source_path: instrumentation/reactor/reactor-kafka-1.0
     scope:
       name: io.opentelemetry.reactor-kafka-1.0
     target_versions:
       javaagent:
       - io.projectreactor.kafka:reactor-kafka:[1.0.0,)
   - name: reactor-3.1
-    srcPath: instrumentation/reactor/reactor-3.1
+    source_path: instrumentation/reactor/reactor-3.1
     scope:
       name: io.opentelemetry.reactor-3.1
     target_versions:
       javaagent:
       - io.projectreactor:reactor-core:[3.1.0.RELEASE,)
   - name: reactor-3.4
-    srcPath: instrumentation/reactor/reactor-3.4
+    source_path: instrumentation/reactor/reactor-3.4
     scope:
       name: io.opentelemetry.reactor-3.4
     target_versions:
       javaagent:
       - io.projectreactor:reactor-core:[3.4.0,)
   - name: reactor-netty-0.9
-    srcPath: instrumentation/reactor/reactor-netty/reactor-netty-0.9
+    source_path: instrumentation/reactor/reactor-netty/reactor-netty-0.9
     scope:
       name: io.opentelemetry.reactor-netty-0.9
     target_versions:
       javaagent:
       - io.projectreactor.netty:reactor-netty:[0.8.2.RELEASE,1.0.0)
   - name: reactor-netty-1.0
-    srcPath: instrumentation/reactor/reactor-netty/reactor-netty-1.0
+    source_path: instrumentation/reactor/reactor-netty/reactor-netty-1.0
     scope:
       name: io.opentelemetry.reactor-netty-1.0
     target_versions:
@@ -1418,7 +1418,7 @@ reactor:
 rediscala:
   instrumentations:
   - name: rediscala-1.8
-    srcPath: instrumentation/rediscala-1.8
+    source_path: instrumentation/rediscala-1.8
     scope:
       name: io.opentelemetry.rediscala-1.8
     target_versions:
@@ -1433,14 +1433,14 @@ rediscala:
 redisson:
   instrumentations:
   - name: redisson-3.17
-    srcPath: instrumentation/redisson/redisson-3.17
+    source_path: instrumentation/redisson/redisson-3.17
     scope:
       name: io.opentelemetry.redisson-3.17
     target_versions:
       javaagent:
       - org.redisson:redisson:[3.17.0,)
   - name: redisson-3.0
-    srcPath: instrumentation/redisson/redisson-3.0
+    source_path: instrumentation/redisson/redisson-3.0
     scope:
       name: io.opentelemetry.redisson-3.0
     target_versions:
@@ -1449,14 +1449,14 @@ redisson:
 resources:
   instrumentations:
   - name: resources
-    srcPath: instrumentation/resources
+    source_path: instrumentation/resources
     scope:
       name: io.opentelemetry.resources
     target_versions: {}
 restlet:
   instrumentations:
   - name: restlet-1.1
-    srcPath: instrumentation/restlet/restlet-1.1
+    source_path: instrumentation/restlet/restlet-1.1
     scope:
       name: io.opentelemetry.restlet-1.1
     target_versions:
@@ -1466,7 +1466,7 @@ restlet:
       - org.restlet:org.restlet:[1.1.5,1.+)
       - com.noelios.restlet:com.noelios.restlet:1.1.5
   - name: restlet-2.0
-    srcPath: instrumentation/restlet/restlet-2.0
+    source_path: instrumentation/restlet/restlet-2.0
     scope:
       name: io.opentelemetry.restlet-2.0
     target_versions:
@@ -1477,7 +1477,7 @@ restlet:
 rmi:
   instrumentations:
   - name: rmi
-    srcPath: instrumentation/rmi
+    source_path: instrumentation/rmi
     scope:
       name: io.opentelemetry.rmi
     target_versions:
@@ -1486,14 +1486,14 @@ rmi:
 rocketmq:
   instrumentations:
   - name: rocketmq-client-5.0
-    srcPath: instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0
+    source_path: instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0
     scope:
       name: io.opentelemetry.rocketmq-client-5.0
     target_versions:
       javaagent:
       - org.apache.rocketmq:rocketmq-client-java:[5.0.0,)
   - name: rocketmq-client-4.8
-    srcPath: instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8
+    source_path: instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8
     scope:
       name: io.opentelemetry.rocketmq-client-4.8
     target_versions:
@@ -1504,27 +1504,27 @@ rocketmq:
 runtime:
   instrumentations:
   - name: runtime-telemetry-java17
-    srcPath: instrumentation/runtime-telemetry/runtime-telemetry-java17
-    minimumJavaVersion: 17
+    source_path: instrumentation/runtime-telemetry/runtime-telemetry-java17
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.runtime-telemetry-java17
     target_versions: {}
   - name: runtime-telemetry-java8
-    srcPath: instrumentation/runtime-telemetry/runtime-telemetry-java8
+    source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
     scope:
       name: io.opentelemetry.runtime-telemetry-java8
     target_versions: {}
 rxjava:
   instrumentations:
   - name: rxjava-1.0
-    srcPath: instrumentation/rxjava/rxjava-1.0
+    source_path: instrumentation/rxjava/rxjava-1.0
     scope:
       name: io.opentelemetry.rxjava-1.0
     target_versions:
       library:
       - io.reactivex:rxjava:1.0.7
   - name: rxjava-3.1.1
-    srcPath: instrumentation/rxjava/rxjava-3.1.1
+    source_path: instrumentation/rxjava/rxjava-3.1.1
     scope:
       name: io.opentelemetry.rxjava-3.1.1
     target_versions:
@@ -1533,7 +1533,7 @@ rxjava:
       library:
       - io.reactivex.rxjava3:rxjava:3.1.1
   - name: rxjava-2.0
-    srcPath: instrumentation/rxjava/rxjava-2.0
+    source_path: instrumentation/rxjava/rxjava-2.0
     scope:
       name: io.opentelemetry.rxjava-2.0
     target_versions:
@@ -1542,7 +1542,7 @@ rxjava:
       library:
       - io.reactivex.rxjava2:rxjava:2.1.3
   - name: rxjava-3.0
-    srcPath: instrumentation/rxjava/rxjava-3.0
+    source_path: instrumentation/rxjava/rxjava-3.0
     scope:
       name: io.opentelemetry.rxjava-3.0
     target_versions:
@@ -1553,7 +1553,7 @@ rxjava:
 scala:
   instrumentations:
   - name: scala-fork-join-2.8
-    srcPath: instrumentation/scala-fork-join-2.8
+    source_path: instrumentation/scala-fork-join-2.8
     scope:
       name: io.opentelemetry.scala-fork-join-2.8
     target_versions:
@@ -1562,21 +1562,21 @@ scala:
 servlet:
   instrumentations:
   - name: servlet-5.0
-    srcPath: instrumentation/servlet/servlet-5.0
+    source_path: instrumentation/servlet/servlet-5.0
     scope:
       name: io.opentelemetry.servlet-5.0
     target_versions:
       javaagent:
       - jakarta.servlet:jakarta.servlet-api:[5.0.0,)
   - name: servlet-2.2
-    srcPath: instrumentation/servlet/servlet-2.2
+    source_path: instrumentation/servlet/servlet-2.2
     scope:
       name: io.opentelemetry.servlet-2.2
     target_versions:
       javaagent:
       - javax.servlet:servlet-api:[2.2, 3.0)
   - name: servlet-3.0
-    srcPath: instrumentation/servlet/servlet-3.0
+    source_path: instrumentation/servlet/servlet-3.0
     scope:
       name: io.opentelemetry.servlet-3.0
     target_versions:
@@ -1585,7 +1585,7 @@ servlet:
 spark:
   instrumentations:
   - name: spark-2.3
-    srcPath: instrumentation/spark-2.3
+    source_path: instrumentation/spark-2.3
     scope:
       name: io.opentelemetry.spark-2.3
     target_versions:
@@ -1594,42 +1594,42 @@ spark:
 spring:
   instrumentations:
   - name: spring-rabbit-1.0
-    srcPath: instrumentation/spring/spring-rabbit-1.0
+    source_path: instrumentation/spring/spring-rabbit-1.0
     scope:
       name: io.opentelemetry.spring-rabbit-1.0
     target_versions:
       javaagent:
       - org.springframework.amqp:spring-rabbit:(,)
   - name: spring-scheduling-3.1
-    srcPath: instrumentation/spring/spring-scheduling-3.1
+    source_path: instrumentation/spring/spring-scheduling-3.1
     scope:
       name: io.opentelemetry.spring-scheduling-3.1
     target_versions:
       javaagent:
       - org.springframework:spring-context:[3.1.0.RELEASE,]
   - name: spring-boot-resources
-    srcPath: instrumentation/spring/spring-boot-resources
+    source_path: instrumentation/spring/spring-boot-resources
     scope:
       name: io.opentelemetry.spring-boot-resources
     target_versions: {}
   - name: spring-batch-3.0
-    disabledByDefault: true
-    srcPath: instrumentation/spring/spring-batch-3.0
+    disabled_by_default: true
+    source_path: instrumentation/spring/spring-batch-3.0
     scope:
       name: io.opentelemetry.spring-batch-3.0
     target_versions:
       javaagent:
       - org.springframework.batch:spring-batch-core:[3.0.0.RELEASE,5)
   - name: spring-cloud-aws-3.0
-    srcPath: instrumentation/spring/spring-cloud-aws-3.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-cloud-aws-3.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-cloud-aws-3.0
     target_versions:
       javaagent:
       - io.awspring.cloud:spring-cloud-aws-sqs:[3.0.0,)
   - name: spring-webflux-5.0
-    srcPath: instrumentation/spring/spring-webflux/spring-webflux-5.0
+    source_path: instrumentation/spring/spring-webflux/spring-webflux-5.0
     scope:
       name: io.opentelemetry.spring-webflux-5.0
     target_versions:
@@ -1638,52 +1638,52 @@ spring:
       - org.springframework:spring-webflux:[5.0.0.RELEASE,)
       - io.projectreactor.netty:reactor-netty:[0.8.0.RELEASE,)
   - name: spring-webflux-5.3
-    srcPath: instrumentation/spring/spring-webflux/spring-webflux-5.3
+    source_path: instrumentation/spring/spring-webflux/spring-webflux-5.3
     scope:
       name: io.opentelemetry.spring-webflux-5.3
     target_versions:
       library:
       - org.springframework:spring-webflux:5.3.0
   - name: spring-jms-6.0
-    srcPath: instrumentation/spring/spring-jms/spring-jms-6.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-jms/spring-jms-6.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-jms-6.0
     target_versions:
       javaagent:
       - org.springframework:spring-jms:[6.0.0,)
   - name: spring-boot-actuator-autoconfigure-2.0
-    disabledByDefault: true
-    srcPath: instrumentation/spring/spring-boot-actuator-autoconfigure-2.0
+    disabled_by_default: true
+    source_path: instrumentation/spring/spring-boot-actuator-autoconfigure-2.0
     scope:
       name: io.opentelemetry.spring-boot-actuator-autoconfigure-2.0
     target_versions:
       javaagent:
       - org.springframework.boot:spring-boot-actuator-autoconfigure:[2.0.0.RELEASE,)
   - name: spring-rmi-4.0
-    srcPath: instrumentation/spring/spring-rmi-4.0
+    source_path: instrumentation/spring/spring-rmi-4.0
     scope:
       name: io.opentelemetry.spring-rmi-4.0
     target_versions:
       javaagent:
       - org.springframework:spring-context:[4.0.0.RELEASE,6)
   - name: spring-webmvc-3.1
-    srcPath: instrumentation/spring/spring-webmvc/spring-webmvc-3.1
+    source_path: instrumentation/spring/spring-webmvc/spring-webmvc-3.1
     scope:
       name: io.opentelemetry.spring-webmvc-3.1
     target_versions:
       javaagent:
       - org.springframework:spring-webmvc:[3.1.0.RELEASE,6)
   - name: spring-webmvc-6.0
-    srcPath: instrumentation/spring/spring-webmvc/spring-webmvc-6.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-webmvc/spring-webmvc-6.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-webmvc-6.0
     target_versions:
       javaagent:
       - org.springframework:spring-webmvc:[6.0.0,)
   - name: spring-data-1.8
-    srcPath: instrumentation/spring/spring-data/spring-data-1.8
+    source_path: instrumentation/spring/spring-data/spring-data-1.8
     scope:
       name: io.opentelemetry.spring-data-1.8
     target_versions:
@@ -1691,50 +1691,50 @@ spring:
       - org.springframework:spring-aop:[1.2,]
       - org.springframework.data:spring-data-commons:[1.8.0.RELEASE,]
   - name: spring-pulsar-1.0
-    srcPath: instrumentation/spring/spring-pulsar-1.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-pulsar-1.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-pulsar-1.0
     target_versions:
       javaagent:
       - org.springframework.pulsar:spring-pulsar:[1.0.0,)
   - name: spring-web-3.1
-    srcPath: instrumentation/spring/spring-web/spring-web-3.1
+    source_path: instrumentation/spring/spring-web/spring-web-3.1
     scope:
       name: io.opentelemetry.spring-web-3.1
     target_versions:
       javaagent:
       - org.springframework:spring-web:[3.1.0.RELEASE,6)
   - name: spring-kafka-2.7
-    srcPath: instrumentation/spring/spring-kafka-2.7
+    source_path: instrumentation/spring/spring-kafka-2.7
     scope:
       name: io.opentelemetry.spring-kafka-2.7
     target_versions:
       javaagent:
       - org.springframework.kafka:spring-kafka:[2.7.0,)
   - name: spring-webmvc-5.3
-    srcPath: instrumentation/spring/spring-webmvc/spring-webmvc-5.3
+    source_path: instrumentation/spring/spring-webmvc/spring-webmvc-5.3
     scope:
       name: io.opentelemetry.spring-webmvc-5.3
     target_versions: {}
   - name: spring-core-2.0
-    srcPath: instrumentation/spring/spring-core-2.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-core-2.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-core-2.0
     target_versions:
       javaagent:
       - org.springframework:spring-core:[2.0,]
   - name: spring-cloud-gateway-2.0
-    srcPath: instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.0
+    source_path: instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.0
     scope:
       name: io.opentelemetry.spring-cloud-gateway-2.0
     target_versions:
       javaagent:
       - org.springframework.cloud:spring-cloud-starter-gateway:[2.0.0.RELEASE,]
   - name: spring-security-config-6.0
-    srcPath: instrumentation/spring/spring-security-config-6.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/spring/spring-security-config-6.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.spring-security-config-6.0
     target_versions:
@@ -1747,7 +1747,7 @@ spring:
       - jakarta.servlet:jakarta.servlet-api:6.0.0
       - org.springframework.security:spring-security-web:6.0.0
   - name: spring-integration-4.1
-    srcPath: instrumentation/spring/spring-integration-4.1
+    source_path: instrumentation/spring/spring-integration-4.1
     scope:
       name: io.opentelemetry.spring-integration-4.1
     target_versions:
@@ -1756,22 +1756,22 @@ spring:
       library:
       - org.springframework.integration:spring-integration-core:[4.1.0.RELEASE,5.+)
   - name: spring-jms-2.0
-    srcPath: instrumentation/spring/spring-jms/spring-jms-2.0
+    source_path: instrumentation/spring/spring-jms/spring-jms-2.0
     scope:
       name: io.opentelemetry.spring-jms-2.0
     target_versions:
       javaagent:
       - org.springframework:spring-jms:[2.0,6)
   - name: spring-ws-2.0
-    disabledByDefault: true
-    srcPath: instrumentation/spring/spring-ws-2.0
+    disabled_by_default: true
+    source_path: instrumentation/spring/spring-ws-2.0
     scope:
       name: io.opentelemetry.spring-ws-2.0
     target_versions:
       javaagent:
       - org.springframework.ws:spring-ws-core:[2.0.0.RELEASE,]
   - name: spring-web-6.0
-    srcPath: instrumentation/spring/spring-web/spring-web-6.0
+    source_path: instrumentation/spring/spring-web/spring-web-6.0
     scope:
       name: io.opentelemetry.spring-web-6.0
     target_versions:
@@ -1780,7 +1780,7 @@ spring:
 spymemcached:
   instrumentations:
   - name: spymemcached-2.12
-    srcPath: instrumentation/spymemcached-2.12
+    source_path: instrumentation/spymemcached-2.12
     scope:
       name: io.opentelemetry.spymemcached-2.12
     target_versions:
@@ -1789,15 +1789,15 @@ spymemcached:
 struts:
   instrumentations:
   - name: struts-2.3
-    srcPath: instrumentation/struts/struts-2.3
+    source_path: instrumentation/struts/struts-2.3
     scope:
       name: io.opentelemetry.struts-2.3
     target_versions:
       javaagent:
       - org.apache.struts:struts2-core:[2.1.0,7)
   - name: struts-7.0
-    srcPath: instrumentation/struts/struts-7.0
-    minimumJavaVersion: 17
+    source_path: instrumentation/struts/struts-7.0
+    minimum_java_version: 17
     scope:
       name: io.opentelemetry.struts-7.0
     target_versions:
@@ -1806,7 +1806,7 @@ struts:
 tapestry:
   instrumentations:
   - name: tapestry-5.4
-    srcPath: instrumentation/tapestry-5.4
+    source_path: instrumentation/tapestry-5.4
     scope:
       name: io.opentelemetry.tapestry-5.4
     target_versions:
@@ -1815,22 +1815,22 @@ tapestry:
 tomcat:
   instrumentations:
   - name: tomcat-10.0
-    srcPath: instrumentation/tomcat/tomcat-10.0
-    minimumJavaVersion: 11
+    source_path: instrumentation/tomcat/tomcat-10.0
+    minimum_java_version: 11
     scope:
       name: io.opentelemetry.tomcat-10.0
     target_versions:
       javaagent:
       - org.apache.tomcat.embed:tomcat-embed-core:[10,)
   - name: tomcat-7.0
-    srcPath: instrumentation/tomcat/tomcat-7.0
+    source_path: instrumentation/tomcat/tomcat-7.0
     scope:
       name: io.opentelemetry.tomcat-7.0
     target_versions:
       javaagent:
       - org.apache.tomcat.embed:tomcat-embed-core:[7.0.4, 10)
   - name: tomcat-jdbc
-    srcPath: instrumentation/tomcat/tomcat-jdbc
+    source_path: instrumentation/tomcat/tomcat-jdbc
     scope:
       name: io.opentelemetry.tomcat-jdbc
     target_versions:
@@ -1839,7 +1839,7 @@ tomcat:
 twilio:
   instrumentations:
   - name: twilio-6.6
-    srcPath: instrumentation/twilio-6.6
+    source_path: instrumentation/twilio-6.6
     scope:
       name: io.opentelemetry.twilio-6.6
     target_versions:
@@ -1848,7 +1848,7 @@ twilio:
 undertow:
   instrumentations:
   - name: undertow-1.4
-    srcPath: instrumentation/undertow-1.4
+    source_path: instrumentation/undertow-1.4
     scope:
       name: io.opentelemetry.undertow-1.4
     target_versions:
@@ -1857,7 +1857,7 @@ undertow:
 vaadin:
   instrumentations:
   - name: vaadin-14.2
-    srcPath: instrumentation/vaadin-14.2
+    source_path: instrumentation/vaadin-14.2
     scope:
       name: io.opentelemetry.vaadin-14.2
     target_versions:
@@ -1867,49 +1867,49 @@ vaadin:
 vertx:
   instrumentations:
   - name: vertx-kafka-client-3.6
-    srcPath: instrumentation/vertx/vertx-kafka-client-3.6
+    source_path: instrumentation/vertx/vertx-kafka-client-3.6
     scope:
       name: io.opentelemetry.vertx-kafka-client-3.6
     target_versions:
       javaagent:
       - io.vertx:vertx-kafka-client:[3.5.1,)
   - name: vertx-redis-client-4.0
-    srcPath: instrumentation/vertx/vertx-redis-client-4.0
+    source_path: instrumentation/vertx/vertx-redis-client-4.0
     scope:
       name: io.opentelemetry.vertx-redis-client-4.0
     target_versions:
       javaagent:
       - io.vertx:vertx-redis-client:[4.0.0,)
   - name: vertx-web-3.0
-    srcPath: instrumentation/vertx/vertx-web-3.0
+    source_path: instrumentation/vertx/vertx-web-3.0
     scope:
       name: io.opentelemetry.vertx-web-3.0
     target_versions:
       javaagent:
       - io.vertx:vertx-web:[3.0.0,)
   - name: vertx-sql-client-4.0
-    srcPath: instrumentation/vertx/vertx-sql-client-4.0
+    source_path: instrumentation/vertx/vertx-sql-client-4.0
     scope:
       name: io.opentelemetry.vertx-sql-client-4.0
     target_versions:
       javaagent:
       - io.vertx:vertx-sql-client:[4.0.0,)
   - name: vertx-http-client-4.0
-    srcPath: instrumentation/vertx/vertx-http-client/vertx-http-client-4.0
+    source_path: instrumentation/vertx/vertx-http-client/vertx-http-client-4.0
     scope:
       name: io.opentelemetry.vertx-http-client-4.0
     target_versions:
       javaagent:
       - io.vertx:vertx-core:[4.0.0,)
   - name: vertx-rx-java-3.5
-    srcPath: instrumentation/vertx/vertx-rx-java-3.5
+    source_path: instrumentation/vertx/vertx-rx-java-3.5
     scope:
       name: io.opentelemetry.vertx-rx-java-3.5
     target_versions:
       javaagent:
       - io.vertx:vertx-rx-java2:[3.5.0,)
   - name: vertx-http-client-3.0
-    srcPath: instrumentation/vertx/vertx-http-client/vertx-http-client-3.0
+    source_path: instrumentation/vertx/vertx-http-client/vertx-http-client-3.0
     scope:
       name: io.opentelemetry.vertx-http-client-3.0
     target_versions:
@@ -1918,7 +1918,7 @@ vertx:
 vibur:
   instrumentations:
   - name: vibur-dbcp-11.0
-    srcPath: instrumentation/vibur-dbcp-11.0
+    source_path: instrumentation/vibur-dbcp-11.0
     scope:
       name: io.opentelemetry.vibur-dbcp-11.0
     target_versions:
@@ -1929,7 +1929,7 @@ vibur:
 wicket:
   instrumentations:
   - name: wicket-8.0
-    srcPath: instrumentation/wicket-8.0
+    source_path: instrumentation/wicket-8.0
     scope:
       name: io.opentelemetry.wicket-8.0
     target_versions:
@@ -1938,21 +1938,21 @@ wicket:
 xxl:
   instrumentations:
   - name: xxl-job-2.3.0
-    srcPath: instrumentation/xxl-job/xxl-job-2.3.0
+    source_path: instrumentation/xxl-job/xxl-job-2.3.0
     scope:
       name: io.opentelemetry.xxl-job-2.3.0
     target_versions:
       javaagent:
       - com.xuxueli:xxl-job-core:[2.3.0,)
   - name: xxl-job-2.1.2
-    srcPath: instrumentation/xxl-job/xxl-job-2.1.2
+    source_path: instrumentation/xxl-job/xxl-job-2.1.2
     scope:
       name: io.opentelemetry.xxl-job-2.1.2
     target_versions:
       javaagent:
       - com.xuxueli:xxl-job-core:[2.1.2,2.3.0)
   - name: xxl-job-1.9.2
-    srcPath: instrumentation/xxl-job/xxl-job-1.9.2
+    source_path: instrumentation/xxl-job/xxl-job-1.9.2
     scope:
       name: io.opentelemetry.xxl-job-1.9.2
     target_versions:
@@ -1961,7 +1961,7 @@ xxl:
 zio:
   instrumentations:
   - name: zio-2.0
-    srcPath: instrumentation/zio/zio-2.0
+    source_path: instrumentation/zio/zio-2.0
     scope:
       name: io.opentelemetry.zio-2.0
     target_versions:

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -50,9 +50,9 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 * name
   * Identifier for instrumentation module, used to enable/disable
   * Configured in `InstrumentationModule` code for each module
-* srcPath
+* source_path
   * Path to the source code of the instrumentation module
-* minimumJavaVersion
+* minimum_java_version
   * Minimum Java version required by the instrumentation module. If not specified, it is assumed to
     be Java 8
 * description
@@ -73,7 +73,7 @@ As of now, the following fields are supported:
 
 ```yaml
 description: "Description of what the instrumentation does."
-disabledByDefault: true
+disabled_by_default: true
 
 # used to mark modules that do not instrument traditional libraries (e.g. methods, annotations)
 # defaults to true

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
@@ -9,17 +9,18 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * Represents the data in a metadata.yaml file. This class is internal and is hence not for public
+ * use. Its APIs are unstable and can change at any time.
  */
 public class InstrumentationMetaData {
+  @Nullable private String description;
+  @Nullable private Boolean isLibraryInstrumentation;
+  @Nullable private Boolean disabledByDefault;
 
   public InstrumentationMetaData() {}
 
   public InstrumentationMetaData(String description) {
     this.description = description;
-    this.isLibraryInstrumentation = true;
-    this.disabledByDefault = false;
   }
 
   public InstrumentationMetaData(
@@ -28,10 +29,6 @@ public class InstrumentationMetaData {
     this.disabledByDefault = disabledByDefault;
     this.description = description;
   }
-
-  @Nullable private String description;
-  @Nullable private Boolean disabledByDefault;
-  @Nullable private Boolean isLibraryInstrumentation;
 
   @Nullable
   public String getDescription() {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -15,9 +15,19 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 
 public class YamlHelper {
+
+  private static final Yaml metaDataYaml = new Yaml();
+
+  static {
+    TypeDescription customDescriptor = new TypeDescription(InstrumentationMetaData.class);
+    customDescriptor.substituteProperty(
+        "disabled_by_default", Boolean.class, "getDisabledByDefault", "setDisabledByDefault");
+    metaDataYaml.addTypeDescription(customDescriptor);
+  }
 
   public static void printInstrumentationList(
       List<InstrumentationEntity> list, BufferedWriter writer) {
@@ -43,14 +53,14 @@ public class YamlHelper {
               }
 
               if (entity.getMetadata().getDisabledByDefault()) {
-                entityMap.put("disabledByDefault", entity.getMetadata().getDisabledByDefault());
+                entityMap.put("disabled_by_default", entity.getMetadata().getDisabledByDefault());
               }
             }
 
-            entityMap.put("srcPath", entity.getSrcPath());
+            entityMap.put("source_path", entity.getSrcPath());
 
             if (entity.getMinJavaVersion() != null) {
-              entityMap.put("minimumJavaVersion", entity.getMinJavaVersion());
+              entityMap.put("minimum_java_version", entity.getMinJavaVersion());
             }
 
             Map<String, Object> scopeMap = getScopeMap(entity);
@@ -97,7 +107,7 @@ public class YamlHelper {
   }
 
   public static InstrumentationMetaData metaDataParser(String input) {
-    return new Yaml().loadAs(input, InstrumentationMetaData.class);
+    return metaDataYaml.loadAs(input, InstrumentationMetaData.class);
   }
 
   private YamlHelper() {}

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -69,9 +69,9 @@ class YamlHelperTest {
               instrumentations:
               - name: spring-web-6.0
                 description: Spring Web 6.0 instrumentation
-                disabledByDefault: true
-                srcPath: instrumentation/spring/spring-web/spring-web-6.0
-                minimumJavaVersion: 11
+                disabled_by_default: true
+                source_path: instrumentation/spring/spring-web/spring-web-6.0
+                minimum_java_version: 11
                 scope:
                   name: io.opentelemetry.spring-web-6.0
                 target_versions:
@@ -80,7 +80,7 @@ class YamlHelperTest {
             struts:
               instrumentations:
               - name: struts-2.3
-                srcPath: instrumentation/struts/struts-2.3
+                source_path: instrumentation/struts/struts-2.3
                 scope:
                   name: io.opentelemetry.struts-2.3
                 target_versions:
@@ -137,8 +137,8 @@ class YamlHelperTest {
               instrumentations:
               - name: spring-web-6.0
                 description: Spring Web 6.0 instrumentation
-                srcPath: instrumentation/spring/spring-web/spring-web-6.0
-                minimumJavaVersion: 11
+                source_path: instrumentation/spring/spring-web/spring-web-6.0
+                minimum_java_version: 11
                 scope:
                   name: io.opentelemetry.spring-web-6.0
                 target_versions:
@@ -155,7 +155,7 @@ class YamlHelperTest {
         """
         description: test description
         isLibraryInstrumentation: false
-        disabledByDefault: true
+        disabled_by_default: true
         """;
 
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
@@ -183,7 +183,7 @@ class YamlHelperTest {
 
   @Test
   void testMetadataParserWithOnlyDisabledByDefault() {
-    String input = "disabledByDefault: true";
+    String input = "disabled_by_default: true";
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
     assertThat(metadata.getIsLibraryInstrumentation()).isTrue();
     assertThat(metadata.getDescription()).isNull();

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/metadata.yaml
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/jaxrs/jaxrs-2.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/jaxrs/jaxrs-3.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/jaxws/jaxws-jws-api-1.1/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-jws-api-1.1/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/jdbc/metadata.yaml
+++ b/instrumentation/jdbc/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/micrometer/micrometer-1.5/metadata.yaml
+++ b/instrumentation/micrometer/micrometer-1.5/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/mybatis-3.2/metadata.yaml
+++ b/instrumentation/mybatis-3.2/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/spring/spring-batch-3.0/metadata.yaml
+++ b/instrumentation/spring/spring-batch-3.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/metadata.yaml
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true

--- a/instrumentation/spring/spring-ws-2.0/metadata.yaml
+++ b/instrumentation/spring/spring-ws-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-disabledByDefault: true
+disabled_by_default: true


### PR DESCRIPTION
Changes the input (metadata.yaml) and output (instrumentation-list.yaml) yaml files to consistently use snake case.

Note: I intentionally did not touch `isLibraryInstrumentation` yet because I will be revamping that piece entirely in my next PR.