### PR TITLE
Fix java http client tests

### DIFF
--- a/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -13,18 +13,20 @@ import java.net.http.HttpClient;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
+class JavaHttpClientTest {
 
-  @RegisterExtension
-  static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forAgent();
+  abstract static class AbstractTest extends AbstractJavaHttpClientTest {
+    @RegisterExtension
+    static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forAgent();
 
-  @Override
-  protected HttpClient configureHttpClient(HttpClient httpClient) {
-    return httpClient;
+    @Override
+    protected HttpClient configureHttpClient(HttpClient httpClient) {
+      return httpClient;
+    }
   }
 
   @Nested
-  static class Http1ClientTest extends JavaHttpClientTest {
+  class Http1ClientTest extends AbstractTest {
 
     @Override
     protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
@@ -33,7 +35,7 @@ public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
   }
 
   @Nested
-  static class Http2ClientTest extends JavaHttpClientTest {
+  class Http2ClientTest extends AbstractTest {
 
     @Override
     protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {

--- a/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -14,24 +14,26 @@ import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
+class JavaHttpClientTest {
 
-  @RegisterExtension
-  static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forLibrary();
+  abstract static class AbstractTest extends AbstractJavaHttpClientTest {
+    @RegisterExtension
+    static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forLibrary();
 
-  @Override
-  protected HttpClient configureHttpClient(HttpClient httpClient) {
-    return JavaHttpClientTelemetry.builder(testing.getOpenTelemetry())
-        .setCapturedRequestHeaders(
-            Collections.singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-        .setCapturedResponseHeaders(
-            Collections.singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
-        .build()
-        .newHttpClient(httpClient);
+    @Override
+    protected HttpClient configureHttpClient(HttpClient httpClient) {
+      return JavaHttpClientTelemetry.builder(testing.getOpenTelemetry())
+          .setCapturedRequestHeaders(
+              Collections.singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
+          .setCapturedResponseHeaders(
+              Collections.singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+          .build()
+          .newHttpClient(httpClient);
+    }
   }
 
   @Nested
-  static class Http1ClientTest extends JavaHttpClientTest {
+  class Http1ClientTest extends AbstractTest {
 
     @Override
     protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {
@@ -40,7 +42,7 @@ public abstract class JavaHttpClientTest extends AbstractJavaHttpClientTest {
   }
 
   @Nested
-  static class Http2ClientTest extends JavaHttpClientTest {
+  class Http2ClientTest extends AbstractTest {
 
     @Override
     protected void configureHttpClientBuilder(HttpClient.Builder httpClientBuilder) {


### PR DESCRIPTION
An alternative to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14034 that keeps tests as `@Nested` tests.