### PR TITLE
Require only MeterProvider for RuntimeMetrics Library

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/README.md
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/README.md
@@ -2,7 +2,7 @@ The main entry point is the `RuntimeMetrics` class in the package `io.openteleme
 
 ```java
 // Initialize JfrTelemetry
-RuntimeMetrics runtimeMetrics = RuntimeMetrics.create(openTelemetry);
+RuntimeMetrics runtimeMetrics = RuntimeMetrics.create(meterProvider);
 
 // Close JfrTelemetry to stop listening for JFR events
 runtimeMetrics.close();
@@ -23,7 +23,7 @@ by the handlers associated with those features.
 Enable or disable a feature as follows:
 
 ```
-RuntimeMetrics runtimeMetrics = RuntimeMetrics.builder(openTelemetry)
+RuntimeMetrics runtimeMetrics = RuntimeMetrics.builder(meterProvider)
   .enableFeature(JfrFeature.BUFFER_METRICS)
   .disableFeature(JfrFeature.LOCK_METRICS)
   .build();

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/HandlerRegistry.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/HandlerRegistry.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.RecordedEventHandler;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.ThreadGrouper;
@@ -47,9 +47,9 @@ final class HandlerRegistry {
   private HandlerRegistry() {}
 
   static List<RecordedEventHandler> getHandlers(
-      OpenTelemetry openTelemetry, Predicate<JfrFeature> featurePredicate) {
+      MeterProvider meterProvider, Predicate<JfrFeature> featurePredicate) {
 
-    MeterBuilder meterBuilder = openTelemetry.meterBuilder(SCOPE_NAME);
+    MeterBuilder meterBuilder = meterProvider.meterBuilder(SCOPE_NAME);
     if (SCOPE_VERSION != null) {
       meterBuilder.setInstrumentationVersion(SCOPE_VERSION);
     }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilder.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilder.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsFactory;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -16,15 +16,15 @@ import javax.annotation.Nullable;
 /** Builder for {@link RuntimeMetrics}. */
 public final class RuntimeMetricsBuilder {
 
-  private final OpenTelemetry openTelemetry;
+  private final MeterProvider meterProvider;
   // Visible for testing
   final EnumMap<JfrFeature, Boolean> enabledFeatureMap;
 
   private boolean disableJmx = false;
   private boolean enableExperimentalJmxTelemetry = false;
 
-  RuntimeMetricsBuilder(OpenTelemetry openTelemetry) {
-    this.openTelemetry = openTelemetry;
+  RuntimeMetricsBuilder(MeterProvider meterProvider) {
+    this.meterProvider = meterProvider;
     enabledFeatureMap = new EnumMap<>(JfrFeature.class);
     for (JfrFeature feature : JfrFeature.values()) {
       enabledFeatureMap.put(feature, feature.isDefaultEnabled());
@@ -87,9 +87,9 @@ public final class RuntimeMetricsBuilder {
         disableJmx
             ? List.of()
             : JmxRuntimeMetricsFactory.buildObservables(
-                openTelemetry, enableExperimentalJmxTelemetry);
+                meterProvider, enableExperimentalJmxTelemetry);
     RuntimeMetrics.JfrRuntimeMetrics jfrRuntimeMetrics = buildJfrMetrics();
-    return new RuntimeMetrics(openTelemetry, observables, jfrRuntimeMetrics);
+    return new RuntimeMetrics(meterProvider, observables, jfrRuntimeMetrics);
   }
 
   @Nullable
@@ -97,6 +97,6 @@ public final class RuntimeMetricsBuilder {
     if (enabledFeatureMap.values().stream().noneMatch(isEnabled -> isEnabled)) {
       return null;
     }
-    return RuntimeMetrics.JfrRuntimeMetrics.build(openTelemetry, enabledFeatureMap::get);
+    return RuntimeMetrics.JfrRuntimeMetrics.build(meterProvider, enabledFeatureMap::get);
   }
 }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import java.util.Arrays;
 import java.util.HashMap;
 import jdk.jfr.FlightRecorder;
@@ -33,27 +33,27 @@ class RuntimeMetricsBuilderTest {
     Arrays.stream(JfrFeature.values())
         .forEach(jfrFeature -> defaultFeatures.put(jfrFeature, jfrFeature.isDefaultEnabled()));
 
-    assertThat(new RuntimeMetricsBuilder(OpenTelemetry.noop()).enabledFeatureMap)
+    assertThat(new RuntimeMetricsBuilder(MeterProvider.noop()).enabledFeatureMap)
         .isEqualTo(defaultFeatures);
   }
 
   @Test
   void enableAllFeatures() {
     assertThat(
-            new RuntimeMetricsBuilder(OpenTelemetry.noop()).enableAllFeatures().enabledFeatureMap)
+            new RuntimeMetricsBuilder(MeterProvider.noop()).enableAllFeatures().enabledFeatureMap)
         .allSatisfy((unused, enabled) -> assertThat(enabled).isTrue());
   }
 
   @Test
   void disableAllFeatures() {
     assertThat(
-            new RuntimeMetricsBuilder(OpenTelemetry.noop()).disableAllFeatures().enabledFeatureMap)
+            new RuntimeMetricsBuilder(MeterProvider.noop()).disableAllFeatures().enabledFeatureMap)
         .allSatisfy((unused, enabled) -> assertThat(enabled).isFalse());
   }
 
   @Test
   void enableDisableFeature() {
-    var builder = new RuntimeMetricsBuilder(OpenTelemetry.noop());
+    var builder = new RuntimeMetricsBuilder(MeterProvider.noop());
 
     assertThat(builder.enabledFeatureMap.get(JfrFeature.BUFFER_METRICS)).isFalse();
 
@@ -65,9 +65,9 @@ class RuntimeMetricsBuilderTest {
 
   @Test
   void build() {
-    var openTelemetry = OpenTelemetry.noop();
-    try (var jfrTelemetry = new RuntimeMetricsBuilder(openTelemetry).build()) {
-      assertThat(jfrTelemetry.getOpenTelemetry()).isSameAs(openTelemetry);
+    var meterProvider = MeterProvider.noop();
+    try (var jfrTelemetry = new RuntimeMetricsBuilder(meterProvider).build()) {
+      assertThat(jfrTelemetry.getMeterProvider()).isSameAs(meterProvider);
       assertThat(jfrTelemetry.getJfrRuntimeMetrics().getRecordedEventHandlers())
           .hasSizeGreaterThan(0)
           .allSatisfy(handler -> assertThat(handler.getFeature().isDefaultEnabled()).isTrue());

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
@@ -72,7 +72,7 @@ class RuntimeMetricsTest {
   @Test
   void builder() {
     try (var jfrTelemetry = RuntimeMetrics.builder(sdk).build()) {
-      assertThat(jfrTelemetry.getOpenTelemetry()).isSameAs(sdk);
+      assertThat(jfrTelemetry.getMeterProvider()).isSameAs(sdk.getMeterProvider());
       assertThat(jfrTelemetry.getJfrRuntimeMetrics().getRecordedEventHandlers())
           .hasSizeGreaterThan(0)
           .allSatisfy(handler -> assertThat(handler.getFeature().isDefaultEnabled()).isTrue());

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/README.md
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/README.md
@@ -33,12 +33,13 @@ Register observers for the desired runtime metrics:
 
 ```java
 OpenTelemetry openTelemetry = // OpenTelemetry instance configured elsewhere
