### PR TITLE
Fix java-http-client tests

### DIFF
--- a/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/Http1ClientTest.java
+++ b/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/Http1ClientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.javahttpclient;
+
+import java.net.http.HttpClient;
+
+class Http1ClientTest extends JavaHttpClientTest {
+
+  @Override
+  protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
+    httpClientBuilder.version(HttpClient.Version.HTTP_1_1);
+  }
+}

--- a/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/Http2ClientTest.java
+++ b/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/Http2ClientTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.javahttpclient;
+
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
+import java.net.http.HttpClient;
+
+class Http2ClientTest extends JavaHttpClientTest {
+
+  @Override
+  protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
+    httpClientBuilder.version(HttpClient.Version.HTTP_2);
+  }
+
+  @Override
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
+
+    optionsBuilder.setHttpProtocolVersion(
+        uri -> {
+          String uriString = uri.toString();
+          if (uriString.equals("http://localhost:61/") || uriString.equals("https://192.0.2.1/")) {
+            return "1.1";
+          }
+          return "2";
+        });
+  }
+}

--- a/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -8,9 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.javahttpclient;
 import io.opentelemetry.instrumentation.javahttpclient.AbstractJavaHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
-import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import java.net.http.HttpClient;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
@@ -21,38 +19,5 @@ public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
   @Override
   protected HttpClient configureHttpClient(HttpClient httpClient) {
     return httpClient;
-  }
-
-  @Nested
-  static class Http1ClientTest extends JavaHttpClientTest {
-
-    @Override
-    protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
-      httpClientBuilder.version(HttpClient.Version.HTTP_1_1);
-    }
-  }
-
-  @Nested
-  static class Http2ClientTest extends JavaHttpClientTest {
-
-    @Override
-    protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
-      httpClientBuilder.version(HttpClient.Version.HTTP_2);
-    }
-
-    @Override
-    protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
-      super.configure(optionsBuilder);
-
-      optionsBuilder.setHttpProtocolVersion(
-          uri -> {
-            String uriString = uri.toString();
-            if (uriString.equals("http://localhost:61/")
-                || uriString.equals("https://192.0.2.1/")) {
-              return "1.1";
-            }
-            return "2";
-          });
-    }
   }
 }


### PR DESCRIPTION
While working on #13468 I noticed these tests weren't emitting metrics like I was expecting. It seems that at least for me locally, these tests are failing to run but not being counted as a failed test run.

I found that running `./gradlew :instrumentation:java-http-client:javaagent:test` resulted in:

```
(2) [WARNING] @Nested class 'io.opentelemetry.javaagent.instrumentation.javahttpclient.JavaHttpClientTest$Http2ClientTest' must not be static. It will not be executed.
    Source: ClassSource [className = 'io.opentelemetry.javaagent.instrumentation.javahttpclient.JavaHttpClientTest$Http2ClientTest', filePosition = null]
            at io.opentelemetry.javaagent.instrumentation.javahttpclient.JavaHttpClientTest$Http2ClientTest.<no-method>(SourceFile:0)
```