### PR TITLE
Remove most usages of junit ArgumentsProvider

### DIFF
--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
@@ -11,23 +11,187 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class RedisCommandSanitizerTest {
 
   @ParameterizedTest
-  @ArgumentsSource(SanitizeArgs.class)
+  @MethodSource("sanitizeArgs")
   void shouldSanitizeExpected(String command, List<String> args, String expected) {
     String result = RedisCommandSanitizer.create(true).sanitize(command, args);
     assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
-  @ArgumentsSource(KeepArguments.class)
+  @CsvSource({
+    // Cluster
+    "CLUSTER",
+    "READONLY",
+    "READWRITE",
+    // Connection
+    "CLIENT",
+    "ECHO",
+    "PING",
+    "QUIT",
+    "SELECT",
+    // Geo
+    "GEOADD",
+    "GEODIST",
+    "GEOHASH",
+    "GEOPOS",
+    "GEORADIUS",
+    "GEORADIUSBYMEMBER",
+    // Hashes
+    "HDEL",
+    "HEXISTS",
+    "HGET",
+    "HGETALL",
+    "HINCRBY",
+    "HINCRBYFLOAT",
+    "HKEYS",
+    "HLEN",
+    "HMGET",
+    "HSCAN",
+    "HSTRLEN",
+    "HVALS",
+    // HyperLogLog
+    "PFCOUNT",
+    "PFMERGE",
+    // Keys
+    "DEL",
+    "DUMP",
+    "EXISTS",
+    "EXPIRE",
+    "EXPIREAT",
+    "KEYS",
+    "MOVE",
+    "OBJECT",
+    "PERSIST",
+    "PEXPIRE",
+    "PEXPIREAT",
+    "PTTL",
+    "RANDOMKEY",
+    "RENAME",
+    "RENAMENX",
+    "RESTORE",
+    "SCAN",
+    "SORT",
+    "TOUCH",
+    "TTL",
+    "TYPE",
+    "UNLINK",
+    "WAIT",
+    // Lists
+    "BLMOVE",
+    "BLPOP",
+    "BRPOP",
+    "BRPOPLPUSH",
+    "LINDEX",
+    "LLEN",
+    "LMOVE",
+    "LPOP",
+    "LRANGE",
+    "LTRIM",
+    "RPOP",
+    "RPOPLPUSH",
+    // Pub/Sub
+    "PSUBSCRIBE",
+    "PUBSUB",
+    "PUNSUBSCRIBE",
+    "SUBSCRIBE",
+    "UNSUBSCRIBE",
+    // Server
+    "ACL",
+    "BGREWRITEAOF",
+    "BGSAVE",
+    "COMMAND",
+    "DBSIZE",
+    "DEBUG",
+    "FLUSHALL",
+    "FLUSHDB",
+    "INFO",
+    "LASTSAVE",
+    "LATENCY",
+    "LOLWUT",
+    "MEMORY",
+    "MODULE",
+    "MONITOR",
+    "PSYNC",
+    "REPLICAOF",
+    "ROLE",
+    "SAVE",
+    "SHUTDOWN",
+    "SLAVEOF",
+    "SLOWLOG",
+    "SWAPDB",
+    "SYNC",
+    "TIME",
+    // Sets
+    "SCARD",
+    "SDIFF",
+    "SDIFFSTORE",
+    "SINTER",
+    "SINTERSTORE",
+    "SMEMBERS",
+    "SPOP",
+    "SRANDMEMBER",
+    "SSCAN",
+    "SUNION",
+    "SUNIONSTORE",
+    // Sorted Sets
+    "BZPOPMAX",
+    "BZPOPMIN",
+    "ZCARD",
+    "ZINTER",
+    "ZINTERSTORE",
+    "ZPOPMAX",
+    "ZPOPMIN",
+    "ZRANGE",
+    "ZREMRANGEBYRANK",
+    "ZREVRANGE",
+    "ZSCAN",
+    "ZUNION",
+    "ZUNIONSTORE",
+    // Streams
+    "XACK",
+    "XCLAIM",
+    "XDEL",
+    "XGROUP",
+    "XINFO",
+    "XLEN",
+    "XPENDING",
+    "XRANGE",
+    "XREAD",
+    "XREADGROUP",
+    "XREVRANGE",
+    "XTRIM",
+    // Strings
+    "BITCOUNT",
+    "BITFIELD",
+    "BITOP",
+    "BITPOS",
+    "DECR",
+    "DECRBY",
+    "GET",
+    "GETBIT",
+    "GETRANGE",
+    "INCR",
+    "INCRBY",
+    "INCRBYFLOAT",
+    "MGET",
+    "SETBIT",
+    "STRALGO",
+    "STRLEN",
+    // Transactions
+    "DISCARD",
+    "EXEC",
+    "MULTI",
+    "UNWATCH",
+    "WATCH"
+  })
   void shouldKeepAllArguments(String command) {
     List<String> args = list("arg1", "arg 2");
     String result = RedisCommandSanitizer.create(true).sanitize(command, args);
@@ -41,260 +205,82 @@ class RedisCommandSanitizerTest {
     assertThat(result).isEqualTo("NEWAUTH ? ?");
   }
 
-  static class SanitizeArgs implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-      return Stream.of(
-          // Connection
-          Arguments.of("AUTH", list("password"), "AUTH ?"),
-          Arguments.of("HELLO", list("3", "AUTH", "username", "password"), "HELLO 3 AUTH ? ?"),
-          Arguments.of("HELLO", list("3"), "HELLO 3"),
-          // Hashes
-          Arguments.of(
-              "HMSET",
-              list("hash", "key1", "value1", "key2", "value2"),
-              "HMSET hash key1 ? key2 ?"),
-          Arguments.of(
-              "HSET", list("hash", "key1", "value1", "key2", "value2"), "HSET hash key1 ? key2 ?"),
-          Arguments.of("HSETNX", list("hash", "key", "value"), "HSETNX hash key ?"),
-          // HyperLogLog
-          Arguments.of("PFADD", list("hll", "a", "b", "c"), "PFADD hll ? ? ?"),
-          // Keys
-          Arguments.of(
-              "MIGRATE",
-              list("127.0.0.1", "4242", "key", "0", "5000", "AUTH", "password"),
-              "MIGRATE 127.0.0.1 4242 key 0 5000 AUTH ?"),
-          Arguments.of("RESTORE", list("key", "42", "value"), "RESTORE key 42 ?"),
-          // Lists
-          Arguments.of(
-              "LINSERT", list("list", "BEFORE", "value1", "value2"), "LINSERT list BEFORE ? ?"),
-          Arguments.of("LPOS", list("list", "value"), "LPOS list ?"),
-          Arguments.of("LPUSH", list("list", "value1", "value2"), "LPUSH list ? ?"),
-          Arguments.of("LPUSHX", list("list", "value1", "value2"), "LPUSHX list ? ?"),
-          Arguments.of("LREM", list("list", "2", "value"), "LREM list ? ?"),
-          Arguments.of("LSET", list("list", "2", "value"), "LSET list ? ?"),
-          Arguments.of("RPUSH", list("list", "value1", "value2"), "RPUSH list ? ?"),
-          Arguments.of("RPUSHX", list("list", "value1", "value2"), "RPUSHX list ? ?"),
-          // Pub/Sub
-          Arguments.of("PUBLISH", list("channel", "message"), "PUBLISH channel ?"),
-          // Scripting
-          Arguments.of(
-              "EVAL", list("script", "2", "key1", "key2", "value"), "EVAL script 2 key1 key2 ?"),
-          Arguments.of("EVALSHA", list("sha1", "0", "value1", "value2"), "EVALSHA sha1 0 ? ?"),
-          // Sets),
-          Arguments.of("SADD", list("set", "value1", "value2"), "SADD set ? ?"),
-          Arguments.of("SISMEMBER", list("set", "value"), "SISMEMBER set ?"),
-          Arguments.of("SMISMEMBER", list("set", "value1", "value2"), "SMISMEMBER set ? ?"),
-          Arguments.of("SMOVE", list("set1", "set2", "value"), "SMOVE set1 set2 ?"),
-          Arguments.of("SREM", list("set", "value1", "value2"), "SREM set ? ?"),
-          // Server
-          Arguments.of(
-              "CONFIG", list("SET", "masterpassword", "password"), "CONFIG SET masterpassword ?"),
-          // Sorted Sets
-          Arguments.of("ZADD", list("sset", "1", "value1", "2", "value2"), "ZADD sset ? ? ? ?"),
-          Arguments.of("ZCOUNT", list("sset", "1", "10"), "ZCOUNT sset ? ?"),
-          Arguments.of("ZINCRBY", list("sset", "1", "value"), "ZINCRBY sset ? ?"),
-          Arguments.of("ZLEXCOUNT", list("sset", "1", "10"), "ZLEXCOUNT sset ? ?"),
-          Arguments.of("ZMSCORE", list("sset", "value1", "value2"), "ZMSCORE sset ? ?"),
-          Arguments.of("ZRANGEBYLEX", list("sset", "1", "10"), "ZRANGEBYLEX sset ? ?"),
-          Arguments.of("ZRANGEBYSCORE", list("sset", "1", "10"), "ZRANGEBYSCORE sset ? ?"),
-          Arguments.of("ZRANK", list("sset", "value"), "ZRANK sset ?"),
-          Arguments.of("ZREM", list("sset", "value1", "value2"), "ZREM sset ? ?"),
-          Arguments.of("ZREMRANGEBYLEX", list("sset", "1", "10"), "ZREMRANGEBYLEX sset ? ?"),
-          Arguments.of("ZREMRANGEBYSCORE", list("sset", "1", "10"), "ZREMRANGEBYSCORE sset ? ?"),
-          Arguments.of("ZREVRANGEBYLEX", list("sset", "1", "10"), "ZREVRANGEBYLEX sset ? ?"),
-          Arguments.of("ZREVRANGEBYSCORE", list("sset", "1", "10"), "ZREVRANGEBYSCORE sset ? ?"),
-          Arguments.of("ZREVRANK", list("sset", "value"), "ZREVRANK sset ?"),
-          Arguments.of("ZSCORE", list("sset", "value"), "ZSCORE sset ?"),
-          // Streams
-          Arguments.of(
-              "XADD",
-              list("stream", "*", "key1", "value1", "key2", "value2"),
-              "XADD stream * key1 ? key2 ?"),
-          // Strings
-          Arguments.of("APPEND", list("key", "value"), "APPEND key ?"),
-          Arguments.of("GETSET", list("key", "value"), "GETSET key ?"),
-          Arguments.of("MSET", list("key1", "value1", "key2", "value2"), "MSET key1 ? key2 ?"),
-          Arguments.of("MSETNX", list("key1", "value1", "key2", "value2"), "MSETNX key1 ? key2 ?"),
-          Arguments.of("PSETEX", list("key", "10000", "value"), "PSETEX key 10000 ?"),
-          Arguments.of("SET", list("key", "value"), "SET key ?"),
-          Arguments.of("SETEX", list("key", "10", "value"), "SETEX key 10 ?"),
-          Arguments.of("SETNX", list("key", "value"), "SETNX key ?"),
-          Arguments.of("SETRANGE", list("key", "42", "value"), "SETRANGE key ? ?"));
-    }
-  }
-
-  static class KeepArguments implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-      return Stream.of(
-              // Cluster
-              "CLUSTER",
-              "READONLY",
-              "READWRITE",
-              // Connection
-              "CLIENT",
-              "ECHO",
-              "PING",
-              "QUIT",
-              "SELECT",
-              // Geo
-              "GEOADD",
-              "GEODIST",
-              "GEOHASH",
-              "GEOPOS",
-              "GEORADIUS",
-              "GEORADIUSBYMEMBER",
-              // Hashes
-              "HDEL",
-              "HEXISTS",
-              "HGET",
-              "HGETALL",
-              "HINCRBY",
-              "HINCRBYFLOAT",
-              "HKEYS",
-              "HLEN",
-              "HMGET",
-              "HSCAN",
-              "HSTRLEN",
-              "HVALS",
-              // HyperLogLog
-              "PFCOUNT",
-              "PFMERGE",
-              // Keys
-              "DEL",
-              "DUMP",
-              "EXISTS",
-              "EXPIRE",
-              "EXPIREAT",
-              "KEYS",
-              "MOVE",
-              "OBJECT",
-              "PERSIST",
-              "PEXPIRE",
-              "PEXPIREAT",
-              "PTTL",
-              "RANDOMKEY",
-              "RENAME",
-              "RENAMENX",
-              "RESTORE",
-              "SCAN",
-              "SORT",
-              "TOUCH",
-              "TTL",
-              "TYPE",
-              "UNLINK",
-              "WAIT",
-              // Lists
-              "BLMOVE",
-              "BLPOP",
-              "BRPOP",
-              "BRPOPLPUSH",
-              "LINDEX",
-              "LLEN",
-              "LMOVE",
-              "LPOP",
-              "LRANGE",
-              "LTRIM",
-              "RPOP",
-              "RPOPLPUSH",
-              // Pub/Sub
-              "PSUBSCRIBE",
-              "PUBSUB",
-              "PUNSUBSCRIBE",
-              "SUBSCRIBE",
-              "UNSUBSCRIBE",
-              // Server
-              "ACL",
-              "BGREWRITEAOF",
-              "BGSAVE",
-              "COMMAND",
-              "DBSIZE",
-              "DEBUG",
-              "FLUSHALL",
-              "FLUSHDB",
-              "INFO",
-              "LASTSAVE",
-              "LATENCY",
-              "LOLWUT",
-              "MEMORY",
-              "MODULE",
-              "MONITOR",
-              "PSYNC",
-              "REPLICAOF",
-              "ROLE",
-              "SAVE",
-              "SHUTDOWN",
-              "SLAVEOF",
-              "SLOWLOG",
-              "SWAPDB",
-              "SYNC",
-              "TIME",
-              // Sets
-              "SCARD",
-              "SDIFF",
-              "SDIFFSTORE",
-              "SINTER",
-              "SINTERSTORE",
-              "SMEMBERS",
-              "SPOP",
-              "SRANDMEMBER",
-              "SSCAN",
-              "SUNION",
-              "SUNIONSTORE",
-              // Sorted Sets
-              "BZPOPMAX",
-              "BZPOPMIN",
-              "ZCARD",
-              "ZINTER",
-              "ZINTERSTORE",
-              "ZPOPMAX",
-              "ZPOPMIN",
-              "ZRANGE",
-              "ZREMRANGEBYRANK",
-              "ZREVRANGE",
-              "ZSCAN",
-              "ZUNION",
-              "ZUNIONSTORE",
-              // Streams
-              "XACK",
-              "XCLAIM",
-              "XDEL",
-              "XGROUP",
-              "XINFO",
-              "XLEN",
-              "XPENDING",
-              "XRANGE",
-              "XREAD",
-              "XREADGROUP",
-              "XREVRANGE",
-              "XTRIM",
-              // Strings
-              "BITCOUNT",
-              "BITFIELD",
-              "BITOP",
-              "BITPOS",
-              "DECR",
-              "DECRBY",
-              "GET",
-              "GETBIT",
-              "GETRANGE",
-              "INCR",
-              "INCRBY",
-              "INCRBYFLOAT",
-              "MGET",
-              "SETBIT",
-              "STRALGO",
-              "STRLEN",
-              // Transactions
-              "DISCARD",
-              "EXEC",
-              "MULTI",
-              "UNWATCH",
-              "WATCH")
-          .map(Arguments::of);
-    }
+  static Stream<Arguments> sanitizeArgs() {
+    return Stream.of(
+        // Connection
+        Arguments.of("AUTH", list("password"), "AUTH ?"),
+        Arguments.of("HELLO", list("3", "AUTH", "username", "password"), "HELLO 3 AUTH ? ?"),
+        Arguments.of("HELLO", list("3"), "HELLO 3"),
+        // Hashes
+        Arguments.of(
+            "HMSET", list("hash", "key1", "value1", "key2", "value2"), "HMSET hash key1 ? key2 ?"),
+        Arguments.of(
+            "HSET", list("hash", "key1", "value1", "key2", "value2"), "HSET hash key1 ? key2 ?"),
+        Arguments.of("HSETNX", list("hash", "key", "value"), "HSETNX hash key ?"),
+        // HyperLogLog
+        Arguments.of("PFADD", list("hll", "a", "b", "c"), "PFADD hll ? ? ?"),
+        // Keys
+        Arguments.of(
+            "MIGRATE",
+            list("127.0.0.1", "4242", "key", "0", "5000", "AUTH", "password"),
+            "MIGRATE 127.0.0.1 4242 key 0 5000 AUTH ?"),
+        Arguments.of("RESTORE", list("key", "42", "value"), "RESTORE key 42 ?"),
+        // Lists
+        Arguments.of(
+            "LINSERT", list("list", "BEFORE", "value1", "value2"), "LINSERT list BEFORE ? ?"),
+        Arguments.of("LPOS", list("list", "value"), "LPOS list ?"),
+        Arguments.of("LPUSH", list("list", "value1", "value2"), "LPUSH list ? ?"),
+        Arguments.of("LPUSHX", list("list", "value1", "value2"), "LPUSHX list ? ?"),
+        Arguments.of("LREM", list("list", "2", "value"), "LREM list ? ?"),
+        Arguments.of("LSET", list("list", "2", "value"), "LSET list ? ?"),
+        Arguments.of("RPUSH", list("list", "value1", "value2"), "RPUSH list ? ?"),
+        Arguments.of("RPUSHX", list("list", "value1", "value2"), "RPUSHX list ? ?"),
+        // Pub/Sub
+        Arguments.of("PUBLISH", list("channel", "message"), "PUBLISH channel ?"),
+        // Scripting
+        Arguments.of(
+            "EVAL", list("script", "2", "key1", "key2", "value"), "EVAL script 2 key1 key2 ?"),
+        Arguments.of("EVALSHA", list("sha1", "0", "value1", "value2"), "EVALSHA sha1 0 ? ?"),
+        // Sets),
+        Arguments.of("SADD", list("set", "value1", "value2"), "SADD set ? ?"),
+        Arguments.of("SISMEMBER", list("set", "value"), "SISMEMBER set ?"),
+        Arguments.of("SMISMEMBER", list("set", "value1", "value2"), "SMISMEMBER set ? ?"),
+        Arguments.of("SMOVE", list("set1", "set2", "value"), "SMOVE set1 set2 ?"),
+        Arguments.of("SREM", list("set", "value1", "value2"), "SREM set ? ?"),
+        // Server
+        Arguments.of(
+            "CONFIG", list("SET", "masterpassword", "password"), "CONFIG SET masterpassword ?"),
+        // Sorted Sets
+        Arguments.of("ZADD", list("sset", "1", "value1", "2", "value2"), "ZADD sset ? ? ? ?"),
+        Arguments.of("ZCOUNT", list("sset", "1", "10"), "ZCOUNT sset ? ?"),
+        Arguments.of("ZINCRBY", list("sset", "1", "value"), "ZINCRBY sset ? ?"),
+        Arguments.of("ZLEXCOUNT", list("sset", "1", "10"), "ZLEXCOUNT sset ? ?"),
+        Arguments.of("ZMSCORE", list("sset", "value1", "value2"), "ZMSCORE sset ? ?"),
+        Arguments.of("ZRANGEBYLEX", list("sset", "1", "10"), "ZRANGEBYLEX sset ? ?"),
+        Arguments.of("ZRANGEBYSCORE", list("sset", "1", "10"), "ZRANGEBYSCORE sset ? ?"),
+        Arguments.of("ZRANK", list("sset", "value"), "ZRANK sset ?"),
+        Arguments.of("ZREM", list("sset", "value1", "value2"), "ZREM sset ? ?"),
+        Arguments.of("ZREMRANGEBYLEX", list("sset", "1", "10"), "ZREMRANGEBYLEX sset ? ?"),
+        Arguments.of("ZREMRANGEBYSCORE", list("sset", "1", "10"), "ZREMRANGEBYSCORE sset ? ?"),
+        Arguments.of("ZREVRANGEBYLEX", list("sset", "1", "10"), "ZREVRANGEBYLEX sset ? ?"),
+        Arguments.of("ZREVRANGEBYSCORE", list("sset", "1", "10"), "ZREVRANGEBYSCORE sset ? ?"),
+        Arguments.of("ZREVRANK", list("sset", "value"), "ZREVRANK sset ?"),
+        Arguments.of("ZSCORE", list("sset", "value"), "ZSCORE sset ?"),
+        // Streams
+        Arguments.of(
+            "XADD",
+            list("stream", "*", "key1", "value1", "key2", "value2"),
+            "XADD stream * key1 ? key2 ?"),
+        // Strings
+        Arguments.of("APPEND", list("key", "value"), "APPEND key ?"),
+        Arguments.of("GETSET", list("key", "value"), "GETSET key ?"),
+        Arguments.of("MSET", list("key1", "value1", "key2", "value2"), "MSET key1 ? key2 ?"),
+        Arguments.of("MSETNX", list("key1", "value1", "key2", "value2"), "MSETNX key1 ? key2 ?"),
+        Arguments.of("PSETEX", list("key", "10000", "value"), "PSETEX key 10000 ?"),
+        Arguments.of("SET", list("key", "value"), "SET key ?"),
+        Arguments.of("SETEX", list("key", "10", "value"), "SETEX key 10 ?"),
+        Arguments.of("SETNX", list("key", "value"), "SETNX key ?"),
+        Arguments.of("SETRANGE", list("key", "42", "value"), "SETRANGE key ? ?"));
   }
 
   static List<String> list(String... args) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -11,23 +11,21 @@ import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class SqlStatementSanitizerTest {
 
   @ParameterizedTest
-  @ArgumentsSource(SqlArgs.class)
+  @MethodSource("sqlArgs")
   void sanitizeSql(String original, String expected) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(original);
     assertThat(result.getFullStatement()).isEqualTo(expected);
   }
 
   @ParameterizedTest
