### PR TITLE
move readme for jmx metrics

### DIFF
--- a/instrumentation/jmx-metrics/README.md
+++ b/instrumentation/jmx-metrics/README.md
@@ -12,7 +12,7 @@ To control the time interval between MBean detection attempts, one can use the `
 
 ## Predefined metrics
 
-JMX is a popular metrics technology used throughout the JVM (see [runtime metrics](../../runtime-telemetry/runtime-telemetry-java8/library/README.md)), application servers, third-party libraries, and applications.
+JMX is a popular metrics technology used throughout the JVM (see [runtime metrics](../runtime-telemetry/runtime-telemetry-java8/library/README.md)), application servers, third-party libraries, and applications.
 JMX Metric Insight comes with a number of predefined configurations containing curated sets of JMX metrics for frequently used application servers or frameworks.
 To enable collection of the predefined metrics, specify a list of targets as the value for the `otel.jmx.target.system` property. For example
 
@@ -25,13 +25,18 @@ $ java -javaagent:path/to/opentelemetry-javaagent.jar \
 
 No targets are enabled by default. The supported target environments are listed below.
 
-- [activemq](activemq.md)
-- [camel](camel.md)
-- [jetty](jetty.md)
-- [kafka-broker](kafka-broker.md)
-- [tomcat](tomcat.md)
-- [wildfly](wildfly.md)
-- [hadoop](hadoop.md)
+- [activemq](javaagent/activemq.md)
+- [camel](javaagent/camel.md)
+- [jetty](javaagent/jetty.md)
+- [kafka-broker](javaagent/kafka-broker.md)
+- [tomcat](javaagent/tomcat.md)
+- [wildfly](javaagent/wildfly.md)
+- [hadoop](javaagent/hadoop.md)
+
+The [jvm](library/jvm.md) metrics definitions are also included in the [jmx-metrics library](./library)
+to allow reusing them without instrumentation. When using instrumentation, the [runtime-telemetry](../runtime-telemetry)
+instrumentation is used and recommended as it provides more metrics attributes that can't be captured
+through the YAML-based metric definitions.
 
 ## Configuration Files
 


### PR DESCRIPTION
Move the jmx-metrics readme one level up and outside of the `javaagent` module as the YAML definitions are being migrated to the `library`.