### PR TITLE
Fix UCP typos and cleanup ES tests

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchEndpointMapTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchEndpointMapTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal.ElasticsearchEndpointDefinition;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.apiclient.ElasticsearchEndpointMap;
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-public class ElasticsearchEndpointMapTest {
+class ElasticsearchEndpointMapTest {
 
   private static final Set<String> SEARCH_ENDPOINTS =
       new HashSet<>(
@@ -57,16 +57,17 @@ public class ElasticsearchEndpointMapTest {
   }
 
   @Test
-  public void testIsSearchEndpoint() {
+  void testIsSearchEndpoint() {
     for (ElasticsearchEndpointDefinition esEndpointDefinition :
         ElasticsearchEndpointMap.getAllEndpoints()) {
       String endpointId = esEndpointDefinition.getEndpointName();
-      assertEquals(SEARCH_ENDPOINTS.contains(endpointId), esEndpointDefinition.isSearchEndpoint());
+      assertThat(SEARCH_ENDPOINTS.contains(endpointId))
+          .isEqualTo(esEndpointDefinition.isSearchEndpoint());
     }
   }
 
   @Test
-  public void testProcessPathParts() {
+  void testProcessPathParts() {
     for (ElasticsearchEndpointDefinition esEndpointDefinition :
         ElasticsearchEndpointMap.getAllEndpoints()) {
       for (String route :
@@ -81,44 +82,45 @@ public class ElasticsearchEndpointMapTest {
         Map<String, String> expectedMap = new HashMap<>();
         pathParts.forEach(part -> expectedMap.put(part, part));
 
-        assertEquals(expectedMap, observedParams);
+        assertThat(expectedMap).isEqualTo(observedParams);
       }
     }
   }
 
   @Test
-  public void testSearchEndpoint() {
+  void testSearchEndpoint() {
     ElasticsearchEndpointDefinition esEndpoint = ElasticsearchEndpointMap.get("search");
     Map<String, String> observedParams = new HashMap<>();
     esEndpoint.processPathParts(
         "/test-index-1,test-index-2/_search", (k, v) -> observedParams.put(k, v));
 
-    assertEquals("test-index-1,test-index-2", observedParams.get("index"));
+    assertThat(observedParams.get("index")).isEqualTo("test-index-1,test-index-2");
   }
 
   @Test
-  public void testBuildRegexPattern() {
+  void testBuildRegexPattern() {
     Pattern pattern =
         ElasticsearchEndpointDefinition.EndpointPattern.buildRegexPattern(
             "/_nodes/{node_id}/shutdown");
-    assertEquals("^/_nodes/(?<node0id>[^/]+)/shutdown$", pattern.pattern());
+    assertThat(pattern.pattern()).isEqualTo("^/_nodes/(?<node0id>[^/]+)/shutdown$");
 
     pattern =
         ElasticsearchEndpointDefinition.EndpointPattern.buildRegexPattern(
             "/_snapshot/{repository}/{snapshot}/_mount");
-    assertEquals("^/_snapshot/(?<repository>[^/]+)/(?<snapshot>[^/]+)/_mount$", pattern.pattern());
+    assertThat(pattern.pattern())
+        .isEqualTo("^/_snapshot/(?<repository>[^/]+)/(?<snapshot>[^/]+)/_mount$");
 
     pattern =
         ElasticsearchEndpointDefinition.EndpointPattern.buildRegexPattern(
             "/_security/profile/_suggest");
-    assertEquals("^/_security/profile/_suggest$", pattern.pattern());
+    assertThat(pattern.pattern()).isEqualTo("^/_security/profile/_suggest$");
 
     pattern =
         ElasticsearchEndpointDefinition.EndpointPattern.buildRegexPattern(
             "/_application/search_application/{name}");
-    assertEquals("^/_application/search_application/(?<name>[^/]+)$", pattern.pattern());
+    assertThat(pattern.pattern()).isEqualTo("^/_application/search_application/(?<name>[^/]+)$");
 
     pattern = ElasticsearchEndpointDefinition.EndpointPattern.buildRegexPattern("/");
-    assertEquals("^/$", pattern.pattern());
+    assertThat(pattern.pattern()).isEqualTo("^/$");
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchClientTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_ELASTICSEARCH_PATH_PARTS;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -33,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,9 +82,9 @@ class ElasticsearchClientTest {
   }
 
   @Test
-  public void elasticsearchStatus() throws IOException {
+  void elasticsearchStatus() throws IOException {
     InfoResponse response = client.info();
-    Assertions.assertEquals(response.version().number(), "7.17.2");
+    assertThat(response.version().number()).isEqualTo("7.17.2");
 
     testing.waitAndAssertTraces(
         trace ->
@@ -114,7 +114,7 @@ class ElasticsearchClientTest {
   }
 
   @Test
-  public void elasticsearchIndex() throws IOException {
+  void elasticsearchIndex() throws IOException {
     client.index(
         r ->
             r.id("test-id")
@@ -157,7 +157,7 @@ class ElasticsearchClientTest {
   }
 
   @Test
-  public void elasticsearchStatusAsync() throws Exception {
+  void elasticsearchStatusAsync() throws Exception {
     CountDownLatch countDownLatch = new CountDownLatch(1);
     AsyncRequest request = new AsyncRequest();
 
@@ -177,7 +177,7 @@ class ElasticsearchClientTest {
     //noinspection ResultOfMethodCallIgnored
     countDownLatch.await(10, TimeUnit.SECONDS);
 
-    Assertions.assertEquals(request.getResponse().version().number(), "7.17.2");
+    assertThat(request.getResponse().version().number()).isEqualTo("7.17.2");
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.SpanKind;
@@ -27,7 +28,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -89,36 +89,32 @@ class ElasticsearchRest5Test {
     Map result = objectMapper.readValue(response.getEntity().getContent(), Map.class);
 
     // usually this test reports green status, but sometimes it is yellow
-    Assertions.assertTrue(
-        "green".equals(result.get("status")) || "yellow".equals(result.get("status")));
+    assertThat(result.get("status")).isIn("green", "yellow");
 
     testing.waitAndAssertTraces(
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasNoParent()
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(0))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
-              });
-        });
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200))));
   }
 
   @Test
@@ -151,10 +147,7 @@ class ElasticsearchRest5Test {
         };
 
     testing.runWithSpan(
-        "parent",
-        () -> {
-          client.performRequestAsync("GET", "_cluster/health", responseListener);
-        });
+        "parent", () -> client.performRequestAsync("GET", "_cluster/health", responseListener));
     countDownLatch.await();
     if (exception[0] != null) {
       throw exception[0];
@@ -162,41 +155,36 @@ class ElasticsearchRest5Test {
     Map result = objectMapper.readValue(requestResponse[0].getEntity().getContent(), Map.class);
 
     // usually this test reports green status, but sometimes it is yellow
-    Assertions.assertTrue(
-        "green".equals(result.get("status")) || "yellow".equals(result.get("status")));
+    assertThat(result.get("status")).isIn("green", "yellow");
 
     testing.waitAndAssertTraces(
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> {
-                span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent();
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(0))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(1))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
-              },
-              span -> {
-                span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0));
-              });
-        });
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200)),
+                span ->
+                    span.hasName("callback")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0))));
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.SpanKind;
@@ -27,7 +28,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -75,46 +75,43 @@ class ElasticsearchRest6Test {
   @Test
   @SuppressWarnings({"deprecation", "rawtypes"})
   // ignore deprecation interface
-  public void elasticsearchStatus() throws IOException {
-
+  void elasticsearchStatus() throws IOException {
     Response response = client.performRequest("GET", "_cluster/health");
     Map result = objectMapper.readValue(response.getEntity().getContent(), Map.class);
 
-    Assertions.assertEquals(result.get("status"), "green");
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
         trace -> {
           trace.hasSpansSatisfyingExactly(
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasNoParent()
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(0))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200L));
-              });
+              span ->
+                  span.hasName("GET")
+                      .hasKind(SpanKind.CLIENT)
+                      .hasNoParent()
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
+                          equalTo(HTTP_REQUEST_METHOD, "GET"),
+                          equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                          equalTo(SERVER_PORT, httpHost.getPort()),
+                          equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
+              span ->
+                  span.hasName("GET")
+                      .hasKind(SpanKind.CLIENT)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                          equalTo(SERVER_PORT, httpHost.getPort()),
+                          equalTo(HTTP_REQUEST_METHOD, "GET"),
+                          equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                          equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)));
         });
   }
 
   @Test
   @SuppressWarnings({"deprecation", "rawtypes"})
   // ignore deprecation interface
