### PR TITLE
Execute native tests with GraalVM 24

### DIFF
--- a/.github/workflows/reusable-native-tests.yml
+++ b/.github/workflows/reusable-native-tests.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         test-java-version:
           - 22
+          - 23
           - 24
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
With this PR the native tests are executed with GraalVM 24.

GraalVM native is supported by Spring Boot for version 22 or above: https://docs.spring.io/spring-boot/system-requirements.html#getting-started.system-requirements.graal