### PR TITLE
feat: Add AWS_SNS_TOPIC_ARN semantic convention support for AWS SNS SDK

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_REQUEST_ID;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SNS_TOPIC_ARN;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
@@ -90,6 +91,7 @@ class AwsSpanAssertions {
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("aws.agent"), "java-aws-sdk"),
             equalTo(MESSAGING_DESTINATION_NAME, topicArn),
+            satisfies(AWS_SNS_TOPIC_ARN, v -> v.isInstanceOf(String.class)),
             satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
             equalTo(RPC_METHOD, rpcMethod),
             equalTo(RPC_SYSTEM, "aws-api"),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkAttributesExtractor.java
@@ -26,6 +26,7 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
   // Copied from AwsIncubatingAttributes
   private static final AttributeKey<String> AWS_SECRETSMANAGER_SECRET_ARN =
       stringKey("aws.secretsmanager.secret.arn");
+  private static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
   private static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
       stringKey("aws.step_functions.activity.arn");
   private static final AttributeKey<String> AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN =
@@ -45,6 +46,7 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
     Object originalRequest = request.getOriginalRequest();
+    setAttribute(attributes, AWS_SNS_TOPIC_ARN, originalRequest, RequestAccess::getSnsTopicArn);
     setAttribute(
         attributes,
         AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN,
@@ -67,6 +69,7 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
     Object awsResp = getAwsResponse(response);
     if (awsResp != null) {
       setAttribute(attributes, AWS_SECRETSMANAGER_SECRET_ARN, awsResp, RequestAccess::getSecretArn);
+      setAttribute(attributes, AWS_SNS_TOPIC_ARN, awsResp, RequestAccess::getSnsTopicArn);
       setAttribute(
           attributes,
           AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN,

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
@@ -74,9 +74,6 @@ final class RequestAccess {
 
   @Nullable
   static String getSnsTopicArn(Object request) {
-    if (request == null) {
-      return null;
-    }
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getTopicArn, request);
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
@@ -73,7 +73,10 @@ final class RequestAccess {
   }
 
   @Nullable
-  static String getTopicArn(Object request) {
+  static String getSnsTopicArn(Object request) {
+    if (request == null) {
+      return null;
+    }
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getTopicArn, request);
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SnsAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SnsAttributesExtractor.java
@@ -32,7 +32,7 @@ public class SnsAttributesExtractor implements AttributesExtractor<Request<?>, R
    * falling back to the target ARN. If neither is found null is returned.
    */
   private static String findMessageDestination(AmazonWebServiceRequest request) {
-    String destination = RequestAccess.getTopicArn(request);
+    String destination = RequestAccess.getSnsTopicArn(request);
     if (destination != null) {
       return destination;
     }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSnsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSnsClientTest.java
@@ -6,24 +6,42 @@
 package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SNS_TOPIC_ARN;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sns.model.CreateTopicRequest;
 import com.amazonaws.services.sns.model.PublishRequest;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
+  private static final String publishResponseBody =
+      "<PublishResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
+          + "    <PublishResult>"
+          + "        <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>"
+          + "    </PublishResult>"
+          + "    <ResponseMetadata>"
+          + "        <RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId>"
+          + "    </ResponseMetadata>"
+          + "</PublishResponse>";
+
+  private static final String createTopicResponseBody =
+      "<CreateTopicResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
+          + "    <CreateTopicResult>"
+          + "        <TopicArn>arn:aws:sns:us-east-1:123456789012:sns-topic-foo</TopicArn>"
+          + "    </CreateTopicResult>"
+          + "    <ResponseMetadata>"
+          + "        <RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId>"
+          + "    </ResponseMetadata>"
+          + "</CreateTopicResponse>";
 
   public abstract AmazonSNSClientBuilder configureClient(AmazonSNSClientBuilder client);
 
@@ -32,9 +50,8 @@ public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
     return true;
   }
 
-  @ParameterizedTest
-  @MethodSource("provideArguments")
-  public void testSendRequestWithMockedResponse(Function<AmazonSNS, Object> call) throws Exception {
+  @Test
+  public void testPublishRequestWithTargetArnAndMockedResponse() throws Exception {
     AmazonSNSClientBuilder clientBuilder = AmazonSNSClientBuilder.standard();
     AmazonSNS client =
         configureClient(clientBuilder)
@@ -42,37 +59,57 @@ public abstract class AbstractSnsClientTest extends AbstractBaseAwsClientTest {
             .withCredentials(credentialsProvider)
             .build();
 
-    String body =
-        "<PublishResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
-            + "    <PublishResult>"
-            + "        <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>"
-            + "    </PublishResult>"
-            + "    <ResponseMetadata>"
-            + "        <RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId>"
-            + "    </ResponseMetadata>"
-            + "</PublishResponse>";
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, body));
-
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, publishResponseBody));
     List<AttributeAssertion> additionalAttributes =
-        singletonList(equalTo(MESSAGING_DESTINATION_NAME, "somearn"));
+        singletonList(equalTo(MESSAGING_DESTINATION_NAME, "target-arn-foo"));
 
-    Object response = call.apply(client);
+    Object response =
+        client.publish(
+            new PublishRequest().withMessage("somemessage").withTargetArn("target-arn-foo"));
     assertRequestWithMockedResponse(
         response, client, "SNS", "Publish", "POST", additionalAttributes);
   }
 
-  private static Stream<Arguments> provideArguments() {
-    return Stream.of(
-        Arguments.of(
-            (Function<AmazonSNS, Object>)
-                c ->
-                    c.publish(
-                        new PublishRequest().withMessage("somemessage").withTopicArn("somearn"))),
-        Arguments.of(
-            (Function<AmazonSNS, Object>)
-                c ->
-                    c.publish(
-                        new PublishRequest().withMessage("somemessage").withTargetArn("somearn"))));
+  @Test
+  public void testPublishRequestWithTopicArnAndMockedResponse() throws Exception {
+    AmazonSNSClientBuilder clientBuilder = AmazonSNSClientBuilder.standard();
+    AmazonSNS client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, publishResponseBody));
+    List<AttributeAssertion> additionalAttributes =
+        asList(
+            equalTo(MESSAGING_DESTINATION_NAME, "topic-arn-foo"),
+            equalTo(AWS_SNS_TOPIC_ARN, "topic-arn-foo"));
+
+    Object response =
+        client.publish(
+            new PublishRequest().withMessage("somemessage").withTopicArn("topic-arn-foo"));
+
+    assertRequestWithMockedResponse(
+        response, client, "SNS", "Publish", "POST", additionalAttributes);
+  }
+
+  @Test
+  public void testCreateTopicRequestWithMockedResponse() throws Exception {
+    AmazonSNSClientBuilder clientBuilder = AmazonSNSClientBuilder.standard();
+    AmazonSNS client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    server.enqueue(
+        HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, createTopicResponseBody));
+    List<AttributeAssertion> additionalAttributes =
+        asList(equalTo(AWS_SNS_TOPIC_ARN, "arn:aws:sns:us-east-1:123456789012:sns-topic-foo"));
+
+    Object response = client.createTopic(new CreateTopicRequest().withName("sns-topic-foo"));
+
+    assertRequestWithMockedResponse(
+        response, client, "SNS", "CreateTopic", "POST", additionalAttributes);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
@@ -26,7 +26,9 @@ enum AwsSdkRequestType {
        * Only one of TopicArn and TargetArn are permitted on an SNS request.
        */
       request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TargetArn"),
-      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn")),
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn"),
+      request(AttributeKeys.AWS_SNS_TOPIC_ARN.getKey(), "TopicArn"),
+      response(AttributeKeys.AWS_SNS_TOPIC_ARN.getKey(), "TopicArn")),
   STEPFUNCTIONS(
       request(AttributeKeys.AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
       request(AttributeKeys.AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn"));
@@ -47,6 +49,7 @@ enum AwsSdkRequestType {
     // Copied from AwsIncubatingAttributes
     static final AttributeKey<String> AWS_SECRETSMANAGER_SECRET_ARN =
         stringKey("aws.secretsmanager.secret.arn");
+    static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
     static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
         stringKey("aws.step_functions.activity.arn");
     static final AttributeKey<String> AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN =


### PR DESCRIPTION
This PR adds the AWS_SNS_TOPIC_ARN semantic convention attribute for the following AWS resources:

AWS SNS SDK v1
AWS SNS SDK v2

The topic ARN is extracted from both request and response objects, and this behavior is covered by unit tests.

Tests Run:
./gradlew spotlessCheck
./gradlew instrumentation:check
./gradlew :smoke-tests:test

All newly added tests pass, and no regressions were found.

Backward Compatibility:
This change is fully backward compatible. It introduces instrumentation for an additional AWS resource without modifying existing behavior in the auto-instrumentation library.