-  @ArgumentsSource(CouchbaseArgs.class)
+  @MethodSource("couchbaseArgs")
   void normalizeCouchbase(String original, String expected) {
     SqlStatementInfo result =
         SqlStatementSanitizer.create(true).sanitize(original, SqlDialect.COUCHBASE);
@@ -35,7 +33,7 @@ public class SqlStatementSanitizerTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(SimplifyArgs.class)
+  @MethodSource("simplifyArgs")
   void simplifySql(String original, Function<String, SqlStatementInfo> expectedFunction) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(original);
     SqlStatementInfo expected = expectedFunction.apply(original);
@@ -61,7 +59,7 @@ public class SqlStatementSanitizerTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(DdlArgs.class)
+  @MethodSource("ddlArgs")
   void checkDdlOperationStatementsAreOk(
       String actual, Function<String, SqlStatementInfo> expectFunc) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(actual);
@@ -158,273 +156,235 @@ public class SqlStatementSanitizerTest {
     assertThat(SqlStatementSanitizer.isCached(largeStatement)).isFalse();
   }
 
-  static class SqlArgs implements ArgumentsProvider {
+  private static Stream<Arguments> sqlArgs() {
+    return Stream.of(
+        Arguments.of("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = 1234", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD>=-1234", "SELECT * FROM TABLE WHERE FIELD>=?"),
+        Arguments.of("SELECT * FROM TABLE WHERE FIELD<-1234", "SELECT * FROM TABLE WHERE FIELD<?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD <.1234", "SELECT * FROM TABLE WHERE FIELD <?"),
+        Arguments.of("SELECT 1.2", "SELECT ?"),
+        Arguments.of("SELECT -1.2", "SELECT ?"),
+        Arguments.of("SELECT -1.2e-9", "SELECT ?"),
+        Arguments.of("SELECT 2E+9", "SELECT ?"),
+        Arguments.of("SELECT +0.2", "SELECT ?"),
+        Arguments.of("SELECT .2", "SELECT ?"),
+        Arguments.of("7", "?"),
+        Arguments.of(".7", "?"),
+        Arguments.of("-7", "?"),
+        Arguments.of("+7", "?"),
+        Arguments.of("SELECT 0x0af764", "SELECT ?"),
+        Arguments.of("SELECT 0xdeadBEEF", "SELECT ?"),
+        Arguments.of("SELECT * FROM \"TABLE\"", "SELECT * FROM \"TABLE\""),
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = 1234", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD>=-1234", "SELECT * FROM TABLE WHERE FIELD>=?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD<-1234", "SELECT * FROM TABLE WHERE FIELD<?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD <.1234", "SELECT * FROM TABLE WHERE FIELD <?"),
-          Arguments.of("SELECT 1.2", "SELECT ?"),
-          Arguments.of("SELECT -1.2", "SELECT ?"),
-          Arguments.of("SELECT -1.2e-9", "SELECT ?"),
-          Arguments.of("SELECT 2E+9", "SELECT ?"),
-          Arguments.of("SELECT +0.2", "SELECT ?"),
-          Arguments.of("SELECT .2", "SELECT ?"),
-          Arguments.of("7", "?"),
-          Arguments.of(".7", "?"),
-          Arguments.of("-7", "?"),
-          Arguments.of("+7", "?"),
-          Arguments.of("SELECT 0x0af764", "SELECT ?"),
-          Arguments.of("SELECT 0xdeadBEEF", "SELECT ?"),
-          Arguments.of("SELECT * FROM \"TABLE\"", "SELECT * FROM \"TABLE\""),
+        // Not numbers but could be confused as such
+        Arguments.of("SELECT A + B", "SELECT A + B"),
+        Arguments.of("SELECT -- comment", "SELECT -- comment"),
+        Arguments.of("SELECT * FROM TABLE123", "SELECT * FROM TABLE123"),
+        Arguments.of(
+            "SELECT FIELD2 FROM TABLE_123 WHERE X<>7", "SELECT FIELD2 FROM TABLE_123 WHERE X<>?"),
 
-          // Not numbers but could be confused as such
-          Arguments.of("SELECT A + B", "SELECT A + B"),
-          Arguments.of("SELECT -- comment", "SELECT -- comment"),
-          Arguments.of("SELECT * FROM TABLE123", "SELECT * FROM TABLE123"),
-          Arguments.of(
-              "SELECT FIELD2 FROM TABLE_123 WHERE X<>7", "SELECT FIELD2 FROM TABLE_123 WHERE X<>?"),
+        // Semi-nonsensical almost-numbers to elide or not
+        Arguments.of("SELECT --83--...--8e+76e3E-1", "SELECT ?"),
+        Arguments.of("SELECT DEADBEEF", "SELECT DEADBEEF"),
+        Arguments.of("SELECT 123-45-6789", "SELECT ?"),
+        Arguments.of("SELECT 1/2/34", "SELECT ?/?/?"),
 
-          // Semi-nonsensical almost-numbers to elide or not
-          Arguments.of("SELECT --83--...--8e+76e3E-1", "SELECT ?"),
-          Arguments.of("SELECT DEADBEEF", "SELECT DEADBEEF"),
-          Arguments.of("SELECT 123-45-6789", "SELECT ?"),
-          Arguments.of("SELECT 1/2/34", "SELECT ?/?/?"),
+        // Basic ' strings
+        Arguments.of("SELECT * FROM TABLE WHERE FIELD = ''", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = 'words and spaces'",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = ' an escaped '' quote mark inside'",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = '\\\\'", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = '\"inside doubles\"'",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = '\"$$$$\"'", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = 'a single \" doublequote inside'",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
 
-          // Basic ' strings
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = ''", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = 'words and spaces'",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = ' an escaped '' quote mark inside'",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = '\\\\'", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = '\"inside doubles\"'",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = '\"$$$$\"'",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = 'a single \" doublequote inside'",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
+        // Some databases allow using dollar-quoted strings
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $$$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $$words and spaces$$",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $$quotes '\" inside$$",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $$\"''\"$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $$\\\\$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
 
-          // Some databases allow using dollar-quoted strings
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $$$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $$words and spaces$$",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $$quotes '\" inside$$",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $$\"''\"$$",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $$\\\\$$", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        // PostgreSQL native parameter marker, we want to keep $1 instead of replacing it with ?
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = $1", "SELECT * FROM TABLE WHERE FIELD = $1"),
 
-          // PostgreSQL native parameter marker, we want to keep $1 instead of replacing it with ?
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = $1", "SELECT * FROM TABLE WHERE FIELD = $1"),
+        // Unicode, including a unicode identifier with a trailing number
+        Arguments.of(
+            "SELECT * FROM TABLEओ7 WHERE FIELD = 'ɣ'", "SELECT * FROM TABLEओ7 WHERE FIELD = ?"),
 
-          // Unicode, including a unicode identifier with a trailing number
-          Arguments.of(
-              "SELECT * FROM TABLEओ7 WHERE FIELD = 'ɣ'", "SELECT * FROM TABLEओ7 WHERE FIELD = ?"),
+        // whitespace normalization
+        Arguments.of(
+            "SELECT    *    \t\r\nFROM  TABLE WHERE FIELD1 = 12344 AND FIELD2 = 5678",
+            "SELECT * FROM TABLE WHERE FIELD1 = ? AND FIELD2 = ?"),
 
-          // whitespace normalization
-          Arguments.of(
-              "SELECT    *    \t\r\nFROM  TABLE WHERE FIELD1 = 12344 AND FIELD2 = 5678",
-              "SELECT * FROM TABLE WHERE FIELD1 = ? AND FIELD2 = ?"),
-
-          // hibernate/jpa query language
-          Arguments.of("FROM TABLE WHERE FIELD=1234", "FROM TABLE WHERE FIELD=?"));
-    }
+        // hibernate/jpa query language
+        Arguments.of("FROM TABLE WHERE FIELD=1234", "FROM TABLE WHERE FIELD=?"));
   }
 
-  static class CouchbaseArgs implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          // Some databases support/encourage " instead of ' with same escape rules
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"\"", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"words and spaces'\"",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \" an escaped \"\" quote mark inside\"",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"\\\\\"", "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"'inside singles'\"",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"'$$$$'\"",
-              "SELECT * FROM TABLE WHERE FIELD = ?"),
-          Arguments.of(
-              "SELECT * FROM TABLE WHERE FIELD = \"a single ' singlequote inside\"",
-              "SELECT * FROM TABLE WHERE FIELD = ?"));
-    }
+  private static Stream<Arguments> couchbaseArgs() {
+    return Stream.of(
+        // Some databases support/encourage " instead of ' with same escape rules
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"\"", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"words and spaces'\"",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \" an escaped \"\" quote mark inside\"",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"\\\\\"", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"'inside singles'\"",
+            "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"'$$$$'\"", "SELECT * FROM TABLE WHERE FIELD = ?"),
+        Arguments.of(
+            "SELECT * FROM TABLE WHERE FIELD = \"a single ' singlequote inside\"",
+            "SELECT * FROM TABLE WHERE FIELD = ?"));
   }
 
-  static class SimplifyArgs implements ArgumentsProvider {
-
-    static Function<String, SqlStatementInfo> expect(String operation, String identifier) {
-      return sql -> SqlStatementInfo.create(sql, operation, identifier);
-    }
-
-    static Function<String, SqlStatementInfo> expect(
-        String sql, String operation, String identifier) {
-      return ignored -> SqlStatementInfo.create(sql, operation, identifier);
-    }
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          // Select
-          Arguments.of("SELECT x, y, z FROM schema.table", expect("SELECT", "schema.table")),
-          Arguments.of("SELECT x, y, z FROM `schema table`", expect("SELECT", "schema table")),
-          Arguments.of(
-              "SELECT x, y, z FROM `schema`.`table`", expect("SELECT", "`schema`.`table`")),
-          Arguments.of("SELECT x, y, z FROM \"schema table\"", expect("SELECT", "schema table")),
-          Arguments.of(
-              "SELECT x, y, z FROM \"schema\".\"table\"", expect("SELECT", "\"schema\".\"table\"")),
-          Arguments.of(
-              "WITH subquery as (select a from b) SELECT x, y, z FROM table",
-              expect("SELECT", null)),
-          Arguments.of("SELECT x, y, (select a from b) as z FROM table", expect("SELECT", null)),
-          Arguments.of(
-              "select delete, insert into, merge, update from table", expect("SELECT", "table")),
-          Arguments.of("select col /* from table2 */ from table", expect("SELECT", "table")),
-          Arguments.of("select col from table join anotherTable", expect("SELECT", null)),
-          Arguments.of("select col from (select * from anotherTable)", expect("SELECT", null)),
-          Arguments.of(
-              "select col from (select * from anotherTable) alias", expect("SELECT", null)),
-          Arguments.of(
-              "select col from table1 union select col from table2", expect("SELECT", null)),
-          Arguments.of(
-              "select col from table where col in (select * from anotherTable)",
-              expect("SELECT", null)),
-          Arguments.of("select col from table1, table2", expect("SELECT", null)),
-          Arguments.of("select col from table1 t1, table2 t2", expect("SELECT", null)),
-          Arguments.of("select col from table1 as t1, table2 as t2", expect("SELECT", null)),
-          Arguments.of(
-              "select col from table where col in (1, 2, 3)",
-              expect("select col from table where col in (?)", "SELECT", "table")),
-          Arguments.of(
-              "select 'a' IN(x, 'b') from table where col in (1) and z IN( '3', '4' )",
-              expect(
-                  "select ? IN(x, ?) from table where col in (?) and z IN(?)", "SELECT", "table")),
-          Arguments.of("select col from table order by col, col2", expect("SELECT", "table")),
-          Arguments.of("select ąś∂ń© from źćļńĶ order by col, col2", expect("SELECT", "źćļńĶ")),
-          Arguments.of("select 12345678", expect("select ?", "SELECT", null)),
-          Arguments.of("/* update comment */ select * from table1", expect("SELECT", "table1")),
-          Arguments.of("select /*((*/abc from table", expect("SELECT", "table")),
-          Arguments.of("SeLeCT * FrOm TAblE", expect("SELECT", "table")),
-          Arguments.of("select next value in hibernate_sequence", expect("SELECT", null)),
-
-          // hibernate/jpa
-          Arguments.of("FROM schema.table", expect("SELECT", "schema.table")),
-          Arguments.of("/* update comment */ from table1", expect("SELECT", "table1")),
-
-          // Insert
-          Arguments.of(" insert into table where lalala", expect("INSERT", "table")),
-          Arguments.of("insert insert into table where lalala", expect("INSERT", "table")),
-          Arguments.of("insert into db.table where lalala", expect("INSERT", "db.table")),
-          Arguments.of("insert into `db table` where lalala", expect("INSERT", "db table")),
-          Arguments.of("insert into \"db table\" where lalala", expect("INSERT", "db table")),
-          Arguments.of("insert without i-n-t-o", expect("INSERT", null)),
-
-          // Delete
-          Arguments.of("delete from table where something something", expect("DELETE", "table")),
-          Arguments.of(
-              "delete from `my table` where something something", expect("DELETE", "my table")),
-          Arguments.of(
-              "delete from \"my table\" where something something", expect("DELETE", "my table")),
-          Arguments.of(
-              "delete from foo where x IN (1,2,3)",
-              expect("delete from foo where x IN (?)", "DELETE", "foo")),
-          Arguments.of("delete from 12345678", expect("delete from ?", "DELETE", null)),
-          Arguments.of("delete   (((", expect("delete (((", "DELETE", null)),
-
-          // Update
-          Arguments.of(
-              "update table set answer=42", expect("update table set answer=?", "UPDATE", "table")),
-          Arguments.of(
-              "update `my table` set answer=42",
-              expect("update `my table` set answer=?", "UPDATE", "my table")),
-          Arguments.of(
-              "update `my table` set answer=42 where x IN('a', 'b') AND y In ('a',  'b')",
-              expect(
-                  "update `my table` set answer=? where x IN(?) AND y In (?)",
-                  "UPDATE",
-                  "my table")),
-          Arguments.of(
-              "update \"my table\" set answer=42",
-              expect("update \"my table\" set answer=?", "UPDATE", "my table")),
-          Arguments.of("update /*table", expect("UPDATE", null)),
-
-          // Call
-          Arguments.of("call test_proc()", expect("CALL", "test_proc")),
-          Arguments.of("call test_proc", expect("CALL", "test_proc")),
-          Arguments.of("call next value in hibernate_sequence", expect("CALL", null)),
-          Arguments.of("call db.test_proc", expect("CALL", "db.test_proc")),
-
-          // Merge
-          Arguments.of("merge into table", expect("MERGE", "table")),
-          Arguments.of("merge into `my table`", expect("MERGE", "my table")),
-          Arguments.of("merge into \"my table\"", expect("MERGE", "my table")),
-          Arguments.of("merge table (into is optional in some dbs)", expect("MERGE", "table")),
-          Arguments.of("merge (into )))", expect("MERGE", null)),
-
-          // Unknown operation
-          Arguments.of("and now for something completely different", expect(null, null)),
-          Arguments.of("", expect(null, null)),
-          Arguments.of(null, expect(null, null)));
-    }
+  private static Function<String, SqlStatementInfo> expect(String operation, String identifier) {
+    return sql -> SqlStatementInfo.create(sql, operation, identifier);
   }
 
