### PR TITLE
Disable flaky java http client http2 tests on jdk25

### DIFF
--- a/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -12,6 +12,8 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions
 import java.net.http.HttpClient;
 import java.util.Collections;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
@@ -39,6 +41,7 @@ public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
     }
   }
 
+  @DisabledForJreRange(min = JRE.JAVA_25) // flaky on jdk25-ea
   @Nested
   static class Http2ClientTest extends JavaHttpClientTest {
 


### PR DESCRIPTION
https://scans.gradle.com/s/3iaqp2vpxqvd6/tests/task/:instrumentation:java-http-client:library:test/details/io.opentelemetry.instrumentation.javahttpclient.JavaHttpClientTest$Http2ClientTest/highConcurrency()?top-execution=1
https://scans.gradle.com/s/mnba2f4ifxahi/tests/task/:instrumentation:java-http-client:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.javahttpclient.JavaHttpClientTest$Http2ClientTest/basicRequestWith2Redirects()?top-execution=1
Lately has caused multiple build failures. Either we are not using the http client correctly or it is a bug in the http client, probably not an instrumentation issue.