### PR TITLE
Introduce instrumentation classifications to metadata

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -2,8 +2,8 @@
 # The structure and contents are a work in progress and subject to change.
 # For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468
 
-activej:
-  instrumentations:
+libraries:
+  activej:
   - name: activej-http-6.0
     source_path: instrumentation/activej-http-6.0
     minimum_java_version: 17
@@ -12,8 +12,7 @@ activej:
     target_versions:
       javaagent:
       - io.activej:activej-http:[6.0,)
-akka:
-  instrumentations:
+  akka:
   - name: akka-http-10.0
     source_path: instrumentation/akka/akka-http-10.0
     scope:
@@ -41,8 +40,7 @@ akka:
       - com.typesafe.akka:akka-actor_2.11:[2.3,)
       - com.typesafe.akka:akka-actor_2.12:[2.3,)
       - com.typesafe.akka:akka-actor_2.13:[2.3,)
-alibaba:
-  instrumentations:
+  alibaba:
   - name: alibaba-druid-1.0
     source_path: instrumentation/alibaba-druid-1.0
     scope:
@@ -52,8 +50,7 @@ alibaba:
       - com.alibaba:druid:(,)
       library:
       - com.alibaba:druid:1.0.0
-apache:
-  instrumentations:
+  apache:
   - name: apache-shenyu-2.4
     source_path: instrumentation/apache-shenyu-2.4
     scope:
@@ -120,8 +117,7 @@ apache:
       - org.apache.commons:commons-dbcp2:[2,)
       library:
       - org.apache.commons:commons-dbcp2:2.0
-armeria:
-  instrumentations:
+  armeria:
   - name: armeria-1.3
     source_path: instrumentation/armeria/armeria-1.3
     scope:
@@ -138,8 +134,7 @@ armeria:
     target_versions:
       javaagent:
       - com.linecorp.armeria:armeria-grpc:[1.14.0,)
-async:
-  instrumentations:
+  async:
   - name: async-http-client-1.9
     source_path: instrumentation/async-http-client/async-http-client-1.9
     scope:
@@ -154,8 +149,7 @@ async:
     target_versions:
       javaagent:
       - org.asynchttpclient:async-http-client:[2.0.0,)
-aws:
-  instrumentations:
+  aws:
   - name: aws-lambda-events-2.2
     source_path: instrumentation/aws-lambda/aws-lambda-events-2.2
     scope:
@@ -203,8 +197,7 @@ aws:
       - software.amazon.awssdk:sqs:2.2.0
       - software.amazon.awssdk:sns:2.2.0
       - software.amazon.awssdk:lambda:2.2.0
-azure:
-  instrumentations:
+  azure:
   - name: azure-core-1.36
     source_path: instrumentation/azure-core/azure-core-1.36
     scope:
@@ -226,8 +219,7 @@ azure:
     target_versions:
       javaagent:
       - com.azure:azure-core:[1.14.0,1.19.0)
-c3p0:
-  instrumentations:
+  c3p0:
   - name: c3p0-0.9
     source_path: instrumentation/c3p0-0.9
     scope:
@@ -237,8 +229,7 @@ c3p0:
       - com.mchange:c3p0:(,)
       library:
       - com.mchange:c3p0:0.9.2
-camel:
-  instrumentations:
+  camel:
   - name: camel-2.20
     source_path: instrumentation/camel-2.20
     scope:
@@ -246,8 +237,7 @@ camel:
     target_versions:
       javaagent:
       - org.apache.camel:camel-core:[2.19,3)
-cassandra:
-  instrumentations:
+  cassandra:
   - name: cassandra-4.0
     source_path: instrumentation/cassandra/cassandra-4.0
     scope:
@@ -271,8 +261,7 @@ cassandra:
     target_versions:
       javaagent:
       - com.datastax.cassandra:cassandra-driver-core:[3.0,4.0)
-clickhouse:
-  instrumentations:
+  clickhouse:
   - name: clickhouse-client-0.5
     description: Instruments the V1 ClickHouseClient, providing database client spans
       and metrics.
@@ -282,8 +271,7 @@ clickhouse:
     target_versions:
       javaagent:
       - com.clickhouse.client:clickhouse-client:[0.5.0,)
-couchbase:
-  instrumentations:
+  couchbase:
   - name: couchbase-3.1.6
     source_path: instrumentation/couchbase/couchbase-3.1.6
     scope:
@@ -319,8 +307,7 @@ couchbase:
     target_versions:
       javaagent:
       - com.couchbase.client:java-client:[3.1,3.1.6)
-dropwizard:
-  instrumentations:
+  dropwizard:
   - name: dropwizard-metrics-4.0
     disabled_by_default: true
     source_path: instrumentation/dropwizard/dropwizard-metrics-4.0
@@ -336,8 +323,7 @@ dropwizard:
     target_versions:
       javaagent:
       - io.dropwizard:dropwizard-views:(,3.0.0)
-elasticsearch:
-  instrumentations:
+  elasticsearch:
   - name: elasticsearch-rest-6.4
     source_path: instrumentation/elasticsearch/elasticsearch-rest-6.4
     scope:
@@ -394,8 +380,7 @@ elasticsearch:
       javaagent:
       - org.elasticsearch.client:transport:[5.3.0,6.0.0)
       - org.elasticsearch:elasticsearch:[5.3.0,6.0.0)
-executors:
-  instrumentations:
+  executors:
   - name: executors
     source_path: instrumentation/executors
     scope:
@@ -403,8 +388,7 @@ executors:
     target_versions:
       javaagent:
       - Java 8+
-finagle:
-  instrumentations:
+  finagle:
   - name: finagle-http-23.11
     source_path: instrumentation/finagle-http-23.11
     scope:
@@ -413,8 +397,7 @@ finagle:
       javaagent:
       - com.twitter:finagle-http_2.13:[23.11.0,]
       - com.twitter:finagle-http_2.12:[23.11.0,]
-finatra:
-  instrumentations:
+  finatra:
   - name: finatra-2.9
     source_path: instrumentation/finatra-2.9
     scope:
@@ -423,8 +406,7 @@ finatra:
       javaagent:
       - com.twitter:finatra-http_2.11:[2.9.0,]
       - com.twitter:finatra-http_2.12:[2.9.0,]
-geode:
-  instrumentations:
+  geode:
   - name: geode-1.4
     source_path: instrumentation/geode-1.4
     scope:
@@ -432,8 +414,7 @@ geode:
     target_versions:
       javaagent:
       - org.apache.geode:geode-core:[1.4.0,)
