### PR TITLE
Fix: Incorrect SNS Auto-Inst Unit Test Parameters in AWS SDK v2

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
@@ -476,15 +476,15 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
                         PublishRequest.builder()
                             .message("somemessage")
                             .topicArn("somearn")
-                            .build()),
-            Arguments.of(
-                (Function<SnsClient, Object>)
-                    c ->
-                        c.publish(
-                            PublishRequest.builder()
-                                .message("somemessage")
-                                .targetArn("somearn")
-                                .build()))));
+                            .build())),
+        Arguments.of(
+            (Function<SnsClient, Object>)
+                c ->
+                    c.publish(
+                        PublishRequest.builder()
+                            .message("somemessage")
+                            .targetArn("somearn")
+                            .build())));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
We want to run the SNS unit test twice, each time with a different parameter: once with TopicArn, and once with TargetArn. However, the second argument was mistakenly nested as a sub-parameter of the first due to misaligned parentheses. As a result, the unit test only runs once—with TopicArn—and never runs with TargetArn.

Tests Run:
./gradlew spotlessCheck
./gradlew clean assemble
./gradlew instrumentation:check
./gradlew :smoke-tests:test

No regression issues found.

Backward Compatibility:
There is no risk of breaking existing functionality. This change only fixes one unit test without modifying the existing behavior of the auto-instrumentation library.