-  static class DdlArgs implements ArgumentsProvider {
+  private static Function<String, SqlStatementInfo> expect(
+      String sql, String operation, String identifier) {
+    return ignored -> SqlStatementInfo.create(sql, operation, identifier);
+  }
 
-    static Function<String, SqlStatementInfo> expect(String operation, String identifier) {
-      return sql -> SqlStatementInfo.create(sql, operation, identifier);
-    }
+  private static Stream<Arguments> simplifyArgs() {
+    return Stream.of(
+        // Select
+        Arguments.of("SELECT x, y, z FROM schema.table", expect("SELECT", "schema.table")),
+        Arguments.of("SELECT x, y, z FROM `schema table`", expect("SELECT", "schema table")),
+        Arguments.of("SELECT x, y, z FROM `schema`.`table`", expect("SELECT", "`schema`.`table`")),
+        Arguments.of("SELECT x, y, z FROM \"schema table\"", expect("SELECT", "schema table")),
+        Arguments.of(
+            "SELECT x, y, z FROM \"schema\".\"table\"", expect("SELECT", "\"schema\".\"table\"")),
+        Arguments.of(
+            "WITH subquery as (select a from b) SELECT x, y, z FROM table", expect("SELECT", null)),
+        Arguments.of("SELECT x, y, (select a from b) as z FROM table", expect("SELECT", null)),
+        Arguments.of(
+            "select delete, insert into, merge, update from table", expect("SELECT", "table")),
+        Arguments.of("select col /* from table2 */ from table", expect("SELECT", "table")),
+        Arguments.of("select col from table join anotherTable", expect("SELECT", null)),
+        Arguments.of("select col from (select * from anotherTable)", expect("SELECT", null)),
+        Arguments.of("select col from (select * from anotherTable) alias", expect("SELECT", null)),
+        Arguments.of("select col from table1 union select col from table2", expect("SELECT", null)),
+        Arguments.of(
+            "select col from table where col in (select * from anotherTable)",
+            expect("SELECT", null)),
+        Arguments.of("select col from table1, table2", expect("SELECT", null)),
+        Arguments.of("select col from table1 t1, table2 t2", expect("SELECT", null)),
+        Arguments.of("select col from table1 as t1, table2 as t2", expect("SELECT", null)),
+        Arguments.of(
+            "select col from table where col in (1, 2, 3)",
+            expect("select col from table where col in (?)", "SELECT", "table")),
+        Arguments.of(
+            "select 'a' IN(x, 'b') from table where col in (1) and z IN( '3', '4' )",
+            expect("select ? IN(x, ?) from table where col in (?) and z IN(?)", "SELECT", "table")),
+        Arguments.of("select col from table order by col, col2", expect("SELECT", "table")),
+        Arguments.of("select ąś∂ń© from źćļńĶ order by col, col2", expect("SELECT", "źćļńĶ")),
+        Arguments.of("select 12345678", expect("select ?", "SELECT", null)),
+        Arguments.of("/* update comment */ select * from table1", expect("SELECT", "table1")),
+        Arguments.of("select /*((*/abc from table", expect("SELECT", "table")),
+        Arguments.of("SeLeCT * FrOm TAblE", expect("SELECT", "table")),
+        Arguments.of("select next value in hibernate_sequence", expect("SELECT", null)),
 
-    static Function<String, SqlStatementInfo> expect(
-        String sql, String operation, String identifier) {
-      return ignored -> SqlStatementInfo.create(sql, operation, identifier);
-    }
+        // hibernate/jpa
+        Arguments.of("FROM schema.table", expect("SELECT", "schema.table")),
+        Arguments.of("/* update comment */ from table1", expect("SELECT", "table1")),
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("CREATE TABLE `table`", expect("CREATE TABLE", "table")),
-          Arguments.of("CREATE TABLE IF NOT EXISTS table", expect("CREATE TABLE", "table")),
-          Arguments.of("DROP TABLE `if`", expect("DROP TABLE", "if")),
-          Arguments.of(
-              "ALTER TABLE table ADD CONSTRAINT c FOREIGN KEY (foreign_id) REFERENCES ref (id)",
-              expect("ALTER TABLE", "table")),
-          Arguments.of("CREATE INDEX types_name ON types (name)", expect("CREATE INDEX", null)),
-          Arguments.of("DROP INDEX types_name ON types (name)", expect("DROP INDEX", null)),
-          Arguments.of(
-              "CREATE VIEW tmp AS SELECT type FROM table WHERE id = ?",
-              expect("CREATE VIEW", null)),
-          Arguments.of(
-              "CREATE PROCEDURE p AS SELECT * FROM table GO", expect("CREATE PROCEDURE", null)));
-    }
+        // Insert
+        Arguments.of(" insert into table where lalala", expect("INSERT", "table")),
+        Arguments.of("insert insert into table where lalala", expect("INSERT", "table")),
+        Arguments.of("insert into db.table where lalala", expect("INSERT", "db.table")),
+        Arguments.of("insert into `db table` where lalala", expect("INSERT", "db table")),
+        Arguments.of("insert into \"db table\" where lalala", expect("INSERT", "db table")),
+        Arguments.of("insert without i-n-t-o", expect("INSERT", null)),
+
+        // Delete
+        Arguments.of("delete from table where something something", expect("DELETE", "table")),
+        Arguments.of(
+            "delete from `my table` where something something", expect("DELETE", "my table")),
+        Arguments.of(
+            "delete from \"my table\" where something something", expect("DELETE", "my table")),
+        Arguments.of(
+            "delete from foo where x IN (1,2,3)",
+            expect("delete from foo where x IN (?)", "DELETE", "foo")),
+        Arguments.of("delete from 12345678", expect("delete from ?", "DELETE", null)),
+        Arguments.of("delete   (((", expect("delete (((", "DELETE", null)),
+
+        // Update
+        Arguments.of(
+            "update table set answer=42", expect("update table set answer=?", "UPDATE", "table")),
+        Arguments.of(
+            "update `my table` set answer=42",
+            expect("update `my table` set answer=?", "UPDATE", "my table")),
+        Arguments.of(
+            "update `my table` set answer=42 where x IN('a', 'b') AND y In ('a',  'b')",
+            expect(
+                "update `my table` set answer=? where x IN(?) AND y In (?)", "UPDATE", "my table")),
+        Arguments.of(
+            "update \"my table\" set answer=42",
+            expect("update \"my table\" set answer=?", "UPDATE", "my table")),
+        Arguments.of("update /*table", expect("UPDATE", null)),
+
+        // Call
+        Arguments.of("call test_proc()", expect("CALL", "test_proc")),
+        Arguments.of("call test_proc", expect("CALL", "test_proc")),
+        Arguments.of("call next value in hibernate_sequence", expect("CALL", null)),
+        Arguments.of("call db.test_proc", expect("CALL", "db.test_proc")),
+
+        // Merge
+        Arguments.of("merge into table", expect("MERGE", "table")),
+        Arguments.of("merge into `my table`", expect("MERGE", "my table")),
+        Arguments.of("merge into \"my table\"", expect("MERGE", "my table")),
+        Arguments.of("merge table (into is optional in some dbs)", expect("MERGE", "table")),
+        Arguments.of("merge (into )))", expect("MERGE", null)),
+
+        // Unknown operation
+        Arguments.of("and now for something completely different", expect(null, null)),
+        Arguments.of("", expect(null, null)),
+        Arguments.of(null, expect(null, null)));
+  }
+
+  private static Stream<Arguments> ddlArgs() {
+    return Stream.of(
+        Arguments.of("CREATE TABLE `table`", expect("CREATE TABLE", "table")),
+        Arguments.of("CREATE TABLE IF NOT EXISTS table", expect("CREATE TABLE", "table")),
+        Arguments.of("DROP TABLE `if`", expect("DROP TABLE", "if")),
+        Arguments.of(
+            "ALTER TABLE table ADD CONSTRAINT c FOREIGN KEY (foreign_id) REFERENCES ref (id)",
+            expect("ALTER TABLE", "table")),
+        Arguments.of("CREATE INDEX types_name ON types (name)", expect("CREATE INDEX", null)),
+        Arguments.of("DROP INDEX types_name ON types (name)", expect("DROP INDEX", null)),
+        Arguments.of(
+            "CREATE VIEW tmp AS SELECT type FROM table WHERE id = ?", expect("CREATE VIEW", null)),
+        Arguments.of(
+            "CREATE PROCEDURE p AS SELECT * FROM table GO", expect("CREATE PROCEDURE", null)));
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressionStrategyTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanSuppressionStrategyTest.java
@@ -22,41 +22,35 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SpanSuppressionStrategyTest {
 
   static final Span span = Span.getInvalid();
 
   @ParameterizedTest
-  @ArgumentsSource(ConfigArgs.class)
+  @MethodSource("configArgs")
   void shouldParseConfig(String value, SpanSuppressionStrategy expectedStrategy) {
     assertEquals(expectedStrategy, SpanSuppressionStrategy.fromConfig(value));
   }
 
-  static final class ConfigArgs implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("none", SpanSuppressionStrategy.NONE),
-          Arguments.of("NONE", SpanSuppressionStrategy.NONE),
-          Arguments.of("span-kind", SpanSuppressionStrategy.SPAN_KIND),
-          Arguments.of("Span-Kind", SpanSuppressionStrategy.SPAN_KIND),
-          Arguments.of("semconv", SpanSuppressionStrategy.SEMCONV),
-          Arguments.of("SemConv", SpanSuppressionStrategy.SEMCONV),
-          Arguments.of("asdfasdfasdf", SpanSuppressionStrategy.SEMCONV),
-          Arguments.of(null, SpanSuppressionStrategy.SEMCONV));
-    }
+  private static Stream<Arguments> configArgs() {
+    return Stream.of(
+        Arguments.of("none", SpanSuppressionStrategy.NONE),
+        Arguments.of("NONE", SpanSuppressionStrategy.NONE),
+        Arguments.of("span-kind", SpanSuppressionStrategy.SPAN_KIND),
+        Arguments.of("Span-Kind", SpanSuppressionStrategy.SPAN_KIND),
+        Arguments.of("semconv", SpanSuppressionStrategy.SEMCONV),
+        Arguments.of("SemConv", SpanSuppressionStrategy.SEMCONV),
+        Arguments.of("asdfasdfasdf", SpanSuppressionStrategy.SEMCONV),
+        Arguments.of(null, SpanSuppressionStrategy.SEMCONV));
   }
 
   @ParameterizedTest
-  @ArgumentsSource(SpanKindsAndKeys.class)
+  @MethodSource("spanKindsAndKeys")
   void none_shouldNotSuppressAnything(SpanKind spanKind, SpanKey spanKey) {
     SpanSuppressor suppressor = SpanSuppressionStrategy.NONE.create(emptySet());
 
@@ -77,7 +71,7 @@ class SpanSuppressionStrategyTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(SpanKindsAndKeys.class)
+  @MethodSource("spanKindsAndKeys")
   void spanKind_shouldStoreInContext(SpanKind spanKind, SpanKey spanKey) {
     SpanSuppressor suppressor = SpanSuppressionStrategy.SPAN_KIND.create(emptySet());
     Context context = Context.root();
@@ -89,7 +83,7 @@ class SpanSuppressionStrategyTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(SpanKindsAndKeys.class)
+  @MethodSource("spanKindsAndKeys")
   void spanKind_shouldSuppressSameKind(SpanKind spanKind, SpanKey spanKey) {
     SpanSuppressor suppressor = SpanSuppressionStrategy.SPAN_KIND.create(emptySet());
     Context context = Context.root();
@@ -100,16 +94,12 @@ class SpanSuppressionStrategyTest {
     assertSame(span, spanKey.fromContextOrNull(newContext));
   }
 
-  static final class SpanKindsAndKeys implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of(SpanKind.SERVER, SpanKey.KIND_SERVER),
-          Arguments.of(SpanKind.CLIENT, SpanKey.KIND_CLIENT),
-          Arguments.of(SpanKind.CONSUMER, SpanKey.KIND_CONSUMER),
-          Arguments.of(SpanKind.PRODUCER, SpanKey.KIND_PRODUCER));
-    }
+  private static Stream<Arguments> spanKindsAndKeys() {
+    return Stream.of(
+        Arguments.of(SpanKind.SERVER, SpanKey.KIND_SERVER),
+        Arguments.of(SpanKind.CLIENT, SpanKey.KIND_CLIENT),
+        Arguments.of(SpanKind.CONSUMER, SpanKey.KIND_CONSUMER),
+        Arguments.of(SpanKind.PRODUCER, SpanKey.KIND_PRODUCER));
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/ForwardedHostAddressAndPortExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/ForwardedHostAddressAndPortExtractorTest.java
@@ -18,11 +18,9 @@ import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,7 +35,7 @@ class ForwardedHostAddressAndPortExtractorTest {
   @InjectMocks ForwardedHostAddressAndPortExtractor<String> underTest;
 
   @ParameterizedTest
-  @ArgumentsSource(ForwardedArgs.class)
+  @MethodSource("forwardedArgs")
   void shouldParseForwarded(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
     when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(headers);
@@ -49,40 +47,36 @@ class ForwardedHostAddressAndPortExtractorTest {
     assertThat(sink.getPort()).isEqualTo(expectedPort);
   }
 
-  static final class ForwardedArgs implements ArgumentsProvider {
+  private static Stream<Arguments> forwardedArgs() {
+    return Stream.of(
+        // empty/invalid headers
+        arguments(singletonList(""), null, null),
+        arguments(singletonList("host="), null, null),
+        arguments(singletonList("host=;"), null, null),
+        arguments(singletonList("host=\""), null, null),
+        arguments(singletonList("host=\"\""), null, null),
+        arguments(singletonList("host=\"example.com"), null, null),
+        arguments(singletonList("by=1.2.3.4, test=abc"), null, null),
+        arguments(singletonList("host=example.com"), "example.com", null),
+        arguments(singletonList("host=\"example.com\""), "example.com", null),
+        arguments(singletonList("host=example.com; test=abc:1234"), "example.com", null),
+        arguments(singletonList("host=\"example.com\"; test=abc:1234"), "example.com", null),
+        arguments(singletonList("host=example.com:port"), "example.com", null),
+        arguments(singletonList("host=\"example.com:port\""), "example.com", null),
+        arguments(singletonList("host=example.com:42"), "example.com", 42),
+        arguments(singletonList("host=\"example.com:42\""), "example.com", 42),
+        arguments(singletonList("host=example.com:42; test=abc:1234"), "example.com", 42),
+        arguments(singletonList("host=\"example.com:42\"; test=abc:1234"), "example.com", 42),
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-      return Stream.of(
-          // empty/invalid headers
-          arguments(singletonList(""), null, null),
-          arguments(singletonList("host="), null, null),
-          arguments(singletonList("host=;"), null, null),
-          arguments(singletonList("host=\""), null, null),
-          arguments(singletonList("host=\"\""), null, null),
-          arguments(singletonList("host=\"example.com"), null, null),
-          arguments(singletonList("by=1.2.3.4, test=abc"), null, null),
-          arguments(singletonList("host=example.com"), "example.com", null),
-          arguments(singletonList("host=\"example.com\""), "example.com", null),
-          arguments(singletonList("host=example.com; test=abc:1234"), "example.com", null),
-          arguments(singletonList("host=\"example.com\"; test=abc:1234"), "example.com", null),
-          arguments(singletonList("host=example.com:port"), "example.com", null),
-          arguments(singletonList("host=\"example.com:port\""), "example.com", null),
-          arguments(singletonList("host=example.com:42"), "example.com", 42),
-          arguments(singletonList("host=\"example.com:42\""), "example.com", 42),
-          arguments(singletonList("host=example.com:42; test=abc:1234"), "example.com", 42),
-          arguments(singletonList("host=\"example.com:42\"; test=abc:1234"), "example.com", 42),
-
-          // multiple headers
-          arguments(
-              asList("proto=https", "host=example.com", "host=github.com:1234"),
-              "example.com",
-              null));
-    }
+        // multiple headers
+        arguments(
+            asList("proto=https", "host=example.com", "host=github.com:1234"),
+            "example.com",
+            null));
   }
 
   @ParameterizedTest
-  @ArgumentsSource(HostArgs.class)
+  @MethodSource("hostArgs")
   @SuppressWarnings("MockitoDoSetup")
   void shouldParseForwardedHost(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
@@ -97,7 +91,7 @@ class ForwardedHostAddressAndPortExtractorTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(HostArgs.class)
+  @MethodSource("hostArgs")
   @SuppressWarnings("MockitoDoSetup")
   void shouldParsePseudoAuthority(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
@@ -113,7 +107,7 @@ class ForwardedHostAddressAndPortExtractorTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(HostArgs.class)
+  @MethodSource("hostArgs")
   @SuppressWarnings("MockitoDoSetup")
   void shouldParseHost(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
@@ -129,24 +123,20 @@ class ForwardedHostAddressAndPortExtractorTest {
     assertThat(sink.getPort()).isEqualTo(expectedPort);
   }
 
-  static final class HostArgs implements ArgumentsProvider {
+  private static Stream<Arguments> hostArgs() {
+    return Stream.of(
+        // empty/invalid headers
+        arguments(singletonList(""), null, null),
+        arguments(singletonList("\""), null, null),
+        arguments(singletonList("\"\""), null, null),
+        arguments(singletonList("example.com"), "example.com", null),
+        arguments(singletonList("example.com:port"), "example.com", null),
+        arguments(singletonList("example.com:42"), "example.com", 42),
+        arguments(singletonList("\"example.com\""), "example.com", null),
+        arguments(singletonList("\"example.com:port\""), "example.com", null),
+        arguments(singletonList("\"example.com:42\""), "example.com", 42),
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-      return Stream.of(
-          // empty/invalid headers
-          arguments(singletonList(""), null, null),
-          arguments(singletonList("\""), null, null),
-          arguments(singletonList("\"\""), null, null),
-          arguments(singletonList("example.com"), "example.com", null),
-          arguments(singletonList("example.com:port"), "example.com", null),
-          arguments(singletonList("example.com:42"), "example.com", 42),
-          arguments(singletonList("\"example.com\""), "example.com", null),
-          arguments(singletonList("\"example.com:port\""), "example.com", null),
-          arguments(singletonList("\"example.com:42\""), "example.com", 42),
-
-          // multiple headers
-          arguments(asList("example.com", "github.com:1234"), "example.com", null));
-    }
+        // multiple headers
+        arguments(asList("example.com", "github.com:1234"), "example.com", null));
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/ForwardedUrlSchemeProviderTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/ForwardedUrlSchemeProviderTest.java
@@ -19,11 +19,9 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,36 +42,32 @@ class ForwardedUrlSchemeProviderTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ForwardedHeaderValues.class)
+  @MethodSource("forwardedHeaderValues")
   void parseForwardedHeader(List<String> values, String expectedScheme) {
     when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(values);
     assertThat(underTest.apply(REQUEST)).isEqualTo(expectedScheme);
   }
 
-  static final class ForwardedHeaderValues implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-      return Stream.of(
-          arguments(singletonList("for=1.1.1.1;proto=xyz"), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto=xyz;"), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto=xyz,"), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto="), null),
-          arguments(singletonList("for=1.1.1.1;proto=;"), null),
-          arguments(singletonList("for=1.1.1.1;proto=,"), null),
-          arguments(singletonList("for=1.1.1.1;proto=\"xyz\""), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto=\"xyz\";"), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto=\"xyz\","), "xyz"),
-          arguments(singletonList("for=1.1.1.1;proto=\""), null),
-          arguments(singletonList("for=1.1.1.1;proto=\"\""), null),
-          arguments(singletonList("for=1.1.1.1;proto=\"\";"), null),
-          arguments(singletonList("for=1.1.1.1;proto=\"\","), null),
-          arguments(asList("for=1.1.1.1", "proto=xyz", "proto=abc"), "xyz"));
-    }
+  private static Stream<Arguments> forwardedHeaderValues() {
+    return Stream.of(
+        arguments(singletonList("for=1.1.1.1;proto=xyz"), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto=xyz;"), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto=xyz,"), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto="), null),
+        arguments(singletonList("for=1.1.1.1;proto=;"), null),
+        arguments(singletonList("for=1.1.1.1;proto=,"), null),
+        arguments(singletonList("for=1.1.1.1;proto=\"xyz\""), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto=\"xyz\";"), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto=\"xyz\","), "xyz"),
+        arguments(singletonList("for=1.1.1.1;proto=\""), null),
+        arguments(singletonList("for=1.1.1.1;proto=\"\""), null),
+        arguments(singletonList("for=1.1.1.1;proto=\"\";"), null),
+        arguments(singletonList("for=1.1.1.1;proto=\"\","), null),
+        arguments(asList("for=1.1.1.1", "proto=xyz", "proto=abc"), "xyz"));
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ForwardedProtoHeaderValues.class)
+  @MethodSource("forwardedProtoHeaderValues")
   @SuppressWarnings("MockitoDoSetup")
   void parseForwardedProtoHeader(List<String> values, String expectedScheme) {
     doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
@@ -81,15 +75,11 @@ class ForwardedUrlSchemeProviderTest {
     assertThat(underTest.apply(REQUEST)).isEqualTo(expectedScheme);
   }
 
-  static final class ForwardedProtoHeaderValues implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-      return Stream.of(
-          arguments(singletonList("xyz"), "xyz"),
-          arguments(singletonList("\"xyz\""), "xyz"),
-          arguments(singletonList("\""), null),
-          arguments(asList("xyz", "abc"), "xyz"));
-    }
+  private static Stream<Arguments> forwardedProtoHeaderValues() {
+    return Stream.of(
+        arguments(singletonList("xyz"), "xyz"),
+        arguments(singletonList("\"xyz\""), "xyz"),
+        arguments(singletonList("\""), null),
+        arguments(asList("xyz", "abc"), "xyz"));
   }
 }

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -73,11 +73,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -562,7 +560,7 @@ public abstract class AbstractGrpcTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ErrorProvider.class)
+  @MethodSource("provideErrorArguments")
   void errorReturned(Status status) throws Exception {
     BindableService greeter =
         new GreeterGrpc.GreeterImplBase() {
@@ -691,7 +689,7 @@ public abstract class AbstractGrpcTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ErrorProvider.class)
+  @MethodSource("provideErrorArguments")
   void errorThrown(Status status) throws Exception {
     BindableService greeter =
         new GreeterGrpc.GreeterImplBase() {
@@ -824,25 +822,22 @@ public abstract class AbstractGrpcTest {
                                                     (long) Status.Code.UNKNOWN.value()))))));
   }
 
