### PR TITLE
Skip propagating context into mysql jdbc cleanup thread

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -184,5 +184,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
     // Skip propagating context into truffle compiler.
     // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8415
     builder.ignoreTaskClass("org.graalvm.compiler.truffle.runtime.CompilationTask");
+
+    // Skip propagating context into mysql jdbc driver cleanup thread.
+    builder.ignoreTaskClass("com.mysql.cj.jdbc.AbandonedConnectionCleanupThread");
   }
 }


### PR DESCRIPTION
Propagating context into cleanup thread doesn't provide any value, for us it is a leaked context.