### PR TITLE
feat: Add auto-instrumentation support for AWS resources in AWS SDK v1

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-stepfunctions:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-lambda:1.11.106")
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
@@ -90,6 +90,7 @@ class AwsSpanAssertions {
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("aws.agent"), "java-aws-sdk"),
             equalTo(MESSAGING_DESTINATION_NAME, topicArn),
+            satisfies(stringKey("aws.sns.topic.arn"), v -> v.isInstanceOf(String.class)),
             satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
             equalTo(RPC_METHOD, rpcMethod),
             equalTo(RPC_SYSTEM, "aws-api"),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/LambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/LambdaClientTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import io.opentelemetry.instrumentation.awssdk.v1_11.AbstractLambdaClientTest;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class LambdaClientTest extends AbstractLambdaClientTest {
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder clientBuilder) {
+    return clientBuilder;
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/StepFunctionsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/StepFunctionsClientTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder;
+import io.opentelemetry.instrumentation.awssdk.v1_11.AbstractStepFunctionsClientTest;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class StepFunctionsClientTest extends AbstractStepFunctionsClientTest {
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSStepFunctionsClientBuilder configureClient(
+      AWSStepFunctionsClientBuilder clientBuilder) {
+    return clientBuilder;
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -17,6 +17,11 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-stepfunctions:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-lambda:1.11.106")
+
+  // Tests on the MacBook indicate that this keeps the core at version 1.11.0.
+  testLibrary("com.amazonaws:aws-java-sdk-secretsmanager:1.11.309")
 
   // last version that does not use json protocol
   latestDepTestLibrary("com.amazonaws:aws-java-sdk-sqs:1.12.583") // documented limitation

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
@@ -16,6 +16,15 @@ final class AwsExperimentalAttributes {
   static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
   static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
+  static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
+      stringKey("aws.stepfunctions.state_machine.arn");
+  static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
+      stringKey("aws.stepfunctions.activity.arn");
+  static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
+  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
+  static final AttributeKey<String> AWS_LAMBDA_NAME = stringKey("aws.lambda.function.name");
+  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
+      stringKey("aws.lambda.resource_mapping.id");
 
   private AwsExperimentalAttributes() {}
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -7,8 +7,14 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AGENT;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BUCKET_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_URL;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_SECRET_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_TABLE_NAME;
 
@@ -35,6 +41,18 @@ class AwsSdkExperimentalAttributesExtractor
     setRequestAttribute(attributes, AWS_QUEUE_NAME, originalRequest, RequestAccess::getQueueName);
     setRequestAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
     setRequestAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
+    setRequestAttribute(
+        attributes, AWS_STATE_MACHINE_ARN, originalRequest, RequestAccess::getStateMachineArn);
+    setRequestAttribute(
+        attributes,
+        AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
+        originalRequest,
+        RequestAccess::getStepFunctionsActivityArn);
+    setRequestAttribute(attributes, AWS_SNS_TOPIC_ARN, originalRequest, RequestAccess::getTopicArn);
+    setRequestAttribute(attributes, AWS_SECRET_ARN, originalRequest, RequestAccess::getSecretArn);
+    setRequestAttribute(attributes, AWS_LAMBDA_NAME, originalRequest, RequestAccess::getLambdaName);
+    setRequestAttribute(
+        attributes, AWS_LAMBDA_RESOURCE_ID, originalRequest, RequestAccess::getLambdaResourceId);
   }
 
   private static void setRequestAttribute(
@@ -54,5 +72,18 @@ class AwsSdkExperimentalAttributesExtractor
       Context context,
       Request<?> request,
       @Nullable Response<?> response,
-      @Nullable Throwable error) {}
+      @Nullable Throwable error) {
+    if (response != null) {
+      Object awsResp = response.getAwsResponse();
+      setRequestAttribute(
+          attributes, AWS_STATE_MACHINE_ARN, awsResp, RequestAccess::getStateMachineArn);
+      setRequestAttribute(
+          attributes,
+          AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
+          awsResp,
+          RequestAccess::getStepFunctionsActivityArn);
+      setRequestAttribute(attributes, AWS_SNS_TOPIC_ARN, awsResp, RequestAccess::getTopicArn);
+      setRequestAttribute(attributes, AWS_SECRET_ARN, awsResp, RequestAccess::getSecretArn);
+    }
+  }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
@@ -11,6 +11,9 @@ import java.lang.invoke.MethodType;
 import javax.annotation.Nullable;
 
 final class RequestAccess {
+  private static final String LAMBDA_REQUEST_CLASS_PREFIX = "com.amazonaws.services.lambda.model.";
+  private static final String SECRETS_MANAGER_REQUEST_CLASS_PREFIX =
+      "com.amazonaws.services.secretsmanager.model.";
 
   private static final ClassValue<RequestAccess> REQUEST_ACCESSORS =
       new ClassValue<RequestAccess>() {
@@ -19,6 +22,51 @@ final class RequestAccess {
           return new RequestAccess(type);
         }
       };
+
+  @Nullable
+  static String getLambdaName(Object request) {
+    if (request == null) {
+      return null;
+    }
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getLambdaName, request);
+  }
+
+  @Nullable
+  static String getLambdaResourceId(Object request) {
+    if (request == null) {
+      return null;
+    }
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getLambdaResourceId, request);
+  }
+
+  @Nullable
+  static String getSecretArn(Object request) {
+    if (request == null) {
+      return null;
+    }
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getSecretArn, request);
+  }
+
+  @Nullable
+  static String getStepFunctionsActivityArn(Object request) {
+    if (request == null) {
+      return null;
+    }
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getStepFunctionsActivityArn, request);
+  }
+
+  @Nullable
+  static String getStateMachineArn(Object request) {
+    if (request == null) {
+      return null;
+    }
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getStateMachineArn, request);
+  }
 
   @Nullable
   static String getBucketName(Object request) {
@@ -52,6 +100,9 @@ final class RequestAccess {
 
   @Nullable
   static String getTopicArn(Object request) {
+    if (request == null) {
+      return null;
+    }
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getTopicArn, request);
   }
@@ -74,15 +125,23 @@ final class RequestAccess {
     }
   }
 