-google:
-  instrumentations:
+  google:
   - name: google-http-client-1.19
     source_path: instrumentation/google-http-client-1.19
     scope:
@@ -441,8 +422,7 @@ google:
     target_versions:
       javaagent:
       - com.google.http-client:google-http-client:[1.19.0,)
-grails:
-  instrumentations:
+  grails:
   - name: grails-3.0
     source_path: instrumentation/grails-3.0
     scope:
@@ -450,8 +430,7 @@ grails:
     target_versions:
       javaagent:
       - org.grails:grails-web-url-mappings:[3.0,)
-graphql:
-  instrumentations:
+  graphql:
   - name: graphql-java-12.0
     source_path: instrumentation/graphql-java/graphql-java-12.0
     scope:
@@ -471,8 +450,7 @@ graphql:
       - com.graphql-java:graphql-java:[20,)
       library:
       - com.graphql-java:graphql-java:20.0
-grizzly:
-  instrumentations:
+  grizzly:
   - name: grizzly-2.3
     source_path: instrumentation/grizzly-2.3
     scope:
@@ -480,8 +458,7 @@ grizzly:
     target_versions:
       javaagent:
       - org.glassfish.grizzly:grizzly-http:[2.3,)
-grpc:
-  instrumentations:
+  grpc:
   - name: grpc-1.6
     source_path: instrumentation/grpc-1.6
     scope:
@@ -491,8 +468,7 @@ grpc:
       - io.grpc:grpc-core:[1.6.0,)
       library:
       - io.grpc:grpc-core:1.6.0
-guava:
-  instrumentations:
+  guava:
   - name: guava-10.0
     source_path: instrumentation/guava-10.0
     scope:
@@ -502,8 +478,7 @@ guava:
       - com.google.guava:guava:[10.0,]
       library:
       - com.google.guava:guava:10.0
-gwt:
-  instrumentations:
+  gwt:
   - name: gwt-2.0
     source_path: instrumentation/gwt-2.0
     scope:
@@ -512,8 +487,7 @@ gwt:
       javaagent:
       - com.google.gwt:gwt-servlet:[2.0.0,)
       - org.gwtproject:gwt-servlet:[2.10.0,)
-hibernate:
-  instrumentations:
+  hibernate:
   - name: hibernate-4.0
     source_path: instrumentation/hibernate/hibernate-4.0
     scope:
@@ -550,8 +524,7 @@ hibernate:
     target_versions:
       javaagent:
       - org.hibernate.reactive:hibernate-reactive-core:(,)
-hikaricp:
-  instrumentations:
+  hikaricp:
   - name: hikaricp-3.0
     source_path: instrumentation/hikaricp-3.0
     scope:
@@ -561,8 +534,7 @@ hikaricp:
       - com.zaxxer:HikariCP:[3.0.0,)
       library:
       - com.zaxxer:HikariCP:3.0.0
-http:
-  instrumentations:
+  http:
   - name: http-url-connection
     source_path: instrumentation/http-url-connection
     scope:
@@ -570,8 +542,7 @@ http:
     target_versions:
       javaagent:
       - Java 8+
-hystrix:
-  instrumentations:
+  hystrix:
   - name: hystrix-1.4
     source_path: instrumentation/hystrix-1.4
     scope:
@@ -579,8 +550,7 @@ hystrix:
     target_versions:
       javaagent:
       - com.netflix.hystrix:hystrix-core:[1.4.0,)
-influxdb:
-  instrumentations:
+  influxdb:
   - name: influxdb-2.4
     source_path: instrumentation/influxdb-2.4
     scope:
@@ -588,8 +558,7 @@ influxdb:
     target_versions:
       javaagent:
       - org.influxdb:influxdb-java:[2.4,)
-java:
-  instrumentations:
+  java:
   - name: java-http-server
     source_path: instrumentation/java-http-server
     scope:
@@ -605,8 +574,7 @@ java:
     target_versions:
       javaagent:
       - Java 11+
-javalin:
-  instrumentations:
+  javalin:
   - name: javalin-5.0
     source_path: instrumentation/javalin-5.0
     minimum_java_version: 11
@@ -615,8 +583,7 @@ javalin:
     target_versions:
       javaagent:
       - io.javalin:javalin:[5.0.0,)
-jaxrs:
-  instrumentations:
+  jaxrs:
   - name: jaxrs-2.0-cxf-3.2
     source_path: instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2
     scope:
@@ -692,8 +659,7 @@ jaxrs:
     target_versions:
       javaagent:
       - javax.ws.rs:jsr311-api:[0.5,)
-jaxws:
-  instrumentations:
+  jaxws:
   - name: jaxws-jws-api-1.1
     disabled_by_default: true
     source_path: instrumentation/jaxws/jaxws-jws-api-1.1
@@ -740,8 +706,7 @@ jaxws:
     target_versions:
       javaagent:
       - com.sun.xml.ws:jaxws-rt:[2.2.0.1,)
-jboss:
-  instrumentations:
+  jboss:
   - name: jboss-logmanager-appender-1.1
     source_path: instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1
     scope:
@@ -756,8 +721,7 @@ jboss:
     target_versions:
       javaagent:
       - org.jboss.logmanager:jboss-logmanager:[1.1.0.GA,)
-jdbc:
-  instrumentations:
+  jdbc:
   - name: jdbc
     disabled_by_default: true
     source_path: instrumentation/jdbc
@@ -766,8 +730,7 @@ jdbc:
     target_versions:
       javaagent:
       - Java 8+
-jedis:
-  instrumentations:
+  jedis:
   - name: jedis-1.4
     source_path: instrumentation/jedis/jedis-1.4
     scope:
@@ -789,8 +752,7 @@ jedis:
     target_versions:
       javaagent:
       - redis.clients:jedis:[3.0.0,4)
-jetty:
-  instrumentations:
+  jetty:
   - name: jetty-httpclient-12.0
     source_path: instrumentation/jetty-httpclient/jetty-httpclient-12.0
     minimum_java_version: 17
@@ -833,8 +795,7 @@ jetty:
     target_versions:
       javaagent:
       - org.eclipse.jetty:jetty-server:[11, 12)
-jms:
-  instrumentations:
+  jms:
   - name: jms-3.0
     source_path: instrumentation/jms/jms-3.0
     minimum_java_version: 11
@@ -852,8 +813,7 @@ jms:
       - javax.jms:javax.jms-api:(,)
       - jakarta.jms:jakarta.jms-api:(,3)
       - javax.jms:jms-api:(,)