-  public void elasticsearchStatusAsync() throws Exception {
+  void elasticsearchStatusAsync() throws Exception {
     Response[] requestResponse = {null};
     Exception[] exception = {null};
     CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -152,40 +149,36 @@ class ElasticsearchRest6Test {
     }
     Map result = objectMapper.readValue(requestResponse[0].getEntity().getContent(), Map.class);
 
-    Assertions.assertEquals(result.get("status"), "green");
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> {
-                span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent();
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(0))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"));
-              },
-              span -> {
-                span.hasName("GET")
-                    .hasKind(SpanKind.CLIENT)
-                    .hasParent(trace.getSpan(1))
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(SERVER_ADDRESS, httpHost.getHostName()),
-                        equalTo(SERVER_PORT, httpHost.getPort()),
-                        equalTo(HTTP_REQUEST_METHOD, "GET"),
-                        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                        equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
-                        equalTo(HTTP_RESPONSE_STATUS_CODE, 200));
-              },
-              span -> {
-                span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0));
-              });
-        });
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), "elasticsearch"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(SERVER_ADDRESS, httpHost.getHostName()),
+                            equalTo(SERVER_PORT, httpHost.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200)),
+                span ->
+                    span.hasName("callback")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0))));
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -28,7 +29,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -76,10 +76,11 @@ class ElasticsearchRest7Test {
   }
 
   @Test
