### PR TITLE
Rename InstrumentationEntity to InstrumentationModule

### DIFF
--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -10,8 +10,8 @@ Run the doc generator:
 
 ## Instrumentation Hierarchy
 
-An "InstrumentationEntity" represents a module that that targets specific code in a
-framework/library/technology. Each entity will have a name, a namespace, and a group.
+An "InstrumentationModule" represents a module that that targets specific code in a
+framework/library/technology. Each module will have a name, a namespace, and a group.
 
 Using these structures as examples:
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.docs;
 
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationEntity;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import java.io.BufferedWriter;
@@ -22,7 +22,7 @@ public class DocGeneratorApplication {
 
   public static void main(String[] args) {
     FileManager fileManager = new FileManager("instrumentation/");
-    List<InstrumentationEntity> entities = new InstrumentationAnalyzer(fileManager).analyze();
+    List<InstrumentationModule> modules = new InstrumentationAnalyzer(fileManager).analyze();
 
     try (BufferedWriter writer =
         Files.newBufferedWriter(
@@ -31,7 +31,7 @@ public class DocGeneratorApplication {
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      YamlHelper.generateInstrumentationYaml(entities, writer);
+      YamlHelper.generateInstrumentationYaml(modules, writer);
     } catch (IOException e) {
       logger.severe("Error writing instrumentation list: " + e.getMessage());
     }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.docs;
 import static io.opentelemetry.instrumentation.docs.parsers.GradleParser.parseGradleFile;
 
 import io.opentelemetry.instrumentation.docs.internal.DependencyInfo;
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationEntity;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
@@ -29,20 +29,21 @@ class InstrumentationAnalyzer {
   }
 
   /**
-   * Converts a list of {@link InstrumentationPath} into a list of {@link InstrumentationEntity},
+   * Converts a list of {@link InstrumentationPath} into a list of {@link InstrumentationModule},
    *
    * @param paths the list of {@link InstrumentationPath} objects to be converted
-   * @return a list of {@link InstrumentationEntity} objects with aggregated types
+   * @return a list of {@link InstrumentationModule} objects with aggregated types
    */
-  public static List<InstrumentationEntity> convertToEntities(List<InstrumentationPath> paths) {
-    Map<String, InstrumentationEntity> entityMap = new HashMap<>();
+  public static List<InstrumentationModule> convertToInstrumentationModules(
+      List<InstrumentationPath> paths) {
+    Map<String, InstrumentationModule> moduleMap = new HashMap<>();
 
     for (InstrumentationPath path : paths) {
       String key = path.group() + ":" + path.namespace() + ":" + path.instrumentationName();
-      if (!entityMap.containsKey(key)) {
-        entityMap.put(
+      if (!moduleMap.containsKey(key)) {
+        moduleMap.put(
             key,
-            new InstrumentationEntity.Builder()
+            new InstrumentationModule.Builder()
                 .srcPath(path.srcPath().replace("/javaagent", "").replace("/library", ""))
                 .instrumentationName(path.instrumentationName())
                 .namespace(path.namespace())
@@ -51,33 +52,33 @@ class InstrumentationAnalyzer {
       }
     }
 
-    return new ArrayList<>(entityMap.values());
+    return new ArrayList<>(moduleMap.values());
   }
 
   /**
-   * Analyzes the given root directory to find all instrumentation paths and then analyze them.
-   * Extracts version information from each instrumentation's build.gradle file. Extracts
+   * Traverses the given root directory to find all instrumentation paths and then analyzes them.
+   * Extracts version information from each instrumentation's build.gradle file, and other
    * information from metadata.yaml files.
    *
-   * @return a list of {@link InstrumentationEntity}
+   * @return a list of {@link InstrumentationModule}
    */
-  List<InstrumentationEntity> analyze() {
+  List<InstrumentationModule> analyze() {
     List<InstrumentationPath> paths = fileManager.getInstrumentationPaths();
-    List<InstrumentationEntity> entities = convertToEntities(paths);
+    List<InstrumentationModule> modules = convertToInstrumentationModules(paths);
 
-    for (InstrumentationEntity entity : entities) {
-      List<String> gradleFiles = fileManager.findBuildGradleFiles(entity.getSrcPath());
-      analyzeVersions(gradleFiles, entity);
+    for (InstrumentationModule module : modules) {
+      List<String> gradleFiles = fileManager.findBuildGradleFiles(module.getSrcPath());
+      analyzeVersions(gradleFiles, module);
 
-      String metadataFile = fileManager.getMetaDataFile(entity.getSrcPath());
+      String metadataFile = fileManager.getMetaDataFile(module.getSrcPath());
       if (metadataFile != null) {
-        entity.setMetadata(YamlHelper.metaDataParser(metadataFile));
+        module.setMetadata(YamlHelper.metaDataParser(metadataFile));
       }
     }
-    return entities;
+    return modules;
   }
 
-  void analyzeVersions(List<String> files, InstrumentationEntity entity) {
+  void analyzeVersions(List<String> files, InstrumentationModule module) {
     Map<InstrumentationType, Set<String>> versions = new HashMap<>();
     for (String file : files) {
       String fileContents = fileManager.readFileToString(file);
@@ -95,9 +96,9 @@ class InstrumentationAnalyzer {
             .addAll(results.versions());
       }
       if (results != null && results.minJavaVersionSupported() != null) {
-        entity.setMinJavaVersion(results.minJavaVersionSupported());
+        module.setMinJavaVersion(results.minJavaVersionSupported());
       }
     }
-    entity.setTargetVersions(versions);
+    module.setTargetVersions(versions);
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
@@ -14,10 +14,12 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * Represents an instrumentation module and all associated metadata.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
-public class InstrumentationEntity {
+public class InstrumentationModule {
   private final String srcPath;
   private final String instrumentationName;
   private final String namespace;
@@ -34,7 +36,7 @@ public class InstrumentationEntity {
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
    * any time.
    */
-  public InstrumentationEntity(Builder builder) {
+  public InstrumentationModule(Builder builder) {
     requireNonNull(builder.srcPath, "srcPath required");
     requireNonNull(builder.instrumentationName, "instrumentationName required");
     requireNonNull(builder.namespace, "namespace required");
@@ -155,8 +157,8 @@ public class InstrumentationEntity {
       return this;
     }
 
-    public InstrumentationEntity build() {
-      return new InstrumentationEntity(this);
+    public InstrumentationModule build() {
+      return new InstrumentationModule(this);
     }
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.docs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationEntity;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
 import java.util.Arrays;
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class InstrumentationAnalyzerTest {
 
   @Test
-  void testConvertToEntities() {
+  void testConvertToInstrumentationModule() {
     List<InstrumentationPath> paths =
         Arrays.asList(
             new InstrumentationPath(
@@ -39,32 +39,33 @@ class InstrumentationAnalyzerTest {
                 "spring",
                 InstrumentationType.LIBRARY));
 
-    List<InstrumentationEntity> entities = InstrumentationAnalyzer.convertToEntities(paths);
+    List<InstrumentationModule> modules =
+        InstrumentationAnalyzer.convertToInstrumentationModules(paths);
 
-    assertThat(entities.size()).isEqualTo(2);
+    assertThat(modules.size()).isEqualTo(2);
 
-    InstrumentationEntity log4jEntity =
-        entities.stream()
+    InstrumentationModule log4jModule =
+        modules.stream()
             .filter(e -> e.getInstrumentationName().equals("log4j-appender-2.17"))
             .findFirst()
             .orElse(null);
 
-    assertThat(log4jEntity.getNamespace()).isEqualTo("log4j");
-    assertThat(log4jEntity.getGroup()).isEqualTo("log4j");
-    assertThat(log4jEntity.getSrcPath()).isEqualTo("instrumentation/log4j/log4j-appender-2.17");
-    assertThat(log4jEntity.getScopeInfo().getName())
+    assertThat(log4jModule.getNamespace()).isEqualTo("log4j");
+    assertThat(log4jModule.getGroup()).isEqualTo("log4j");
+    assertThat(log4jModule.getSrcPath()).isEqualTo("instrumentation/log4j/log4j-appender-2.17");
+    assertThat(log4jModule.getScopeInfo().getName())
         .isEqualTo("io.opentelemetry.log4j-appender-2.17");
 
-    InstrumentationEntity springEntity =
-        entities.stream()
+    InstrumentationModule springModule =
+        modules.stream()
             .filter(e -> e.getInstrumentationName().equals("spring-web"))
             .findFirst()
             .orElse(null);
 
-    assertThat(springEntity).isNotNull();
-    assertThat(springEntity.getNamespace()).isEqualTo("spring");
-    assertThat(springEntity.getGroup()).isEqualTo("spring");
-    assertThat(springEntity.getSrcPath()).isEqualTo("instrumentation/spring/spring-web");
-    assertThat(springEntity.getScopeInfo().getName()).isEqualTo("io.opentelemetry.spring-web");
+    assertThat(springModule).isNotNull();
+    assertThat(springModule.getNamespace()).isEqualTo("spring");
+    assertThat(springModule.getGroup()).isEqualTo("spring");
+    assertThat(springModule.getSrcPath()).isEqualTo("instrumentation/spring/spring-web");
+    assertThat(springModule.getScopeInfo().getName()).isEqualTo("io.opentelemetry.spring-web");
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -8,8 +8,8 @@ package io.opentelemetry.instrumentation.docs.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationEntity;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetaData;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import java.io.BufferedWriter;
 import java.io.StringWriter;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 class YamlHelperTest {
   @Test
   void testPrintInstrumentationList() throws Exception {
-    List<InstrumentationEntity> entities = new ArrayList<>();
+    List<InstrumentationModule> modules = new ArrayList<>();
     Map<InstrumentationType, Set<String>> targetVersions1 = new HashMap<>();
     targetVersions1.put(
         InstrumentationType.JAVAAGENT,
@@ -36,8 +36,8 @@ class YamlHelperTest {
             InstrumentationClassification.LIBRARY.toString(),
             true);
 
-    entities.add(
-        new InstrumentationEntity.Builder()
+    modules.add(
+        new InstrumentationModule.Builder()
             .srcPath("instrumentation/spring/spring-web/spring-web-6.0")
             .instrumentationName("spring-web-6.0")
             .namespace("spring")
@@ -52,8 +52,8 @@ class YamlHelperTest {
     targetVersions2.put(
         InstrumentationType.LIBRARY,
         new HashSet<>(List.of("org.apache.struts:struts2-core:2.1.0")));
-    entities.add(
-        new InstrumentationEntity.Builder()
+    modules.add(
+        new InstrumentationModule.Builder()
             .srcPath("instrumentation/struts/struts-2.3")
             .instrumentationName("struts-2.3")
             .namespace("struts")
@@ -64,7 +64,7 @@ class YamlHelperTest {
     StringWriter stringWriter = new StringWriter();
     BufferedWriter writer = new BufferedWriter(stringWriter);
 
-    YamlHelper.generateInstrumentationYaml(entities, writer);
+    YamlHelper.generateInstrumentationYaml(modules, writer);
     writer.flush();
 
     String expectedYaml =
@@ -96,7 +96,7 @@ class YamlHelperTest {
 
   @Test
   void testGenerateInstrumentationYamlSeparatesClassifications() throws Exception {
-    List<InstrumentationEntity> entities = new ArrayList<>();
+    List<InstrumentationModule> modules = new ArrayList<>();
     Map<InstrumentationType, Set<String>> springTargetVersions = new HashMap<>();
     springTargetVersions.put(
         InstrumentationType.JAVAAGENT,
@@ -108,8 +108,8 @@ class YamlHelperTest {
             InstrumentationClassification.LIBRARY.toString(),
             false);
 
-    entities.add(
-        new InstrumentationEntity.Builder()
+    modules.add(
+        new InstrumentationModule.Builder()
             .srcPath("instrumentation/spring/spring-web/spring-web-6.0")
             .instrumentationName("spring-web-6.0")
             .namespace("spring")
@@ -122,8 +122,8 @@ class YamlHelperTest {
     InstrumentationMetaData internalMetadata =
         new InstrumentationMetaData(null, InstrumentationClassification.INTERNAL.toString(), null);
 
-    entities.add(
-        new InstrumentationEntity.Builder()
+    modules.add(
+        new InstrumentationModule.Builder()
             .srcPath("instrumentation/internal/internal-application-logger")
             .instrumentationName("internal-application-logger")
             .namespace("internal")
@@ -135,8 +135,8 @@ class YamlHelperTest {
     InstrumentationMetaData customMetadata =
         new InstrumentationMetaData(null, InstrumentationClassification.CUSTOM.toString(), null);
 
-    entities.add(
-        new InstrumentationEntity.Builder()
+    modules.add(
+        new InstrumentationModule.Builder()
             .srcPath("instrumentation/opentelemetry-external-annotations-1.0")
             .instrumentationName("opentelemetry-external-annotations")
             .namespace("opentelemetry-external-annotations")
@@ -148,7 +148,7 @@ class YamlHelperTest {
     StringWriter stringWriter = new StringWriter();
     BufferedWriter writer = new BufferedWriter(stringWriter);
 
-    YamlHelper.generateInstrumentationYaml(entities, writer);
+    YamlHelper.generateInstrumentationYaml(modules, writer);
     writer.flush();
 
     String expectedYaml =


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468

Following up on a [comment from a previous PR](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13672#discussion_r2036385668)

Renames `InstrumentationEntity` to `InstrumentationModel` in order to avoid confusion with other "Entities" (https://github.com/open-telemetry/opentelemetry-specification/pull/4442)