### PR TITLE
Add db semconv tests for db client instrumentations

### DIFF
--- a/instrumentation/alibaba-druid-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/alibaba-druid-1.0/javaagent/build.gradle.kts
@@ -18,3 +18,13 @@ dependencies {
 
   testImplementation(project(":instrumentation:alibaba-druid-1.0:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/alibaba-druid-1.0/library/build.gradle.kts
+++ b/instrumentation/alibaba-druid-1.0/library/build.gradle.kts
@@ -8,3 +8,13 @@ dependencies {
 
   testImplementation(project(":instrumentation:alibaba-druid-1.0:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/apache-dbcp-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-dbcp-2.0/javaagent/build.gradle.kts
@@ -18,3 +18,13 @@ dependencies {
 
   testImplementation(project(":instrumentation:apache-dbcp-2.0:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/apache-dbcp-2.0/library/build.gradle.kts
+++ b/instrumentation/apache-dbcp-2.0/library/build.gradle.kts
@@ -8,3 +8,13 @@ dependencies {
 
   testImplementation(project(":instrumentation:apache-dbcp-2.0:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}


### PR DESCRIPTION
Related to #12608 and #12601 

These instrumentations leverage the [semconv DbConnectionPoolMetrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/alibaba-druid-1.0/library/src/main/java/io/opentelemetry/instrumentation/alibabadruid/v1_0/ConnectionPoolMetrics.java#L27) which has [behavior based on whether db semconv flag](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java#L61) is set, so this PR ensures that functionality is tested.