### PR TITLE
indy ready migration - part1

### DIFF
--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -24,11 +24,11 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import javax.annotation.Nullable;
 
 public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
 

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -55,9 +55,15 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
   public static class ServeAdvice {
 
     public static class AdviceLocals {
-      public HttpRequest httpRequest;
-      public Context context;
-      public Scope scope;
+      public final HttpRequest httpRequest;
+      public final Context context;
+      public final Scope scope;
+
+      public AdviceLocals(Context context, HttpRequest httpRequest) {
+        this.context = context;
+        this.scope = context.makeCurrent();
+        this.httpRequest = httpRequest;
+      }
     }
 
     @Nullable
@@ -69,11 +75,7 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
       }
-      AdviceLocals locals = new AdviceLocals();
-      locals.httpRequest = request;
-      locals.context = instrumenter().start(parentContext, request);
-      locals.scope = locals.context.makeCurrent();
-      return locals;
+      return new AdviceLocals(instrumenter().start(parentContext, request), request);
     }
 
     @AssignReturned.ToReturned

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -54,11 +54,11 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
   public static class ServeAdvice {
 
     public static class AdviceScope {
-      public final HttpRequest httpRequest;
-      public final Context context;
-      public final Scope scope;
+      private final HttpRequest httpRequest;
+      private final Context context;
+      private final Scope scope;
 
-      public AdviceScope(Context context, Scope scope, HttpRequest httpRequest) {
+      private AdviceScope(Context context, Scope scope, HttpRequest httpRequest) {
         this.context = context;
         this.scope = scope;
         this.httpRequest = httpRequest;

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -25,8 +25,10 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import javax.annotation.Nullable;
 
 public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
 
@@ -52,39 +54,46 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class ServeAdvice {
 
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void methodEnter(
-        @Advice.This AsyncServlet asyncServlet,
-        @Advice.Argument(0) HttpRequest request,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope,
-        @Advice.Local("httpRequest") HttpRequest httpRequest) {
-      Context parentContext = currentContext();
-      httpRequest = request;
-      if (!instrumenter().shouldStart(parentContext, request)) {
-        return;
-      }
-      context = instrumenter().start(parentContext, request);
-      scope = context.makeCurrent();
+    public static class AdviceLocals {
+      public HttpRequest httpRequest;
+      public Context context;
+      public Scope scope;
     }
 
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AdviceLocals methodEnter(
+        @Advice.This AsyncServlet asyncServlet, @Advice.Argument(0) HttpRequest request) {
+
+      Context parentContext = currentContext();
+      if (!instrumenter().shouldStart(parentContext, request)) {
+        return null;
+      }
+      AdviceLocals locals = new AdviceLocals();
+      locals.httpRequest = request;
+      locals.context = instrumenter().start(parentContext, request);
+      locals.scope = locals.context.makeCurrent();
+      return locals;
+    }
+
+    @AssignReturned.ToReturned
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void methodExit(
+    public static Promise<HttpResponse> methodExit(
         @Advice.This AsyncServlet asyncServlet,
-        @Advice.Return(readOnly = false) Promise<HttpResponse> responsePromise,
+        @Advice.Return Promise<HttpResponse> responsePromise,
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope,
-        @Advice.Local("httpRequest") HttpRequest httpRequest) {
-      if (scope == null) {
-        return;
+        @Advice.Enter @Nullable AdviceLocals locals) {
+
+      if (locals == null || locals.scope == null) {
+        return responsePromise;
       }
-      scope.close();
+      locals.scope.close();
       if (throwable != null) {
-        instrumenter().end(context, httpRequest, null, throwable);
+        instrumenter().end(locals.context, locals.httpRequest, null, throwable);
       } else {
-        responsePromise = PromiseWrapper.wrap(responsePromise, httpRequest, context);
+        responsePromise = PromiseWrapper.wrap(responsePromise, locals.httpRequest, locals.context);
       }
+      return responsePromise;
     }
   }
 }

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -90,12 +90,14 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
         return responsePromise;
       }
       locals.scope.close();
+
+      Promise<HttpResponse> returnValue = responsePromise;
       if (throwable != null) {
         instrumenter().end(locals.context, locals.httpRequest, null, throwable);
       } else {
-        responsePromise = PromiseWrapper.wrap(responsePromise, locals.httpRequest, locals.context);
+        returnValue = PromiseWrapper.wrap(responsePromise, locals.httpRequest, locals.context);
       }
-      return responsePromise;
+      return returnValue;
     }
   }
 }

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -79,10 +79,10 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
         Promise<HttpResponse> returnValue = responsePromise;
         if (throwable != null) {
           instrumenter().end(context, httpRequest, null, throwable);
+          return responsePromise;
         } else {
-          returnValue = PromiseWrapper.wrap(responsePromise, httpRequest, context);
+          return PromiseWrapper.wrap(responsePromise, httpRequest, context);
         }
-        return returnValue;
       }
     }
 

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerInstrumentationModule.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerInstrumentationModule.java
@@ -11,14 +11,21 @@ import static java.util.Collections.singletonList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public class ActivejHttpServerInstrumentationModule extends InstrumentationModule {
+public class ActivejHttpServerInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
 
   public ActivejHttpServerInstrumentationModule() {
     super("activej-http", "activej-http-6.0");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorInstrumentationModule.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorInstrumentationModule.java
@@ -10,12 +10,19 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class AkkaActorInstrumentationModule extends InstrumentationModule {
+public class AkkaActorInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public AkkaActorInstrumentationModule() {
     super("akka-actor", "akka-actor-2.3");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -46,8 +46,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments({@ToArgument(2)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterSchedule(@Advice.Argument(2) Runnable runnable) {
-      runnable = AkkaSchedulerTaskWrapper.wrap(runnable);
-      return runnable;
+      return AkkaSchedulerTaskWrapper.wrap(runnable);
     }
   }
 
@@ -57,8 +56,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments({@ToArgument(1)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterScheduleOnce(@Advice.Argument(1) Runnable runnable) {
-      runnable = AkkaSchedulerTaskWrapper.wrap(runnable);
-      return runnable;
+      return AkkaSchedulerTaskWrapper.wrap(runnable);
     }
   }
 }

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -43,7 +43,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class ScheduleAdvice {
 
-    @AssignReturned.ToArguments({@ToArgument(2)})
+    @AssignReturned.ToArguments(@ToArgument(2))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterSchedule(@Advice.Argument(2) Runnable runnable) {
       Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);
@@ -54,7 +54,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class ScheduleOnceAdvice {
 
-    @AssignReturned.ToArguments({@ToArgument(1)})
+    @AssignReturned.ToArguments(@ToArgument(1))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterScheduleOnce(@Advice.Argument(1) Runnable runnable) {
       Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -11,6 +11,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -41,20 +43,22 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class ScheduleAdvice {
 
+    @AssignReturned.ToArguments({@ToArgument(2)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void enterSchedule(
-        @Advice.Argument(value = 2, readOnly = false) Runnable runnable) {
+    public static Runnable enterSchedule(@Advice.Argument(2) Runnable runnable) {
       runnable = AkkaSchedulerTaskWrapper.wrap(runnable);
+      return runnable;
     }
   }
 
   @SuppressWarnings("unused")
   public static class ScheduleOnceAdvice {
 
+    @AssignReturned.ToArguments({@ToArgument(1)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void enterScheduleOnce(
-        @Advice.Argument(value = 1, readOnly = false) Runnable runnable) {
+    public static Runnable enterScheduleOnce(@Advice.Argument(1) Runnable runnable) {
       runnable = AkkaSchedulerTaskWrapper.wrap(runnable);
+      return runnable;
     }
   }
 }

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -46,8 +46,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(2))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterSchedule(@Advice.Argument(2) Runnable runnable) {
-      Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);
-      return wrapped;
+      return AkkaSchedulerTaskWrapper.wrap(runnable);
     }
   }
 
@@ -57,8 +56,7 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(1))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterScheduleOnce(@Advice.Argument(1) Runnable runnable) {
-      Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);
-      return wrapped;
+      return AkkaSchedulerTaskWrapper.wrap(runnable);
     }
   }
 }

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -46,7 +46,8 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments({@ToArgument(2)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterSchedule(@Advice.Argument(2) Runnable runnable) {
-      return AkkaSchedulerTaskWrapper.wrap(runnable);
+      Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);
+      return wrapped;
     }
   }
 
@@ -56,7 +57,8 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments({@ToArgument(1)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Runnable enterScheduleOnce(@Advice.Argument(1) Runnable runnable) {
-      return AkkaSchedulerTaskWrapper.wrap(runnable);
+      Runnable wrapped = AkkaSchedulerTaskWrapper.wrap(runnable);
+      return wrapped;
     }
   }
 }

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorForkJoinInstrumentationModule.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorForkJoinInstrumentationModule.java
@@ -10,12 +10,19 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class AkkaActorForkJoinInstrumentationModule extends InstrumentationModule {
+public class AkkaActorForkJoinInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public AkkaActorForkJoinInstrumentationModule() {
     super("akka-actor-fork-join", "akka-actor-fork-join-2.5", "akka-actor");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientInstrumentationModule.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientInstrumentationModule.java
@@ -10,12 +10,19 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class AkkaHttpClientInstrumentationModule extends InstrumentationModule {
+public class AkkaHttpClientInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public AkkaHttpClientInstrumentationModule() {
     super("akka-http", "akka-http-10.0", "akka-http-client");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -24,7 +24,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import scala.concurrent.Future;
 
@@ -81,7 +80,7 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
       }
     }
 
-    @AssignReturned.ToArguments(@ToArgument(value = 0, index = 1, typing = Assigner.Typing.DYNAMIC))
+    @AssignReturned.ToArguments(@ToArgument(value = 0, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(@Advice.Argument(0) HttpRequest request) {
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -54,7 +54,6 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(@Advice.Argument(0) HttpRequest request) {
 
-      AdviceLocals locals = new AdviceLocals();
       /*
       Versions 10.0 and 10.1 have slightly different structure that is hard to distinguish so here
       we cast 'wider net' and avoid instrumenting twice.
@@ -63,9 +62,9 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
        */
       Context parentContext = currentContext();
       if (!instrumenter().shouldStart(parentContext, request)) {
-        return new Object[] {locals, request};
+        return new Object[] {null, request};
       }
-
+      AdviceLocals locals = new AdviceLocals();
       locals.context = instrumenter().start(parentContext, request);
       locals.scope = locals.context.makeCurrent();
       // Request is immutable, so we have to assign new value once we update headers
@@ -83,7 +82,7 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
         @Advice.Enter Object[] enterResult) {
 
       AdviceLocals locals = (AdviceLocals) enterResult[0];
-      if (locals.scope == null) {
+      if (locals == null || locals.scope == null) {
         return responseFuture;
       }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -63,6 +63,8 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
           return new Object[] {null, request};
         }
         Context context = instrumenter().start(parentContext, request);
+        // Making context current is required for header context propagation to work as expected
+        // because it implicitly relies on the current context when injecting headers.
         Scope scope = context.makeCurrent();
         // Request is immutable, so we have to assign new value once we update headers
         HttpRequest modifiedRequest = setter().inject(request);

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -78,16 +78,14 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
           @Nullable Throwable throwable) {
 
         scope.close();
-        if (actorSystem == null) {
-          return responseFuture;
-        }
-        if (throwable == null) {
-          responseFuture.onComplete(
-              new OnCompleteHandler(context, request), actorSystem.dispatcher());
-          responseFuture =
-              FutureWrapper.wrap(responseFuture, actorSystem.dispatcher(), currentContext());
-        } else {
-          instrumenter().end(context, request, null, throwable);
+        if (actorSystem != null) {
+          if (throwable == null) {
+            responseFuture.onComplete(
+                new OnCompleteHandler(context, request), actorSystem.dispatcher());
+            return FutureWrapper.wrap(responseFuture, actorSystem.dispatcher(), currentContext());
+          } else {
+            instrumenter().end(context, request, null, throwable);
+          }
         }
         return responseFuture;
       }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -56,9 +56,7 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
       public Scope scope;
     }
 
-    @AssignReturned.ToArguments({
-      @ToArgument(value = 0, index = 1, typing = Assigner.Typing.DYNAMIC)
-    })
+    @AssignReturned.ToArguments(@ToArgument(value = 0, index = 1, typing = Assigner.Typing.DYNAMIC))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(@Advice.Argument(0) HttpRequest request) {
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -101,10 +101,10 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
         instrumenter().end(locals.context, request, null, throwable);
       }
       if (responseFuture != null) {
-        responseFuture =
-            FutureWrapper.wrap(responseFuture, actorSystem.dispatcher(), currentContext());
+        return FutureWrapper.wrap(responseFuture, actorSystem.dispatcher(), currentContext());
+      } else {
+        return null;
       }
-      return responseFuture;
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -46,6 +46,11 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
   public static class SingleRequestAdvice {
 
     public static class AdviceLocals {
+      public AdviceLocals(Context context) {
+        this.context = context;
+        this.scope = context.makeCurrent();
+      }
+
       public Context context;
       public Scope scope;
     }
@@ -64,9 +69,7 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
       if (!instrumenter().shouldStart(parentContext, request)) {
         return new Object[] {null, request};
       }
-      AdviceLocals locals = new AdviceLocals();
-      locals.context = instrumenter().start(parentContext, request);
-      locals.scope = locals.context.makeCurrent();
+      AdviceLocals locals = new AdviceLocals(instrumenter().start(parentContext, request));
       // Request is immutable, so we have to assign new value once we update headers
       request = setter().inject(request);
       return new Object[] {locals, request};

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/HttpExtClientInstrumentation.java
@@ -69,8 +69,8 @@ public class HttpExtClientInstrumentation implements TypeInstrumentation {
         return new Object[] {adviceScope, modifiedRequest};
       }
 
-      public void end(ActorSystem actorSystem, Future<HttpResponse> responseFuture,
-          Throwable throwable) {
+      public void end(
+          ActorSystem actorSystem, Future<HttpResponse> responseFuture, Throwable throwable) {
         scope.close();
         if (throwable == null) {
           responseFuture.onComplete(

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
@@ -23,6 +23,11 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule
   }
 
   @Override
+  public boolean isIndyReady() {
+    return true;
+  }
+
+  @Override
   public String getModuleGroup() {
     return "akka-http";
   }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -35,7 +35,7 @@ public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation 
   @SuppressWarnings("unused")
   public static class AkkaBindAndHandleAdvice {
 
-    @AssignReturned.ToArguments({@ToArgument(0)})
+    @AssignReturned.ToArguments(@ToArgument(0))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -14,6 +14,8 @@ import akka.stream.scaladsl.Flow;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -33,10 +35,12 @@ public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation 
   @SuppressWarnings("unused")
   public static class AkkaBindAndHandleAdvice {
 
+    @AssignReturned.ToArguments({@ToArgument(0)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void wrapHandler(
-        @Advice.Argument(value = 0, readOnly = false) Flow<HttpRequest, HttpResponse, ?> handler) {
+    public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
+        @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
       handler = AkkaFlowWrapper.wrap(handler);
+      return handler;
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -39,7 +39,8 @@ public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      return AkkaFlowWrapper.wrap(handler);
+      Flow<HttpRequest, HttpResponse, ?> wrapped = AkkaFlowWrapper.wrap(handler);
+      return wrapped;
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -39,8 +39,7 @@ public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      handler = AkkaFlowWrapper.wrap(handler);
-      return handler;
+      return AkkaFlowWrapper.wrap(handler);
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -39,8 +39,7 @@ public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      Flow<HttpRequest, HttpResponse, ?> wrapped = AkkaFlowWrapper.wrap(handler);
-      return wrapped;
+      return AkkaFlowWrapper.wrap(handler);
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
@@ -39,8 +39,7 @@ public class HttpExtServerInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      Flow<HttpRequest, HttpResponse, ?> wrapped = AkkaFlowWrapper.wrap(handler);
-      return wrapped;
+      return AkkaFlowWrapper.wrap(handler);
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
@@ -14,6 +14,8 @@ import akka.stream.scaladsl.Flow;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -33,10 +35,12 @@ public class HttpExtServerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class AkkaBindAndHandleAdvice {
 
+    @AssignReturned.ToArguments({@ToArgument(0)})
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void wrapHandler(
-        @Advice.Argument(value = 0, readOnly = false) Flow<HttpRequest, HttpResponse, ?> handler) {
+    public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
+        @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
       handler = AkkaFlowWrapper.wrap(handler);
+      return handler;
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
@@ -39,8 +39,7 @@ public class HttpExtServerInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      handler = AkkaFlowWrapper.wrap(handler);
-      return handler;
+      return AkkaFlowWrapper.wrap(handler);
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
@@ -35,7 +35,7 @@ public class HttpExtServerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class AkkaBindAndHandleAdvice {
 
-    @AssignReturned.ToArguments({@ToArgument(0)})
+    @AssignReturned.ToArguments(@ToArgument(0))
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/HttpExtServerInstrumentation.java
@@ -39,7 +39,8 @@ public class HttpExtServerInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(0) Flow<HttpRequest, HttpResponse, ?> handler) {
-      return AkkaFlowWrapper.wrap(handler);
+      Flow<HttpRequest, HttpResponse, ?> wrapped = AkkaFlowWrapper.wrap(handler);
+      return wrapped;
     }
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/route/AkkaHttpServerRouteInstrumentationModule.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/route/AkkaHttpServerRouteInstrumentationModule.java
@@ -25,6 +25,11 @@ public class AkkaHttpServerRouteInstrumentationModule extends InstrumentationMod
   }
 
   @Override
+  public boolean isIndyReady() {
+    return true;
+  }
+
+  @Override
   public String getModuleGroup() {
     return "akka-http";
   }

--- a/instrumentation/alibaba-druid-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/alibabadruid/v1_0/DruidInstrumentationModule.java
+++ b/instrumentation/alibaba-druid-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/alibabadruid/v1_0/DruidInstrumentationModule.java
@@ -10,13 +10,20 @@ import static java.util.Collections.singletonList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class DruidInstrumentationModule extends InstrumentationModule {
+public class DruidInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
 
   public DruidInstrumentationModule() {
     super("alibaba-druid", "alibaba-druid-1.0");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpException;
@@ -63,11 +65,15 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
   @SuppressWarnings("unused")
   public static class ClientAdvice {
 
+    @AssignReturned.ToArguments({
+      @ToArgument(value = 0, index = 0),
+      @ToArgument(value = 3, index = 1)
+    })
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void methodEnter(
-        @Advice.Argument(value = 0, readOnly = false) HttpAsyncRequestProducer requestProducer,
+    public static Object[] methodEnter(
+        @Advice.Argument(0) HttpAsyncRequestProducer requestProducer,
         @Advice.Argument(2) HttpContext httpContext,
-        @Advice.Argument(value = 3, readOnly = false) FutureCallback<?> futureCallback) {
+        @Advice.Argument(3) FutureCallback<?> futureCallback) {
 
       Context parentContext = currentContext();
 
@@ -75,7 +81,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
           new WrappedFutureCallback<>(parentContext, httpContext, futureCallback);
       requestProducer =
           new DelegatingRequestProducer(parentContext, requestProducer, wrappedFutureCallback);
-      futureCallback = wrappedFutureCallback;
+      return new Object[] {requestProducer, wrappedFutureCallback};
     }
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -25,6 +25,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
@@ -66,8 +67,8 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
   public static class ClientAdvice {
 
     @AssignReturned.ToArguments({
-      @ToArgument(value = 0, index = 0),
-      @ToArgument(value = 3, index = 1)
+      @ToArgument(value = 0, index = 0, typing = Assigner.Typing.DYNAMIC),
+      @ToArgument(value = 3, index = 1, typing = Assigner.Typing.DYNAMIC)
     })
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(
@@ -79,9 +80,9 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
 
       WrappedFutureCallback<?> wrappedFutureCallback =
           new WrappedFutureCallback<>(parentContext, httpContext, futureCallback);
-      requestProducer =
+      HttpAsyncRequestProducer modifiedRequestProducer =
           new DelegatingRequestProducer(parentContext, requestProducer, wrappedFutureCallback);
-      return new Object[] {requestProducer, wrappedFutureCallback};
+      return new Object[] {modifiedRequestProducer, wrappedFutureCallback};
     }
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -25,7 +25,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
@@ -67,8 +66,8 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
   public static class ClientAdvice {
 
     @AssignReturned.ToArguments({
-      @ToArgument(value = 0, index = 0, typing = Assigner.Typing.DYNAMIC),
-      @ToArgument(value = 3, index = 1, typing = Assigner.Typing.DYNAMIC)
+      @ToArgument(value = 0, index = 0),
+      @ToArgument(value = 3, index = 1)
     })
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Object[] methodEnter(

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentationModule.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentationModule.java
@@ -10,12 +10,19 @@ import static java.util.Collections.singletonList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class ApacheHttpAsyncClientInstrumentationModule extends InstrumentationModule {
+public class ApacheHttpAsyncClientInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
   public ApacheHttpAsyncClientInstrumentationModule() {
     super("apache-httpasyncclient", "apache-httpasyncclient-4.1");
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 
   @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.tooling.instrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.ForceDynamicallyTypedAssignReturnedFactory;
 import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
@@ -22,7 +23,9 @@ final class TypeTransformerImpl implements TypeTransformer {
     this.agentBuilder = agentBuilder;
     adviceMapping =
         Advice.withCustomMapping()
-            .with(new Advice.AssignReturned.Factory().withSuppressed(Throwable.class));
+            .with(
+                new ForceDynamicallyTypedAssignReturnedFactory(
+                    new Advice.AssignReturned.Factory().withSuppressed(Throwable.class)));
   }
 
   @Override


### PR DESCRIPTION
Part of #https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13031

two transformations applied:
- advice rewrite with help from automated tool provided by @JonasKunz https://github.com/JonasKunz/indy-advice-transformer
- implement `ExperimentalInstrumentationModule.isIndyReady()` to mark instrumentation indy-ready

covered instrumentations