### PR TITLE
feat: Add auto-instrumentation support for AWS Step Functions SDK v2

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+  testLibrary("software.amazon.awssdk:sfn:2.2.0")
 }
 
 val testLatestDeps = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkReques
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SECRETSMANAGER;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SNS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SQS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.STEPFUNCTIONS;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.request;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.response;
 
@@ -37,6 +38,7 @@ enum AwsSdkRequest {
   SqsRequest(SQS, "SqsRequest"),
   KinesisRequest(KINESIS, "KinesisRequest"),
   SecretsManagerRequest(SECRETSMANAGER, "SecretsManagerRequest"),
+  StepFunctionsRequest(STEPFUNCTIONS, "SfnRequest"),
   // specific requests
   BatchGetItem(
       DYNAMODB,

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
@@ -26,7 +26,10 @@ enum AwsSdkRequestType {
        * Only one of TopicArn and TargetArn are permitted on an SNS request.
        */
       request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TargetArn"),
-      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn"));
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn")),
+  STEPFUNCTIONS(
+      request(AttributeKeys.AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
+      request(AttributeKeys.AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn"));
 
   // Wrapping in unmodifiableMap
   @SuppressWarnings("ImmutableEnumChecker")
@@ -44,6 +47,10 @@ enum AwsSdkRequestType {
     // Copied from AwsIncubatingAttributes
     static final AttributeKey<String> AWS_SECRETSMANAGER_SECRET_ARN =
         stringKey("aws.secretsmanager.secret.arn");
+    static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
+        stringKey("aws.step_functions.activity.arn");
+    static final AttributeKey<String> AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN =
+        stringKey("aws.step_functions.state_machine.arn");
 
     // copied from MessagingIncubatingAttributes
     static final AttributeKey<String> MESSAGING_DESTINATION_NAME =

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   compileOnly("software.amazon.awssdk:s3:2.2.0")
   compileOnly("software.amazon.awssdk:secretsmanager:2.2.0")
   compileOnly("software.amazon.awssdk:ses:2.2.0")
+  compileOnly("software.amazon.awssdk:sfn:2.2.0")
   compileOnly("software.amazon.awssdk:sns:2.2.0")
   compileOnly("software.amazon.awssdk:sqs:2.2.0")
 


### PR DESCRIPTION
This PR introduces auto-instrumentation support for the following AWS resource:

AWS Step Functions SDK v2

Tests Run:
./gradlew spotlessCheck
./gradlew clean assemble
./gradlew instrumentation:check
./gradlew :smoke-tests:test

All newly added tests pass, and no regression issues were found.

Backward Compatibility:
This change is backward compatible. It adds instrumentation for an additional AWS resource without modifying existing behavior in the auto-instrumentation library.