### PR TITLE
Try to work around flaky mongo tests

### DIFF
--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
   library("org.mongodb:mongodb-driver-core:4.0.0")
 
+  // using 4.0.1 in tests to work around https://jira.mongodb.org/browse/JAVA-3647
+  testLibrary("org.mongodb:mongodb-driver-core:4.0.1")
   testLibrary("org.mongodb:mongodb-driver-sync:4.0.0")
   testLibrary("org.mongodb:mongodb-driver-reactivestreams:4.0.0")
 


### PR DESCRIPTION
https://scans.gradle.com/s/4ohgeeln7m3k4/tests/task/:instrumentation:mongo:mongo-4.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.mongo.v4_0.Mongo4ReactiveClientTest/testError()?top-execution=1
lately we have a lot of these