-jodd:
-  instrumentations:
+  jodd:
   - name: jodd-http-4.2
     source_path: instrumentation/jodd-http-4.2
     scope:
@@ -861,8 +821,7 @@ jodd:
     target_versions:
       javaagent:
       - org.jodd:jodd-http:[4.2.0,)
-jsf:
-  instrumentations:
+  jsf:
   - name: jsf-myfaces-3.0
     source_path: instrumentation/jsf/jsf-myfaces-3.0
     minimum_java_version: 11
@@ -897,8 +856,7 @@ jsf:
       - com.sun.faces:jsf-impl:[2.0,2.1)
       - org.glassfish:javax.faces:[2.0.7,3)
       - javax.faces:jsf-impl:[1.2,2)
-jsp:
-  instrumentations:
+  jsp:
   - name: jsp-2.3
     source_path: instrumentation/jsp-2.3
     scope:
@@ -906,8 +864,7 @@ jsp:
     target_versions:
       javaagent:
       - org.apache.tomcat:tomcat-jasper:[7.0.19,10)
-kafka:
-  instrumentations:
+  kafka:
   - name: kafka-streams-0.11
     source_path: instrumentation/kafka/kafka-streams-0.11
     scope:
@@ -929,8 +886,7 @@ kafka:
     target_versions:
       javaagent:
       - org.apache.kafka:kafka-clients:[0.11.0.0,)
-kotlinx:
-  instrumentations:
+  kotlinx:
   - name: kotlinx-coroutines
     source_path: instrumentation/kotlinx-coroutines
     scope:
@@ -956,8 +912,7 @@ kotlinx:
       javaagent:
       - org.jetbrains.kotlinx:kotlinx-coroutines-core:[1.3.0,1.3.8)
       - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:[1.3.9,)
-ktor:
-  instrumentations:
+  ktor:
   - name: ktor-2.0
     source_path: instrumentation/ktor/ktor-2.0
     scope:
@@ -987,8 +942,7 @@ ktor:
     target_versions:
       library:
       - io.ktor:ktor-server-core:[1.0.0,1.+)
-kubernetes:
-  instrumentations:
+  kubernetes:
   - name: kubernetes-client-7.0
     source_path: instrumentation/kubernetes-client-7.0
     scope:
@@ -996,8 +950,7 @@ kubernetes:
     target_versions:
       javaagent:
       - io.kubernetes:client-java-api:[7.0.0,)
-lettuce:
-  instrumentations:
+  lettuce:
   - name: lettuce-5.1
     source_path: instrumentation/lettuce/lettuce-5.1
     scope:
@@ -1021,8 +974,7 @@ lettuce:
     target_versions:
       javaagent:
       - biz.paluch.redis:lettuce:[4.0.Final,)
-liberty:
-  instrumentations:
+  liberty:
   - name: liberty-dispatcher-20.0
     source_path: instrumentation/liberty/liberty-dispatcher-20.0
     scope:
@@ -1033,8 +985,7 @@ liberty:
     scope:
       name: io.opentelemetry.liberty-20.0
     target_versions: {}
-log4j:
-  instrumentations:
+  log4j:
   - name: log4j-context-data-2.7
     source_path: instrumentation/log4j/log4j-context-data/log4j-context-data-2.7
     scope:
@@ -1072,8 +1023,7 @@ log4j:
     target_versions:
       javaagent:
       - org.apache.logging.log4j:log4j-core:[2.17.0,)
-logback:
-  instrumentations:
+  logback:
   - name: logback-mdc-1.0
     source_path: instrumentation/logback/logback-mdc-1.0
     scope:
@@ -1095,8 +1045,7 @@ logback:
       - net.logstash.logback:logstash-logback-encoder:3.0
       - org.slf4j:slf4j-api:2.0.0
       - ch.qos.logback:logback-classic:1.3.0
-micrometer:
-  instrumentations:
+  micrometer:
   - name: micrometer-1.5
     disabled_by_default: true
     source_path: instrumentation/micrometer/micrometer-1.5
@@ -1107,8 +1056,7 @@ micrometer:
       - io.micrometer:micrometer-core:[1.5.0,)
       library:
       - io.micrometer:micrometer-core:1.5.0
-mongo:
-  instrumentations:
+  mongo:
   - name: mongo-4.0
     source_path: instrumentation/mongo/mongo-4.0
     scope:
@@ -1140,8 +1088,7 @@ mongo:
     target_versions:
       javaagent:
       - org.mongodb:mongodb-driver-async:[3.3,)
-mybatis:
-  instrumentations:
+  mybatis:
   - name: mybatis-3.2
     disabled_by_default: true
     source_path: instrumentation/mybatis-3.2
@@ -1150,8 +1097,7 @@ mybatis:
     target_versions:
       javaagent:
       - org.mybatis:mybatis:[3.2.0,)
-netty:
-  instrumentations:
+  netty:
   - name: netty-3.8
     source_path: instrumentation/netty/netty-3.8
     scope:
@@ -1177,8 +1123,7 @@ netty:
       - io.netty:netty-all:[4.1.0.Final,5.0.0)
       library:
       - io.netty:netty-codec-http:4.1.0.Final
-okhttp:
-  instrumentations:
+  okhttp:
   - name: okhttp-3.0
     source_path: instrumentation/okhttp/okhttp-3.0
     scope:
@@ -1195,8 +1140,7 @@ okhttp:
     target_versions:
       javaagent:
       - com.squareup.okhttp:okhttp:[2.2,3)
-opensearch:
-  instrumentations:
+  opensearch:
   - name: opensearch-rest-1.0
     source_path: instrumentation/opensearch/opensearch-rest-1.0
     minimum_java_version: 11
@@ -1205,8 +1149,7 @@ opensearch:
     target_versions:
       javaagent:
       - org.opensearch.client:opensearch-rest-client:[1.0,)
-oracle:
-  instrumentations:
+  oracle:
   - name: oracle-ucp-11.2
     source_path: instrumentation/oracle-ucp-11.2
     scope:
@@ -1217,8 +1160,7 @@ oracle:
       library:
       - com.oracle.database.jdbc:ucp:11.2.0.4
       - com.oracle.database.jdbc:ojdbc8:12.2.0.1
-oshi:
-  instrumentations:
+  oshi:
   - name: oshi
     source_path: instrumentation/oshi
     scope:
