### PR TITLE
Remove unneeded test flags

### DIFF
--- a/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/build.gradle.kts
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/build.gradle.kts
@@ -18,6 +18,5 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-  jvmArgs("-Dotel.instrumentation.common.experimental.view-telemetry.enabled=true")
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
 }

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
@@ -63,5 +63,4 @@ tasks {
 
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
-  jvmArgs("-Dotel.instrumentation.common.experimental.view-telemetry.enabled=true")
 }

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -99,5 +99,4 @@ configurations.configureEach {
 }
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
-  jvmArgs("-Dotel.instrumentation.common.experimental.view-telemetry.enabled=true")
 }


### PR DESCRIPTION
While doing some work on the configuration documentation project, I noticed that this flag was set on tests for modules that don't reference or do anything with it.

From what I can tell, only the [jsp-2.3 and spring webmvc instrumentations](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-java-instrumentation%20viewTelemetryEnabled&type=code) respect this flag