### PR TITLE
Remove note about 1.x releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,6 @@ This package includes the instrumentation agent as well as
 instrumentations for all supported libraries and all available data exporters.
 The package provides a completely automatic, out-of-the-box experience.
 
-*Note: There are 2.x releases and 1.x releases. The 2.0 release included significant breaking
-changes, the details of which can be found in the [release notes](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0).
-It is recommended to use the latest 2.x release which will have the latest features and improvements.
-1.x will receive security patches for a limited time and will not include other bug fixes and
-enhancements.*
-
-
 Enable the instrumentation agent using the `-javaagent` flag to the JVM.
 
 ```


### PR DESCRIPTION
Last 1.x release was in [August 2024](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.33.6). Feels safe to remove this note now.