### PR TITLE
Try to fix link check rate limiting

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -23,5 +23,5 @@ jobs:
             --exclude "^http://code.google.com/p/concurrentlinkedhashmap$"
             --exclude "^https://softwareengineering.stackexchange.com/questions/29727"
             --max-retries 6
-            --max-concurrency 2
+            --max-concurrency 1
             .

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -21,4 +21,5 @@ jobs:
             --exclude "^https://github.com/open-telemetry/opentelemetry-java-instrumentation/(issues|pull)/\\d+$"
             --exclude "^http://code.google.com/p/concurrentlinkedhashmap$"
             --max-retries 6
+            --max-concurrency 1
             .

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -13,9 +13,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           # excluding links to pull requests and issues is done for performance
           args: >
             --include-fragments

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -14,7 +14,6 @@ jobs:
 
       - uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           # excluding links to pull requests and issues is done for performance
           # stackexchange link fails with 403 when accessed by lychee
           args: >

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -16,10 +16,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # excluding links to pull requests and issues is done for performance
+          # stackexchange link fails with 403 when accessed by lychee
           args: >
             --include-fragments
             --exclude "^https://github.com/open-telemetry/opentelemetry-java-instrumentation/(issues|pull)/\\d+$"
             --exclude "^http://code.google.com/p/concurrentlinkedhashmap$"
+            --exclude "^https://softwareengineering.stackexchange.com/questions/29727"
             --max-retries 6
-            --max-concurrency 1
+            --max-concurrency 2
             .

--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # excluding links to pull requests and issues is done for performance
           args: >


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13808
Work around the `229 Network error: Too Many Requests` for github links by limiting concurrency. This will make the link check task significantly slower but at least it succeeds. I also tried adding the token (used `${{ secrets.GITHUB_TOKEN }}`) as described in https://github.com/lycheeverse/lychee?tab=readme-ov-file#github-token but that didn't seem to help. Idk may I did something wrong.