@@ -1228,15 +1170,13 @@ oshi:
       - com.github.oshi:oshi-core:[5.3.1,)
       library:
       - com.github.oshi:oshi-core:5.3.1
-payara:
-  instrumentations:
+  payara:
   - name: payara
     source_path: instrumentation/payara
     scope:
       name: io.opentelemetry.payara
     target_versions: {}
-pekko:
-  instrumentations:
+  pekko:
   - name: pekko-actor-1.0
     source_path: instrumentation/pekko/pekko-actor-1.0
     scope:
@@ -1258,8 +1198,7 @@ pekko:
       - org.apache.pekko:pekko-http_3:[1.0,)
       - com.softwaremill.sttp.tapir:tapir-pekko-http-server_2.13:[1.7,)
       - org.apache.pekko:pekko-http_2.13:[1.0,)
-play:
-  instrumentations:
+  play:
   - name: play-ws-1.0
     source_path: instrumentation/play/play-ws/play-ws-1.0
     scope:
@@ -1301,8 +1240,7 @@ play:
       javaagent:
       - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.1.0,]
       - com.typesafe.play:play-ahc-ws-standalone_2.12:[2.1.0,]
-powerjob:
-  instrumentations:
+  powerjob:
   - name: powerjob-4.0
     source_path: instrumentation/powerjob-4.0
     scope:
@@ -1310,8 +1248,7 @@ powerjob:
     target_versions:
       javaagent:
       - tech.powerjob:powerjob-worker:[4.0.0,)
-pulsar:
-  instrumentations:
+  pulsar:
   - name: pulsar-2.8
     source_path: instrumentation/pulsar/pulsar-2.8
     scope:
@@ -1319,8 +1256,7 @@ pulsar:
     target_versions:
       javaagent:
       - org.apache.pulsar:pulsar-client:[2.8.0,)
-quarkus:
-  instrumentations:
+  quarkus:
   - name: quarkus-resteasy-reactive
     source_path: instrumentation/quarkus-resteasy-reactive
     scope:
@@ -1328,8 +1264,7 @@ quarkus:
     target_versions:
       javaagent:
       - io.quarkus:quarkus-resteasy-reactive:(,3.9.0)
-quartz:
-  instrumentations:
+  quartz:
   - name: quartz-2.0
     source_path: instrumentation/quartz-2.0
     scope:
@@ -1339,8 +1274,7 @@ quartz:
       - org.quartz-scheduler:quartz:[2.0.0,)
       library:
       - org.quartz-scheduler:quartz:2.0.0
-r2dbc:
-  instrumentations:
+  r2dbc:
   - name: r2dbc-1.0
     source_path: instrumentation/r2dbc-1.0
     scope:
@@ -1350,8 +1284,7 @@ r2dbc:
       - io.r2dbc:r2dbc-spi:[1.0.0.RELEASE,)
       library:
       - io.r2dbc:r2dbc-spi:1.0.0.RELEASE
-rabbitmq:
-  instrumentations:
+  rabbitmq:
   - name: rabbitmq-2.7
     source_path: instrumentation/rabbitmq-2.7
     scope:
@@ -1359,8 +1292,7 @@ rabbitmq:
     target_versions:
       javaagent:
       - com.rabbitmq:amqp-client:[2.7.0,)
-ratpack:
-  instrumentations:
+  ratpack:
   - name: ratpack-1.4
     source_path: instrumentation/ratpack/ratpack-1.4
     scope:
@@ -1377,8 +1309,7 @@ ratpack:
       - io.ratpack:ratpack-core:[1.7.0,)
       library:
       - io.ratpack:ratpack-core:1.7.0
-reactor:
-  instrumentations:
+  reactor:
   - name: reactor-kafka-1.0
     source_path: instrumentation/reactor/reactor-kafka-1.0
     scope:
@@ -1415,8 +1346,7 @@ reactor:
       javaagent:
       - io.projectreactor.netty:reactor-netty-http:[1.0.0,)
       - io.projectreactor.netty:reactor-netty:[1.0.0,)
-rediscala:
-  instrumentations:
+  rediscala:
   - name: rediscala-1.8
     source_path: instrumentation/rediscala-1.8
     scope:
@@ -1430,8 +1360,7 @@ rediscala:
       - io.github.rediscala:rediscala_2.13:[1.10.0,)
       - com.github.etaty:rediscala_2.13:[1.9.0,)
       - com.github.Ma27:rediscala_2.12:[1.8.1,)
-redisson:
-  instrumentations:
+  redisson:
   - name: redisson-3.17
     source_path: instrumentation/redisson/redisson-3.17
     scope:
@@ -1446,15 +1375,13 @@ redisson:
     target_versions:
       javaagent:
       - org.redisson:redisson:[3.0.0,3.17.0)
-resources:
-  instrumentations:
+  resources:
   - name: resources
     source_path: instrumentation/resources
     scope:
       name: io.opentelemetry.resources
     target_versions: {}
-restlet:
-  instrumentations:
+  restlet:
   - name: restlet-1.1
     source_path: instrumentation/restlet/restlet-1.1
     scope:
@@ -1474,8 +1401,7 @@ restlet:
       - org.restlet.jse:org.restlet:[2.0.0,)
       library:
       - org.restlet.jse:org.restlet:2.0.2
-rmi:
-  instrumentations:
+  rmi:
   - name: rmi
     source_path: instrumentation/rmi
     scope:
@@ -1483,8 +1409,7 @@ rmi:
     target_versions:
       javaagent:
       - Java 8+
-rocketmq:
-  instrumentations:
+  rocketmq:
   - name: rocketmq-client-5.0
     source_path: instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0
     scope:
@@ -1501,8 +1426,7 @@ rocketmq:
       - org.apache.rocketmq:rocketmq-client:[4.0.0,)
       library:
       - org.apache.rocketmq:rocketmq-client:4.8.0
-runtime:
-  instrumentations:
+  runtime:
   - name: runtime-telemetry-java17
     source_path: instrumentation/runtime-telemetry/runtime-telemetry-java17
     minimum_java_version: 17
@@ -1514,8 +1438,7 @@ runtime:
     scope:
       name: io.opentelemetry.runtime-telemetry-java8
     target_versions: {}
-rxjava:
-  instrumentations:
+  rxjava:
   - name: rxjava-1.0
     source_path: instrumentation/rxjava/rxjava-1.0
     scope:
@@ -1550,8 +1473,7 @@ rxjava:
       - io.reactivex.rxjava3:rxjava:[3.0.0,3.1.0]
       library:
       - io.reactivex.rxjava3:rxjava:[3.0.12,3.1.0)
