### PR TITLE
Clear virtual fields from jdbc statement when the statement is closed

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -55,6 +55,9 @@ public class StatementInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         namedOneOf("executeBatch", "executeLargeBatch").and(takesNoArguments()).and(isPublic()),
         StatementInstrumentation.class.getName() + "$ExecuteBatchAdvice");
+    transformer.applyAdviceToMethod(
+        named("close").and(isPublic()).and(takesNoArguments()),
+        StatementInstrumentation.class.getName() + "$CloseAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -193,6 +196,15 @@ public class StatementInstrumentation implements TypeInstrumentation {
         scope.close();
         statementInstrumenter().end(context, request, null, throwable);
       }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class CloseAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void closeStatement(@Advice.This Statement statement) {
+      JdbcData.close(statement);
     }
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
@@ -95,6 +95,17 @@ public final class JdbcData {
     return batchInfo != null ? batchInfo.getBatchSize() : null;
   }
 
+  public static void close(Statement statement) {
+    // when statement is closed remove all of our virtual fields in case the JDBC driver reuses the
+    // same statement instance for a subsequent query
+    statementBatch.set(statement, null);
+    if (statement instanceof PreparedStatement) {
+      PreparedStatement prepared = (PreparedStatement) statement;
+      preparedStatement.set(prepared, null);
+      preparedStatementBatch.set(prepared, null);
+    }
+  }
+
   /**
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
    * any time.

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
@@ -116,6 +116,7 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
 
   @Override
   public void close() throws SQLException {
+    JdbcData.close(this);
     delegate.close();
   }
 


### PR DESCRIPTION
I'm not aware of this causing any issues for now, added just in case.