### PR TITLE
Allow advice to define custom mappings

### DIFF
--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
@@ -19,7 +19,6 @@ import io.opentelemetry.instrumentation.api.annotation.support.async.AsyncOperat
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.lang.reflect.Method;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -57,8 +56,17 @@ public class MethodInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         namedOneOf(methodNames.toArray(new String[0])),
+        mapping ->
+            mapping.bind(
+                MethodReturnType.class,
+                (instrumentedType, instrumentedMethod, assigner, argumentHandler, sort) ->
+                    Advice.OffsetMapping.Target.ForStackManipulation.of(
+                        instrumentedMethod.getReturnType().asErasure())),
         MethodInstrumentation.class.getName() + "$MethodAdvice");
   }
+
+  // custom annotation that represents the return type of the method
+  @interface MethodReturnType {}
 
   @SuppressWarnings("unused")
   public static class MethodAdvice {
@@ -82,7 +90,7 @@ public class MethodInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Origin Method method,
+        @MethodReturnType Class<?> methodReturnType,
         @Advice.Local("otelMethod") ClassAndMethod classAndMethod,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
@@ -94,7 +102,7 @@ public class MethodInstrumentation implements TypeInstrumentation {
       scope.close();
 
       returnValue =
-          AsyncOperationEndSupport.create(instrumenter(), Void.class, method.getReturnType())
+          AsyncOperationEndSupport.create(instrumenter(), Void.class, methodReturnType)
               .asyncEnd(context, classAndMethod, returnValue, throwable);
     }
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/TypeTransformer.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/TypeTransformer.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.javaagent.extension.instrumentation;
 
+import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -21,8 +23,19 @@ public interface TypeTransformer {
    * Apply the advice class named {@code adviceClassName} to the instrumented type methods that
    * match {@code methodMatcher}.
    */
+  default void applyAdviceToMethod(
+      ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName) {
+    applyAdviceToMethod(methodMatcher, Function.identity(), adviceClassName);
+  }
+
+  /**
+   * Apply the advice class named {@code adviceClassName} to the instrumented type methods that
+   * match {@code methodMatcher}.
+   */
   void applyAdviceToMethod(
-      ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName);
+      ElementMatcher<? super MethodDescription> methodMatcher,
+      Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
+      String adviceClassName);
 
   /**
    * Apply a custom ByteBuddy {@link AgentBuilder.Transformer} to the instrumented type. Note that

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.tooling.instrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
+import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -26,10 +27,12 @@ final class TypeTransformerImpl implements TypeTransformer {
 
   @Override
   public void applyAdviceToMethod(
-      ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName) {
+      ElementMatcher<? super MethodDescription> methodMatcher,
+      Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
+      String adviceClassName) {
     agentBuilder =
         agentBuilder.transform(
-            new AgentBuilder.Transformer.ForAdvice(adviceMapping)
+            new AgentBuilder.Transformer.ForAdvice(mappingCustomizer.apply(adviceMapping))
                 .include(
                     Utils.getBootstrapProxy(),
                     Utils.getAgentClassLoader(),

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceTransformer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceTransformer.java
@@ -155,8 +155,12 @@ class AdviceTransformer {
   private static List<OutputArgument> getWritableArguments(MethodNode source) {
     List<OutputArgument> result = new ArrayList<>();
     if (source.visibleParameterAnnotations != null) {
-      int i = 0;
-      for (List<AnnotationNode> list : source.visibleParameterAnnotations) {
+      for (int i = 0; i < source.visibleParameterAnnotations.length; i++) {
+        List<AnnotationNode> list = source.visibleParameterAnnotations[i];
+        if (list == null) {
+          continue;
+        }
+
         for (AnnotationNode annotationNode : list) {
           Type annotationType = Type.getType(annotationNode.desc);
           if (ADVICE_ARGUMENT.equals(annotationType) && isWriteable(annotationNode)) {
@@ -166,7 +170,6 @@ class AdviceTransformer {
             }
           }
         }
-        i++;
       }
     }
 
@@ -178,15 +181,18 @@ class AdviceTransformer {
   /** Argument annotated with {@code @Advice.Return(readOnly = false)} or {@code null}. */
   private static OutputArgument getWritableReturnValue(MethodNode source) {
     if (source.visibleParameterAnnotations != null) {
-      int i = 0;
-      for (List<AnnotationNode> list : source.visibleParameterAnnotations) {
+      for (int i = 0; i < source.visibleParameterAnnotations.length; i++) {
+        List<AnnotationNode> list = source.visibleParameterAnnotations[i];
+        if (list == null) {
+          continue;
+        }
+
         for (AnnotationNode annotationNode : list) {
           Type annotationType = Type.getType(annotationNode.desc);
           if (ADVICE_RETURN.equals(annotationType) && isWriteable(annotationNode)) {
             return new OutputArgument(i, -1);
           }
         }
-        i++;
       }
     }
 
@@ -199,8 +205,12 @@ class AdviceTransformer {
   private static OutputArgument getEnterArgument(MethodNode source) {
     Type[] argumentTypes = Type.getArgumentTypes(source.desc);
     if (source.visibleParameterAnnotations != null) {
-      int i = 0;
-      for (List<AnnotationNode> list : source.visibleParameterAnnotations) {
+      for (int i = 0; i < source.visibleParameterAnnotations.length; i++) {
+        List<AnnotationNode> list = source.visibleParameterAnnotations[i];
+        if (list == null) {
+          continue;
+        }
+
         for (AnnotationNode annotationNode : list) {
           Type annotationType = Type.getType(annotationNode.desc);
           if (ADVICE_ENTER.equals(annotationType)
@@ -208,7 +218,6 @@ class AdviceTransformer {
             return new OutputArgument(i, -1);
           }
         }
-        i++;
       }
     }
 
@@ -221,8 +230,12 @@ class AdviceTransformer {
   private static List<AdviceLocal> getLocals(MethodNode source) {
     List<AdviceLocal> result = new ArrayList<>();
     if (source.visibleParameterAnnotations != null) {
-      int i = 0;
-      for (List<AnnotationNode> list : source.visibleParameterAnnotations) {
+      for (int i = 0; i < source.visibleParameterAnnotations.length; i++) {
+        List<AnnotationNode> list = source.visibleParameterAnnotations[i];
+        if (list == null) {
+          continue;
+        }
+
         for (AnnotationNode annotationNode : list) {
           Type annotationType = Type.getType(annotationNode.desc);
           if (ADVICE_LOCAL.equals(annotationType)) {
@@ -232,7 +245,6 @@ class AdviceTransformer {
             }
           }
         }
-        i++;
       }
     }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
@@ -12,6 +12,7 @@ import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -49,13 +50,15 @@ public final class IndyTypeTransformerImpl implements TypeTransformer {
 
   @Override
   public void applyAdviceToMethod(
-      ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName) {
+      ElementMatcher<? super MethodDescription> methodMatcher,
+      Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
+      String adviceClassName) {
     // default strategy used by AgentBuilder.Transformer.ForAdvice
     AgentBuilder.PoolStrategy poolStrategy = AgentBuilder.PoolStrategy.Default.FAST;
 
     agentBuilder =
         agentBuilder.transform(
-            new AgentBuilder.Transformer.ForAdvice(adviceMapping)
+            new AgentBuilder.Transformer.ForAdvice(mappingCustomizer.apply(adviceMapping))
                 .advice(methodMatcher, adviceClassName)
                 // advice transformation already performs uninlining
                 .with(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -25,9 +25,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.StringMatcher;
@@ -181,7 +183,9 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
         new TypeTransformer() {
           @Override
           public void applyAdviceToMethod(
-              ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName) {
+              ElementMatcher<? super MethodDescription> methodMatcher,
+              Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
+              String adviceClassName) {
             adviceNames.add(adviceClassName);
           }
 

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/generation/AdviceClassNameCollector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/generation/AdviceClassNameCollector.java
@@ -8,7 +8,9 @@ package io.opentelemetry.javaagent.tooling.muzzle.generation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -17,7 +19,9 @@ final class AdviceClassNameCollector implements TypeTransformer {
 
   @Override
   public void applyAdviceToMethod(
-      ElementMatcher<? super MethodDescription> methodMatcher, String adviceClassName) {
+      ElementMatcher<? super MethodDescription> methodMatcher,
+      Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
+      String adviceClassName) {
     adviceClassNames.add(adviceClassName);
   }
 


### PR DESCRIPTION
Custom mappings let us bind an advice method argument to a constant or a computed value using a custom annotation. For example in this PR we use this to provide the return type of the instrumented method to the advice. This is more efficient than using `@Advice.Origin Method` since we don't need to look up the method but can instead just ldc the return type from constant pool (if the class version allows this).