-  static class ErrorProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          arguments(Status.UNKNOWN.withCause(new RuntimeException("some error"))),
-          arguments(Status.DEADLINE_EXCEEDED.withCause(new RuntimeException("some error"))),
-          arguments(Status.UNIMPLEMENTED.withCause(new RuntimeException("some error"))),
-          arguments(Status.INTERNAL.withCause(new RuntimeException("some error"))),
-          arguments(Status.UNAVAILABLE.withCause(new RuntimeException("some error"))),
-          arguments(Status.DATA_LOSS.withCause(new RuntimeException("some error"))),
-          arguments(Status.NOT_FOUND.withCause(new RuntimeException("some error"))),
-          arguments(Status.UNKNOWN.withDescription("some description")),
-          arguments(Status.DEADLINE_EXCEEDED.withDescription("some description")),
-          arguments(Status.UNIMPLEMENTED.withDescription("some description")),
-          arguments(Status.INTERNAL.withDescription("some description")),
-          arguments(Status.UNAVAILABLE.withDescription("some description")),
-          arguments(Status.DATA_LOSS.withDescription("some description")),
-          arguments(Status.NOT_FOUND.withDescription("some description")));
-    }
+  private static Stream<Arguments> provideErrorArguments() {
+    return Stream.of(
+        arguments(Status.UNKNOWN.withCause(new RuntimeException("some error"))),
+        arguments(Status.DEADLINE_EXCEEDED.withCause(new RuntimeException("some error"))),
+        arguments(Status.UNIMPLEMENTED.withCause(new RuntimeException("some error"))),
+        arguments(Status.INTERNAL.withCause(new RuntimeException("some error"))),
+        arguments(Status.UNAVAILABLE.withCause(new RuntimeException("some error"))),
+        arguments(Status.DATA_LOSS.withCause(new RuntimeException("some error"))),
+        arguments(Status.NOT_FOUND.withCause(new RuntimeException("some error"))),
+        arguments(Status.UNKNOWN.withDescription("some description")),
+        arguments(Status.DEADLINE_EXCEEDED.withDescription("some description")),
+        arguments(Status.UNIMPLEMENTED.withDescription("some description")),
+        arguments(Status.INTERNAL.withDescription("some description")),
+        arguments(Status.UNAVAILABLE.withDescription("some description")),
+        arguments(Status.DATA_LOSS.withDescription("some description")),
+        arguments(Status.NOT_FOUND.withDescription("some description")));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
@@ -25,12 +25,10 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OpenTelemetryDataSourceTest {
 
@@ -39,7 +37,7 @@ class OpenTelemetryDataSourceTest {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @ParameterizedTest
-  @ArgumentsSource(GetConnectionMethods.class)
+  @MethodSource("getConnectionMethodsArguments")
   void shouldEmitGetConnectionSpans(GetConnectionFunction getConnection) throws SQLException {
     JdbcTelemetry telemetry = JdbcTelemetry.create(testing.getOpenTelemetry());
     DataSource dataSource = telemetry.wrap(new TestDataSource());
@@ -73,7 +71,7 @@ class OpenTelemetryDataSourceTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(GetConnectionMethods.class)
+  @MethodSource("getConnectionMethodsArguments")
   void shouldNotEmitGetConnectionSpansWithoutParentSpan(GetConnectionFunction getConnection)
       throws SQLException {
     JdbcTelemetry telemetry = JdbcTelemetry.create(testing.getOpenTelemetry());
@@ -88,14 +86,10 @@ class OpenTelemetryDataSourceTest {
     assertDbInfo(dbInfo);
   }
 
-  static class GetConnectionMethods implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-      GetConnectionFunction getConnection = DataSource::getConnection;
-      GetConnectionFunction getConnectionWithUserAndPass = ds -> ds.getConnection(null, null);
-      return Stream.of(arguments(getConnection), arguments(getConnectionWithUserAndPass));
-    }
+  private static Stream<Arguments> getConnectionMethodsArguments() {
+    GetConnectionFunction getConnection = DataSource::getConnection;
+    GetConnectionFunction getConnectionWithUserAndPass = ds -> ds.getConnection(null, null);
+    return Stream.of(arguments(getConnection), arguments(getConnectionWithUserAndPass));
   }
 
   @FunctionalInterface

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -15,11 +15,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class JdbcConnectionUrlParserTest {
@@ -50,1256 +48,1211 @@ class JdbcConnectionUrlParserTest {
     assertThat(JdbcConnectionUrlParser.parse(null, null)).isEqualTo(DbInfo.DEFAULT);
   }
 
-  static final class PostgresProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://jdbc.postgresql.org/documentation/94/connect.html
-          arg("jdbc:postgresql:///")
-              .setShortUrl("postgresql://localhost:5432")
-              .setSystem("postgresql")
-              .setHost("localhost")
-              .setPort(5432)
-              .build(),
-          arg("jdbc:postgresql:///")
-              .setProperties(stdProps())
-              .setShortUrl("postgresql://stdServerName:9999")
-              .setSystem("postgresql")
-              .setUser("stdUserName")
-              .setHost("stdServerName")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:postgresql://pg.host")
-              .setShortUrl("postgresql://pg.host:5432")
-              .setSystem("postgresql")
-              .setHost("pg.host")
-              .setPort(5432)
-              .build(),
-          arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
-              .setShortUrl("postgresql://pg.host:11")
-              .setSystem("postgresql")
-              .setUser("pguser")
-              .setHost("pg.host")
-              .setPort(11)
-              .setDb("pgdb")
-              .build(),
-          arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
-              .setProperties(stdProps())
-              .setShortUrl("postgresql://pg.host:11")
-              .setSystem("postgresql")
-              .setUser("pguser")
-              .setHost("pg.host")
-              .setPort(11)
-              .setDb("pgdb")
-              .build());
-    }
+  private static Stream<Arguments> mySqlArguments() {
+    return args(
+        // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html
+        // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
+        arg("jdbc:mysql:///")
+            .setShortUrl("mysql://localhost:3306")
+            .setSystem("mysql")
+            .setHost("localhost")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:mysql:///")
+            .setProperties(stdProps())
+            .setShortUrl("mysql://stdServerName:9999")
+            .setSystem("mysql")
+            .setUser("stdUserName")
+            .setHost("stdServerName")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:mysql://my.host")
+            .setShortUrl("mysql://my.host:3306")
+            .setSystem("mysql")
+            .setHost("my.host")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:mysql://my.host?user=myuser&password=PW")
+            .setShortUrl("mysql://my.host:3306")
+            .setSystem("mysql")
+            .setUser("myuser")
+            .setHost("my.host")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:mysql://my.host:22/mydb?user=myuser&password=PW")
+            .setShortUrl("mysql://my.host:22")
+            .setSystem("mysql")
+            .setUser("myuser")
+            .setHost("my.host")
+            .setPort(22)
+            .setDb("mydb")
+            .build(),
+        arg("jdbc:mysql://127.0.0.1:22/mydb?user=myuser&password=PW")
+            .setProperties(stdProps())
+            .setShortUrl("mysql://127.0.0.1:22")
+            .setSystem("mysql")
+            .setUser("myuser")
+            .setHost("127.0.0.1")
+            .setPort(22)
+            .setDb("mydb")
+            .build(),
+        arg("jdbc:mysql://myuser:password@my.host:22/mydb")
+            .setShortUrl("mysql://my.host:22")
+            .setSystem("mysql")
+            .setUser("myuser")
+            .setHost("my.host")
+            .setPort(22)
+            .setDb("mydb")
+            .build(),
+        arg("jdbc:mysql:aurora://mdb.host/mdbdb")
+            .setShortUrl("mysql:aurora://mdb.host:3306")
+            .setSystem("mysql")
+            .setSubtype("aurora")
+            .setHost("mdb.host")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mysql:failover://localhost/mdbdb?autoReconnect=true")
+            .setShortUrl("mysql:failover://localhost:3306")
+            .setSystem("mysql")
+            .setSubtype("failover")
+            .setHost("localhost")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mysql:loadbalance://127.0.0.1,127.0.0.1:3306/mdbdb?user=mdbuser&password=PW")
+            .setShortUrl("mysql:loadbalance://127.0.0.1:3306")
+            .setSystem("mysql")
+            .setSubtype("loadbalance")
+            .setUser("mdbuser")
+            .setHost("127.0.0.1")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mysql:replication://address=(HOST=127.0.0.1)(port=33)(user=mdbuser)(password=PW),address=(host=mdb.host)(port=3306)(user=otheruser)(password=PW)/mdbdb?user=wrong&password=PW")
+            .setShortUrl("mysql:replication://127.0.0.1:33")
+            .setSystem("mysql")
+            .setSubtype("replication")
+            .setUser("mdbuser")
+            .setHost("127.0.0.1")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mysql:replication://address=(HOST=mdb.host),address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW")
+            .setShortUrl("mysql:replication://mdb.host:3306")
+            .setSystem("mysql")
+            .setSubtype("replication")
+            .setUser("mdbuser")
+            .setHost("mdb.host")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(MySqlProvider.class)
+  @MethodSource("mySqlArguments")
   void testMySqlParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class MySqlProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html
-          // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
-          arg("jdbc:mysql:///")
-              .setShortUrl("mysql://localhost:3306")
-              .setSystem("mysql")
-              .setHost("localhost")
-              .setPort(3306)
-              .build(),
-          arg("jdbc:mysql:///")
-              .setProperties(stdProps())
-              .setShortUrl("mysql://stdServerName:9999")
-              .setSystem("mysql")
-              .setUser("stdUserName")
-              .setHost("stdServerName")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:mysql://my.host")
-              .setShortUrl("mysql://my.host:3306")
-              .setSystem("mysql")
-              .setHost("my.host")
-              .setPort(3306)
-              .build(),
-          arg("jdbc:mysql://my.host?user=myuser&password=PW")
-              .setShortUrl("mysql://my.host:3306")
-              .setSystem("mysql")
-              .setUser("myuser")
-              .setHost("my.host")
-              .setPort(3306)
-              .build(),
-          arg("jdbc:mysql://my.host:22/mydb?user=myuser&password=PW")
-              .setShortUrl("mysql://my.host:22")
-              .setSystem("mysql")
-              .setUser("myuser")
-              .setHost("my.host")
-              .setPort(22)
-              .setDb("mydb")
-              .build(),
-          arg("jdbc:mysql://127.0.0.1:22/mydb?user=myuser&password=PW")
-              .setProperties(stdProps())
-              .setShortUrl("mysql://127.0.0.1:22")
-              .setSystem("mysql")
-              .setUser("myuser")
-              .setHost("127.0.0.1")
-              .setPort(22)
-              .setDb("mydb")
-              .build(),
-          arg("jdbc:mysql://myuser:password@my.host:22/mydb")
-              .setShortUrl("mysql://my.host:22")
-              .setSystem("mysql")
-              .setUser("myuser")
-              .setHost("my.host")
-              .setPort(22)
-              .setDb("mydb")
-              .build(),
-          arg("jdbc:mysql:aurora://mdb.host/mdbdb")
-              .setShortUrl("mysql:aurora://mdb.host:3306")
-              .setSystem("mysql")
-              .setSubtype("aurora")
-              .setHost("mdb.host")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mysql:failover://localhost/mdbdb?autoReconnect=true")
-              .setShortUrl("mysql:failover://localhost:3306")
-              .setSystem("mysql")
-              .setSubtype("failover")
-              .setHost("localhost")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mysql:loadbalance://127.0.0.1,127.0.0.1:3306/mdbdb?user=mdbuser&password=PW")
-              .setShortUrl("mysql:loadbalance://127.0.0.1:3306")
-              .setSystem("mysql")
-              .setSubtype("loadbalance")
-              .setUser("mdbuser")
-              .setHost("127.0.0.1")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mysql:replication://address=(HOST=127.0.0.1)(port=33)(user=mdbuser)(password=PW),address=(host=mdb.host)(port=3306)(user=otheruser)(password=PW)/mdbdb?user=wrong&password=PW")
-              .setShortUrl("mysql:replication://127.0.0.1:33")
-              .setSystem("mysql")
-              .setSubtype("replication")
-              .setUser("mdbuser")
-              .setHost("127.0.0.1")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mysql:replication://address=(HOST=mdb.host),address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW")
-              .setShortUrl("mysql:replication://mdb.host:3306")
-              .setSystem("mysql")
-              .setSubtype("replication")
-              .setUser("mdbuser")
-              .setHost("mdb.host")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build());
-    }
+  private static Stream<Arguments> clickHouseArguments() {
+    return args(
+        // https://clickhouse.com/docs/integrations/language-clients/java/jdbc#configuration
+        arg("jdbc:clickhouse:http://localhost:8123/mydb")
+            .setShortUrl("clickhouse:http://localhost:8123")
+            .setSystem("clickhouse")
+            .setSubtype("http")
+            .setHost("localhost")
+            .setPort(8123)
+            .setDb("mydb")
+            .build(),
+        arg("jdbc:clickhouse:https://localhost:8443?ssl=true")
+            .setShortUrl("clickhouse:https://localhost:8443")
+            .setSystem("clickhouse")
+            .setSubtype("https")
+            .setHost("localhost")
+            .setPort(8443)
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(ClickHouseProvider.class)
+  @MethodSource("clickHouseArguments")
   void testClickHouseParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class ClickHouseProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://clickhouse.com/docs/integrations/language-clients/java/jdbc#configuration
-          arg("jdbc:clickhouse:http://localhost:8123/mydb")
-              .setShortUrl("clickhouse:http://localhost:8123")
-              .setSystem("clickhouse")
-              .setSubtype("http")
-              .setHost("localhost")
-              .setPort(8123)
-              .setDb("mydb")
-              .build(),
-          arg("jdbc:clickhouse:https://localhost:8443?ssl=true")
-              .setShortUrl("clickhouse:https://localhost:8443")
-              .setSystem("clickhouse")
-              .setSubtype("https")
-              .setHost("localhost")
-              .setPort(8443)
-              .build());
-    }
+  private static Stream<Arguments> postgresArguments() {
+    return args(
+        // https://jdbc.postgresql.org/documentation/94/connect.html
+        arg("jdbc:postgresql:///")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem("postgresql")
+            .setHost("localhost")
+            .setPort(5432)
+            .build(),
+        arg("jdbc:postgresql:///")
+            .setProperties(stdProps())
+            .setShortUrl("postgresql://stdServerName:9999")
+            .setSystem("postgresql")
+            .setUser("stdUserName")
+            .setHost("stdServerName")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:postgresql://pg.host")
+            .setShortUrl("postgresql://pg.host:5432")
+            .setSystem("postgresql")
+            .setHost("pg.host")
+            .setPort(5432)
+            .build(),
+        arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
+            .setShortUrl("postgresql://pg.host:11")
+            .setSystem("postgresql")
+            .setUser("pguser")
+            .setHost("pg.host")
+            .setPort(11)
+            .setDb("pgdb")
+            .build(),
+        arg("jdbc:postgresql://pg.host:11/pgdb?user=pguser&password=PW")
+            .setProperties(stdProps())
+            .setShortUrl("postgresql://pg.host:11")
+            .setSystem("postgresql")
+            .setUser("pguser")
+            .setHost("pg.host")
+            .setPort(11)
+            .setDb("pgdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(PostgresProvider.class)
+  @MethodSource("postgresArguments")
   void testPostgresParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class MariaDbProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings
-          arg("jdbc:mariadb:127.0.0.1:33/mdbdb")
-              .setShortUrl("mariadb://127.0.0.1:33")
-              .setSystem("mariadb")
-              .setHost("127.0.0.1")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:localhost/mdbdb")
-              .setShortUrl("mariadb://localhost:3306")
-              .setSystem("mariadb")
-              .setHost("localhost")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:localhost/mdbdb?user=mdbuser&password=PW")
-              .setProperties(stdProps())
-              .setShortUrl("mariadb://localhost:9999")
-              .setSystem("mariadb")
-              .setUser("mdbuser")
-              .setHost("localhost")
-              .setPort(9999)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:localhost:33/mdbdb")
-              .setProperties(stdProps())
-              .setShortUrl("mariadb://localhost:33")
-              .setSystem("mariadb")
-              .setUser("stdUserName")
-              .setHost("localhost")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
-              .setShortUrl("mariadb://mdb.host:33")
-              .setSystem("mariadb")
-              .setUser("mdbuser")
-              .setHost("mdb.host")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:aurora://mdb.host/mdbdb")
-              .setShortUrl("mariadb:aurora://mdb.host:3306")
-              .setSystem("mariadb")
-              .setSubtype("aurora")
-              .setHost("mdb.host")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:failover://mdb.host1:33,mdb.host/mdbdb?characterEncoding=utf8")
-              .setShortUrl("mariadb:failover://mdb.host1:33")
-              .setSystem("mariadb")
-              .setSubtype("failover")
-              .setHost("mdb.host1")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:sequential://mdb.host1,mdb.host2:33/mdbdb")
-              .setShortUrl("mariadb:sequential://mdb.host1:3306")
-              .setSystem("mariadb")
-              .setSubtype("sequential")
-              .setHost("mdb.host1")
-              .setPort(3306)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:loadbalance://127.0.0.1:33,mdb.host/mdbdb")
-              .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
-              .setSystem("mariadb")
-              .setSubtype("loadbalance")
-              .setHost("127.0.0.1")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:loadbalance://127.0.0.1:33/mdbdb")
-              .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
-              .setSystem("mariadb")
-              .setSubtype("loadbalance")
-              .setHost("127.0.0.1")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb")
-              .setShortUrl("mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33")
-              .setSystem("mariadb")
-              .setSubtype("loadbalance")
-              .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build(),
-          arg("jdbc:mariadb:replication://localhost:33,anotherhost:3306/mdbdb")
-              .setShortUrl("mariadb:replication://localhost:33")
-              .setSystem("mariadb")
-              .setSubtype("replication")
-              .setHost("localhost")
-              .setPort(33)
-              .setDb("mdbdb")
-              .build());
-    }
+  private static Stream<Arguments> mariaDbArguments() {
+    return args(
+        // https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings
+        arg("jdbc:mariadb:127.0.0.1:33/mdbdb")
+            .setShortUrl("mariadb://127.0.0.1:33")
+            .setSystem("mariadb")
+            .setHost("127.0.0.1")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:localhost/mdbdb")
+            .setShortUrl("mariadb://localhost:3306")
+            .setSystem("mariadb")
+            .setHost("localhost")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:localhost/mdbdb?user=mdbuser&password=PW")
+            .setProperties(stdProps())
+            .setShortUrl("mariadb://localhost:9999")
+            .setSystem("mariadb")
+            .setUser("mdbuser")
+            .setHost("localhost")
+            .setPort(9999)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:localhost:33/mdbdb")
+            .setProperties(stdProps())
+            .setShortUrl("mariadb://localhost:33")
+            .setSystem("mariadb")
+            .setUser("stdUserName")
+            .setHost("localhost")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
+            .setShortUrl("mariadb://mdb.host:33")
+            .setSystem("mariadb")
+            .setUser("mdbuser")
+            .setHost("mdb.host")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:aurora://mdb.host/mdbdb")
+            .setShortUrl("mariadb:aurora://mdb.host:3306")
+            .setSystem("mariadb")
+            .setSubtype("aurora")
+            .setHost("mdb.host")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:failover://mdb.host1:33,mdb.host/mdbdb?characterEncoding=utf8")
+            .setShortUrl("mariadb:failover://mdb.host1:33")
+            .setSystem("mariadb")
+            .setSubtype("failover")
+            .setHost("mdb.host1")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:sequential://mdb.host1,mdb.host2:33/mdbdb")
+            .setShortUrl("mariadb:sequential://mdb.host1:3306")
+            .setSystem("mariadb")
+            .setSubtype("sequential")
+            .setHost("mdb.host1")
+            .setPort(3306)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:loadbalance://127.0.0.1:33,mdb.host/mdbdb")
+            .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
+            .setSystem("mariadb")
+            .setSubtype("loadbalance")
+            .setHost("127.0.0.1")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:loadbalance://127.0.0.1:33/mdbdb")
+            .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
+            .setSystem("mariadb")
+            .setSubtype("loadbalance")
+            .setHost("127.0.0.1")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb")
+            .setShortUrl("mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33")
+            .setSystem("mariadb")
+            .setSubtype("loadbalance")
+            .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build(),
+        arg("jdbc:mariadb:replication://localhost:33,anotherhost:3306/mdbdb")
+            .setShortUrl("mariadb:replication://localhost:33")
+            .setSystem("mariadb")
+            .setSubtype("replication")
+            .setHost("localhost")
+            .setPort(33)
+            .setDb("mdbdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(MariaDbProvider.class)
+  @MethodSource("mariaDbArguments")
   void testMariaDbParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class SqlServerProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
-          arg("jdbc:microsoft:sqlserver://;")
-              .setShortUrl("microsoft:sqlserver://localhost:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("localhost")
-              .setPort(1433)
-              .build(),
-          arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
-              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
-              .setSystem("mssql")
-              .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
-              .setPort(1433)
-              .build(),
-          arg("jdbc:sqlserver://;serverName=2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-              .setShortUrl("sqlserver://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1433")
-              .setSystem("mssql")
-              .setHost("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")
-              .setPort(1433)
-              .build(),
-          arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
-              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
-              .setSystem("mssql")
-              .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
-              .setPort(43)
-              .build(),
-          arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance")
-              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
-              .setSystem("mssql")
-              .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
-              .setPort(1433)
-              .setName("ssinstance")
-              .build(),
-          arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance]:43")
-              .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
-              .setSystem("mssql")
-              .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
-              .setPort(43)
-              .setName("ssinstance")
-              .build(),
-          arg("jdbc:microsoft:sqlserver://;")
-              .setProperties(stdProps())
-              .setShortUrl("microsoft:sqlserver://stdServerName:9999")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setUser("stdUserName")
-              .setHost("stdServerName")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:sqlserver://ss.host\\ssinstance:44;databaseName=ssdb;user=ssuser;password=pw")
-              .setShortUrl("sqlserver://ss.host:44")
-              .setSystem("mssql")
-              .setUser("ssuser")
-              .setHost("ss.host")
-              .setPort(44)
-              .setName("ssinstance")
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:sqlserver://;serverName=ss.host\\ssinstance:44;DatabaseName=;")
-              .setShortUrl("sqlserver://ss.host:44")
-              .setSystem("mssql")
-              .setHost("ss.host")
-              .setPort(44)
-              .setName("ssinstance")
-              .build(),
-          arg("jdbc:sqlserver://ss.host;serverName=althost;DatabaseName=ssdb;")
-              .setShortUrl("sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;")
-              .setShortUrl("microsoft:sqlserver://ss.host:44")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setUser("ssuser")
-              .setHost("ss.host")
-              .setPort(44)
-              .setDb("ssdb")
-              .build(),
+  private static Stream<Arguments> sqlServerArguments() {
+    return args(
+        // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
+        arg("jdbc:microsoft:sqlserver://;")
+            .setShortUrl("microsoft:sqlserver://localhost:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("localhost")
+            .setPort(1433)
+            .build(),
+        arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
+            .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
+            .setSystem("mssql")
+            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setPort(1433)
+            .build(),
+        arg("jdbc:sqlserver://;serverName=2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+            .setShortUrl("sqlserver://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1433")
+            .setSystem("mssql")
+            .setHost("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")
+            .setPort(1433)
+            .build(),
+        arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
+            .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
+            .setSystem("mssql")
+            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setPort(43)
+            .build(),
+        arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance")
+            .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
+            .setSystem("mssql")
+            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setPort(1433)
+            .setName("ssinstance")
+            .build(),
+        arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance]:43")
+            .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
+            .setSystem("mssql")
+            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setPort(43)
+            .setName("ssinstance")
+            .build(),
+        arg("jdbc:microsoft:sqlserver://;")
+            .setProperties(stdProps())
+            .setShortUrl("microsoft:sqlserver://stdServerName:9999")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setUser("stdUserName")
+            .setHost("stdServerName")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:sqlserver://ss.host\\ssinstance:44;databaseName=ssdb;user=ssuser;password=pw")
+            .setShortUrl("sqlserver://ss.host:44")
+            .setSystem("mssql")
+            .setUser("ssuser")
+            .setHost("ss.host")
+            .setPort(44)
+            .setName("ssinstance")
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:sqlserver://;serverName=ss.host\\ssinstance:44;DatabaseName=;")
+            .setShortUrl("sqlserver://ss.host:44")
+            .setSystem("mssql")
+            .setHost("ss.host")
+            .setPort(44)
+            .setName("ssinstance")
+            .build(),
+        arg("jdbc:sqlserver://ss.host;serverName=althost;DatabaseName=ssdb;")
+            .setShortUrl("sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;")
+            .setShortUrl("microsoft:sqlserver://ss.host:44")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setUser("ssuser")
+            .setHost("ss.host")
+            .setPort(44)
+            .setDb("ssdb")
+            .build(),
 
-          // http://jtds.sourceforge.net/faq.html#urlFormat
-          arg("jdbc:jtds:sqlserver://ss.host/ssdb")
-              .setShortUrl("jtds:sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb")
-              .setShortUrl("jtds:sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;user=ssuser")
-              .setShortUrl("jtds:sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setUser("ssuser")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:jtds:sqlserver://ss.host/ssdb;instance=ssinstance")
-              .setShortUrl("jtds:sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setName("ssinstance")
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:jtds:sqlserver://ss.host:1444/ssdb;instance=ssinstance")
-              .setShortUrl("jtds:sqlserver://ss.host:1444")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("ss.host")
-              .setPort(1444)
-              .setName("ssinstance")
-              .setDb("ssdb")
-              .build(),
-          arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;instance=ssinstance;user=ssuser")
-              .setShortUrl("jtds:sqlserver://ss.host:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setUser("ssuser")
-              .setHost("ss.host")
-              .setPort(1433)
-              .setName("ssinstance")
-              .setDb("ssdb")
-              .build());
-    }
+        // http://jtds.sourceforge.net/faq.html#urlFormat
+        arg("jdbc:jtds:sqlserver://ss.host/ssdb")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;user=ssuser")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setUser("ssuser")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:jtds:sqlserver://ss.host/ssdb;instance=ssinstance")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setName("ssinstance")
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:jtds:sqlserver://ss.host:1444/ssdb;instance=ssinstance")
+            .setShortUrl("jtds:sqlserver://ss.host:1444")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("ss.host")
+            .setPort(1444)
+            .setName("ssinstance")
+            .setDb("ssdb")
+            .build(),
+        arg("jdbc:jtds:sqlserver://ss.host:1433/ssdb;instance=ssinstance;user=ssuser")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setUser("ssuser")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setName("ssinstance")
+            .setDb("ssdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(SqlServerProvider.class)
+  @MethodSource("sqlServerArguments")
   void testSqlServerParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class OracleProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
-          // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
-          arg("jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn")
-              .setShortUrl("oracle:thin://localhost:55")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setUser("orcluser")
-              .setHost("localhost")
-              .setPort(55)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:orcluser/PW@//orcl.host:55/orclsn")
-              .setShortUrl("oracle:thin://orcl.host:55")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setUser("orcluser")
-              .setHost("orcl.host")
-              .setPort(55)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:orcluser/PW@127.0.0.1:orclsn")
-              .setShortUrl("oracle:thin://127.0.0.1:1521")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setUser("orcluser")
-              .setHost("127.0.0.1")
-              .setPort(1521) // Default Oracle port assumed as not specified in the URL
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:orcluser/PW@//orcl.host/orclsn")
-              .setShortUrl("oracle:thin://orcl.host:1521")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setUser("orcluser")
-              .setHost("orcl.host")
-              .setPort(1521) // Default Oracle port assumed as not specified in the URL
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:@//orcl.host:55/orclsn")
-              .setShortUrl("oracle:thin://orcl.host:55")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("orcl.host")
-              .setPort(55)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:@ldap://orcl.host:55/some,cn=OracleContext,dc=com")
-              .setShortUrl("oracle:thin://orcl.host:55")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("orcl.host")
-              .setPort(55)
-              .setName("some,cn=oraclecontext,dc=com")
-              .build(),
-          arg("jdbc:oracle:thin:127.0.0.1:orclsn")
-              .setShortUrl("oracle:thin://127.0.0.1:1521")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("127.0.0.1")
-              .setPort(1521) // Default Oracle port assumed as not specified in the URL
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:orcl.host:orclsn")
-              .setProperties(stdProps())
-              .setShortUrl("oracle:thin://orcl.host:9999")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setUser("stdUserName")
-              .setHost("orcl.host")
-              .setPort(9999)
-              .setName("orclsn")
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=666))"
-                  + "(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=orclsn)))")
-              .setShortUrl("oracle:thin://127.0.0.1:666")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("127.0.0.1")
-              .setPort(666)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:thin:@ ( description = (connect_timeout=90)(retry_count=20)(retry_delay=3) (transport_connect_timeout=3000) (address_list = (load_balance = on) (failover = on) (address = (protocol = tcp)(host = orcl.host1 )(port = 1521 )) (address = (protocol = tcp)(host = orcl.host2)(port = 1521)) (address = (protocol = tcp)(host = orcl.host3)(port = 1521)) (address = (protocol = tcp)(host = orcl.host4)(port = 1521)) ) (connect_data = (server = dedicated) (service_name = orclsn)))")
-              .setShortUrl("oracle:thin://orcl.host1:1521")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("orcl.host1")
-              .setPort(1521)
-              .setName("orclsn")
-              .build(),
+  private static Stream<Arguments> oracleArguments() {
+    return args(
+        // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
+        // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
+        arg("jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn")
+            .setShortUrl("oracle:thin://localhost:55")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setUser("orcluser")
+            .setHost("localhost")
+            .setPort(55)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:orcluser/PW@//orcl.host:55/orclsn")
+            .setShortUrl("oracle:thin://orcl.host:55")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setUser("orcluser")
+            .setHost("orcl.host")
+            .setPort(55)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:orcluser/PW@127.0.0.1:orclsn")
+            .setShortUrl("oracle:thin://127.0.0.1:1521")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setUser("orcluser")
+            .setHost("127.0.0.1")
+            .setPort(1521) // Default Oracle port assumed as not specified in the URL
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:orcluser/PW@//orcl.host/orclsn")
+            .setShortUrl("oracle:thin://orcl.host:1521")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setUser("orcluser")
+            .setHost("orcl.host")
+            .setPort(1521) // Default Oracle port assumed as not specified in the URL
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:@//orcl.host:55/orclsn")
+            .setShortUrl("oracle:thin://orcl.host:55")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host")
+            .setPort(55)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:@ldap://orcl.host:55/some,cn=OracleContext,dc=com")
+            .setShortUrl("oracle:thin://orcl.host:55")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host")
+            .setPort(55)
+            .setName("some,cn=oraclecontext,dc=com")
+            .build(),
+        arg("jdbc:oracle:thin:127.0.0.1:orclsn")
+            .setShortUrl("oracle:thin://127.0.0.1:1521")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("127.0.0.1")
+            .setPort(1521) // Default Oracle port assumed as not specified in the URL
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:orcl.host:orclsn")
+            .setProperties(stdProps())
+            .setShortUrl("oracle:thin://orcl.host:9999")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setUser("stdUserName")
+            .setHost("orcl.host")
+            .setPort(9999)
+            .setName("orclsn")
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=666))"
+                + "(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=orclsn)))")
+            .setShortUrl("oracle:thin://127.0.0.1:666")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("127.0.0.1")
+            .setPort(666)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:thin:@ ( description = (connect_timeout=90)(retry_count=20)(retry_delay=3) (transport_connect_timeout=3000) (address_list = (load_balance = on) (failover = on) (address = (protocol = tcp)(host = orcl.host1 )(port = 1521 )) (address = (protocol = tcp)(host = orcl.host2)(port = 1521)) (address = (protocol = tcp)(host = orcl.host3)(port = 1521)) (address = (protocol = tcp)(host = orcl.host4)(port = 1521)) ) (connect_data = (server = dedicated) (service_name = orclsn)))")
+            .setShortUrl("oracle:thin://orcl.host1:1521")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host1")
+            .setPort(1521)
+            .setName("orclsn")
+            .build(),
 
-          // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
-          arg("jdbc:oracle:drivertype:orcluser/PW@orcl.host:55/orclsn")
-              .setShortUrl("oracle:drivertype://orcl.host:55")
-              .setSystem("oracle")
-              .setSubtype("drivertype")
-              .setUser("orcluser")
-              .setHost("orcl.host")
-              .setPort(55)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:oci8:@")
-              .setShortUrl("oracle:oci8:")
-              .setSystem("oracle")
-              .setSubtype("oci8")
-              .setPort(1521)
-              .build(),
-          arg("jdbc:oracle:oci8:@")
-              .setProperties(stdProps())
-              .setShortUrl("oracle:oci8://stdServerName:9999")
-              .setSystem("oracle")
-              .setSubtype("oci8")
-              .setUser("stdUserName")
-              .setHost("stdServerName")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:oracle:oci8:@orclsn")
-              .setShortUrl("oracle:oci8:")
-              .setSystem("oracle")
-              .setSubtype("oci8")
-              .setPort(1521)
-              .setName("orclsn")
-              .build(),
-          arg("jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=orcl.host)(PORT=55))(CONNECT_DATA=(SERVICE_NAME=orclsn)))")
-              .setShortUrl("oracle:oci://orcl.host:55")
-              .setSystem("oracle")
-              .setSubtype("oci")
-              .setHost("orcl.host")
-              .setPort(55)
-              .setName("orclsn")
-              .build());
-    }
+        // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
+        arg("jdbc:oracle:drivertype:orcluser/PW@orcl.host:55/orclsn")
+            .setShortUrl("oracle:drivertype://orcl.host:55")
+            .setSystem("oracle")
+            .setSubtype("drivertype")
+            .setUser("orcluser")
+            .setHost("orcl.host")
+            .setPort(55)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:oci8:@")
+            .setShortUrl("oracle:oci8:")
+            .setSystem("oracle")
+            .setSubtype("oci8")
+            .setPort(1521)
+            .build(),
+        arg("jdbc:oracle:oci8:@")
+            .setProperties(stdProps())
+            .setShortUrl("oracle:oci8://stdServerName:9999")
+            .setSystem("oracle")
+            .setSubtype("oci8")
+            .setUser("stdUserName")
+            .setHost("stdServerName")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:oracle:oci8:@orclsn")
+            .setShortUrl("oracle:oci8:")
+            .setSystem("oracle")
+            .setSubtype("oci8")
+            .setPort(1521)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=orcl.host)(PORT=55))(CONNECT_DATA=(SERVICE_NAME=orclsn)))")
+            .setShortUrl("oracle:oci://orcl.host:55")
+            .setSystem("oracle")
+            .setSubtype("oci")
+            .setHost("orcl.host")
+            .setPort(55)
+            .setName("orclsn")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(OracleProvider.class)
+  @MethodSource("oracleArguments")
   void testOracleParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class Db2Provider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/java/src/tpc/imjcc_tjvjcccn.html
-          // https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052342.html
-          arg("jdbc:db2://db2.host")
-              .setShortUrl("db2://db2.host:50000")
-              .setSystem("db2")
-              .setHost("db2.host")
-              .setPort(50000)
-              .build(),
-          arg("jdbc:db2://db2.host")
-              .setProperties(stdProps())
-              .setShortUrl("db2://db2.host:9999")
-              .setSystem("db2")
-              .setUser("stdUserName")
-              .setHost("db2.host")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
-              .setShortUrl("db2://db2.host:77")
-              .setSystem("db2")
-              .setUser("db2user")
-              .setHost("db2.host")
-              .setPort(77)
-              .setName("db2db")
-              .build(),
-          arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
-              .setProperties(stdProps())
-              .setShortUrl("db2://db2.host:77")
-              .setSystem("db2")
-              .setUser("db2user")
-              .setHost("db2.host")
-              .setPort(77)
-              .setName("db2db")
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:as400://ashost:66/asdb:user=asuser;password=PW;")
-              .setShortUrl("as400://ashost:66")
-              .setSystem("db2")
-              .setUser("asuser")
-              .setHost("ashost")
-              .setPort(66)
-              .setName("asdb")
-              .build());
-    }
+  private static Stream<Arguments> db2Arguments() {
+    return args(
+        // https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/java/src/tpc/imjcc_tjvjcccn.html
+        // https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052342.html
+        arg("jdbc:db2://db2.host")
+            .setShortUrl("db2://db2.host:50000")
+            .setSystem("db2")
+            .setHost("db2.host")
+            .setPort(50000)
+            .build(),
+        arg("jdbc:db2://db2.host")
+            .setProperties(stdProps())
+            .setShortUrl("db2://db2.host:9999")
+            .setSystem("db2")
+            .setUser("stdUserName")
+            .setHost("db2.host")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
+            .setShortUrl("db2://db2.host:77")
+            .setSystem("db2")
+            .setUser("db2user")
+            .setHost("db2.host")
+            .setPort(77)
+            .setName("db2db")
+            .build(),
+        arg("jdbc:db2://db2.host:77/db2db:user=db2user;password=PW;")
+            .setProperties(stdProps())
+            .setShortUrl("db2://db2.host:77")
+            .setSystem("db2")
+            .setUser("db2user")
+            .setHost("db2.host")
+            .setPort(77)
+            .setName("db2db")
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:as400://ashost:66/asdb:user=asuser;password=PW;")
+            .setShortUrl("as400://ashost:66")
+            .setSystem("db2")
+            .setUser("asuser")
+            .setHost("ashost")
+            .setPort(66)
+            .setName("asdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(Db2Provider.class)
+  @MethodSource("db2Arguments")
   void testDb2Parsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class SapProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.03/en-US/ff15928cf5594d78b841fbbe649f04b4.html
-          arg("jdbc:sap://sap.host")
-              .setShortUrl("sap://sap.host")
-              .setSystem("hanadb")
-              .setHost("sap.host")
-              .build(),
-          arg("jdbc:sap://sap.host")
-              .setProperties(stdProps())
-              .setShortUrl("sap://sap.host:9999")
-              .setSystem("hanadb")
-              .setUser("stdUserName")
-              .setHost("sap.host")
-              .setPort(9999)
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:sap://sap.host:88/?databaseName=sapdb&user=sapuser&password=PW")
-              .setShortUrl("sap://sap.host:88")
-              .setSystem("hanadb")
-              .setUser("sapuser")
-              .setHost("sap.host")
-              .setPort(88)
-              .setDb("sapdb")
-              .build());
-    }
+  private static Stream<Arguments> sapArguments() {
+    return args(
+        // https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.03/en-US/ff15928cf5594d78b841fbbe649f04b4.html
+        arg("jdbc:sap://sap.host")
+            .setShortUrl("sap://sap.host")
+            .setSystem("hanadb")
+            .setHost("sap.host")
+            .build(),
+        arg("jdbc:sap://sap.host")
+            .setProperties(stdProps())
+            .setShortUrl("sap://sap.host:9999")
+            .setSystem("hanadb")
+            .setUser("stdUserName")
+            .setHost("sap.host")
+            .setPort(9999)
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:sap://sap.host:88/?databaseName=sapdb&user=sapuser&password=PW")
+            .setShortUrl("sap://sap.host:88")
+            .setSystem("hanadb")
+            .setUser("sapuser")
+            .setHost("sap.host")
+            .setPort(88)
+            .setDb("sapdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(SapProvider.class)
+  @MethodSource("sapArguments")
   void testSapParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class InformixProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://www.ibm.com/support/pages/how-configure-informix-jdbc-connection-string-connect-group
-          arg("jdbc:informix-sqli://infxhost:99/infxdb:INFORMIXSERVER=infxsn;user=infxuser;password=PW")
-              .setSystem("informix-sqli")
-              .setUser("infxuser")
-              .setShortUrl("informix-sqli://infxhost:99")
-              .setHost("infxhost")
-              .setPort(99)
-              .setName("infxdb")
-              .build(),
-          arg("jdbc:informix-sqli://localhost:9088/stores_demo:INFORMIXSERVER=informix")
-              .setSystem("informix-sqli")
-              .setShortUrl("informix-sqli://localhost:9088")
-              .setHost("localhost")
-              .setPort(9088)
-              .setName("stores_demo")
-              .build(),
-          arg("jdbc:informix-sqli://infxhost:99")
-              .setSystem("informix-sqli")
-              .setShortUrl("informix-sqli://infxhost:99")
-              .setHost("infxhost")
-              .setPort(99)
-              .build(),
-          arg("jdbc:informix-sqli://infxhost/")
-              .setSystem("informix-sqli")
-              .setShortUrl("informix-sqli://infxhost:9088")
-              .setHost("infxhost")
-              .setPort(9088)
-              .build(),
-          arg("jdbc:informix-sqli:")
-              .setSystem("informix-sqli")
-              .setShortUrl("informix-sqli:")
-              .setPort(9088)
-              .build(),
+  private static Stream<Arguments> informixArguments() {
+    return args(
+        // https://www.ibm.com/support/pages/how-configure-informix-jdbc-connection-string-connect-group
+        arg("jdbc:informix-sqli://infxhost:99/infxdb:INFORMIXSERVER=infxsn;user=infxuser;password=PW")
+            .setSystem("informix-sqli")
+            .setUser("infxuser")
+            .setShortUrl("informix-sqli://infxhost:99")
+            .setHost("infxhost")
+            .setPort(99)
+            .setName("infxdb")
+            .build(),
+        arg("jdbc:informix-sqli://localhost:9088/stores_demo:INFORMIXSERVER=informix")
+            .setSystem("informix-sqli")
+            .setShortUrl("informix-sqli://localhost:9088")
+            .setHost("localhost")
+            .setPort(9088)
+            .setName("stores_demo")
+            .build(),
+        arg("jdbc:informix-sqli://infxhost:99")
+            .setSystem("informix-sqli")
+            .setShortUrl("informix-sqli://infxhost:99")
+            .setHost("infxhost")
+            .setPort(99)
+            .build(),
+        arg("jdbc:informix-sqli://infxhost/")
+            .setSystem("informix-sqli")
+            .setShortUrl("informix-sqli://infxhost:9088")
+            .setHost("infxhost")
+            .setPort(9088)
+            .build(),
+        arg("jdbc:informix-sqli:")
+            .setSystem("informix-sqli")
+            .setShortUrl("informix-sqli:")
+            .setPort(9088)
+            .build(),
 
-          // https://www.ibm.com/docs/en/informix-servers/12.10?topic=method-format-database-urls
-          arg("jdbc:informix-direct://infxdb:999;user=infxuser;password=PW")
-              .setSystem("informix-direct")
-              .setShortUrl("informix-direct:")
-              .setUser("infxuser")
-              .setName("infxdb")
-              .build(),
-          arg("jdbc:informix-direct://infxdb;user=infxuser;password=PW")
-              .setSystem("informix-direct")
-              .setShortUrl("informix-direct:")
-              .setUser("infxuser")
-              .setName("infxdb")
-              .build(),
-          arg("jdbc:informix-direct://infxdb")
-              .setSystem("informix-direct")
-              .setShortUrl("informix-direct:")
-              .setName("infxdb")
-              .build(),
-          arg("jdbc:informix-direct:")
-              .setSystem("informix-direct")
-              .setShortUrl("informix-direct:")
-              .build());
-    }
+        // https://www.ibm.com/docs/en/informix-servers/12.10?topic=method-format-database-urls
+        arg("jdbc:informix-direct://infxdb:999;user=infxuser;password=PW")
+            .setSystem("informix-direct")
+            .setShortUrl("informix-direct:")
+            .setUser("infxuser")
+            .setName("infxdb")
+            .build(),
+        arg("jdbc:informix-direct://infxdb;user=infxuser;password=PW")
+            .setSystem("informix-direct")
+            .setShortUrl("informix-direct:")
+            .setUser("infxuser")
+            .setName("infxdb")
+            .build(),
+        arg("jdbc:informix-direct://infxdb")
+            .setSystem("informix-direct")
+            .setShortUrl("informix-direct:")
+            .setName("infxdb")
+            .build(),
+        arg("jdbc:informix-direct:")
+            .setSystem("informix-direct")
+            .setShortUrl("informix-direct:")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(InformixProvider.class)
+  @MethodSource("informixArguments")
   void testInformixParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class H2Provider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // http://www.h2database.com/html/features.html#database_url
-          arg("jdbc:h2:mem:").setShortUrl("h2:mem:").setSystem("h2").setSubtype("mem").build(),
-          arg("jdbc:h2:mem:")
-              .setProperties(stdProps())
-              .setShortUrl("h2:mem:")
-              .setSystem("h2")
-              .setSubtype("mem")
-              .setUser("stdUserName")
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:h2:mem:h2db")
-              .setShortUrl("h2:mem:")
-              .setSystem("h2")
-              .setSubtype("mem")
-              .setName("h2db")
-              .build(),
-          arg("jdbc:h2:tcp://h2.host:111/path/h2db;user=h2user;password=PW")
-              .setShortUrl("h2:tcp://h2.host:111")
-              .setSystem("h2")
-              .setSubtype("tcp")
-              .setUser("h2user")
-              .setHost("h2.host")
-              .setPort(111)
-              .setName("path/h2db")
-              .build(),
-          arg("jdbc:h2:ssl://h2.host:111/path/h2db;user=h2user;password=PW")
-              .setShortUrl("h2:ssl://h2.host:111")
-              .setSystem("h2")
-              .setSubtype("ssl")
-              .setUser("h2user")
-              .setHost("h2.host")
-              .setPort(111)
-              .setName("path/h2db")
-              .build(),
-          arg("jdbc:h2:/data/h2file")
-              .setShortUrl("h2:file:")
-              .setSystem("h2")
-              .setSubtype("file")
-              .setName("/data/h2file")
-              .build(),
-          arg("jdbc:h2:file:~/h2file;USER=h2user;PASSWORD=PW")
-              .setShortUrl("h2:file:")
-              .setSystem("h2")
-              .setSubtype("file")
-              .setName("~/h2file")
-              .build(),
-          arg("jdbc:h2:file:/data/h2file")
-              .setShortUrl("h2:file:")
-              .setSystem("h2")
-              .setSubtype("file")
-              .setName("/data/h2file")
-              .build(),
-          arg("jdbc:h2:file:C:/data/h2file")
-              .setShortUrl("h2:file:")
-              .setSystem("h2")
-              .setSubtype("file")
-              .setName("c:/data/h2file")
-              .build(),
-          arg("jdbc:h2:zip:~/db.zip!/h2zip")
-              .setShortUrl("h2:zip:")
-              .setSystem("h2")
-              .setSubtype("zip")
-              .setName("~/db.zip!/h2zip")
-              .build());
-    }
+  private static Stream<Arguments> h2Arguments() {
+    return args(
+        // http://www.h2database.com/html/features.html#database_url
+        arg("jdbc:h2:mem:").setShortUrl("h2:mem:").setSystem("h2").setSubtype("mem").build(),
+        arg("jdbc:h2:mem:")
+            .setProperties(stdProps())
+            .setShortUrl("h2:mem:")
+            .setSystem("h2")
+            .setSubtype("mem")
+            .setUser("stdUserName")
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:h2:mem:h2db")
+            .setShortUrl("h2:mem:")
+            .setSystem("h2")
+            .setSubtype("mem")
+            .setName("h2db")
+            .build(),
+        arg("jdbc:h2:tcp://h2.host:111/path/h2db;user=h2user;password=PW")
+            .setShortUrl("h2:tcp://h2.host:111")
+            .setSystem("h2")
+            .setSubtype("tcp")
+            .setUser("h2user")
+            .setHost("h2.host")
+            .setPort(111)
+            .setName("path/h2db")
+            .build(),
+        arg("jdbc:h2:ssl://h2.host:111/path/h2db;user=h2user;password=PW")
+            .setShortUrl("h2:ssl://h2.host:111")
+            .setSystem("h2")
+            .setSubtype("ssl")
+            .setUser("h2user")
+            .setHost("h2.host")
+            .setPort(111)
+            .setName("path/h2db")
+            .build(),
+        arg("jdbc:h2:/data/h2file")
+            .setShortUrl("h2:file:")
+            .setSystem("h2")
+            .setSubtype("file")
+            .setName("/data/h2file")
+            .build(),
+        arg("jdbc:h2:file:~/h2file;USER=h2user;PASSWORD=PW")
+            .setShortUrl("h2:file:")
+            .setSystem("h2")
+            .setSubtype("file")
+            .setName("~/h2file")
+            .build(),
+        arg("jdbc:h2:file:/data/h2file")
+            .setShortUrl("h2:file:")
+            .setSystem("h2")
+            .setSubtype("file")
+            .setName("/data/h2file")
+            .build(),
+        arg("jdbc:h2:file:C:/data/h2file")
+            .setShortUrl("h2:file:")
+            .setSystem("h2")
+            .setSubtype("file")
+            .setName("c:/data/h2file")
+            .build(),
+        arg("jdbc:h2:zip:~/db.zip!/h2zip")
+            .setShortUrl("h2:zip:")
+            .setSystem("h2")
+            .setSubtype("zip")
+            .setName("~/db.zip!/h2zip")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(H2Provider.class)
+  @MethodSource("h2Arguments")
   void testH2Parsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class HsqlDbProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // http://hsqldb.org/doc/2.0/guide/dbproperties-chapt.html
-          arg("jdbc:hsqldb:hsdb")
-              .setShortUrl("hsqldb:mem:")
-              .setSystem("hsqldb")
-              .setSubtype("mem")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:hsdb")
-              .setProperties(stdProps())
-              .setShortUrl("hsqldb:mem:")
-              .setSystem("hsqldb")
-              .setSubtype("mem")
-              .setUser("stdUserName")
-              .setName("hsdb")
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:hsqldb:mem:hsdb")
-              .setShortUrl("hsqldb:mem:")
-              .setSystem("hsqldb")
-              .setSubtype("mem")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:mem:hsdb;shutdown=true")
-              .setShortUrl("hsqldb:mem:")
-              .setSystem("hsqldb")
-              .setSubtype("mem")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:mem:hsdb?shutdown=true")
-              .setShortUrl("hsqldb:mem:")
-              .setSystem("hsqldb")
-              .setSubtype("mem")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:file:hsdb")
-              .setShortUrl("hsqldb:file:")
-              .setSystem("hsqldb")
-              .setSubtype("file")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:file:hsdb;user=aUserName;password=3xLVz")
-              .setShortUrl("hsqldb:file:")
-              .setSystem("hsqldb")
-              .setSubtype("file")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:file:hsdb;create=false?user=aUserName&password=3xLVz")
-              .setShortUrl("hsqldb:file:")
-              .setSystem("hsqldb")
-              .setSubtype("file")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:file:/loc/hsdb")
-              .setShortUrl("hsqldb:file:")
-              .setSystem("hsqldb")
-              .setSubtype("file")
-              .setUser("SA")
-              .setName("/loc/hsdb")
-              .build(),
-          arg("jdbc:hsqldb:file:C:/hsdb")
-              .setShortUrl("hsqldb:file:")
-              .setSystem("hsqldb")
-              .setSubtype("file")
-              .setUser("SA")
-              .setName("c:/hsdb")
-              .build(),
-          arg("jdbc:hsqldb:res:hsdb")
-              .setShortUrl("hsqldb:res:")
-              .setSystem("hsqldb")
-              .setSubtype("res")
-              .setUser("SA")
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:res:/cp/hsdb")
-              .setShortUrl("hsqldb:res:")
-              .setSystem("hsqldb")
-              .setSubtype("res")
-              .setUser("SA")
-              .setName("/cp/hsdb")
-              .build(),
-          arg("jdbc:hsqldb:hsql://hs.host:333/hsdb")
-              .setShortUrl("hsqldb:hsql://hs.host:333")
-              .setSystem("hsqldb")
-              .setSubtype("hsql")
-              .setUser("SA")
-              .setHost("hs.host")
-              .setPort(333)
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:hsqls://hs.host/hsdb")
-              .setShortUrl("hsqldb:hsqls://hs.host:9001")
-              .setSystem("hsqldb")
-              .setSubtype("hsqls")
-              .setUser("SA")
-              .setHost("hs.host")
-              .setPort(9001)
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:http://hs.host")
-              .setShortUrl("hsqldb:http://hs.host:80")
-              .setSystem("hsqldb")
-              .setSubtype("http")
-              .setUser("SA")
-              .setHost("hs.host")
-              .setPort(80)
-              .build(),
-          arg("jdbc:hsqldb:http://hs.host:333/hsdb")
-              .setShortUrl("hsqldb:http://hs.host:333")
-              .setSystem("hsqldb")
-              .setSubtype("http")
-              .setUser("SA")
-              .setHost("hs.host")
-              .setPort(333)
-              .setName("hsdb")
-              .build(),
-          arg("jdbc:hsqldb:https://127.0.0.1/hsdb")
-              .setShortUrl("hsqldb:https://127.0.0.1:443")
-              .setSystem("hsqldb")
-              .setSubtype("https")
-              .setUser("SA")
-              .setHost("127.0.0.1")
-              .setPort(443)
-              .setName("hsdb")
-              .build());
-    }
+  private static Stream<Arguments> hsqlDbArguments() {
+    return args(
+        // http://hsqldb.org/doc/2.0/guide/dbproperties-chapt.html
+        arg("jdbc:hsqldb:hsdb")
+            .setShortUrl("hsqldb:mem:")
+            .setSystem("hsqldb")
+            .setSubtype("mem")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:hsdb")
+            .setProperties(stdProps())
+            .setShortUrl("hsqldb:mem:")
+            .setSystem("hsqldb")
+            .setSubtype("mem")
+            .setUser("stdUserName")
+            .setName("hsdb")
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:hsqldb:mem:hsdb")
+            .setShortUrl("hsqldb:mem:")
+            .setSystem("hsqldb")
+            .setSubtype("mem")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:mem:hsdb;shutdown=true")
+            .setShortUrl("hsqldb:mem:")
+            .setSystem("hsqldb")
+            .setSubtype("mem")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:mem:hsdb?shutdown=true")
+            .setShortUrl("hsqldb:mem:")
+            .setSystem("hsqldb")
+            .setSubtype("mem")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:file:hsdb")
+            .setShortUrl("hsqldb:file:")
+            .setSystem("hsqldb")
+            .setSubtype("file")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:file:hsdb;user=aUserName;password=3xLVz")
+            .setShortUrl("hsqldb:file:")
+            .setSystem("hsqldb")
+            .setSubtype("file")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:file:hsdb;create=false?user=aUserName&password=3xLVz")
+            .setShortUrl("hsqldb:file:")
+            .setSystem("hsqldb")
+            .setSubtype("file")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:file:/loc/hsdb")
+            .setShortUrl("hsqldb:file:")
+            .setSystem("hsqldb")
+            .setSubtype("file")
+            .setUser("SA")
+            .setName("/loc/hsdb")
+            .build(),
+        arg("jdbc:hsqldb:file:C:/hsdb")
+            .setShortUrl("hsqldb:file:")
+            .setSystem("hsqldb")
+            .setSubtype("file")
+            .setUser("SA")
+            .setName("c:/hsdb")
+            .build(),
+        arg("jdbc:hsqldb:res:hsdb")
+            .setShortUrl("hsqldb:res:")
+            .setSystem("hsqldb")
+            .setSubtype("res")
+            .setUser("SA")
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:res:/cp/hsdb")
+            .setShortUrl("hsqldb:res:")
+            .setSystem("hsqldb")
+            .setSubtype("res")
+            .setUser("SA")
+            .setName("/cp/hsdb")
+            .build(),
+        arg("jdbc:hsqldb:hsql://hs.host:333/hsdb")
+            .setShortUrl("hsqldb:hsql://hs.host:333")
+            .setSystem("hsqldb")
+            .setSubtype("hsql")
+            .setUser("SA")
+            .setHost("hs.host")
+            .setPort(333)
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:hsqls://hs.host/hsdb")
+            .setShortUrl("hsqldb:hsqls://hs.host:9001")
+            .setSystem("hsqldb")
+            .setSubtype("hsqls")
+            .setUser("SA")
+            .setHost("hs.host")
+            .setPort(9001)
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:http://hs.host")
+            .setShortUrl("hsqldb:http://hs.host:80")
+            .setSystem("hsqldb")
+            .setSubtype("http")
+            .setUser("SA")
+            .setHost("hs.host")
+            .setPort(80)
+            .build(),
+        arg("jdbc:hsqldb:http://hs.host:333/hsdb")
+            .setShortUrl("hsqldb:http://hs.host:333")
+            .setSystem("hsqldb")
+            .setSubtype("http")
+            .setUser("SA")
+            .setHost("hs.host")
+            .setPort(333)
+            .setName("hsdb")
+            .build(),
+        arg("jdbc:hsqldb:https://127.0.0.1/hsdb")
+            .setShortUrl("hsqldb:https://127.0.0.1:443")
+            .setSystem("hsqldb")
+            .setSubtype("https")
+            .setUser("SA")
+            .setHost("127.0.0.1")
+            .setPort(443)
+            .setName("hsdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(HsqlDbProvider.class)
+  @MethodSource("hsqlDbArguments")
   void testHsqlDbParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class DerbyProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://db.apache.org/derby/papers/DerbyClientSpec.html#Connection+URL+Format
-          // https://db.apache.org/derby/docs/10.8/devguide/cdevdvlp34964.html
-          arg("jdbc:derby:derbydb")
-              .setShortUrl("derby:directory:")
-              .setSystem("derby")
-              .setSubtype("directory")
-              .setUser("APP")
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby:derbydb")
-              .setProperties(stdProps())
-              .setShortUrl("derby:directory:")
-              .setSystem("derby")
-              .setSubtype("directory")
-              .setUser("stdUserName")
-              .setName("derbydb")
-              .setDb("stdDatabaseName")
-              .build(),
-          arg("jdbc:derby:derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:directory:")
-              .setSystem("derby")
-              .setSubtype("directory")
-              .setUser("derbyuser")
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby:memory:derbydb")
-              .setShortUrl("derby:memory:")
-              .setSystem("derby")
-              .setSubtype("memory")
-              .setUser("APP")
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby:memory:;databaseName=derbydb")
-              .setShortUrl("derby:memory:")
-              .setSystem("derby")
-              .setSubtype("memory")
-              .setUser("APP")
-              .setDb("derbydb")
-              .build(),
-          arg("jdbc:derby:memory:derbydb;databaseName=altdb")
-              .setShortUrl("derby:memory:")
-              .setSystem("derby")
-              .setSubtype("memory")
-              .setUser("APP")
-              .setName("derbydb")
-              .setDb("altdb")
-              .build(),
-          arg("jdbc:derby:memory:derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:memory:")
-              .setSystem("derby")
-              .setSubtype("memory")
-              .setUser("derbyuser")
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby://derby.host:222/memory:derbydb;create=true")
-              .setShortUrl("derby:network://derby.host:222")
-              .setSystem("derby")
-              .setSubtype("network")
-              .setUser("APP")
-              .setHost("derby.host")
-              .setPort(222)
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby://derby.host/memory:derbydb;create=true;user=derbyuser;password=pw")
-              .setShortUrl("derby:network://derby.host:1527")
-              .setSystem("derby")
-              .setSubtype("network")
-              .setUser("derbyuser")
-              .setHost("derby.host")
-              .setPort(1527)
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby://127.0.0.1:1527/memory:derbydb;create=true;user=derbyuser;password=pw")
-              .setShortUrl("derby:network://127.0.0.1:1527")
-              .setSystem("derby")
-              .setSubtype("network")
-              .setUser("derbyuser")
-              .setHost("127.0.0.1")
-              .setPort(1527)
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby:directory:derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:directory:")
-              .setSystem("derby")
-              .setSubtype("directory")
-              .setUser("derbyuser")
-              .setName("derbydb")
-              .build(),
-          arg("jdbc:derby:classpath:/some/derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:classpath:")
-              .setSystem("derby")
-              .setSubtype("classpath")
-              .setUser("derbyuser")
-              .setName("/some/derbydb")
-              .build(),
-          arg("jdbc:derby:jar:/derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:jar:")
-              .setSystem("derby")
-              .setSubtype("jar")
-              .setUser("derbyuser")
-              .setName("/derbydb")
-              .build(),
-          arg("jdbc:derby:jar:(~/path/to/db.jar)/other/derbydb;user=derbyuser;password=pw")
-              .setShortUrl("derby:jar:")
-              .setSystem("derby")
-              .setSubtype("jar")
-              .setUser("derbyuser")
-              .setName("(~/path/to/db.jar)/other/derbydb")
-              .build(),
-          arg("jdbc:derby:directory:/usr/ibm/pep/was9/ibm/websphere/appserver/profiles/my_profile/databases/ejbtimers/myhostname/ejbtimerdb")
-              .setShortUrl("derby:directory:")
-              .setSystem("derby")
-              .setSubtype("directory")
-              .setUser("APP")
-              .setName("ejbtimerdb")
-              .build());
-    }
+  private static Stream<Arguments> derbyArguments() {
+    return args(
+        // https://db.apache.org/derby/papers/DerbyClientSpec.html#Connection+URL+Format
+        // https://db.apache.org/derby/docs/10.8/devguide/cdevdvlp34964.html
+        arg("jdbc:derby:derbydb")
+            .setShortUrl("derby:directory:")
+            .setSystem("derby")
+            .setSubtype("directory")
+            .setUser("APP")
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby:derbydb")
+            .setProperties(stdProps())
+            .setShortUrl("derby:directory:")
+            .setSystem("derby")
+            .setSubtype("directory")
+            .setUser("stdUserName")
+            .setName("derbydb")
+            .setDb("stdDatabaseName")
+            .build(),
+        arg("jdbc:derby:derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:directory:")
+            .setSystem("derby")
+            .setSubtype("directory")
+            .setUser("derbyuser")
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby:memory:derbydb")
+            .setShortUrl("derby:memory:")
+            .setSystem("derby")
+            .setSubtype("memory")
+            .setUser("APP")
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby:memory:;databaseName=derbydb")
+            .setShortUrl("derby:memory:")
+            .setSystem("derby")
+            .setSubtype("memory")
+            .setUser("APP")
+            .setDb("derbydb")
+            .build(),
+        arg("jdbc:derby:memory:derbydb;databaseName=altdb")
+            .setShortUrl("derby:memory:")
+            .setSystem("derby")
+            .setSubtype("memory")
+            .setUser("APP")
+            .setName("derbydb")
+            .setDb("altdb")
+            .build(),
+        arg("jdbc:derby:memory:derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:memory:")
+            .setSystem("derby")
+            .setSubtype("memory")
+            .setUser("derbyuser")
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby://derby.host:222/memory:derbydb;create=true")
+            .setShortUrl("derby:network://derby.host:222")
+            .setSystem("derby")
+            .setSubtype("network")
+            .setUser("APP")
+            .setHost("derby.host")
+            .setPort(222)
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby://derby.host/memory:derbydb;create=true;user=derbyuser;password=pw")
+            .setShortUrl("derby:network://derby.host:1527")
+            .setSystem("derby")
+            .setSubtype("network")
+            .setUser("derbyuser")
+            .setHost("derby.host")
+            .setPort(1527)
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby://127.0.0.1:1527/memory:derbydb;create=true;user=derbyuser;password=pw")
+            .setShortUrl("derby:network://127.0.0.1:1527")
+            .setSystem("derby")
+            .setSubtype("network")
+            .setUser("derbyuser")
+            .setHost("127.0.0.1")
+            .setPort(1527)
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby:directory:derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:directory:")
+            .setSystem("derby")
+            .setSubtype("directory")
+            .setUser("derbyuser")
+            .setName("derbydb")
+            .build(),
+        arg("jdbc:derby:classpath:/some/derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:classpath:")
+            .setSystem("derby")
+            .setSubtype("classpath")
+            .setUser("derbyuser")
+            .setName("/some/derbydb")
+            .build(),
+        arg("jdbc:derby:jar:/derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:jar:")
+            .setSystem("derby")
+            .setSubtype("jar")
+            .setUser("derbyuser")
+            .setName("/derbydb")
+            .build(),
+        arg("jdbc:derby:jar:(~/path/to/db.jar)/other/derbydb;user=derbyuser;password=pw")
+            .setShortUrl("derby:jar:")
+            .setSystem("derby")
+            .setSubtype("jar")
+            .setUser("derbyuser")
+            .setName("(~/path/to/db.jar)/other/derbydb")
+            .build(),
+        arg("jdbc:derby:directory:/usr/ibm/pep/was9/ibm/websphere/appserver/profiles/my_profile/databases/ejbtimers/myhostname/ejbtimerdb")
+            .setShortUrl("derby:directory:")
+            .setSystem("derby")
+            .setSubtype("directory")
+            .setUser("APP")
+            .setName("ejbtimerdb")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(DerbyProvider.class)
+  @MethodSource("derbyArguments")
   void testDerbyParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class DataDirectProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://docs.progress.com/bundle/datadirect-connect-jdbc-51/page/URL-Formats-DataDirect-Connect-for-JDBC-Drivers.html
-          arg("jdbc:datadirect:sqlserver://server_name:1433;DatabaseName=dbname")
-              .setShortUrl("datadirect:sqlserver://server_name:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("server_name")
-              .setPort(1433)
-              .setDb("dbname")
-              .build(),
-          arg("jdbc:datadirect:oracle://server_name:1521;ServiceName=your_servicename")
-              .setShortUrl("datadirect:oracle://server_name:1521")
-              .setSystem("oracle")
-              .setSubtype("oracle")
-              .setHost("server_name")
-              .setPort(1521)
-              .build(),
-          arg("jdbc:datadirect:mysql://server_name:3306")
-              .setShortUrl("datadirect:mysql://server_name:3306")
-              .setSystem("mysql")
-              .setSubtype("mysql")
-              .setHost("server_name")
-              .setPort(3306)
-              .build(),
-          arg("jdbc:datadirect:postgresql://server_name:5432;DatabaseName=dbname")
-              .setShortUrl("datadirect:postgresql://server_name:5432")
-              .setSystem("postgresql")
-              .setSubtype("postgresql")
-              .setHost("server_name")
-              .setPort(5432)
-              .setDb("dbname")
-              .build(),
-          arg("jdbc:datadirect:db2://server_name:50000;DatabaseName=dbname")
-              .setShortUrl("datadirect:db2://server_name:50000")
-              .setSystem("db2")
-              .setSubtype("db2")
-              .setHost("server_name")
-              .setPort(50000)
-              .setDb("dbname")
-              .build());
-    }
+  private static Stream<Arguments> dataDirectArguments() {
+    return args(
+        // https://docs.progress.com/bundle/datadirect-connect-jdbc-51/page/URL-Formats-DataDirect-Connect-for-JDBC-Drivers.html
+        arg("jdbc:datadirect:sqlserver://server_name:1433;DatabaseName=dbname")
+            .setShortUrl("datadirect:sqlserver://server_name:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("server_name")
+            .setPort(1433)
+            .setDb("dbname")
+            .build(),
+        arg("jdbc:datadirect:oracle://server_name:1521;ServiceName=your_servicename")
+            .setShortUrl("datadirect:oracle://server_name:1521")
+            .setSystem("oracle")
+            .setSubtype("oracle")
+            .setHost("server_name")
+            .setPort(1521)
+            .build(),
+        arg("jdbc:datadirect:mysql://server_name:3306")
+            .setShortUrl("datadirect:mysql://server_name:3306")
+            .setSystem("mysql")
+            .setSubtype("mysql")
+            .setHost("server_name")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:datadirect:postgresql://server_name:5432;DatabaseName=dbname")
+            .setShortUrl("datadirect:postgresql://server_name:5432")
+            .setSystem("postgresql")
+            .setSubtype("postgresql")
+            .setHost("server_name")
+            .setPort(5432)
+            .setDb("dbname")
+            .build(),
+        arg("jdbc:datadirect:db2://server_name:50000;DatabaseName=dbname")
+            .setShortUrl("datadirect:db2://server_name:50000")
+            .setSystem("db2")
+            .setSubtype("db2")
+            .setHost("server_name")
+            .setPort(50000)
+            .setDb("dbname")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(DataDirectProvider.class)
+  @MethodSource("dataDirectArguments")
   void testDataDirectParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class TibcoProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // "the TIBCO JDBC drivers are based on the Progress DataDirect Connect drivers"
-          // https://community.jaspersoft.com/documentation/tibco-jasperreports-server-administrator-guide/v601/working-data-sources
-          arg("jdbc:tibcosoftware:sqlserver://server_name:1433;DatabaseName=dbname")
-              .setShortUrl("tibcosoftware:sqlserver://server_name:1433")
-              .setSystem("mssql")
-              .setSubtype("sqlserver")
-              .setHost("server_name")
-              .setPort(1433)
-              .setDb("dbname")
-              .build(),
-          arg("jdbc:tibcosoftware:oracle://server_name:1521;ServiceName=your_servicename")
-              .setShortUrl("tibcosoftware:oracle://server_name:1521")
-              .setSystem("oracle")
-              .setSubtype("oracle")
-              .setHost("server_name")
-              .setPort(1521)
-              .build(),
-          arg("jdbc:tibcosoftware:mysql://server_name:3306")
-              .setShortUrl("tibcosoftware:mysql://server_name:3306")
-              .setSystem("mysql")
-              .setSubtype("mysql")
-              .setHost("server_name")
-              .setPort(3306)
-              .build(),
-          arg("jdbc:tibcosoftware:postgresql://server_name:5432;DatabaseName=dbname")
-              .setShortUrl("tibcosoftware:postgresql://server_name:5432")
-              .setSystem("postgresql")
-              .setSubtype("postgresql")
-              .setHost("server_name")
-              .setPort(5432)
-              .setDb("dbname")
-              .build(),
-          arg("jdbc:tibcosoftware:db2://server_name:50000;DatabaseName=dbname")
-              .setShortUrl("tibcosoftware:db2://server_name:50000")
-              .setSystem("db2")
-              .setSubtype("db2")
-              .setHost("server_name")
-              .setPort(50000)
-              .setDb("dbname")
-              .build());
-    }
+  private static Stream<Arguments> tibcoArguments() {
+    return args(
+        // "the TIBCO JDBC drivers are based on the Progress DataDirect Connect drivers"
+        // https://community.jaspersoft.com/documentation/tibco-jasperreports-server-administrator-guide/v601/working-data-sources
+        arg("jdbc:tibcosoftware:sqlserver://server_name:1433;DatabaseName=dbname")
+            .setShortUrl("tibcosoftware:sqlserver://server_name:1433")
+            .setSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("server_name")
+            .setPort(1433)
+            .setDb("dbname")
+            .build(),
+        arg("jdbc:tibcosoftware:oracle://server_name:1521;ServiceName=your_servicename")
+            .setShortUrl("tibcosoftware:oracle://server_name:1521")
+            .setSystem("oracle")
+            .setSubtype("oracle")
+            .setHost("server_name")
+            .setPort(1521)
+            .build(),
+        arg("jdbc:tibcosoftware:mysql://server_name:3306")
+            .setShortUrl("tibcosoftware:mysql://server_name:3306")
+            .setSystem("mysql")
+            .setSubtype("mysql")
+            .setHost("server_name")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:tibcosoftware:postgresql://server_name:5432;DatabaseName=dbname")
+            .setShortUrl("tibcosoftware:postgresql://server_name:5432")
+            .setSystem("postgresql")
+            .setSubtype("postgresql")
+            .setHost("server_name")
+            .setPort(5432)
+            .setDb("dbname")
+            .build(),
+        arg("jdbc:tibcosoftware:db2://server_name:50000;DatabaseName=dbname")
+            .setShortUrl("tibcosoftware:db2://server_name:50000")
+            .setSystem("db2")
+            .setSubtype("db2")
+            .setHost("server_name")
+            .setPort(50000)
+            .setDb("dbname")
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(TibcoProvider.class)
+  @MethodSource("tibcoArguments")
   void testTibcoParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  static final class SecretsManagerProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return args(
-          // https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_jdbc.html
-          arg("jdbc-secretsmanager:mysql://example.com:50000")
-              .setShortUrl("mysql://example.com:50000")
-              .setSystem("mysql")
-              .setHost("example.com")
-              .setPort(50000)
-              .build(),
-          arg("jdbc-secretsmanager:postgresql://example.com:50000/dbname")
-              .setShortUrl("postgresql://example.com:50000")
-              .setSystem("postgresql")
-              .setHost("example.com")
-              .setPort(50000)
-              .setDb("dbname")
-              .build(),
-          arg("jdbc-secretsmanager:oracle:thin:@example.com:50000/ORCL")
-              .setShortUrl("oracle:thin://example.com:50000")
-              .setSystem("oracle")
-              .setSubtype("thin")
-              .setHost("example.com")
-              .setPort(50000)
-              .setName("orcl")
-              .build(),
-          arg("jdbc-secretsmanager:sqlserver://example.com:50000")
-              .setShortUrl("sqlserver://example.com:50000")
-              .setSystem("mssql")
-              .setHost("example.com")
-              .setPort(50000)
-              .build());
-    }
+  private static Stream<Arguments> secretsManagerArguments() {
+    return args(
+        // https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_jdbc.html
+        arg("jdbc-secretsmanager:mysql://example.com:50000")
+            .setShortUrl("mysql://example.com:50000")
+            .setSystem("mysql")
+            .setHost("example.com")
+            .setPort(50000)
+            .build(),
+        arg("jdbc-secretsmanager:postgresql://example.com:50000/dbname")
+            .setShortUrl("postgresql://example.com:50000")
+            .setSystem("postgresql")
+            .setHost("example.com")
+            .setPort(50000)
+            .setDb("dbname")
+            .build(),
+        arg("jdbc-secretsmanager:oracle:thin:@example.com:50000/ORCL")
+            .setShortUrl("oracle:thin://example.com:50000")
+            .setSystem("oracle")
+            .setSubtype("thin")
+            .setHost("example.com")
+            .setPort(50000)
+            .setName("orcl")
+            .build(),
+        arg("jdbc-secretsmanager:sqlserver://example.com:50000")
+            .setShortUrl("sqlserver://example.com:50000")
+            .setSystem("mssql")
+            .setHost("example.com")
+            .setPort(50000)
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @ArgumentsSource(SecretsManagerProvider.class)
+  @MethodSource("secretsManagerArguments")
   void testSecretsManagerParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -39,12 +39,10 @@ import org.apache.activemq.command.ActiveMQTextMessage;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -93,8 +91,8 @@ abstract class AbstractJms1Test {
     }
   }
 
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void testMessageListener(
       DestinationFactory destinationFactory, String destinationName, boolean isTemporary)
       throws Exception {
@@ -150,8 +148,8 @@ abstract class AbstractJms1Test {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
-  @ArgumentsSource(EmptyReceiveArgumentsProvider.class)
   @ParameterizedTest
+  @MethodSource("emptyReceiveArguments")
   void shouldNotEmitTelemetryOnEmptyReceive(
       DestinationFactory destinationFactory, MessageReceiver receiver) throws JMSException {
 
@@ -170,8 +168,8 @@ abstract class AbstractJms1Test {
     testing.waitForTraces(0);
   }
 
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void shouldCaptureMessageHeaders(
       DestinationFactory destinationFactory, String destinationName, boolean isTemporary)
       throws Exception {
@@ -241,8 +239,8 @@ abstract class AbstractJms1Test {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void shouldFailWhenSendingReadOnlyMessage(
       DestinationFactory destinationFactory, String destinationName, boolean isTemporary)
       throws Exception {
@@ -307,38 +305,30 @@ abstract class AbstractJms1Test {
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
   }
 
-  static final class EmptyReceiveArgumentsProvider implements ArgumentsProvider {
+  private static Stream<Arguments> emptyReceiveArguments() {
+    DestinationFactory topic = session -> session.createTopic("someTopic");
+    DestinationFactory queue = session -> session.createQueue("someQueue");
+    MessageReceiver receive = consumer -> consumer.receive(100);
+    MessageReceiver receiveNoWait = MessageConsumer::receiveNoWait;
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      DestinationFactory topic = session -> session.createTopic("someTopic");
-      DestinationFactory queue = session -> session.createQueue("someQueue");
-      MessageReceiver receive = consumer -> consumer.receive(100);
-      MessageReceiver receiveNoWait = MessageConsumer::receiveNoWait;
-
-      return Stream.of(
-          arguments(topic, receive),
-          arguments(queue, receive),
-          arguments(topic, receiveNoWait),
-          arguments(queue, receiveNoWait));
-    }
+    return Stream.of(
+        arguments(topic, receive),
+        arguments(queue, receive),
+        arguments(topic, receiveNoWait),
+        arguments(queue, receiveNoWait));
   }
 
-  static final class DestinationsProvider implements ArgumentsProvider {
+  private static Stream<Arguments> destinationArguments() {
+    DestinationFactory topic = session -> session.createTopic("someTopic");
+    DestinationFactory queue = session -> session.createQueue("someQueue");
+    DestinationFactory tempTopic = Session::createTemporaryTopic;
+    DestinationFactory tempQueue = Session::createTemporaryQueue;
 
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      DestinationFactory topic = session -> session.createTopic("someTopic");
-      DestinationFactory queue = session -> session.createQueue("someQueue");
-      DestinationFactory tempTopic = Session::createTemporaryTopic;
-      DestinationFactory tempQueue = Session::createTemporaryQueue;
-
-      return Stream.of(
-          arguments(topic, "someTopic", false),
-          arguments(queue, "someQueue", false),
-          arguments(tempTopic, "(temporary)", true),
-          arguments(tempQueue, "(temporary)", true));
-    }
+    return Stream.of(
+        arguments(topic, "someTopic", false),
+        arguments(queue, "someQueue", false),
+        arguments(tempTopic, "(temporary)", true),
+        arguments(tempQueue, "(temporary)", true));
   }
 
   @FunctionalInterface

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -318,7 +318,7 @@ abstract class AbstractJms1Test {
         arguments(queue, receiveNoWait));
   }
 
-  private static Stream<Arguments> destinationArguments() {
+  protected static Stream<Arguments> destinationArguments() {
     DestinationFactory topic = session -> session.createTopic("someTopic");
     DestinationFactory queue = session -> session.createQueue("someQueue");
     DestinationFactory tempTopic = Session::createTemporaryTopic;

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -23,13 +23,13 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.TextMessage;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Jms1InstrumentationTest extends AbstractJms1Test {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void testMessageConsumer(
       DestinationFactory destinationFactory, String destinationName, boolean isTemporary)
       throws JMSException {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -20,13 +20,13 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.TextMessage;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void testMessageConsumer(
       DestinationFactory destinationFactory, String destinationName, boolean isTemporary)
       throws JMSException {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -24,13 +24,13 @@ import jakarta.jms.TextMessage;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Jms3InstrumentationTest extends AbstractJms3Test {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void testMessageConsumer(DestinationFactory destinationFactory, boolean isTemporary)
       throws JMSException {
 

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -21,13 +21,13 @@ import jakarta.jms.MessageProducer;
 import jakarta.jms.TextMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @ArgumentsSource(DestinationsProvider.class)
   @ParameterizedTest
+  @MethodSource("destinationArguments")
   void testMessageConsumer(DestinationFactory destinationFactory, boolean isTemporary)
       throws JMSException {
 

--- a/instrumentation/jsf/jsf-jakarta-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/jakarta/BaseJsfTest.java
+++ b/instrumentation/jsf/jsf-jakarta-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/jakarta/BaseJsfTest.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -48,12 +47,9 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
 
@@ -102,7 +98,7 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(PathTestArgs.class)
+  @CsvSource({"hello.jsf, *.jsf", "faces/hello.xhtml, faces/*"})
   void testPath(String path, String route) {
     AggregatedHttpResponse response =
         client.get(address.resolve(path).toString()).aggregate().join();
@@ -133,14 +129,6 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
                                     val.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo(TEST_CLIENT_IP),
                                         v -> assertThat(v).isNull())))));
-  }
-
-  static class PathTestArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("hello.xhtml", "*.xhtml"), Arguments.of("faces/hello.xhtml", "faces/*"));
-    }
   }
 
   @Test

--- a/instrumentation/jsf/jsf-javax-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/javax/BaseJsfTest.java
+++ b/instrumentation/jsf/jsf-javax-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/javax/BaseJsfTest.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
@@ -50,12 +49,9 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
   @RegisterExtension
@@ -111,7 +107,7 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(PathTestArgs.class)
+  @CsvSource({"hello.jsf, *.jsf", "faces/hello.xhtml, faces/*"})
   void testPath(String path, String route) {
     AggregatedHttpResponse response =
         client.get(address.resolve(path).toString()).aggregate().join();
@@ -142,14 +138,6 @@ public abstract class BaseJsfTest extends AbstractHttpServerUsingTest<Server> {
                                     val.satisfiesAnyOf(
                                         v -> assertThat(v).isEqualTo(TEST_CLIENT_IP),
                                         v -> assertThat(v).isNull())))));
-  }
-
-  static class PathTestArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("hello.jsf", "*.jsf"), Arguments.of("faces/hello.xhtml", "faces/*"));
-    }
   }
 
   @Test

--- a/instrumentation/jsp-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jsp/JspInstrumentationBasicTests.java
+++ b/instrumentation/jsp-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jsp/JspInstrumentationBasicTests.java
@@ -35,12 +35,10 @@ import org.apache.jasper.JasperException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
@@ -103,7 +101,7 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
   }
 
   @ParameterizedTest(name = "GET {0}")
-  @ArgumentsSource(NonErroneousArgs.class)
+  @MethodSource("nonErroneousArgs")
   void testNonErroneousGet(
       String testName, String jspFileName, String jspClassName, String jspClassNamePrefix) {
     AggregatedHttpResponse res = client.get(jspFileName).aggregate().join();
@@ -137,14 +135,11 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
                             .build())));
   }
 
-  static class NonErroneousArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("no java jsp", "/nojava.jsp", "nojava_jsp", ""),
-          Arguments.of("basic loop jsp", "/common/loop.jsp", "loop_jsp", "common."),
-          Arguments.of("invalid HTML markup", "/invalidMarkup.jsp", "invalidMarkup_jsp", ""));
-    }
+  private static Stream<Arguments> nonErroneousArgs() {
+    return Stream.of(
+        Arguments.of("no java jsp", "/nojava.jsp", "nojava_jsp", ""),
+        Arguments.of("basic loop jsp", "/common/loop.jsp", "loop_jsp", "common."),
+        Arguments.of("invalid HTML markup", "/invalidMarkup.jsp", "invalidMarkup_jsp", ""));
   }
 
   @Test
