### PR TITLE
Update urls for sonatype central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,10 @@ nexusPublishing {
   packageGroup.set("io.opentelemetry")
 
   repositories {
+    // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
     sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
       username.set(System.getenv("SONATYPE_USER"))
       password.set(System.getenv("SONATYPE_KEY"))
     }

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -97,7 +97,10 @@ nexusPublishing {
   packageGroup.set("io.opentelemetry")
 
   repositories {
+    // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
     sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
       username.set(System.getenv("SONATYPE_USER"))
       password.set(System.getenv("SONATYPE_KEY"))
     }


### PR DESCRIPTION
See this announcement: https://central.sonatype.org/news/20250326_ossrh_sunset/

and see this for the docs on this change https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

The org has already been migrated, but a new user token will need to be generated and put into GH repo variables.