### PR TITLE
Compile runtime-telemetry-java17 for java8

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/build.gradle.kts
@@ -58,16 +58,14 @@ tasks {
     dependsOn(testSerial)
   }
 
-  tasks {
-    compileJava {
-      // We compile this module for java 8 because it is used as a dependency in spring-boot-autoconfigure.
-      // If this module is compiled for java 17 then gradle can figure out based on the metadata that
-      // spring-boot-autoconfigure has a dependency that requires 17 and fails the build when it is used
-      // in a project that targets an earlier java version.
-      // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13384
-      sourceCompatibility = "1.8"
-      targetCompatibility = "1.8"
-      options.release.set(null as Int?)
-    }
+  compileJava {
+    // We compile this module for java 8 because it is used as a dependency in spring-boot-autoconfigure.
+    // If this module is compiled for java 17 then gradle can figure out based on the metadata that
+    // spring-boot-autoconfigure has a dependency that requires 17 and fails the build when it is used
+    // in a project that targets an earlier java version.
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13384
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+    options.release.set(null as Int?)
   }
 }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/ThreadGrouper.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/ThreadGrouper.java
@@ -19,8 +19,8 @@ public final class ThreadGrouper {
   @Nullable
   public String groupedName(RecordedEvent ev) {
     Object thisField = ev.getValue("eventThread");
-    if (thisField instanceof RecordedThread thread) {
-      return thread.getJavaName();
+    if (thisField instanceof RecordedThread) {
+      return ((RecordedThread) thisField).getJavaName();
     }
     return null;
   }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/MetaspaceSummaryHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/MetaspaceSummaryHandler.java
@@ -128,8 +128,8 @@ public final class MetaspaceSummaryHandler implements RecordedEventHandler {
       return;
     }
     Object value = event.getValue(field);
-    if (value instanceof RecordedObject recordedObject) {
-      closure.accept(recordedObject);
+    if (value instanceof RecordedObject) {
+      closure.accept((RecordedObject) value);
     }
   }
 

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ParallelHeapSummaryHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ParallelHeapSummaryHandler.java
@@ -145,8 +145,8 @@ public final class ParallelHeapSummaryHandler implements RecordedEventHandler {
       return;
     }
     Object value = event.getValue(field);
-    if (value instanceof RecordedObject recordedObject) {
-      closure.accept(recordedObject);
+    if (value instanceof RecordedObject) {
+      closure.accept((RecordedObject) value);
     }
   }
 


### PR DESCRIPTION
An alternative for https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13678
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13393 had a small bug where it added a nested `tasks` element so the source version change didn't really apply