### PR TITLE
The `HostIdResourceProvider` should instantiate an `HostIdResource`, not an `HostResource`

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResourceProvider.java
@@ -21,7 +21,7 @@ public final class HostIdResourceProvider implements ConditionalResourceProvider
 
   @Override
   public Resource createResource(ConfigProperties config) {
-    return HostResource.get();
+    return HostIdResource.get();
   }
 
   @Override


### PR DESCRIPTION
The `HostIdResourceProvider` should instantiate an `HostIdResource`, not an `HostResource`.

It's the `HostResourceProvider` that is in charge of returning the `HostResource` as seen here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.14.0/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostResourceProvider.java