### PR TITLE
Revert lettuce testLatestDep fix

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -25,17 +25,8 @@ dependencies {
 
 tasks {
   withType<Test>().configureEach {
-    val testLatestDeps = findProperty("testLatestDeps") as Boolean
-    systemProperty("testLatestDeps", testLatestDeps)
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
-
-    dependencies {
-      if (testLatestDeps) {
-        // This is only needed for 6.7.0, can be removed when 6.7.1 is released.
-        // See https://github.com/redis/lettuce/issues/3317
-        testLibrary("io.micrometer:micrometer-core:1.5.0")
-      }
-    }
   }
 
   val testStableSemconv by registering(Test::class) {

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -14,17 +14,8 @@ dependencies {
 
 tasks {
   withType<Test>().configureEach {
-    val testLatestDeps = findProperty("testLatestDeps") as Boolean
-    systemProperty("testLatestDeps", testLatestDeps)
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
-
-    dependencies {
-      if (testLatestDeps) {
-        // This is only needed for 6.7.0, can be removed when 6.7.1 is released.
-        // See https://github.com/redis/lettuce/issues/3317
-        testLibrary("io.micrometer:micrometer-core:1.5.0")
-      }
-    }
   }
 
   val testStableSemconv by registering(Test::class) {


### PR DESCRIPTION
Reverts #13976 

Lettuce released 6.7.1 with a patch, so this is no longer needed.