@@ -236,7 +231,7 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
   }
 
   @ParameterizedTest(name = "GET jsp with {0}")
-  @ArgumentsSource(ErroneousRuntimeErrorsArgs.class)
+  @MethodSource("erroneousRuntimeErrorsArgs")
   void testErroneousRuntimeErrorsGet(
       String testName,
       String jspFileName,
@@ -277,25 +272,22 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
                             .build())));
   }
 
-  static class ErroneousRuntimeErrorsArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of(
-              "java runtime error",
-              "/runtimeError.jsp",
-              "runtimeError_jsp",
-              ArithmeticException.class,
-              false),
-          Arguments.of(
-              "invalid write",
-              "/invalidWrite.jsp",
-              "invalidWrite_jsp",
-              IndexOutOfBoundsException.class,
-              true),
-          Arguments.of(
-              "invalid write", "/getQuery.jsp", "getQuery_jsp", NullPointerException.class, true));
-    }
+  private static Stream<Arguments> erroneousRuntimeErrorsArgs() {
+    return Stream.of(
+        Arguments.of(
+            "java runtime error",
+            "/runtimeError.jsp",
+            "runtimeError_jsp",
+            ArithmeticException.class,
+            false),
+        Arguments.of(
+            "invalid write",
+            "/invalidWrite.jsp",
+            "invalidWrite_jsp",
+            IndexOutOfBoundsException.class,
+            true),
+        Arguments.of(
+            "invalid write", "/getQuery.jsp", "getQuery_jsp", NullPointerException.class, true));
   }
 
   @Test
