### PR TITLE
Apply method instrumentation only to methods

### DIFF
--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.instrumentation.methods.MethodSingletons.getBootstrapLoader;
 import static io.opentelemetry.javaagent.instrumentation.methods.MethodSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
@@ -55,7 +56,7 @@ public class MethodInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        namedOneOf(methodNames.toArray(new String[0])),
+        namedOneOf(methodNames.toArray(new String[0])).and(isMethod()),
         mapping ->
             mapping.bind(
                 MethodReturnType.class,


### PR DESCRIPTION
This is mostly for consistency with annotation based method instrumentations. The name that matched constructor is an empty string, but that isn't accepted by the `MethodsConfigurationParser`.