### PR TITLE
Rename auto spotless workflows

### DIFF
--- a/.github/workflows/auto-spotless.yml
+++ b/.github/workflows/auto-spotless.yml
@@ -1,4 +1,4 @@
-name: Auto spotless check
+name: Auto spotless
 on:
   pull_request:
     types:

--- a/.github/workflows/auto-update-pull-request.yml
+++ b/.github/workflows/auto-update-pull-request.yml
@@ -1,8 +1,8 @@
-name: Auto spotless apply
+name: Auto update pull request
 on:
   workflow_run:
     workflows:
-      - "Auto spotless check"
+      - "Auto spotless"
     types:
       - completed
 


### PR DESCRIPTION
Rename the "apply" step to make it clear it can be reused by other "auto ..." workflow actions.