-scala:
-  instrumentations:
+  scala:
   - name: scala-fork-join-2.8
     source_path: instrumentation/scala-fork-join-2.8
     scope:
@@ -1559,8 +1481,7 @@ scala:
     target_versions:
       javaagent:
       - org.scala-lang:scala-library:[2.8.0,2.12.0)
-servlet:
-  instrumentations:
+  servlet:
   - name: servlet-5.0
     source_path: instrumentation/servlet/servlet-5.0
     scope:
@@ -1582,8 +1503,7 @@ servlet:
     target_versions:
       javaagent:
       - javax.servlet:javax.servlet-api:[3.0,)
-spark:
-  instrumentations:
+  spark:
   - name: spark-2.3
     source_path: instrumentation/spark-2.3
     scope:
@@ -1591,8 +1511,7 @@ spark:
     target_versions:
       javaagent:
       - com.sparkjava:spark-core:[2.3,)
-spring:
-  instrumentations:
+  spring:
   - name: spring-rabbit-1.0
     source_path: instrumentation/spring/spring-rabbit-1.0
     scope:
@@ -1777,8 +1696,7 @@ spring:
     target_versions:
       javaagent:
       - org.springframework:spring-web:[6.0.0,)
-spymemcached:
-  instrumentations:
+  spymemcached:
   - name: spymemcached-2.12
     source_path: instrumentation/spymemcached-2.12
     scope:
@@ -1786,8 +1704,7 @@ spymemcached:
     target_versions:
       javaagent:
       - net.spy:spymemcached:[2.12.0,)
-struts:
-  instrumentations:
+  struts:
   - name: struts-2.3
     source_path: instrumentation/struts/struts-2.3
     scope:
@@ -1803,8 +1720,7 @@ struts:
     target_versions:
       javaagent:
       - org.apache.struts:struts2-core:[7.0.0,)
-tapestry:
-  instrumentations:
+  tapestry:
   - name: tapestry-5.4
     source_path: instrumentation/tapestry-5.4
     scope:
@@ -1812,8 +1728,7 @@ tapestry:
     target_versions:
       javaagent:
       - org.apache.tapestry:tapestry-core:[5.4.0,)
-tomcat:
-  instrumentations:
+  tomcat:
   - name: tomcat-10.0
     source_path: instrumentation/tomcat/tomcat-10.0
     minimum_java_version: 11
@@ -1836,8 +1751,7 @@ tomcat:
     target_versions:
       javaagent:
       - org.apache.tomcat:tomcat-jdbc:[8.5.0,)
-twilio:
-  instrumentations:
+  twilio:
   - name: twilio-6.6
     source_path: instrumentation/twilio-6.6
     scope:
@@ -1845,8 +1759,7 @@ twilio:
     target_versions:
       javaagent:
       - com.twilio.sdk:twilio:(,8.0.0)
-undertow:
-  instrumentations:
+  undertow:
   - name: undertow-1.4
     source_path: instrumentation/undertow-1.4
     scope:
@@ -1854,8 +1767,7 @@ undertow:
     target_versions:
       javaagent:
       - io.undertow:undertow-core:[1.4.0.Final,)
-vaadin:
-  instrumentations:
+  vaadin:
   - name: vaadin-14.2
     source_path: instrumentation/vaadin-14.2
     scope:
@@ -1864,8 +1776,7 @@ vaadin:
       javaagent:
       - com.vaadin:flow-server:[2.2.0,3)
       - com.vaadin:flow-server:[3.1.0,)
-vertx:
-  instrumentations:
+  vertx:
   - name: vertx-kafka-client-3.6
     source_path: instrumentation/vertx/vertx-kafka-client-3.6
     scope:
@@ -1915,8 +1826,7 @@ vertx:
     target_versions:
       javaagent:
       - io.vertx:vertx-core:[3.0.0,4.0.0)
-vibur:
-  instrumentations:
+  vibur:
   - name: vibur-dbcp-11.0
     source_path: instrumentation/vibur-dbcp-11.0
     scope:
@@ -1926,8 +1836,7 @@ vibur:
       - org.vibur:vibur-dbcp:[11.0,)
       library:
       - org.vibur:vibur-dbcp:11.0
-wicket:
-  instrumentations:
+  wicket:
   - name: wicket-8.0
     source_path: instrumentation/wicket-8.0
     scope:
@@ -1935,8 +1844,7 @@ wicket:
     target_versions:
       javaagent:
       - org.apache.wicket:wicket:[8.0.0,]
-xxl:
-  instrumentations:
+  xxl:
   - name: xxl-job-2.3.0
     source_path: instrumentation/xxl-job/xxl-job-2.3.0
     scope:
@@ -1958,8 +1866,7 @@ xxl:
     target_versions:
       javaagent:
       - com.xuxueli:xxl-job-core:[1.9.2, 2.1.2)
-zio:
-  instrumentations:
+  zio:
   - name: zio-2.0
     source_path: instrumentation/zio/zio-2.0
     scope:
@@ -1969,3 +1876,109 @@ zio:
       - dev.zio:zio_2.13:[2.0.0,)
       - dev.zio:zio_3:[2.0.0,)
       - dev.zio:zio_2.12:[2.0.0,)
