### PR TITLE
Exclude opentelemetrybot/**/* from branch creation restriction

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -94,6 +94,7 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
     - `renovate/**/*`
     - `otelbot/**/*`
     - `revert-*/**/*` (these are created when using the GitHub UI to revert a PR)
+    - `opentelemetrybot/**/*`
 - Restrict creations: CHECKED
 
 ### Restrict updating tags


### PR DESCRIPTION
`semantic-conventions-java` `prepare-release-branch` workflow failed because it tried to create a branch restricted by the repo rulesets. 

I added an exclusion of `opentelemetrybot/**/*` to get release back on track, but found that `semantic-conventions-java` references this repo's `repository-settings.md` as its source of truth.

It appears that this repo uses a release branch name pattern of `otelbot/**/*`, which is out of sync with `opentelemetry-java` and `semantic-conventions-java`. An alternative would be to update those two repos to use the name release branch naming pattern of `opentelemetry-java-instrumentation`. 