### PR TITLE
Remove deprecated gradle system property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 # Currently causes failure when importing project in IntelliJ
 # org.gradle.warning.mode=fail
 
-# To allow caching more tasks in buildSrc project
-# This property is not mentioned in Gradle documentation
-# See https://github.com/gradle/gradle/issues/15214 for background info
-systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
-
 # Workaround https://youtrack.jetbrains.com/issue/KT-34862
 kotlin.incremental=false
 


### PR DESCRIPTION
This property has been deprecated. It defaults to `true` in gradle 8 https://github.com/gradle/gradle/issues/20416