+internal:
+- name: opentelemetry-api-1.15
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.15
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.15
+- name: opentelemetry-api-1.10
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.10
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.10
+- name: opentelemetry-api-1.27
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.27
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.27
+- name: internal-application-logger
+  source_path: instrumentation/internal/internal-application-logger
+  scope:
+    name: io.opentelemetry.internal-application-logger
+- name: internal-class-loader
+  source_path: instrumentation/internal/internal-class-loader
+  scope:
+    name: io.opentelemetry.internal-class-loader
+- name: java-util-logging
+  source_path: instrumentation/java-util-logging
+  scope:
+    name: io.opentelemetry.java-util-logging
+- name: internal-reflection
+  source_path: instrumentation/internal/internal-reflection
+  scope:
+    name: io.opentelemetry.internal-reflection
+- name: opentelemetry-instrumentation-api
+  source_path: instrumentation/opentelemetry-instrumentation-api
+  scope:
+    name: io.opentelemetry.opentelemetry-instrumentation-api
+- name: opentelemetry-api-1.37
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.37
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.37
+- name: opentelemetry-api-1.38
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.38
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.38
+- name: opentelemetry-api-1.31
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.31
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.31
+- name: opentelemetry-api-1.32
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.32
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.32
+- name: opentelemetry-api-1.42
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.42
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.42
+- name: opentelemetry-api-1.40
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.40
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.40
+- name: opentelemetry-api-1.47
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.47
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.47
+- name: internal-lambda
+  source_path: instrumentation/internal/internal-lambda
+  scope:
+    name: io.opentelemetry.internal-lambda
+- name: internal-eclipse-osgi-3.6
+  source_path: instrumentation/internal/internal-eclipse-osgi-3.6
+  scope:
+    name: io.opentelemetry.internal-eclipse-osgi-3.6
+- name: internal-url-class-loader
+  source_path: instrumentation/internal/internal-url-class-loader
+  scope:
+    name: io.opentelemetry.internal-url-class-loader
+- name: opentelemetry-api-1.4
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.4
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.4
+- name: opentelemetry-api-1.0
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.0
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.0
+custom:
+- name: external-annotations
+  source_path: instrumentation/external-annotations
+  scope:
+    name: io.opentelemetry.external-annotations
+- name: opentelemetry-extension-annotations-1.0
+  source_path: instrumentation/opentelemetry-extension-annotations-1.0
+  scope:
+    name: io.opentelemetry.opentelemetry-extension-annotations-1.0
+- name: opentelemetry-instrumentation-annotations-1.16
+  source_path: instrumentation/opentelemetry-instrumentation-annotations-1.16
+  scope:
+    name: io.opentelemetry.opentelemetry-instrumentation-annotations-1.16
+- name: jmx-metrics
+  source_path: instrumentation/jmx-metrics
+  scope:
+    name: io.opentelemetry.jmx-metrics
+- name: methods
+  source_path: instrumentation/methods
+  scope:
+    name: io.opentelemetry.methods
+- name: opentelemetry-extension-kotlin-1.0
+  source_path: instrumentation/opentelemetry-extension-kotlin-1.0
+  scope:
+    name: io.opentelemetry.opentelemetry-extension-kotlin-1.0

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -10,8 +10,8 @@ Run the doc generator:
 
 ## Instrumentation Hierarchy
 
-An "InstrumentationEntity" represents a module that that targets specific code in a framework/library/technology.
-Each instrumentation uses muzzle to determine which versions of the target code it supports.
+An "InstrumentationEntity" represents a module that that targets specific code in a
+framework/library/technology. Each entity will have a name, a namespace, and a group.
 
 Using these structures as examples:
 
@@ -28,8 +28,10 @@ Using these structures as examples:
 │   │   │   └── spring-cloud-gateway-common
 ```
 
-* Name
-  * Ex: `clickhouse-client-05`, `jaxrs-1.0`, `spring-cloud-gateway-2.0`
+Results in the following:
+
+* Name - the full name of the instrumentation module
+  * `clickhouse-client-05`, `jaxrs-1.0`, `spring-cloud-gateway-2.0`
 * Namespace - direct parent. if none, use name and strip version
   * `clickhouse-client`, `jaxrs`, `spring-cloud-gateway`
 * Group - top most parent
@@ -47,6 +49,10 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 
 ## Instrumentation metadata
 
+* classification
+  * `library` - Instrumentation that targets a library
+  * `internal` - Instrumentation that is used internally by the OpenTelemetry Java Agent
+  * `custom` - Utilities that are used to create custom instrumentation
 * name
   * Identifier for instrumentation module, used to enable/disable
   * Configured in `InstrumentationModule` code for each module
@@ -69,15 +75,12 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 Within each instrumentation source directory, a `metadata.yaml` file can be created to provide
 additional information about the instrumentation module.
 
-As of now, the following fields are supported:
+As of now, the following fields are supported, all of which are optional:
 
 ```yaml