@@ -397,7 +389,7 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(CompileErrorsArgs.class)
+  @MethodSource("compileErrorsArgs")
   void testCompileErrorShouldNotProduceRenderTracesAndSpans(
       String jspFileName, String jspClassName, String jspClassNamePrefix) {
     AggregatedHttpResponse res = client.get(jspFileName).aggregate().join();
@@ -442,14 +434,11 @@ class JspInstrumentationBasicTests extends AbstractHttpServerUsingTest<Tomcat> {
                                 "org.apache.jasper.compiler.JDTCompiler"))));
   }
 
-  static class CompileErrorsArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("/compileError.jsp", "compileError_jsp", ""),
-          Arguments.of(
-              "/forwards/forwardWithCompileError.jsp", "forwardWithCompileError_jsp", "forwards."));
-    }
+  private static Stream<Arguments> compileErrorsArgs() {
+    return Stream.of(
+        Arguments.of("/compileError.jsp", "compileError_jsp", ""),
+        Arguments.of(
+            "/forwards/forwardWithCompileError.jsp", "forwardWithCompileError_jsp", "forwards."));
   }
 
   @ParameterizedTest

--- a/instrumentation/jsp-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jsp/JspInstrumentationForwardTests.java
+++ b/instrumentation/jsp-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jsp/JspInstrumentationForwardTests.java
@@ -30,12 +30,10 @@ import org.apache.jasper.JasperException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class JspInstrumentationForwardTests extends AbstractHttpServerUsingTest<Tomcat> {
 
@@ -97,7 +95,7 @@ class JspInstrumentationForwardTests extends AbstractHttpServerUsingTest<Tomcat>
   }
 
   @ParameterizedTest(name = "Forward to {0}")
