### PR TITLE
feat: AWS SDK v2 Secrets Manager auto-instrumentation support

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -121,9 +121,10 @@ dependencies {
   testLibrary("software.amazon.awssdk:lambda:2.2.0")
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
-  testLibrary("software.amazon.awssdk:sqs:2.2.0")
-  testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:sns:2.2.0")
+  testLibrary("software.amazon.awssdk:sqs:2.2.0")
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -18,8 +18,9 @@ dependencies {
   testLibrary("software.amazon.awssdk:lambda:2.2.0")
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
-  testLibrary("software.amazon.awssdk:sqs:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
+  testLibrary("software.amazon.awssdk:sqs:2.2.0")
 }
 
 tasks {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:kinesis:2.2.0")
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
+  testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
 }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+final class AwsExperimentalAttributes {
+  static final AttributeKey<String> AWS_BUCKET_NAME = stringKey("aws.bucket.name");
+  static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
+  static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
+  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
+  static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
+  static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
+
+  private AwsExperimentalAttributes() {}
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkReques
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.DYNAMODB;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.KINESIS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.S3;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SECRETSMANAGER;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SNS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SQS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.request;
@@ -35,6 +36,7 @@ enum AwsSdkRequest {
   SnsRequest(SNS, "SnsRequest"),
   SqsRequest(SQS, "SqsRequest"),
   KinesisRequest(KINESIS, "KinesisRequest"),
+  SecretsManagerRequest(SECRETSMANAGER, "SecretsManagerRequest"),
   // specific requests
   BatchGetItem(
       DYNAMODB,

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
@@ -5,7 +5,14 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_BUCKET_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_QUEUE_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_QUEUE_URL;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_SECRET_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_STREAM_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_TABLE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.request;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.response;
 
 import io.opentelemetry.api.common.AttributeKey;
 import java.util.Collections;
@@ -13,11 +20,12 @@ import java.util.List;
 import java.util.Map;
 
 enum AwsSdkRequestType {
-  S3(request("aws.bucket.name", "Bucket")),
-  SQS(request("aws.queue.url", "QueueUrl"), request("aws.queue.name", "QueueName")),
-  KINESIS(request("aws.stream.name", "StreamName")),
-  DYNAMODB(request("aws.table.name", "TableName")),
+  S3(request(AWS_BUCKET_NAME.getKey(), "Bucket")),
+  SQS(request(AWS_QUEUE_URL.getKey(), "QueueUrl"), request(AWS_QUEUE_NAME.getKey(), "QueueName")),
+  KINESIS(request(AWS_STREAM_NAME.getKey(), "StreamName")),
+  DYNAMODB(request(AWS_TABLE_NAME.getKey(), "TableName")),
   BEDROCK_RUNTIME(),
+  SECRETSMANAGER(response(AWS_SECRET_ARN.getKey(), "ARN")),
   SNS(
       /*
        * Only one of TopicArn and TargetArn are permitted on an SNS request.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -18,9 +18,10 @@ dependencies {
   compileOnly("software.amazon.awssdk:lambda:2.2.0")
   compileOnly("software.amazon.awssdk:rds:2.2.0")
   compileOnly("software.amazon.awssdk:s3:2.2.0")
-  compileOnly("software.amazon.awssdk:sqs:2.2.0")
-  compileOnly("software.amazon.awssdk:sns:2.2.0")
+  compileOnly("software.amazon.awssdk:secretsmanager:2.2.0")
   compileOnly("software.amazon.awssdk:ses:2.2.0")
+  compileOnly("software.amazon.awssdk:sns:2.2.0")
+  compileOnly("software.amazon.awssdk:sqs:2.2.0")
 
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
   implementation("org.elasticmq:elasticmq-rest-sqs_2.13")


### PR DESCRIPTION
This PR adds auto-instrumentation support for the following AWS resource:

Secrets Manager

Tests Run:
./gradlew spotlessCheck
./gradlew clean assemble
./gradlew instrumentation:check
./gradlew :smoke-tests:test

No regression issues found. All newly added tests pass.

Backward Compatibility:
There is no risk of breaking existing functionality. This change only adds instrumentation for additional AWS resources without modifying the existing behavior of the auto-instrumentation library.