### PR TITLE
Add readme for spark instrumentation

### DIFF
--- a/instrumentation/spark-2.3/README.md
+++ b/instrumentation/spark-2.3/README.md
@@ -1,0 +1,10 @@
+# Spark Instrumentation
+
+This instrumentation is for 
+[Spark](https://github.com/perwendel/spark) -
+a tiny web framework for Java. It is also sometimes referred to as 
+"Spark Java" to differentiate it from Apache Spark.
+
+This instrumentation is NOT for Apache Spark.
+
+The instrumentation here facilitates tracing by generating HTTP SERVER spans.


### PR DESCRIPTION
People see "spark" and now think it means "Apache Spark". Adding this readme in hopes of clarifying that for some confused users.