### PR TITLE
Delete deprecated property for disabling kafka metrics

### DIFF
--- a/instrumentation/kafka/README.md
+++ b/instrumentation/kafka/README.md
@@ -4,4 +4,3 @@
 |-----------------------------------------------------------| ------- |---------|--------------------------------------------------------------------------------------------------------------------------------|
 | `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                                                                            |
 | `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                                                                         |
-| `otel.instrumentation.kafka.metric-reporter.enabled`      | Boolean | `true`  | Enable kafka consumer and producer metrics. **Deprecated**, disable instrumentation with name `kafka-clients-metrics` instead. |

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/metrics/KafkaMetricsUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/metrics/KafkaMetricsUtil.java
@@ -9,27 +9,18 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.MetricsReporterList;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.OpenTelemetryMetricsReporter;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.OpenTelemetrySupplier;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
-import io.opentelemetry.javaagent.bootstrap.internal.DeprecatedConfigProperties;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.CommonClientConfigs;
 
 public final class KafkaMetricsUtil {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.kafka-clients-0.11";
-  private static final boolean METRICS_ENABLED =
-      DeprecatedConfigProperties.getBoolean(
-          AgentInstrumentationConfig.get(),
-          "otel.instrumentation.kafka.metric-reporter.enabled",
-          "otel.instrumentation.kafka-clients-metrics.enabled",
-          true);
 
   @SuppressWarnings("unchecked")
   public static void enhanceConfig(Map<? super String, Object> config) {
-    // skip enhancing configuration when metrics are disabled or when we have already enhanced it
-    if (!METRICS_ENABLED
-        || config.get(OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME)
-            != null) {
+    // skip enhancing configuration when we have already enhanced it
+    if (config.get(OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME)
+        != null) {
       return;
     }
     config.merge(


### PR DESCRIPTION
`otel.instrumentation.kafka.metric-reporter.enabled` has been deprecated for over a year