### PR TITLE
Remove deprecated methods from runtime-telemetry

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilder.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilder.java
@@ -82,18 +82,6 @@ public final class RuntimeMetricsBuilder {
     return this;
   }
 
-  /**
-   * Enable experimental JMX telemetry collection.
-   *
-   * @deprecated Use {@link #emitExperimentalTelemetry()} instead.
-   */
-  @Deprecated
-  @CanIgnoreReturnValue
-  public RuntimeMetricsBuilder enableExperimentalJmxTelemetry() {
-    emitExperimentalTelemetry = true;
-    return this;
-  }
-
   /** Enable the capture of the jvm.gc.cause attribute with the jvm.gc.duration metric. */
   @CanIgnoreReturnValue
   public RuntimeMetricsBuilder captureGcCause() {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetricsBuilder.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetricsBuilder.java
@@ -29,18 +29,6 @@ public final class RuntimeMetricsBuilder {
     return this;
   }
 
-  /**
-   * Enable experimental JMX telemetry collection.
-   *
-   * @deprecated Use {@link #emitExperimentalTelemetry()} instead.
-   */
-  @Deprecated
-  @CanIgnoreReturnValue
-  public RuntimeMetricsBuilder enableExperimentalJmxTelemetry() {
-    emitExperimentalTelemetry = true;
-    return this;
-  }
-
   /** Enable the capture of the jvm.gc.cause attribute with the jvm.gc.duration metric. */
   @CanIgnoreReturnValue
   public RuntimeMetricsBuilder captureGcCause() {


### PR DESCRIPTION
Follow-up: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13791