-description: "Description of what the instrumentation does."
-disabled_by_default: true
-
-# used to mark modules that do not instrument traditional libraries (e.g. methods, annotations)
-# defaults to true
-isLibraryInstrumentation: false
+description: "Instruments..."   # Description of the instrumentation module
+disabled_by_default: true       # Defaults to `false`
+classification: internal        # instrumentation classification: library | internal | custom
 ```
 
 ### Gradle File Derived Information

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -31,7 +31,7 @@ public class DocGeneratorApplication {
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      YamlHelper.printInstrumentationList(entities, writer);
+      YamlHelper.generateInstrumentationYaml(entities, writer);
     } catch (IOException e) {
       logger.severe("Error writing instrumentation list: " + e.getMessage());
     }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -22,20 +22,17 @@ import java.util.Set;
 
 class InstrumentationAnalyzer {
 
-  private final FileManager fileSearch;
+  private final FileManager fileManager;
 
-  InstrumentationAnalyzer(FileManager fileSearch) {
-    this.fileSearch = fileSearch;
+  InstrumentationAnalyzer(FileManager fileManager) {
+    this.fileManager = fileManager;
   }
 
   /**
-   * Converts a list of InstrumentationPath objects into a list of InstrumentationEntity objects.
-   * Each InstrumentationEntity represents a unique combination of group, namespace, and
-   * instrumentation name. The types of instrumentation (e.g., library, javaagent) are aggregated
-   * into a list within each entity.
+   * Converts a list of {@link InstrumentationPath} into a list of {@link InstrumentationEntity},
    *
-   * @param paths the list of InstrumentationPath objects to be converted
-   * @return a list of InstrumentationEntity objects with aggregated types
+   * @param paths the list of {@link InstrumentationPath} objects to be converted
+   * @return a list of {@link InstrumentationEntity} objects with aggregated types
    */
   public static List<InstrumentationEntity> convertToEntities(List<InstrumentationPath> paths) {
     Map<String, InstrumentationEntity> entityMap = new HashMap<>();
@@ -62,17 +59,17 @@ class InstrumentationAnalyzer {
    * Extracts version information from each instrumentation's build.gradle file. Extracts
    * information from metadata.yaml files.
    *
-   * @return a list of InstrumentationEntity objects with target versions
+   * @return a list of {@link InstrumentationEntity}
    */
   List<InstrumentationEntity> analyze() {
-    List<InstrumentationPath> paths = fileSearch.getInstrumentationPaths();
+    List<InstrumentationPath> paths = fileManager.getInstrumentationPaths();
     List<InstrumentationEntity> entities = convertToEntities(paths);
 
     for (InstrumentationEntity entity : entities) {
-      List<String> gradleFiles = fileSearch.findBuildGradleFiles(entity.getSrcPath());
+      List<String> gradleFiles = fileManager.findBuildGradleFiles(entity.getSrcPath());
       analyzeVersions(gradleFiles, entity);
 
-      String metadataFile = fileSearch.getMetaDataFile(entity.getSrcPath());
+      String metadataFile = fileManager.getMetaDataFile(entity.getSrcPath());
       if (metadataFile != null) {
         entity.setMetadata(YamlHelper.metaDataParser(metadataFile));
       }
@@ -83,7 +80,7 @@ class InstrumentationAnalyzer {
   void analyzeVersions(List<String> files, InstrumentationEntity entity) {
     Map<InstrumentationType, Set<String>> versions = new HashMap<>();
     for (String file : files) {
-      String fileContents = fileSearch.readFileToString(file);
+      String fileContents = fileManager.readFileToString(file);
       DependencyInfo results = null;
 
       if (file.contains("/javaagent/")) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationClassification.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationClassification.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.internal;
+
+import java.util.Locale;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public enum InstrumentationClassification {
+  LIBRARY,
+  CUSTOM,
+  INTERNAL;
+
+  @Nullable
+  public static InstrumentationClassification fromString(@Nullable String type) {
+    if (type == null) {
+      return null;
+    }
+    return switch (type.toLowerCase(Locale.getDefault())) {
+      case "library" -> LIBRARY;
+      case "internal" -> INTERNAL;
+      case "custom" -> CUSTOM;
+      default -> null;
+    };
+  }
+
+  @Override
+  public String toString() {
+    return name().toLowerCase(Locale.getDefault());
+  }
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationEntity.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationEntity.java
@@ -70,8 +70,11 @@ public class InstrumentationEntity {
     return scopeInfo;
   }
 
-  @Nullable
   public InstrumentationMetaData getMetadata() {
+    if (metadata == null) {
+      metadata = new InstrumentationMetaData();
+    }
+
     return metadata;
   }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.docs.internal;
 
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -14,18 +15,14 @@ import javax.annotation.Nullable;
  */
 public class InstrumentationMetaData {
   @Nullable private String description;
-  @Nullable private Boolean isLibraryInstrumentation;
   @Nullable private Boolean disabledByDefault;
+  private String classification;
 
   public InstrumentationMetaData() {}
 
-  public InstrumentationMetaData(String description) {
-    this.description = description;
-  }
-
   public InstrumentationMetaData(
-      String description, Boolean isLibraryInstrumentation, Boolean disabledByDefault) {
-    this.isLibraryInstrumentation = isLibraryInstrumentation;
+      String description, String classification, Boolean disabledByDefault) {
+    this.classification = classification;
     this.disabledByDefault = disabledByDefault;
     this.description = description;
   }
@@ -35,8 +32,11 @@ public class InstrumentationMetaData {
     return description;
   }
 
-  public Boolean getIsLibraryInstrumentation() {
-    return Objects.requireNonNullElse(isLibraryInstrumentation, true);
+  @Nonnull
+  public InstrumentationClassification getClassification() {
+    return Objects.requireNonNullElse(
+        InstrumentationClassification.fromString(classification),
+        InstrumentationClassification.LIBRARY);
   }
 
   public Boolean getDisabledByDefault() {
@@ -47,8 +47,8 @@ public class InstrumentationMetaData {
     this.description = description;
   }
 
-  public void setIsLibraryInstrumentation(@Nullable Boolean libraryInstrumentation) {
-    isLibraryInstrumentation = libraryInstrumentation;
+  public void setClassification(@Nullable String classification) {
+    this.classification = classification;
   }
 
   public void setDisabledByDefault(@Nullable Boolean disabledByDefault) {

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.docs.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationEntity;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetaData;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
@@ -29,8 +30,11 @@ class YamlHelperTest {
         InstrumentationType.JAVAAGENT,
         new HashSet<>(List.of("org.springframework:spring-web:[6.0.0,)")));
 
-    InstrumentationMetaData metadata1 =
-        new InstrumentationMetaData("Spring Web 6.0 instrumentation", true, true);
+    InstrumentationMetaData springMetadata =
+        new InstrumentationMetaData(
+            "Spring Web 6.0 instrumentation",
+            InstrumentationClassification.LIBRARY.toString(),
+            true);
 
     entities.add(
         new InstrumentationEntity.Builder()
@@ -39,7 +43,7 @@ class YamlHelperTest {
             .namespace("spring")
             .group("spring")
             .targetVersions(targetVersions1)
-            .metadata(metadata1)
+            .metadata(springMetadata)
             .minJavaVersion(11)
             .build());
 
@@ -60,13 +64,13 @@ class YamlHelperTest {
     StringWriter stringWriter = new StringWriter();
     BufferedWriter writer = new BufferedWriter(stringWriter);
 
-    YamlHelper.printInstrumentationList(entities, writer);
+    YamlHelper.generateInstrumentationYaml(entities, writer);
     writer.flush();
 
     String expectedYaml =
         """
-            spring:
-              instrumentations:
+            libraries:
+              spring:
               - name: spring-web-6.0
                 description: Spring Web 6.0 instrumentation
                 disabled_by_default: true
@@ -77,8 +81,7 @@ class YamlHelperTest {
                 target_versions:
                   javaagent:
                   - org.springframework:spring-web:[6.0.0,)
-            struts:
-              instrumentations:
+              struts:
               - name: struts-2.3
                 source_path: instrumentation/struts/struts-2.3
                 scope:
@@ -92,15 +95,18 @@ class YamlHelperTest {
   }
 
   @Test
-  void testPrintInstrumentationListIgnoresNonLibraryInstrumentation() throws Exception {
+  void testGenerateInstrumentationYamlSeparatesClassifications() throws Exception {
     List<InstrumentationEntity> entities = new ArrayList<>();
-    Map<InstrumentationType, Set<String>> targetVersions1 = new HashMap<>();
-    targetVersions1.put(
+    Map<InstrumentationType, Set<String>> springTargetVersions = new HashMap<>();
+    springTargetVersions.put(
         InstrumentationType.JAVAAGENT,
         new HashSet<>(List.of("org.springframework:spring-web:[6.0.0,)")));
 
-    InstrumentationMetaData metadata1 =
-        new InstrumentationMetaData("Spring Web 6.0 instrumentation");
+    InstrumentationMetaData springMetadata =
+        new InstrumentationMetaData(
+            "Spring Web 6.0 instrumentation",
+            InstrumentationClassification.LIBRARY.toString(),
+            false);
 
     entities.add(
         new InstrumentationEntity.Builder()
@@ -108,12 +114,13 @@ class YamlHelperTest {
             .instrumentationName("spring-web-6.0")
             .namespace("spring")
             .group("spring")
-            .targetVersions(targetVersions1)
-            .metadata(metadata1)
+            .targetVersions(springTargetVersions)
+            .metadata(springMetadata)
             .minJavaVersion(11)
             .build());
 
-    InstrumentationMetaData metadata2 = new InstrumentationMetaData(null, false, null);
+    InstrumentationMetaData internalMetadata =
+        new InstrumentationMetaData(null, InstrumentationClassification.INTERNAL.toString(), null);
 
     entities.add(
         new InstrumentationEntity.Builder()
@@ -121,20 +128,33 @@ class YamlHelperTest {
             .instrumentationName("internal-application-logger")
             .namespace("internal")
             .group("internal")
-            .metadata(metadata2)
+            .metadata(internalMetadata)
+            .targetVersions(new HashMap<>())
+            .build());
+
+    InstrumentationMetaData customMetadata =
+        new InstrumentationMetaData(null, InstrumentationClassification.CUSTOM.toString(), null);
+
+    entities.add(
+        new InstrumentationEntity.Builder()
+            .srcPath("instrumentation/opentelemetry-external-annotations-1.0")
+            .instrumentationName("opentelemetry-external-annotations")
+            .namespace("opentelemetry-external-annotations")
+            .group("opentelemetry-external-annotations")
+            .metadata(customMetadata)
             .targetVersions(new HashMap<>())
             .build());
 
     StringWriter stringWriter = new StringWriter();
     BufferedWriter writer = new BufferedWriter(stringWriter);
 
-    YamlHelper.printInstrumentationList(entities, writer);
+    YamlHelper.generateInstrumentationYaml(entities, writer);
     writer.flush();
 
     String expectedYaml =
         """
-            spring:
-              instrumentations:
+            libraries:
+              spring:
               - name: spring-web-6.0
                 description: Spring Web 6.0 instrumentation
                 source_path: instrumentation/spring/spring-web/spring-web-6.0
@@ -144,6 +164,16 @@ class YamlHelperTest {
                 target_versions:
                   javaagent:
                   - org.springframework:spring-web:[6.0.0,)
+            internal:
+            - name: internal-application-logger
+              source_path: instrumentation/internal/internal-application-logger
+              scope:
+                name: io.opentelemetry.internal-application-logger
+            custom:
+            - name: opentelemetry-external-annotations
+              source_path: instrumentation/opentelemetry-external-annotations-1.0
+              scope:
+                name: io.opentelemetry.opentelemetry-external-annotations
             """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -153,22 +183,22 @@ class YamlHelperTest {
   void testMetadataParser() {
     String input =
         """
-        description: test description
-        isLibraryInstrumentation: false
-        disabled_by_default: true
-        """;
+            description: test description
+            classification: internal
+            disabled_by_default: true
+            """;
 
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
-    assertThat(metadata.getIsLibraryInstrumentation()).isFalse();
+    assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.INTERNAL);
     assertThat(metadata.getDescription()).isEqualTo("test description");
     assertThat(metadata.getDisabledByDefault()).isEqualTo(true);
   }
 
   @Test
   void testMetadataParserWithOnlyLibraryEntry() {
-    String input = "isLibraryInstrumentation: false";
+    String input = "classification: internal";
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
-    assertThat(metadata.getIsLibraryInstrumentation()).isFalse();
+    assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.INTERNAL);
     assertThat(metadata.getDescription()).isNull();
     assertThat(metadata.getDisabledByDefault()).isFalse();
   }
@@ -177,7 +207,7 @@ class YamlHelperTest {
   void testMetadataParserWithOnlyDescription() {
     String input = "description: false";
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
-    assertThat(metadata.getIsLibraryInstrumentation()).isTrue();
+    assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
     assertThat(metadata.getDisabledByDefault()).isFalse();
   }
 
@@ -185,7 +215,7 @@ class YamlHelperTest {
   void testMetadataParserWithOnlyDisabledByDefault() {
     String input = "disabled_by_default: true";
     InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
-    assertThat(metadata.getIsLibraryInstrumentation()).isTrue();
+    assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
     assertThat(metadata.getDescription()).isNull();
     assertThat(metadata.getDisabledByDefault()).isTrue();
   }

--- a/instrumentation/external-annotations/metadata.yaml
+++ b/instrumentation/external-annotations/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/internal/internal-application-logger/metadata.yaml
+++ b/instrumentation/internal/internal-application-logger/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/internal/internal-class-loader/metadata.yaml
+++ b/instrumentation/internal/internal-class-loader/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/internal/internal-eclipse-osgi-3.6/metadata.yaml
+++ b/instrumentation/internal/internal-eclipse-osgi-3.6/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/internal/internal-lambda/metadata.yaml
+++ b/instrumentation/internal/internal-lambda/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/internal/internal-reflection/metadata.yaml
+++ b/instrumentation/internal/internal-reflection/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/internal/internal-url-class-loader/metadata.yaml
+++ b/instrumentation/internal/internal-url-class-loader/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/java-util-logging/metadata.yaml
+++ b/instrumentation/java-util-logging/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/jmx-metrics/metadata.yaml
+++ b/instrumentation/jmx-metrics/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/methods/metadata.yaml
+++ b/instrumentation/methods/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.10/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.10/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.15/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.15/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.27/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.27/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.31/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.31/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.32/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.32/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.37/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.37/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.38/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.38/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.4/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.4/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.40/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.40/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.42/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.42/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/metadata.yaml
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal

--- a/instrumentation/opentelemetry-extension-annotations-1.0/metadata.yaml
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/metadata.yaml
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/metadata.yaml
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: custom

--- a/instrumentation/opentelemetry-instrumentation-api/metadata.yaml
+++ b/instrumentation/opentelemetry-instrumentation-api/metadata.yaml
@@ -1,1 +1,1 @@
-isLibraryInstrumentation: false
+classification: internal


### PR DESCRIPTION
Related to #13468 

Deprecates the `isLibraryInstrumentation` label in the metadata.yaml file and replaces it with `classification`. 

Introduces 3 classification types:
- library
- internal
- custom

I am open to ideas around these particular names/groupings in case anyone has a different way of thinking about them.

The instrumentation-list.yaml output now includes these other non-library instrumentation modules, and omits the "target_versions" since they are not applicable.

Also removed the `instrumentations` label within each instrumentation group, and instead just list each instrumentation.