### PR TITLE
Prevent OpenTelemetryDataSource constructor issues during config refresh by adding proxy

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessor.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessor.java
@@ -46,46 +46,65 @@ final class DataSourcePostProcessor implements BeanPostProcessor, Ordered {
   }
 
   @CanIgnoreReturnValue
-  @Override
-  public Object postProcessAfterInitialization(Object bean, String beanName) {
-    // Exclude scoped proxy beans to avoid double wrapping
-    if (bean instanceof DataSource
-        && !isRoutingDatasource(bean)
-        && !ScopedProxyUtils.isScopedTarget(beanName)) {
-      DataSource dataSource = (DataSource) bean;
-      DataSource wrapped = JdbcTelemetry.builder(openTelemetryProvider.getObject())
-          .setStatementSanitizationEnabled(
-              InstrumentationConfigUtil.isStatementSanitizationEnabled(
-                  configPropertiesProvider.getObject(),
-                  "otel.instrumentation.jdbc.statement-sanitizer.enabled"))
-          .setCaptureQueryParameters(
-              configPropertiesProvider
-                  .getObject()
-                  .getBoolean(
-                      "otel.instrumentation.jdbc.experimental.capture-query-parameters", false))
-          .setTransactionInstrumenterEnabled(
-              configPropertiesProvider
-                  .getObject()
-                  .getBoolean("otel.instrumentation.jdbc.experimental.transaction.enabled", false))
-          .build()
-          .wrap(dataSource);
+@Override
+public Object postProcessAfterInitialization(Object bean, String beanName) {
+  // Exclude scoped proxy beans to avoid double wrapping
+  if (bean instanceof DataSource
+      && !isRoutingDatasource(bean)
+      && !ScopedProxyUtils.isScopedTarget(beanName)) {
+    DataSource dataSource = (DataSource) bean;
 
-      ProxyFactory proxyFactory = new ProxyFactory(DataSource.class);
-      proxyFactory.setTarget(bean);
-      proxyFactory.addAdvice(
-          new MethodInterceptor() {
-            @Nullable
-            @Override
-            public Object invoke(@Nonnull MethodInvocation invocation) throws Throwable {
-              return AopUtils.invokeJoinpointUsingReflection(
-                  wrapped, invocation.getMethod(), invocation.getArguments());
-            }
-          });
+    // Wrap the original DataSource with OpenTelemetry instrumentation
+    DataSource wrapped = JdbcTelemetry.builder(openTelemetryProvider.getObject())
+        .setStatementSanitizationEnabled(
+            InstrumentationConfigUtil.isStatementSanitizationEnabled(
+                configPropertiesProvider.getObject(),
+                "otel.instrumentation.jdbc.statement-sanitizer.enabled"))
+        .setCaptureQueryParameters(
+            configPropertiesProvider
+                .getObject()
+                .getBoolean(
+                    "otel.instrumentation.jdbc.experimental.capture-query-parameters", false))
+        .setTransactionInstrumenterEnabled(
+            configPropertiesProvider
+                .getObject()
+                .getBoolean("otel.instrumentation.jdbc.experimental.transaction.enabled", false))
+        .build()
+        .wrap(dataSource);
 
-      return proxyFactory.getProxy();
-    }
-    return bean;
+    /**
+     * Spring Boot's configuration binding and rebinding mechanisms (such as those triggered by
+     * Nacos configuration refresh) may attempt to reconstruct beans using their concrete class
+     * constructors. If a custom DataSource implementation (such as OpenTelemetryDataSource)
+     * is returned directly, Spring may not find a suitable constructor during rebinding, resulting
+     * in errors like "ExistingValue must be an instance of com.zaxxer.hikari.HikariDataSource".
+     *
+     * To prevent this, we create a JDK dynamic proxy implementing only the DataSource interface.
+     * The proxy delegates all method calls to the wrapped (instrumented) DataSource.
+     * This approach "hides" the actual implementation class and ensures that Spring interacts only
+     * with the DataSource interface, avoiding issues related to constructor resolution or type casting
+     * during bean rebinding.
+     */
+    ProxyFactory proxyFactory = new ProxyFactory(DataSource.class);
+    // Set the original bean as the target (important for AOP and bean lifecycle)
+    proxyFactory.setTarget(bean);
+    // Delegate all method calls to the wrapped, instrumented DataSource
+    proxyFactory.addAdvice(
+        new MethodInterceptor() {
+          @Nullable
+          @Override
+          public Object invoke(@Nonnull MethodInvocation invocation) throws Throwable {
+            return AopUtils.invokeJoinpointUsingReflection(
+                wrapped, invocation.getMethod(), invocation.getArguments());
+          }
+        });
+
+    // Return the proxy instead of the instrumented DataSource instance
+    // This ensures proper interaction with Spring's bean lifecycle and rebinding
+    return proxyFactory.getProxy();
   }
+  return bean;
+}
 
   // To be one of the first bean post-processors to be executed
   @Override

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessor.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.jdbc;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -5,11 +10,9 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.InstrumentationConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
-
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.framework.ProxyFactory;
@@ -46,65 +49,67 @@ final class DataSourcePostProcessor implements BeanPostProcessor, Ordered {
   }
 
   @CanIgnoreReturnValue
-@Override
-public Object postProcessAfterInitialization(Object bean, String beanName) {
-  // Exclude scoped proxy beans to avoid double wrapping
-  if (bean instanceof DataSource
-      && !isRoutingDatasource(bean)
-      && !ScopedProxyUtils.isScopedTarget(beanName)) {
-    DataSource dataSource = (DataSource) bean;
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) {
+    // Exclude scoped proxy beans to avoid double wrapping
+    if (bean instanceof DataSource
+        && !isRoutingDatasource(bean)
+        && !ScopedProxyUtils.isScopedTarget(beanName)) {
+      DataSource dataSource = (DataSource) bean;
 
-    // Wrap the original DataSource with OpenTelemetry instrumentation
-    DataSource wrapped = JdbcTelemetry.builder(openTelemetryProvider.getObject())
-        .setStatementSanitizationEnabled(
-            InstrumentationConfigUtil.isStatementSanitizationEnabled(
-                configPropertiesProvider.getObject(),
-                "otel.instrumentation.jdbc.statement-sanitizer.enabled"))
-        .setCaptureQueryParameters(
-            configPropertiesProvider
-                .getObject()
-                .getBoolean(
-                    "otel.instrumentation.jdbc.experimental.capture-query-parameters", false))
-        .setTransactionInstrumenterEnabled(
-            configPropertiesProvider
-                .getObject()
-                .getBoolean("otel.instrumentation.jdbc.experimental.transaction.enabled", false))
-        .build()
-        .wrap(dataSource);
+      // Wrap the original DataSource with OpenTelemetry instrumentation
+      DataSource wrapped =
+          JdbcTelemetry.builder(openTelemetryProvider.getObject())
+              .setStatementSanitizationEnabled(
+                  InstrumentationConfigUtil.isStatementSanitizationEnabled(
+                      configPropertiesProvider.getObject(),
+                      "otel.instrumentation.jdbc.statement-sanitizer.enabled"))
+              .setCaptureQueryParameters(
+                  configPropertiesProvider
+                      .getObject()
+                      .getBoolean(
+                          "otel.instrumentation.jdbc.experimental.capture-query-parameters", false))
+              .setTransactionInstrumenterEnabled(
+                  configPropertiesProvider
+                      .getObject()
+                      .getBoolean(
+                          "otel.instrumentation.jdbc.experimental.transaction.enabled", false))
+              .build()
+              .wrap(dataSource);
 
-    /**
-     * Spring Boot's configuration binding and rebinding mechanisms (such as those triggered by
-     * Nacos configuration refresh) may attempt to reconstruct beans using their concrete class
-     * constructors. If a custom DataSource implementation (such as OpenTelemetryDataSource)
-     * is returned directly, Spring may not find a suitable constructor during rebinding, resulting
-     * in errors like "ExistingValue must be an instance of com.zaxxer.hikari.HikariDataSource".
-     *
-     * To prevent this, we create a JDK dynamic proxy implementing only the DataSource interface.
-     * The proxy delegates all method calls to the wrapped (instrumented) DataSource.
-     * This approach "hides" the actual implementation class and ensures that Spring interacts only
-     * with the DataSource interface, avoiding issues related to constructor resolution or type casting
-     * during bean rebinding.
-     */
-    ProxyFactory proxyFactory = new ProxyFactory(DataSource.class);
-    // Set the original bean as the target (important for AOP and bean lifecycle)
-    proxyFactory.setTarget(bean);
-    // Delegate all method calls to the wrapped, instrumented DataSource
-    proxyFactory.addAdvice(
-        new MethodInterceptor() {
-          @Nullable
-          @Override
-          public Object invoke(@Nonnull MethodInvocation invocation) throws Throwable {
-            return AopUtils.invokeJoinpointUsingReflection(
-                wrapped, invocation.getMethod(), invocation.getArguments());
-          }
-        });
+      /**
+       * Spring Boot's configuration binding and rebinding mechanisms (such as those triggered by
+       * Nacos configuration refresh) may attempt to reconstruct beans using their concrete class
+       * constructors. If a custom DataSource implementation (such as OpenTelemetryDataSource) is
+       * returned directly, Spring may not find a suitable constructor during rebinding, resulting
+       * in errors like "ExistingValue must be an instance of com.zaxxer.hikari.HikariDataSource".
+       *
+       * <p>To prevent this, we create a JDK dynamic proxy implementing only the DataSource
+       * interface. The proxy delegates all method calls to the wrapped (instrumented) DataSource.
+       * This approach "hides" the actual implementation class and ensures that Spring interacts
+       * only with the DataSource interface, avoiding issues related to constructor resolution or
+       * type casting during bean rebinding.
+       */
+      ProxyFactory proxyFactory = new ProxyFactory(DataSource.class);
+      // Set the original bean as the target (important for AOP and bean lifecycle)
+      proxyFactory.setTarget(bean);
+      // Delegate all method calls to the wrapped, instrumented DataSource
+      proxyFactory.addAdvice(
+          new MethodInterceptor() {
+            @Nullable
+            @Override
+            public Object invoke(@Nonnull MethodInvocation invocation) throws Throwable {
+              return AopUtils.invokeJoinpointUsingReflection(
+                  wrapped, invocation.getMethod(), invocation.getArguments());
+            }
+          });
 
-    // Return the proxy instead of the instrumented DataSource instance
-    // This ensures proper interaction with Spring's bean lifecycle and rebinding
-    return proxyFactory.getProxy();
+      // Return the proxy instead of the instrumented DataSource instance
+      // This ensures proper interaction with Spring's bean lifecycle and rebinding
+      return proxyFactory.getProxy();
+    }
+    return bean;
   }
-  return bean;
-}
 
   // To be one of the first bean post-processors to be executed
   @Override

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessorContextTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessorContextTest.java
@@ -1,16 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.jdbc;
-
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 
 class DataSourcePostProcessorTest {
 
@@ -41,9 +44,8 @@ class DataSourcePostProcessorTest {
       ObjectProvider<OpenTelemetry> openTelemetryProvider = () -> openTelemetry;
       ObjectProvider<ConfigProperties> configPropertiesProvider = () -> configProperties;
 
-      DataSourcePostProcessor postProcessor = new DataSourcePostProcessor(
-          openTelemetryProvider, configPropertiesProvider
-      );
+      DataSourcePostProcessor postProcessor =
+          new DataSourcePostProcessor(openTelemetryProvider, configPropertiesProvider);
 
       // Act
       Object processed = postProcessor.postProcessAfterInitialization(original, "myDataSource");

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessorContextTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/jdbc/DataSourcePostProcessorContextTest.java
@@ -1,0 +1,66 @@
+package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.jdbc;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class DataSourcePostProcessorTest {
+
+  @Test
+  void shouldWrapDataSourceWithProxy() throws Exception {
+    // Set up mocks
+    DataSource original = mock(DataSource.class);
+    Connection mockConn = mock(Connection.class);
+    when(original.getConnection()).thenReturn(mockConn);
+
+    // Create mocks for OpenTelemetry and ConfigProperties
+    OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
+    ConfigProperties configProperties = mock(ConfigProperties.class);
+    when(configProperties.getBoolean(anyString(), anyBoolean())).thenReturn(false);
+
+    // Mock JdbcTelemetry builder chain to return a mock DataSource as 'wrapped'
+    JdbcTelemetry.Builder builder = mock(JdbcTelemetry.Builder.class, RETURNS_SELF);
+    JdbcTelemetry telemetry = mock(JdbcTelemetry.class);
+    DataSource wrapped = mock(DataSource.class);
+    when(wrapped.getConnection()).thenReturn(mockConn);
+    when(telemetry.wrap(any(DataSource.class))).thenReturn(wrapped);
+    when(builder.build()).thenReturn(telemetry);
+
+    // Mock the static builder method (requires mockito-inline or PowerMockito)
+    try (var mocked = Mockito.mockStatic(JdbcTelemetry.class)) {
+      mocked.when(() -> JdbcTelemetry.builder(any())).thenReturn(builder);
+
+      ObjectProvider<OpenTelemetry> openTelemetryProvider = () -> openTelemetry;
+      ObjectProvider<ConfigProperties> configPropertiesProvider = () -> configProperties;
+
+      DataSourcePostProcessor postProcessor = new DataSourcePostProcessor(
+          openTelemetryProvider, configPropertiesProvider
+      );
+
+      // Act
+      Object processed = postProcessor.postProcessAfterInitialization(original, "myDataSource");
+
+      // Assert
+      assertThat(processed).isInstanceOf(DataSource.class);
+      assertThat(processed).isNotSameAs(original);
+
+      // The proxy should delegate calls to the wrapped DataSource
+      DataSource proxied = (DataSource) processed;
+      Connection proxiedConnection = proxied.getConnection();
+      assertThat(proxiedConnection).isEqualTo(mockConn);
+
+      // The original DataSource should NOT be called directly by the proxy
+      verify(original, never()).getConnection();
+      // The wrapped DataSource should be called
+      verify(wrapped, times(1)).getConnection();
+    }
+  }
+}


### PR DESCRIPTION
Fixes [#13512](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13512):

- Addresses issue where Spring Boot configuration refresh (e.g., via Nacos) fails due to constructor/type errors with instrumented   DataSource beans.
- Wraps the instrumented DataSource with a JDK dynamic proxy implementing only the DataSource interface.
- Proxy ensures Spring interacts only with the DataSource interface, avoiding exposure of implementation details (like OpenTelemetryDataSource).
- Prevents errors such as "ExistingValue must be an instance of com.zaxxer.hikari.HikariDataSource" during bean rebinding.
- Maintains compatibility with Spring’s configuration properties rebinding and refresh mechanisms.
- The proxy delegates all method calls to the underlying instrumented DataSource, preserving all functionality and telemetry.
- Adds in-code comments explaining the rationale for proxying the DataSource.
- Adds a test case to verify the DataSource proxying and configuration rebinding fix, ensuring that the solution is validated and regressions are prevented.