### PR TITLE
Preload ThreadLocalRandom to avoid java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -123,6 +124,11 @@ public class AgentInstaller {
     EmbeddedInstrumentationProperties.setPropertiesLoader(extensionClassLoader);
     setDefineClassHandler();
     FieldBackedImplementationConfiguration.configure(earlyConfig);
+    // preload ThreadLocalRandom to avoid occasional
+    // java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
+    // see https://github.com/raphw/byte-buddy/issues/1666 and
+    // https://bugs.openjdk.org/browse/JDK-8164165
+    ThreadLocalRandom.current();
 
     AgentBuilder agentBuilder =
         new AgentBuilder.Default(


### PR DESCRIPTION
See https://scans.gradle.com/s/ghszeelntq2n6/console-log/task/:instrumentation:pekko:pekko-http-1.0:javaagent:tapirTest?anchor=574&page=1
During transformation of `ThreadLocalRandom` we get a circularity
```
java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom	
	at java.base/java.util.concurrent.ConcurrentHashMap.fullAddCount(ConcurrentHashMap.java:2574)	
	at java.base/java.util.concurrent.ConcurrentHashMap.addCount(ConcurrentHashMap.java:2326)	
	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1075)	
	at java.base/java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541)	
	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.concurrentlinkedhashmap.ConcurrentLinkedHashMap.put(ConcurrentLinkedHashMap.java:720)	
	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.concurrentlinkedhashmap.ConcurrentLinkedHashMap.put(ConcurrentLinkedHashMap.java:694)	
	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.MapBackedCache.put(MapBackedCache.java:33)	
	at io.opentelemetry.javaagent.tooling.muzzle.AgentCachingPoolStrategy$SharedResolutionCacheAdapter.register(AgentCachingPoolStrategy.java:305)	
	at io.opentelemetry.javaagent.tooling.muzzle.AgentCachingPoolStrategy$AgentTypePool.doResolve(AgentCachingPoolStrategy.java:352)	
	at io.opentelemetry.javaagent.tooling.muzzle.AgentCachingPoolStrategy$AgentTypePool$CachingTypeDescription.delegate(AgentCachingPoolStrategy.java:422)	
	at net.bytebuddy.description.type.TypeDescription$AbstractBase$OfSimpleType$WithDelegation.getModifiers(TypeDescription.java:8601)	
	at net.bytebuddy.matcher.ModifierMatcher.doMatch(ModifierMatcher.java:60)	
	at net.bytebuddy.matcher.ModifierMatcher.doMatch(ModifierMatcher.java:27)	
	at net.bytebuddy.matcher.ElementMatcher$Junction$ForNonNullValues.matches(ElementMatcher.java:252)	
	at net.bytebuddy.matcher.NegatingMatcher.matches(NegatingMatcher.java:47)	
	at net.bytebuddy.matcher.ElementMatcher$Junction$Conjunction.matches(ElementMatcher.java:148)	
	at io.opentelemetry.javaagent.tooling.util.IgnoreFailedTypeMatcher.matches(IgnoreFailedTypeMatcher.java:27)	
	at io.opentelemetry.javaagent.tooling.util.IgnoreFailedTypeMatcher.matches(IgnoreFailedTypeMatcher.java:18)	
	at io.opentelemetry.javaagent.tooling.util.NamedMatcher.matches(NamedMatcher.java:26)	
	at net.bytebuddy.agent.builder.AgentBuilder$RawMatcher$ForElementMatchers.matches(AgentBuilder.java:1965)	
	at net.bytebuddy.agent.builder.AgentBuilder$RawMatcher$Conjunction.matches(AgentBuilder.java:1800)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:12702)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:12660)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1800(AgentBuilder.java:12369)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:13151)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:13081)	
	at java.base/java.security.AccessController.doPrivileged(Native Method)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doPrivileged(AgentBuilder.java)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:12603)	
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)	
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)	
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)	
	at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)	
	at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader.java:1263)	
	at java.base/java.lang.System$2.findBootstrapClassOrNull(System.java:2151)	
	at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadClassOrNull(ClassLoaders.java:118)	
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:609)	
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:579)	
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)	
	at io.opentelemetry.javaagent.bootstrap.AgentClassLoader$PlatformDelegatingClassLoader.loadClass(AgentClassLoader.java:519)	
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:581)	
	at io.opentelemetry.javaagent.bootstrap.AgentClassLoader.loadClass(AgentClassLoader.java:161)	
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)	
	at io.opentelemetry.sdk.internal.RandomSupplier.platformDefault(RandomSupplier.java:32)	
	at io.opentelemetry.sdk.trace.RandomIdGenerator.<clinit>(RandomIdGenerator.java:18)	
	at io.opentelemetry.sdk.trace.IdGenerator.random(IdGenerator.java:25)	
	at io.opentelemetry.sdk.trace.SdkTracerProviderBuilder.<init>(SdkTracerProviderBuilder.java:34)	
	at io.opentelemetry.sdk.trace.SdkTracerProvider.builder(SdkTracerProvider.java:45)	
	at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.configureSdk(AutoConfiguredOpenTelemetrySdkBuilder.java:514)	
	at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.build(AutoConfiguredOpenTelemetrySdkBuilder.java:465)	
	at io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installOpenTelemetrySdk(OpenTelemetryInstaller.java:29)	
	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:160)	
	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:110)	
	at io.opentelemetry.javaagent.tooling.AgentStarterImpl.start(AgentStarterImpl.java:101)	
	at io.opentelemetry.javaagent.bootstrap.AgentInitializer$2.run(AgentInitializer.java:66)	
	at io.opentelemetry.javaagent.bootstrap.AgentInitializer$2.run(AgentInitializer.java:60)	
	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.execute(AgentInitializer.java:82)	
	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:59)	
	at io.opentelemetry.javaagent.OpenTelemetryAgent.startAgent(OpenTelemetryAgent.java:59)	
	at io.opentelemetry.javaagent.OpenTelemetryAgent.premain(OpenTelemetryAgent.java:46)	
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)	
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)	
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)	
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)	
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)	
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
```
Note that the code path in `ConcurrentHashMap` that loads the `ThreadLocalRandom` isn't always taken which makes this hard to reproduce. Also this isn't the only code path in the transformation that uses `ConcurrentHashMap` and can trigger this failure. Now the transformation failing isn't really a big deal as the exceptions during the transform are suppressed. What is problematic is that this error leaves `ConcurrentHashMap` in a broken state where the next usage of it also produces the same error, see https://bugs.openjdk.org/browse/JDK-8164165 So further down we have another `ClassCircularityError` that is visible to the application
```
Uncaught error from thread [my-system-pekko.actor.default-dispatcher-5]: java/util/concurrent/ThreadLocalRandom, shutting down JVM since 'pekko.jvm-exit-on-fatal-error' is enabled for ActorSystem[my-system]	
    java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom	
    	at java.base/java.util.concurrent.ConcurrentHashMap.fullAddCount(ConcurrentHashMap.java:2574)	
    	at java.base/java.util.concurrent.ConcurrentHashMap.addCount(ConcurrentHashMap.java:2326)	
    	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1075)	
    	at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.internal.shaded.AbstractWeakConcurrentMap.put(AbstractWeakConcurrentMap.java:138)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.internal.shaded.WeakConcurrentMap.put(WeakConcurrentMap.java:47)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.StrictContextStorage$StrictScope.<init>(StrictContextStorage.java:155)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.StrictContextStorage.attach(StrictContextStorage.java:113)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.Context.makeCurrent(Context.java:231)	
    	at io.opentelemetry.javaagent.shaded.io.opentelemetry.context.Context.lambda$wrap$1(Context.java:240)	
    	at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)	
    	at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:57)	
    	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)	
    	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)	
    	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)	
    	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)	
    	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```