-  @ArgumentsSource(NonErroneousGetForwardArgs.class)
+  @MethodSource("nonErroneousGetForwardArgs")
   void testNonErroneousGetForwardTo(
       String name,
       String forwardFromFileName,
@@ -152,27 +150,24 @@ class JspInstrumentationForwardTests extends AbstractHttpServerUsingTest<Tomcat>
                             .build())));
   }
 
-  static class NonErroneousGetForwardArgs implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of(
-              "no java jsp",
-              "/forwards/forwardToNoJavaJsp.jsp",
-              "/nojava.jsp",
-              "forwardToNoJavaJsp_jsp",
-              "forwards.",
-              "nojava_jsp",
-              ""),
-          Arguments.of(
-              "normal java jsp",
-              "/forwards/forwardToSimpleJava.jsp",
-              "/common/loop.jsp",
-              "forwardToSimpleJava_jsp",
-              "forwards.",
-              "loop_jsp",
-              "common."));
-    }
+  private static Stream<Arguments> nonErroneousGetForwardArgs() {
+    return Stream.of(
+        Arguments.of(
+            "no java jsp",
+            "/forwards/forwardToNoJavaJsp.jsp",
+            "/nojava.jsp",
+            "forwardToNoJavaJsp_jsp",
+            "forwards.",
+            "nojava_jsp",
+            ""),
+        Arguments.of(
+            "normal java jsp",
+            "/forwards/forwardToSimpleJava.jsp",
+            "/common/loop.jsp",
+            "forwardToSimpleJava_jsp",
+            "forwards.",
+            "loop_jsp",
+            "common."));
   }
 
   @Test

