### PR TITLE
Fix instrumentation for ibm https url connection connect

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/IbmHttpsUrlConnectionTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/IbmHttpsUrlConnectionTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest
+
+import io.opentelemetry.proto.trace.v1.Span
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.Container
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import java.time.Duration
+
+import static io.opentelemetry.smoketest.TestContainerManager.useWindowsContainers
+
+@IgnoreIf({ useWindowsContainers() })
+class IbmHttpsUrlConnectionTest extends Specification {
+  private static final Logger logger = LoggerFactory.getLogger(IbmHttpsUrlConnectionTest)
+
+  private static final String TARGET_AGENT_FILENAME = "opentelemetry-javaagent.jar"
+  private static final String agentPath = System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path")
+  private static final int BACKEND_PORT = 8080
+  private static final String BACKEND_ALIAS = "backend"
+
+  private final Network network = Network.newNetwork()
+
+  def "test https url connection"() {
+    setup:
+    GenericContainer backend =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20221127.3559314891"))
+            .withExposedPorts(BACKEND_PORT)
+            .withEnv("JAVA_TOOL_OPTIONS", "-Xmx128m")
+            .waitingFor(Wait.forHttp("/health").forPort(BACKEND_PORT))
+            .withNetwork(network)
+            .withNetworkAliases(BACKEND_ALIAS)
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+    backend.start()
+
+    def telemetryRetriever = new TelemetryRetriever(backend.getMappedPort(BACKEND_PORT))
+
+    GenericContainer target =
+      new GenericContainer<>(DockerImageName.parse("ibmjava:8-sdk"))
+        .withStartupTimeout(Duration.ofMinutes(5))
+        .withNetwork(network)
+        .withLogConsumer(new Slf4jLogConsumer(logger))
+        .withCopyFileToContainer(
+          MountableFile.forHostPath(agentPath), "/" + TARGET_AGENT_FILENAME)
+        .withCopyFileToContainer(
+          MountableFile.forClasspathResource("ibmhttpsurlconnection/IbmHttpsUrlConnectionTest.java"), "/IbmHttpsUrlConnectionTest.java")
+        .withCopyFileToContainer(
+          MountableFile.forClasspathResource("ibmhttpsurlconnection/start.sh", 777), "/start.sh")
+        .withCopyFileToContainer(
+          MountableFile.forClasspathResource("ibmhttpsurlconnection/test.sh", 777), "/test.sh")
+        .waitingFor(
+          Wait.forLogMessage(".*started.*\\n", 1)
+        )
+        .withCommand("/bin/sh", "-c", "/start.sh")
+    target.start()
+
+    when:
+    Container.ExecResult result = target.execInContainer("/bin/sh", "-c", "/test.sh")
+    then:
+    result.getExitCode() == 0
+
+    TraceInspector traces = new TraceInspector(telemetryRetriever.waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Client span in the distributed trace"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_CLIENT) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName("GET") == 1
+
+    cleanup:
+    System.err.println(result.toString())
+    target.stop()
+    backend.stop()
+  }
+}

--- a/smoke-tests/src/test/resources/ibmhttpsurlconnection/IbmHttpsUrlConnectionTest.java
+++ b/smoke-tests/src/test/resources/ibmhttpsurlconnection/IbmHttpsUrlConnectionTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class IbmHttpsUrlConnectionTest {
+
+  public static void main(String... args) throws Exception {
+    HttpURLConnection connection =
+        (HttpURLConnection) new URL("https://google.com").openConnection();
+    connection.connect();
+    InputStream stream = connection.getInputStream();
+    stream.close();
+  }
+}

--- a/smoke-tests/src/test/resources/ibmhttpsurlconnection/start.sh
+++ b/smoke-tests/src/test/resources/ibmhttpsurlconnection/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+echo "started"
+while :
+do
+  sleep 1
+done

--- a/smoke-tests/src/test/resources/ibmhttpsurlconnection/test.sh
+++ b/smoke-tests/src/test/resources/ibmhttpsurlconnection/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+echo "compiling"
+javac IbmHttpsUrlConnectionTest.java
+echo "finish compiling"
+echo "executing"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://backend:8080
+export OTEL_JAVAAGENT_DEBUG=true
+java -javaagent:opentelemetry-javaagent.jar IbmHttpsUrlConnectionTest


### PR DESCRIPTION
Instrumentation of IBM implementation of https url connection fails when `connect` is called before `getInputStream`/`getOutputStream` with
```
java.lang.IllegalStateException: Already connected
at sun.net.www.protocol.http.HttpURLConnection.setRequestProperty(HttpURLConnection.java:3214)
at io.opentelemetry.javaagent.instrumentation.httpurlconnection.RequestPropertySetter.set(RequestPropertySetter.java:16)
at io.opentelemetry.javaagent.instrumentation.httpurlconnection.RequestPropertySetter.set(RequestPropertySetter.java:11)
at io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator.inject(W3CTraceContextPropagator.java:123)
at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.propagation.MultiTextMapPropagator.inject(MultiTextMapPropagator.java:52)
at io.opentelemetry.javaagent.shaded.instrumentation.api.instrumenter.PropagatingToDownstreamInstrumenter.start(PropagatingToDownstreamInstrumenter.java:28)
at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1545)
at com.ibm.net.ssl.www2.protocol.https.b.getInputStream(b.java:74)
```
because IBM implementation overrides the `connect` method and does not delegate to the jdk implementation. We don't instrument the `connect` in IBM class because it is not included in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/5c10b1f5a8389e6a4f45e3ad1d3e78746673f741/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java#L33 So we end up attempting to start the span in `getInputStream` where headers can't be modified any more. This PR adds instrumentation for `plainConnect` method that is called from the `connect` in the IBM class.