-  public void elasticsearchStatus() throws Exception {
+  void elasticsearchStatus() throws Exception {
     Response response = client.performRequest(new Request("GET", "_cluster/health"));
     Map<?, ?> result = objectMapper.readValue(response.getEntity().getContent(), Map.class);
-    Assertions.assertEquals(result.get("status"), "green");
+
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
         trace ->
@@ -108,7 +109,7 @@ class ElasticsearchRest7Test {
   }
 
   @Test
-  public void elasticsearchStatusAsync() throws Exception {
+  void elasticsearchStatusAsync() throws Exception {
     AsyncRequest asyncRequest = new AsyncRequest();
     CountDownLatch countDownLatch = new CountDownLatch(1);
     ResponseListener responseListener =
@@ -148,7 +149,7 @@ class ElasticsearchRest7Test {
     Map<?, ?> result =
         objectMapper.readValue(
             asyncRequest.getRequestResponse().getEntity().getContent(), Map.class);
-    Assertions.assertEquals(result.get("status"), "green");
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -26,7 +27,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -75,10 +75,10 @@ class ElasticsearchRest7Test {
   }
 
   @Test
-  public void elasticsearchStatus() throws Exception {
+  void elasticsearchStatus() throws Exception {
     Response response = client.performRequest(new Request("GET", "_cluster/health"));
     Map<?, ?> result = objectMapper.readValue(response.getEntity().getContent(), Map.class);
-    Assertions.assertEquals(result.get("status"), "green");
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
         trace ->
@@ -136,7 +136,7 @@ class ElasticsearchRest7Test {
     Map<?, ?> result =
         objectMapper.readValue(
             asyncRequest.getRequestResponse().getEntity().getContent(), Map.class);
-    Assertions.assertEquals(result.get("status"), "green");
+    assertThat(result.get("status")).isEqualTo("green");
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/oracle-ucp-11.2/library/src/main/java/io/opentelemetry/instrumentation/oracleucp/v11_2/ConnectionPoolMetrics.java
+++ b/instrumentation/oracle-ucp-11.2/library/src/main/java/io/opentelemetry/instrumentation/oracleucp/v11_2/ConnectionPoolMetrics.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import oracle.ucp.UniversalConnectionPool;
 
 final class ConnectionPoolMetrics {
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.orcale-ucp-11.2";
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.oracle-ucp-11.2";
 
   // a weak map does not make sense here because each Meter holds a reference to the connection pool
   // none of the UniversalConnectionPool implementations contain equals()/hashCode(), so it's safe

--- a/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
+++ b/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractOracleUcpInstrumentationTest {
   private static final Logger logger =
       LoggerFactory.getLogger(AbstractOracleUcpInstrumentationTest.class);
 
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.orcale-ucp-11.2";
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.oracle-ucp-11.2";
   private static OracleContainer oracle;
 
   protected abstract InstrumentationExtension testing();


### PR DESCRIPTION
Came across a typo in the UCP instrumentation name and some small nitpicks for elasticsearch tests so they follow the same conventions as other tests