--- a/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesRequestUtilsTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesRequestUtilsTest.java
@@ -9,11 +9,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class KubernetesRequestUtilsTest {
 
@@ -41,7 +39,7 @@ class KubernetesRequestUtilsTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ParseCoreResourceArgumentsProvider.class)
+  @MethodSource("parseCoreResourceArguments")
   void parseCoreResource(
       String urlPath,
       String apiGroup,
@@ -61,7 +59,7 @@ class KubernetesRequestUtilsTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(ParseRegularResourceArgumentsProvider.class)
+  @MethodSource("parseRegularResourceArguments")
   void parseRegularResource(
       String urlPath,
       String apiGroup,
@@ -83,7 +81,7 @@ class KubernetesRequestUtilsTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(K8sRequestVerbsArgumentsProvider.class)
+  @MethodSource("k8sRequestVerbsArguments")
   void k8sRequestVerbs(
       String httpVerb,
       boolean hasNamePathParam,
@@ -93,100 +91,86 @@ class KubernetesRequestUtilsTest {
         .isEqualTo(kubernetesVerb);
   }
 
-  private static class K8sRequestVerbsArgumentsProvider implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
-        throws Exception {
-      return Stream.of(
-          Arguments.of("GET", true, false, KubernetesVerb.GET),
-          Arguments.of("GET", false, true, KubernetesVerb.WATCH),
-          Arguments.of("GET", false, false, KubernetesVerb.LIST),
-          Arguments.of("POST", false, false, KubernetesVerb.CREATE),
-          Arguments.of("PUT", false, false, KubernetesVerb.UPDATE),
-          Arguments.of("PATCH", false, false, KubernetesVerb.PATCH),
-          Arguments.of("DELETE", true, false, KubernetesVerb.DELETE),
-          Arguments.of("DELETE", false, false, KubernetesVerb.DELETE_COLLECTION));
-    }
+  private static Stream<Arguments> k8sRequestVerbsArguments() {
+    return Stream.of(
+        Arguments.of("GET", true, false, KubernetesVerb.GET),
+        Arguments.of("GET", false, true, KubernetesVerb.WATCH),
+        Arguments.of("GET", false, false, KubernetesVerb.LIST),
+        Arguments.of("POST", false, false, KubernetesVerb.CREATE),
+        Arguments.of("PUT", false, false, KubernetesVerb.UPDATE),
+        Arguments.of("PATCH", false, false, KubernetesVerb.PATCH),
+        Arguments.of("DELETE", true, false, KubernetesVerb.DELETE),
+        Arguments.of("DELETE", false, false, KubernetesVerb.DELETE_COLLECTION));
   }
 
-  private static class ParseRegularResourceArgumentsProvider implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
-        throws Exception {
-      return Stream.of(
-          Arguments.of("/apis/apps/v1/deployments", "apps", "v1", "deployments", null, null, null),
-          Arguments.of(
-              "/apis/apps/v1/namespaces/default/deployments",
-              "apps",
-              "v1",
-              "deployments",
-              null,
-              "default",
-              null),
-          Arguments.of(
-              "/apis/apps/v1/namespaces/default/deployments/foo",
-              "apps",
-              "v1",
-              "deployments",
-              null,
-              "default",
-              "foo"),
-          Arguments.of(
-              "/apis/apps/v1/namespaces/default/deployments/foo/status",
-              "apps",
-              "v1",
-              "deployments",
-              "status",
-              "default",
-              "foo"),
-          Arguments.of(
-              "/apis/example.io/v1alpha1/foos", "example.io", "v1alpha1", "foos", null, null, null),
-          Arguments.of(
-              "/apis/example.io/v1alpha1/namespaces/default/foos",
-              "example.io",
-              "v1alpha1",
-              "foos",
-              null,
-              "default",
-              null),
-          Arguments.of(
-              "/apis/example.io/v1alpha1/namespaces/default/foos/foo",
-              "example.io",
-              "v1alpha1",
-              "foos",
-              null,
-              "default",
-              "foo"),
-          Arguments.of(
-              "/apis/example.io/v1alpha1/namespaces/default/foos/foo/status",
-              "example.io",
-              "v1alpha1",
-              "foos",
-              "status",
-              "default",
-              "foo"));
-    }
+  private static Stream<Arguments> parseRegularResourceArguments() {
+    return Stream.of(
+        Arguments.of("/apis/apps/v1/deployments", "apps", "v1", "deployments", null, null, null),
+        Arguments.of(
+            "/apis/apps/v1/namespaces/default/deployments",
+            "apps",
+            "v1",
+            "deployments",
+            null,
+            "default",
+            null),
+        Arguments.of(
+            "/apis/apps/v1/namespaces/default/deployments/foo",
+            "apps",
+            "v1",
+            "deployments",
+            null,
+            "default",
+            "foo"),
+        Arguments.of(
+            "/apis/apps/v1/namespaces/default/deployments/foo/status",
+            "apps",
+            "v1",
+            "deployments",
+            "status",
+            "default",
+            "foo"),
+        Arguments.of(
+            "/apis/example.io/v1alpha1/foos", "example.io", "v1alpha1", "foos", null, null, null),
+        Arguments.of(
+            "/apis/example.io/v1alpha1/namespaces/default/foos",
+            "example.io",
+            "v1alpha1",
+            "foos",
+            null,
+            "default",
+            null),
+        Arguments.of(
+            "/apis/example.io/v1alpha1/namespaces/default/foos/foo",
+            "example.io",
+            "v1alpha1",
+            "foos",
+            null,
+            "default",
+            "foo"),
+        Arguments.of(
+            "/apis/example.io/v1alpha1/namespaces/default/foos/foo/status",
+            "example.io",
+            "v1alpha1",
+            "foos",
+            "status",
+            "default",
+            "foo"));
   }
 
-  private static class ParseCoreResourceArgumentsProvider implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of("/api/v1/pods", "", "v1", "pods", null, null, null),
-          Arguments.of("/api/v1/namespaces/default/pods", "", "v1", "pods", null, "default", null),
-          Arguments.of(
-              "/api/v1/namespaces/default/pods/foo", "", "v1", "pods", null, "default", "foo"),
-          Arguments.of(
-              "/api/v1/namespaces/default/pods/foo/exec",
-              "",
-              "v1",
-              "pods",
-              "exec",
-              "default",
-              "foo"));
-    }
+  private static Stream<Arguments> parseCoreResourceArguments() {
+    return Stream.of(
+        Arguments.of("/api/v1/pods", "", "v1", "pods", null, null, null),
+        Arguments.of("/api/v1/namespaces/default/pods", "", "v1", "pods", null, "default", null),
+        Arguments.of(
+            "/api/v1/namespaces/default/pods/foo", "", "v1", "pods", null, "default", "foo"),
+        Arguments.of(
+            "/api/v1/namespaces/default/pods/foo/exec",
+            "",
+            "v1",
+            "pods",
+            "exec",
+            "default",
+            "foo"));
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/FailedRequestWithUrlMakerTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/FailedRequestWithUrlMakerTest.java
@@ -6,20 +6,15 @@
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,7 +63,10 @@ class FailedRequestWithUrlMakerTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(DefaultPortsArguments.class)
+  @CsvSource({
+    "80, false",
+    "443, true",
+  })
   @SuppressWarnings("MockitoDoSetup")
   void shouldSkipDefaultPorts(int port, boolean isSecure) {
     when(config.baseUrl()).thenReturn("/");
@@ -82,13 +80,5 @@ class FailedRequestWithUrlMakerTest {
 
     assertThat(request.resourceUrl())
         .isEqualTo((isSecure ? "https" : "http") + "://opentelemetry.io/docs");
-  }
-
-  static final class DefaultPortsArguments implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-      return Stream.of(arguments(80, false), arguments(443, true));
-    }
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -18,11 +18,9 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -101,7 +99,7 @@ class JarServiceNameDetectorTest {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(SunCommandLineProvider.class)
+  @MethodSource("sunCommandLineArguments")
   void createResource_sunCommandLine(String commandLine, Path jarPath) {
     Function<String, String> getProperty =
         key -> "sun.java.command".equals(key) ? commandLine : null;
@@ -131,18 +129,14 @@ class JarServiceNameDetectorTest {
     assertThat(resource.getAttributes()).isEmpty();
   }
 
-  static final class SunCommandLineProvider implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      Path path = Paths.get("path", "to", "my-service.jar");
-      Path pathWithSpaces = Paths.get("path to app", "with spaces", "my-service.jar");
-      Path pathWithoutExtension = Paths.get("path to app", "with spaces", "my-service");
-      return Stream.of(
-          arguments(path.toString(), path),
-          arguments(pathWithSpaces + " 1 2 3", pathWithSpaces),
-          arguments(pathWithoutExtension + " 1 2 3", pathWithoutExtension));
-    }
+  private static Stream<Arguments> sunCommandLineArguments() {
+    Path path = Paths.get("path", "to", "my-service.jar");
+    Path pathWithSpaces = Paths.get("path to app", "with spaces", "my-service.jar");
+    Path pathWithoutExtension = Paths.get("path to app", "with spaces", "my-service");
+    return Stream.of(
+        arguments(path.toString(), path),
+        arguments(pathWithSpaces + " 1 2 3", pathWithSpaces),
+        arguments(pathWithoutExtension + " 1 2 3", pathWithoutExtension));
   }
 
   static boolean failPath(Path file) {

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/AbstractSpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/AbstractSpringJmsListenerTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -19,15 +18,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -68,8 +63,8 @@ abstract class AbstractSpringJmsListenerTest {
     }
   }
 
-  @ArgumentsSource(SpringJmsListenerTest.ConfigClasses.class)
   @ParameterizedTest
+  @ValueSource(classes = {AnnotatedListenerConfig.class, ManualListenerConfig.class})
   @SuppressWarnings("unchecked")
   void testSpringJmsListener(Class<?> configClass)
       throws ExecutionException, InterruptedException, TimeoutException {
@@ -101,14 +96,5 @@ abstract class AbstractSpringJmsListenerTest {
     props.put("spring.main.web-application-type", "none");
     props.put("test.broker-url", "tcp://" + broker.getHost() + ":" + broker.getMappedPort(61616));
     return props;
-  }
-
-  static final class ConfigClasses implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          arguments(AnnotatedListenerConfig.class), arguments(ManualListenerConfig.class));
-    }
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.jms.core.JmsTemplate;
@@ -82,8 +82,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
-  @ArgumentsSource(ConfigClasses.class)
   @ParameterizedTest
+  @ValueSource(classes = {AnnotatedListenerConfig.class, ManualListenerConfig.class})
   @SuppressWarnings("unchecked")
   void shouldCaptureHeaders(Class<?> configClass)
       throws ExecutionException, InterruptedException, TimeoutException {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -13,16 +13,14 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.TreeSet;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AgentConfigTest {
 
   @ParameterizedTest(name = "isInstrumentationEnabled({0}) = {4}")
-  @ArgumentsSource(InstrumentationEnabledParams.class)
+  @MethodSource("instrumentationEnabledParams")
   void testIsInstrumentationEnabled(
       @SuppressWarnings("unused") String description,
       Boolean firstEnabled,
@@ -40,48 +38,43 @@ class AgentConfigTest {
             config, new TreeSet<>(asList("first", "second")), defaultEnabled));
   }
 
-  private static class InstrumentationEnabledParams implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          Arguments.of(
-              "enabled by default, both instrumentations are off", false, false, true, false),
-          Arguments.of("enabled by default, first instrumentation is on", true, null, true, true),
-          Arguments.of("enabled by default, second instrumentation is on", null, true, true, true),
-          Arguments.of("enabled by default, both instrumentations are on", true, true, true, true),
-          Arguments.of(
-              "enabled by default, first instrumentation is off, second is on",
-              false,
-              true,
-              true,
-              false),
-          Arguments.of(
-              "enabled by default, first instrumentation is on, second is off",
-              true,
-              false,
-              true,
-              true),
-          Arguments.of("enabled by default", null, null, true, true),
-          Arguments.of(
-              "disabled by default, both instrumentations are off", false, false, false, false),
-          Arguments.of("disabled by default, first instrumentation is on", true, null, false, true),
-          Arguments.of(
-              "disabled by default, second instrumentation is on", null, true, false, true),
-          Arguments.of("disabled by default, both instrumentation are on", true, true, false, true),
-          Arguments.of(
-              "disabled by default, first instrumentation is off, second is on",
-              false,
-              true,
-              false,
-              false),
-          Arguments.of(
-              "disabled by default, first instrumentation is on, second is off",
-              true,
-              false,
-              false,
-              true),
-          Arguments.of("disabled by default", null, null, false, false));
-    }
+  private static Stream<Arguments> instrumentationEnabledParams() {
+    return Stream.of(
+        Arguments.of(
+            "enabled by default, both instrumentations are off", false, false, true, false),
+        Arguments.of("enabled by default, first instrumentation is on", true, null, true, true),
+        Arguments.of("enabled by default, second instrumentation is on", null, true, true, true),
+        Arguments.of("enabled by default, both instrumentations are on", true, true, true, true),
+        Arguments.of(
+            "enabled by default, first instrumentation is off, second is on",
+            false,
+            true,
+            true,
+            false),
+        Arguments.of(
+            "enabled by default, first instrumentation is on, second is off",
+            true,
+            false,
+            true,
+            true),
+        Arguments.of("enabled by default", null, null, true, true),
+        Arguments.of(
+            "disabled by default, both instrumentations are off", false, false, false, false),
+        Arguments.of("disabled by default, first instrumentation is on", true, null, false, true),
+        Arguments.of("disabled by default, second instrumentation is on", null, true, false, true),
+        Arguments.of("disabled by default, both instrumentation are on", true, true, false, true),
+        Arguments.of(
+            "disabled by default, first instrumentation is off, second is on",
+            false,
+            true,
+            false,
+            false),
+        Arguments.of(
+            "disabled by default, first instrumentation is on, second is off",
+            true,
+            false,
+            false,
+            true),
+        Arguments.of("disabled by default", null, null, false, false));
   }
 }


### PR DESCRIPTION
Junit update in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13959 deprecates the `providesArgument` method that we use. The fix would be to add an extra argument. Instead of adding that extra argument this PR replaces `@ArgumentSource` with `@ MethodSource` or `@CsvSource`.