+MeterProvider meterProvider = openTelemetry.getMeterProvider();
 
-Classes.registerObservers(openTelemetry);
-Cpu.registerObservers(openTelemetry);
-MemoryPools.registerObservers(openTelemetry);
-Threads.registerObservers(openTelemetry);
-GarbageCollector.registerObservers(openTelemetry);
+Classes.registerObservers(meterProvider);
+Cpu.registerObservers(meterProvider);
+MemoryPools.registerObservers(meterProvider);
+Threads.registerObservers(meterProvider);
+GarbageCollector.registerObservers(meterProvider);
 ```
 
 ## Garbage Collector Dependent Metrics

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Classes.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Classes.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsUtil;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
@@ -39,13 +40,13 @@ public final class Classes {
   static final Classes INSTANCE = new Classes();
 
   /** Register observers for java runtime class metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
-    return INSTANCE.registerObservers(openTelemetry, ManagementFactory.getClassLoadingMXBean());
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
+    return INSTANCE.registerObservers(meterProvider, ManagementFactory.getClassLoadingMXBean());
   }
 
   // Visible for testing
-  List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry, ClassLoadingMXBean classBean) {
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+  List<AutoCloseable> registerObservers(MeterProvider meterProvider, ClassLoadingMXBean classBean) {
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     List<AutoCloseable> observables = new ArrayList<>();
 
     observables.add(

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Cpu.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Cpu.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.CpuMethods;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsUtil;
@@ -44,9 +44,9 @@ public final class Cpu {
   private static final double NANOS_PER_S = TimeUnit.SECONDS.toNanos(1);
 
   /** Register observers for java runtime CPU metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
     return INSTANCE.registerObservers(
-        openTelemetry,
+        meterProvider,
         Runtime.getRuntime()::availableProcessors,
         CpuMethods.processCpuTime(),
         CpuMethods.processCpuUtilization());
@@ -54,11 +54,11 @@ public final class Cpu {
 
   // Visible for testing
   List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry,
+      MeterProvider meterProvider,
       IntSupplier availableProcessors,
       @Nullable Supplier<Long> processCpuTime,
       @Nullable Supplier<Double> processCpuUtilization) {
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     List<AutoCloseable> observables = new ArrayList<>();
 
     if (processCpuTime != null) {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/GarbageCollector.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/GarbageCollector.java
@@ -9,7 +9,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import com.sun.management.GarbageCollectionNotificationInfo;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
@@ -62,7 +62,7 @@ public final class GarbageCollector {
               .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION);
 
   /** Register observers for java runtime memory metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
     if (!isNotificationClassPresent()) {
       logger.fine(
           "The com.sun.management.GarbageCollectionNotificationInfo class is not available;"
@@ -71,17 +71,17 @@ public final class GarbageCollector {
     }
 
     return registerObservers(
-        openTelemetry,
+        meterProvider,
         ManagementFactory.getGarbageCollectorMXBeans(),
         GarbageCollector::extractNotificationInfo);
   }
 
   // Visible for testing
   static List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry,
+      MeterProvider meterProvider,
       List<GarbageCollectorMXBean> gcBeans,
       Function<Notification, GarbageCollectionNotificationInfo> notificationInfoExtractor) {
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
 
     DoubleHistogram gcDuration =
         meter

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/MemoryPools.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/MemoryPools.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -47,14 +47,14 @@ import java.util.function.Function;
 public final class MemoryPools {
 
   /** Register observers for java runtime memory metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
-    return registerObservers(openTelemetry, ManagementFactory.getMemoryPoolMXBeans());
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
+    return registerObservers(meterProvider, ManagementFactory.getMemoryPoolMXBeans());
   }
 
   // Visible for testing
   static List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry, List<MemoryPoolMXBean> poolBeans) {
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+      MeterProvider meterProvider, List<MemoryPoolMXBean> poolBeans) {
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     List<AutoCloseable> observables = new ArrayList<>();
 
     observables.add(

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetrics.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsUtil;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +35,19 @@ public final class RuntimeMetrics implements AutoCloseable {
    * @param openTelemetry the {@link OpenTelemetry} instance used to record telemetry
    */
   public static RuntimeMetrics create(OpenTelemetry openTelemetry) {
-    return new RuntimeMetricsBuilder(openTelemetry).build();
+    return new RuntimeMetricsBuilder(openTelemetry.getMeterProvider()).build();
+  }
+
+  /**
+   * Create and start {@link RuntimeMetrics}.
+   *
+   * <p>Listens for select JMX beans, extracts data, and records to various metrics. Recording will
+   * continue until {@link #close()} is called.
+   *
+   * @param meterProvider the {@link MeterProvider} instance used to record telemetry
+   */
+  public static RuntimeMetrics create(MeterProvider meterProvider) {
+    return new RuntimeMetricsBuilder(meterProvider).build();
   }
 
   /**
@@ -43,7 +56,16 @@ public final class RuntimeMetrics implements AutoCloseable {
    * @param openTelemetry the {@link OpenTelemetry} instance used to record telemetry
    */
   public static RuntimeMetricsBuilder builder(OpenTelemetry openTelemetry) {
-    return new RuntimeMetricsBuilder(openTelemetry);
+    return new RuntimeMetricsBuilder(openTelemetry.getMeterProvider());
+  }
+
+  /**
+   * Create a builder for configuring {@link RuntimeMetrics}.
+   *
+   * @param meterProvider the {@link MeterProvider} instance used to record telemetry
+   */
+  public static RuntimeMetricsBuilder builder(MeterProvider meterProvider) {
+    return new RuntimeMetricsBuilder(meterProvider);
   }
 
   /** Stop recording JMX metrics. */

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetricsBuilder.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetricsBuilder.java
@@ -6,19 +6,19 @@
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsFactory;
 import java.util.List;
 
 /** Builder for {@link RuntimeMetrics}. */
 public final class RuntimeMetricsBuilder {
 
-  private final OpenTelemetry openTelemetry;
+  private final MeterProvider meterProvider;
 
   private boolean enableExperimentalJmxTelemetry = false;
 
-  RuntimeMetricsBuilder(OpenTelemetry openTelemetry) {
-    this.openTelemetry = openTelemetry;
+  RuntimeMetricsBuilder(MeterProvider meterProvider) {
+    this.meterProvider = meterProvider;
   }
 
   /** Enable all JMX telemetry collection. */
@@ -31,7 +31,7 @@ public final class RuntimeMetricsBuilder {
   /** Build and start an {@link RuntimeMetrics} with the config from this builder. */
   public RuntimeMetrics build() {
     List<AutoCloseable> observables =
-        JmxRuntimeMetricsFactory.buildObservables(openTelemetry, enableExperimentalJmxTelemetry);
+        JmxRuntimeMetricsFactory.buildObservables(meterProvider, enableExperimentalJmxTelemetry);
     return new RuntimeMetrics(observables);
   }
 }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPools.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPools.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.runtimemetrics.java8.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -31,18 +31,18 @@ public final class ExperimentalBufferPools {
       stringKey("jvm.buffer.pool.name");
 
   /** Register observers for java runtime buffer pool metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
     List<BufferPoolMXBean> bufferBeans =
         ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
-    return registerObservers(openTelemetry, bufferBeans);
+    return registerObservers(meterProvider, bufferBeans);
   }
 
   // Visible for testing
   static List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry, List<BufferPoolMXBean> bufferBeans) {
+      MeterProvider meterProvider, List<BufferPoolMXBean> bufferBeans) {
 
     List<AutoCloseable> observables = new ArrayList<>();
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     observables.add(
         meter
             .upDownCounterBuilder("jvm.buffer.memory.used")

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalCpu.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalCpu.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8.internal;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.Meter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
@@ -23,20 +23,20 @@ import javax.annotation.Nullable;
 public final class ExperimentalCpu {
 
   /** Register observers for java runtime experimental CPU metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
     return registerObservers(
-        openTelemetry,
+        meterProvider,
         ManagementFactory.getOperatingSystemMXBean(),
         CpuMethods.systemCpuUtilization());
   }
 
   // Visible for testing
   static List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry,
+      MeterProvider meterProvider,
       OperatingSystemMXBean osBean,
       @Nullable Supplier<Double> systemCpuUtilization) {
 
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     List<AutoCloseable> observables = new ArrayList<>();
     observables.add(
         meter

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalMemoryPools.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalMemoryPools.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.runtimemetrics.java8.internal;
 
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
@@ -29,15 +29,15 @@ import java.util.function.Consumer;
 public final class ExperimentalMemoryPools {
 
   /** Register observers for java runtime experimental memory metrics. */
-  public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
-    return registerObservers(openTelemetry, ManagementFactory.getMemoryPoolMXBeans());
+  public static List<AutoCloseable> registerObservers(MeterProvider meterProvider) {
+    return registerObservers(meterProvider, ManagementFactory.getMemoryPoolMXBeans());
   }
 
   // Visible for testing
   static List<AutoCloseable> registerObservers(
-      OpenTelemetry openTelemetry, List<MemoryPoolMXBean> poolBeans) {
+      MeterProvider meterProvider, List<MemoryPoolMXBean> poolBeans) {
 
-    Meter meter = JmxRuntimeMetricsUtil.getMeter(openTelemetry);
+    Meter meter = JmxRuntimeMetricsUtil.getMeter(meterProvider);
     return singletonList(
         meter
             .upDownCounterBuilder("jvm.memory.init")

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/JmxRuntimeMetricsFactory.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/JmxRuntimeMetricsFactory.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8.internal;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
@@ -21,18 +22,18 @@ import java.util.List;
 public class JmxRuntimeMetricsFactory {
   @SuppressWarnings("CatchingUnchecked")
   public static List<AutoCloseable> buildObservables(
-      OpenTelemetry openTelemetry, boolean enableExperimentalJmxTelemetry) {
+      MeterProvider meterProvider, boolean enableExperimentalJmxTelemetry) {
     // Set up metrics gathered by JMX
     List<AutoCloseable> observables = new ArrayList<>();
-    observables.addAll(Classes.registerObservers(openTelemetry));
-    observables.addAll(Cpu.registerObservers(openTelemetry));
-    observables.addAll(GarbageCollector.registerObservers(openTelemetry));
-    observables.addAll(MemoryPools.registerObservers(openTelemetry));
-    observables.addAll(Threads.registerObservers(openTelemetry));
+    observables.addAll(Classes.registerObservers(meterProvider));
+    observables.addAll(Cpu.registerObservers(meterProvider));
+    observables.addAll(GarbageCollector.registerObservers(meterProvider));
+    observables.addAll(MemoryPools.registerObservers(meterProvider));
+    observables.addAll(Threads.registerObservers(meterProvider));
     if (enableExperimentalJmxTelemetry) {
-      observables.addAll(ExperimentalBufferPools.registerObservers(openTelemetry));
-      observables.addAll(ExperimentalCpu.registerObservers(openTelemetry));
-      observables.addAll(ExperimentalMemoryPools.registerObservers(openTelemetry));
+      observables.addAll(ExperimentalBufferPools.registerObservers(meterProvider));
+      observables.addAll(ExperimentalCpu.registerObservers(meterProvider));
+      observables.addAll(ExperimentalMemoryPools.registerObservers(meterProvider));
     }
     return observables;
   }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/JmxRuntimeMetricsUtil.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/JmxRuntimeMetricsUtil.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8.internal;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -24,8 +25,8 @@ public class JmxRuntimeMetricsUtil {
   private static final String INSTRUMENTATION_VERSION =
       EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
 
-  public static Meter getMeter(OpenTelemetry openTelemetry) {
-    MeterBuilder meterBuilder = openTelemetry.meterBuilder(INSTRUMENTATION_NAME);
+  public static Meter getMeter(MeterProvider meterProvider) {
+    MeterBuilder meterBuilder = meterProvider.meterBuilder(INSTRUMENTATION_NAME);
     if (INSTRUMENTATION_VERSION != null) {
       meterBuilder.setInstrumentationVersion(INSTRUMENTATION_VERSION);
     }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ClassesStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ClassesStableSemconvTest.java
@@ -33,7 +33,7 @@ class ClassesStableSemconvTest {
     when(classBean.getUnloadedClassCount()).thenReturn(2L);
     when(classBean.getLoadedClassCount()).thenReturn(1);
 
-    Classes.INSTANCE.registerObservers(testing.getOpenTelemetry(), classBean);
+    Classes.INSTANCE.registerObservers(testing.getOpenTelemetry().getMeterProvider(), classBean);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/CpuStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/CpuStableSemconvTest.java
@@ -28,7 +28,7 @@ class CpuStableSemconvTest {
     Supplier<Double> processCpuUtilization = () -> 0.05;
 
     Cpu.INSTANCE.registerObservers(
-        testing.getOpenTelemetry(), availableProcessors, processCpuTime, processCpuUtilization);
+        testing.getOpenTelemetry().getMeterProvider(), availableProcessors, processCpuTime, processCpuUtilization);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/GarbageCollectorTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/GarbageCollectorTest.java
@@ -51,7 +51,7 @@ class GarbageCollectorTest {
   @Test
   void registerObservers() {
     GarbageCollector.registerObservers(
-        testing.getOpenTelemetry(),
+        testing.getOpenTelemetry().getMeterProvider(),
         singletonList(gcBean),
         GarbageCollectorTest::getGcNotificationInfo);
 

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/MemoryPoolsStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/MemoryPoolsStableSemconvTest.java
@@ -78,7 +78,7 @@ class MemoryPoolsStableSemconvTest {
     when(nonHeapUsage.getMax()).thenReturn(17L);
     when(heapCollectionUsage.getUsed()).thenReturn(18L);
     when(nonHeapCollectionUsage.getUsed()).thenReturn(19L);
-    MemoryPools.registerObservers(testing.getOpenTelemetry(), beans);
+    MemoryPools.registerObservers(testing.getOpenTelemetry().getMeterProvider(), beans);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/ThreadsStableSemconvTest.java
@@ -49,7 +49,7 @@ class ThreadsStableSemconvTest {
     when(threadBean.getDaemonThreadCount()).thenReturn(2);
 
     Threads.INSTANCE
-        .registerObservers(testing.getOpenTelemetry(), threadBean)
+        .registerObservers(testing.getOpenTelemetry().getMeterProvider(), threadBean)
         .forEach(cleanup::deferCleanup);
 
     testing.waitAndAssertMetrics(
@@ -86,7 +86,7 @@ class ThreadsStableSemconvTest {
     Thread[] threads = new Thread[] {threadInfo1, threadInfo2};
 
     Threads.INSTANCE
-        .registerObservers(testing.getOpenTelemetry(), () -> threads)
+        .registerObservers(testing.getOpenTelemetry().getMeterProvider(), () -> threads)
         .forEach(cleanup::deferCleanup);
 
     testing.waitAndAssertMetrics(
@@ -131,7 +131,7 @@ class ThreadsStableSemconvTest {
         .thenReturn(new ThreadInfo[] {threadInfo1, null, threadInfo2});
 
     Threads.INSTANCE
-        .registerObservers(testing.getOpenTelemetry(), threadBean)
+        .registerObservers(testing.getOpenTelemetry().getMeterProvider(), threadBean)
         .forEach(cleanup::deferCleanup);
 
     testing.waitAndAssertMetrics(

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPoolsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPoolsTest.java
@@ -52,7 +52,7 @@ class ExperimentalBufferPoolsTest {
     when(bufferPoolBean.getTotalCapacity()).thenReturn(11L);
     when(bufferPoolBean.getCount()).thenReturn(12L);
 
-    ExperimentalBufferPools.registerObservers(testing.getOpenTelemetry(), beans);
+    ExperimentalBufferPools.registerObservers(testing.getOpenTelemetry().getMeterProvider(), beans);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalCpuTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalCpuTest.java
@@ -32,7 +32,7 @@ class ExperimentalCpuTest {
     when(osBean.getSystemLoadAverage()).thenReturn(2.2);
     Supplier<Double> systemCpuUtilization = () -> 0.11;
 
-    ExperimentalCpu.registerObservers(testing.getOpenTelemetry(), osBean, systemCpuUtilization);
+    ExperimentalCpu.registerObservers(testing.getOpenTelemetry().getMeterProvider(), osBean, systemCpuUtilization);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalMemoryPoolsTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalMemoryPoolsTest.java
@@ -56,7 +56,7 @@ class ExperimentalMemoryPoolsTest {
   void registerObservers() {
     when(heapPoolUsage.getInit()).thenReturn(11L);
     when(nonHeapUsage.getInit()).thenReturn(15L);
-    ExperimentalMemoryPools.registerObservers(testing.getOpenTelemetry(), beans);
+    ExperimentalMemoryPools.registerObservers(testing.getOpenTelemetry().getMeterProvider(), beans);
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.runtime-telemetry-java8",


### PR DESCRIPTION
This library only generates metrics, so we don't need the full OpenTelemetry class.  This allows consumers to simplify instantiation if they're only using OpenTelemetry metrics.

This should be a non-breaking change.