### PR TITLE
Add controller telemetry flag to spring boot starter

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -285,6 +285,12 @@
       "defaultValue": true
     },
     {
+      "name": "otel.instrumentation.common.experimental.controller-telemetry.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables experimental controller spans.",
+      "defaultValue": false
+    },
+    {
       "name": "otel.instrumentation.common.default-enabled",
       "type": "java.lang.Boolean",
       "description": "Enables all instrumentations. Set to <code>false</code> to disable all instrumentations and then enable specific modules individually, e.g. <code>otel.instrumentation.jdbc.enabled=true</code>.",


### PR DESCRIPTION
It came up in https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/13721 that this flag is missing from the spring boot starter.

I was able to build this module and confirm that the configuration option autocomplete picks up on the new value, but if there's anything else that should be tested or done, let me know.

<img width="770" alt="image" src="https://github.com/user-attachments/assets/f255152d-77ee-4d06-bb09-ee90d9c97e11" />

