### PR TITLE
Fix instrumentation failure when constructor has @WithSpan annotation

### DIFF
--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.none;
@@ -79,13 +80,13 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
         tracedMethods.and(not(annotatedParametersMatcher));
 
     transformer.applyAdviceToMethod(
-        tracedMethodsWithoutParameters,
+        tracedMethodsWithoutParameters.and(isMethod()),
         WithSpanInstrumentation.class.getName() + "$WithSpanAdvice");
 
     // Only apply advice for tracing parameters as attributes if any of the parameters are annotated
     // with @SpanAttribute to avoid unnecessarily copying the arguments into an array.
     transformer.applyAdviceToMethod(
-        tracedMethodsWithParameters,
+        tracedMethodsWithParameters.and(isMethod()),
         WithSpanInstrumentation.class.getName() + "$WithSpanAttributesAdvice");
   }
 

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
@@ -12,6 +12,12 @@ import java.util.concurrent.CompletionStage;
 @SuppressWarnings("deprecation") // testing instrumentation of deprecated class
 public class TracedWithSpan {
 
+  public TracedWithSpan() {}
+
+  // used to verify that constructor with @WithSpan annotation doesn't break instrumentation
+  @io.opentelemetry.extension.annotations.WithSpan
+  public TracedWithSpan(String unused) {}
+
   @io.opentelemetry.extension.annotations.WithSpan
   public String otel() {
     return "hello!";

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.javaagent.instrumentation.instrumentationannotati
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.whereAny;
@@ -66,13 +67,13 @@ class WithSpanInstrumentation implements TypeInstrumentation {
         tracedMethods.and(not(annotatedParametersMatcher));
 
     transformer.applyAdviceToMethod(
-        tracedMethodsWithoutParameters,
+        tracedMethodsWithoutParameters.and(isMethod()),
         WithSpanInstrumentation.class.getName() + "$WithSpanAdvice");
 
     // Only apply advice for tracing parameters as attributes if any of the parameters are annotated
     // with @SpanAttribute to avoid unnecessarily copying the arguments into an array.
     transformer.applyAdviceToMethod(
-        tracedMethodsWithParameters,
+        tracedMethodsWithParameters.and(isMethod()),
         WithSpanInstrumentation.class.getName() + "$WithSpanAttributesAdvice");
   }
 

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
@@ -13,6 +13,12 @@ import java.util.concurrent.CompletionStage;
 
 public class TracedWithSpan {
 
+  TracedWithSpan() {}
+
+  // used to verify that constructor with @WithSpan annotation doesn't break instrumentation
+  @WithSpan
+  TracedWithSpan(String unused) {}
+
   @WithSpan
   public String otel() {
     return "hello!";


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13920
This PR excludes constructors from `@WithSpan` instrumentation since it currently does not work at all. This is not ideal as `@WithSpan` annotation is allowed on constructors, I don't think we can change that.
Implementing `@WithSpan` support for constructors is slightly problematic because as far as I can tell on constructors byte buddy does not allow `OnMethodExit` with `onThrowable`.