### PR TITLE
Fix NPE in netty 3.8 instrumentation

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
@@ -54,7 +54,7 @@ public class ChannelFutureListenerInstrumentation implements TypeInstrumentation
        - To capture scope only in case of error.
        */
       Throwable cause = future.getCause();
-      if (cause == null) {
+      if (cause == null || future.getChannel() == null) {
         return null;
       }
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13797
cause and channel can both be `null` when future was cancelled, see https://github.com/netty/netty/blob/5f56a03bcb0aa23bdc9f68686e5c2abcf963a9cd/src/main/java/org/jboss/netty/channel/DefaultChannelFuture.java#L104