### PR TITLE
Improve handling of quoted table names

### DIFF
--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -277,7 +277,11 @@ public class SqlStatementSanitizerTest {
           // Select
           Arguments.of("SELECT x, y, z FROM schema.table", expect("SELECT", "schema.table")),
           Arguments.of("SELECT x, y, z FROM `schema table`", expect("SELECT", "schema table")),
+          Arguments.of(
+              "SELECT x, y, z FROM `schema`.`table`", expect("SELECT", "`schema`.`table`")),
           Arguments.of("SELECT x, y, z FROM \"schema table\"", expect("SELECT", "schema table")),
+          Arguments.of(
+              "SELECT x, y, z FROM \"schema\".\"table\"", expect("SELECT", "\"schema\".\"table\"")),
           Arguments.of(
               "WITH subquery as (select a from b) SELECT x, y, z FROM table",
               expect("SELECT", null)),


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13608
This PR adds handling for identifier names in the form `"schema"."table"` and `` `schema`.`table` ``