-  @Nullable private final MethodHandle getBucketName;
-  @Nullable private final MethodHandle getQueueUrl;
-  @Nullable private final MethodHandle getQueueName;
-  @Nullable private final MethodHandle getStreamName;
-  @Nullable private final MethodHandle getTableName;
-  @Nullable private final MethodHandle getTopicArn;
-  @Nullable private final MethodHandle getTargetArn;
+  @Nullable private MethodHandle getBucketName;
+  @Nullable private MethodHandle getQueueUrl;
+  @Nullable private MethodHandle getQueueName;
+  @Nullable private MethodHandle getStreamName;
+  @Nullable private MethodHandle getTableName;
+  @Nullable private MethodHandle getTopicArn;
+  @Nullable private MethodHandle getTargetArn;
+  @Nullable private MethodHandle getStateMachineArn;
+  @Nullable private MethodHandle getStepFunctionsActivityArn;
+  @Nullable private MethodHandle getSecretArn;
+  @Nullable private MethodHandle getLambdaName;
+  @Nullable private MethodHandle getLambdaResourceId;
 
   private RequestAccess(Class<?> clz) {
+    if (clz == null) {
+      return;
+    }
     getBucketName = findAccessorOrNull(clz, "getBucketName");
     getQueueUrl = findAccessorOrNull(clz, "getQueueUrl");
     getQueueName = findAccessorOrNull(clz, "getQueueName");
@@ -90,6 +149,16 @@ final class RequestAccess {
     getTableName = findAccessorOrNull(clz, "getTableName");
     getTopicArn = findAccessorOrNull(clz, "getTopicArn");
     getTargetArn = findAccessorOrNull(clz, "getTargetArn");
+    getStateMachineArn = findAccessorOrNull(clz, "getStateMachineArn");
+    getStepFunctionsActivityArn = findAccessorOrNull(clz, "getActivityArn");
+    String className = clz.getName();
+    if (className.startsWith(SECRETS_MANAGER_REQUEST_CLASS_PREFIX)) {
+      getSecretArn = findAccessorOrNull(clz, "getARN");
+    }
+    if (className.startsWith(LAMBDA_REQUEST_CLASS_PREFIX)) {
+      getLambdaName = findAccessorOrNull(clz, "getFunctionName");
+      getLambdaResourceId = findAccessorOrNull(clz, "getUUID");
+    }
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/LambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/LambdaClientTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class LambdaClientTest extends AbstractLambdaClientTest {
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder clientBuilder) {
+    return clientBuilder.withRequestHandlers(
+        AwsSdkTelemetry.builder(testing().getOpenTelemetry())
+            .setCaptureExperimentalSpanAttributes(true)
+            .build()
+            .newRequestHandler());
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SecretsManagerClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SecretsManagerClientTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class SecretsManagerClientTest extends AbstractSecretsManagerClientTest {
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSSecretsManagerClientBuilder configureClient(
+      AWSSecretsManagerClientBuilder clientBuilder) {
+
+    return clientBuilder.withRequestHandlers(
+        AwsSdkTelemetry.builder(testing().getOpenTelemetry())
+            .setCaptureExperimentalSpanAttributes(true)
+            .build()
+            .newRequestHandler());
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/StepFunctionsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/StepFunctionsClientTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class StepFunctionsClientTest extends AbstractStepFunctionsClientTest {
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSStepFunctionsClientBuilder configureClient(
+      AWSStepFunctionsClientBuilder clientBuilder) {
+    return clientBuilder.withRequestHandlers(
+        AwsSdkTelemetry.builder(testing().getOpenTelemetry())
+            .setCaptureExperimentalSpanAttributes(true)
+            .build()
+            .newRequestHandler());
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
   compileOnly("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-sns:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+  compileOnly("com.amazonaws:aws-java-sdk-secretsmanager:1.11.309")
+  compileOnly("com.amazonaws:aws-java-sdk-stepfunctions:1.11.106")
+  compileOnly("com.amazonaws:aws-java-sdk-lambda:1.11.106")
 
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
   implementation("org.elasticmq:elasticmq-rest-sqs_2.13")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import com.amazonaws.services.lambda.model.GetEventSourceMappingRequest;
+import com.amazonaws.services.lambda.model.GetFunctionRequest;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+import io.opentelemetry.testing.internal.armeria.common.MediaType;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public abstract class AbstractLambdaClientTest extends AbstractBaseAwsClientTest {
+
+  public abstract AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder client);
+
+  @Override
+  protected boolean hasRequestId() {
+    return false;
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArguments")
+  public void testSendRequestWithMockedResponse(
+      String operation,
+      List<AttributeAssertion> additionalAttributes,
+      Function<AWSLambda, Object> call)
+      throws Exception {
+
+    AWSLambdaClientBuilder clientBuilder = AWSLambdaClientBuilder.standard();
+
+    AWSLambda client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
+
+    Object response = call.apply(client);
+    assertRequestWithMockedResponse(
+        response, client, "AWSLambda", operation, "GET", additionalAttributes);
+  }
+
+  private static Stream<Arguments> provideArguments() {
+    return Stream.of(
+        Arguments.of(
+            "GetEventSourceMapping",
+            singletonList(equalTo(stringKey("aws.lambda.resource_mapping.id"), "uuid")),
+            (Function<AWSLambda, Object>)
+                c -> c.getEventSourceMapping(new GetEventSourceMappingRequest().withUUID("uuid"))),
+        Arguments.of(
+            "GetFunction",
+            singletonList(equalTo(stringKey("aws.lambda.function.name"), "functionName")),
+            (Function<AWSLambda, Object>)
+                c -> c.getFunction(new GetFunctionRequest().withFunctionName("functionName"))));
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSecretsManagerClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSecretsManagerClientTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.secretsmanager.model.CreateSecretRequest;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+import io.opentelemetry.testing.internal.armeria.common.MediaType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractSecretsManagerClientTest extends AbstractBaseAwsClientTest {
+
+  public abstract AWSSecretsManagerClientBuilder configureClient(
+      AWSSecretsManagerClientBuilder client);
+
+  @Override
+  protected boolean hasRequestId() {
+    return false;
+  }
+
+  @Test
+  public void sendRequestWithMockedResponse() throws Exception {
+    AWSSecretsManagerClientBuilder clientBuilder = AWSSecretsManagerClientBuilder.standard();
+    AWSSecretsManager client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    String body =
+        "{"
+            + "\"ARN\": \"arn:aws:secretsmanager:us-west-2:123456789012:secret:MyTestDatabaseSecret-a1b2c3\","
+            + "\"Name\": \"MyTestDatabaseSecret\","
+            + "\"VersionId\": \"EXAMPLE1-90ab-cdef-fedc-ba987SECRET1\""
+            + "}";
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, body));
+
+    Object response =
+        client.createSecret(
+            new CreateSecretRequest().withName("secretName").withSecretString("secretValue"));
+
+    List<AttributeAssertion> additionalAttributes =
+        singletonList(
+            equalTo(
+                stringKey("aws.secretsmanager.secret.arn"),
+                "arn:aws:secretsmanager:us-west-2:123456789012:secret:MyTestDatabaseSecret-a1b2c3"));
+
+    assertRequestWithMockedResponse(
+        response, client, "AWSSecretsManager", "CreateSecret", "POST", additionalAttributes);
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSnsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSnsClientTest.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.amazonaws.services.sns.AmazonSNS;
@@ -17,11 +19,7 @@ import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
 
@@ -32,9 +30,8 @@ public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
     return true;
   }
 
-  @ParameterizedTest
-  @MethodSource("provideArguments")
-  public void testSendRequestWithMockedResponse(Function<AmazonSNS, Object> call) throws Exception {
+  @Test
+  public void testSendRequestWithwithTargetArnMockedResponse() throws Exception {
     AmazonSNSClientBuilder clientBuilder = AmazonSNSClientBuilder.standard();
     AmazonSNS client =
         configureClient(clientBuilder)
@@ -53,26 +50,44 @@ public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
             + "</PublishResponse>";
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, body));
-
     List<AttributeAssertion> additionalAttributes =
         singletonList(equalTo(MESSAGING_DESTINATION_NAME, "somearn"));
 
-    Object response = call.apply(client);
+    Object response =
+        client.publish(new PublishRequest().withMessage("somemessage").withTargetArn("somearn"));
     assertRequestWithMockedResponse(
         response, client, "SNS", "Publish", "POST", additionalAttributes);
   }
 
-  private static Stream<Arguments> provideArguments() {
-    return Stream.of(
-        Arguments.of(
-            (Function<AmazonSNS, Object>)
-                c ->
-                    c.publish(
-                        new PublishRequest().withMessage("somemessage").withTopicArn("somearn"))),
-        Arguments.of(
-            (Function<AmazonSNS, Object>)
-                c ->
-                    c.publish(
-                        new PublishRequest().withMessage("somemessage").withTargetArn("somearn"))));
+  @Test
+  public void testSendRequestWithwithTopicArnMockedResponse() throws Exception {
+    AmazonSNSClientBuilder clientBuilder = AmazonSNSClientBuilder.standard();
+    AmazonSNS client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    String body =
+        "<PublishResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
+            + "    <PublishResult>"
+            + "        <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>"
+            + "    </PublishResult>"
+            + "    <ResponseMetadata>"
+            + "        <RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId>"
+            + "    </ResponseMetadata>"
+            + "</PublishResponse>";
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, body));
+    List<AttributeAssertion> additionalAttributes =
+        asList(
+            equalTo(MESSAGING_DESTINATION_NAME, "somearn"),
+            equalTo(stringKey("aws.sns.topic.arn"), "somearn"));
+
+    Object response =
+        client.publish(new PublishRequest().withMessage("somemessage").withTopicArn("somearn"));
+
+    assertRequestWithMockedResponse(
+        response, client, "SNS", "Publish", "POST", additionalAttributes);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractStepFunctionsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractStepFunctionsClientTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
+
+import com.amazonaws.services.stepfunctions.AWSStepFunctions;
+import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder;
+import com.amazonaws.services.stepfunctions.model.DescribeActivityRequest;
+import com.amazonaws.services.stepfunctions.model.DescribeStateMachineRequest;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+import io.opentelemetry.testing.internal.armeria.common.MediaType;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public abstract class AbstractStepFunctionsClientTest extends AbstractBaseAwsClientTest {
+
+  public abstract AWSStepFunctionsClientBuilder configureClient(
+      AWSStepFunctionsClientBuilder client);
+
+  @Override
+  protected boolean hasRequestId() {
+    return false;
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArguments")
+  public void testSendRequestWithMockedResponse(
+      String operation,
+      List<AttributeAssertion> additionalAttributes,
+      Function<AWSStepFunctions, Object> call)
+      throws Exception {
+
+    AWSStepFunctionsClientBuilder clientBuilder = AWSStepFunctionsClientBuilder.standard();
+
+    AWSStepFunctions client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
+
+    Object response = call.apply(client);
+    assertRequestWithMockedResponse(
+        response, client, "AWSStepFunctions", operation, "POST", additionalAttributes);
+  }
+
+  private static Stream<Arguments> provideArguments() {
+    return Stream.of(
+        Arguments.of(
+            "DescribeStateMachine",
+            singletonList(
+                equalTo(stringKey("aws.stepfunctions.state_machine.arn"), "stateMachineArn")),
+            (Function<AWSStepFunctions, Object>)
+                c ->
+                    c.describeStateMachine(
+                        new DescribeStateMachineRequest().withStateMachineArn("stateMachineArn"))),
+        Arguments.of(
+            "DescribeActivity",
+            singletonList(equalTo(stringKey("aws.stepfunctions.activity.arn"), "activityArn")),
+            (Function<AWSStepFunctions, Object>)
+                c ->
+                    c.describeActivity(
+                        new DescribeActivityRequest().withActivityArn("activityArn"))));
+  }
+}


### PR DESCRIPTION
This PR adds auto-instrumentation support for the following AWS resources:

Lambda
Secrets Manager
SNS
Step Functions

Tests Run:
./gradlew spotlessCheck
./gradlew clean assemble
./gradlew instrumentation:test
./gradlew :smoke-tests:test

No regression issues found. All newly added tests pass.

Backward Compatibility:
There is no risk of breaking existing functionality. This change only adds instrumentation for additional AWS resources without modifying the existing behavior of the auto-instrumentation library.