### PR TITLE
Remove `thread.name` from metrics

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/AbstractThreadDispatchingHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/AbstractThreadDispatchingHandler.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17.internal;
 
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import jdk.jfr.consumer.RecordedEvent;
@@ -15,8 +16,17 @@ import jdk.jfr.consumer.RecordedEvent;
  * any time.
  */
 public abstract class AbstractThreadDispatchingHandler implements RecordedEventHandler {
-  // Will need pruning code for fast-cycling thread frameworks to prevent memory leaks
-  private final Map<String, Consumer<RecordedEvent>> perThread = new HashMap<>();
+  private final Map<String, Consumer<RecordedEvent>> perThread =
+      Collections.synchronizedMap(
+          // Use an access-ordered LinkedHashMap so we get a bounded LRU cache
+          new LinkedHashMap<String, Consumer<RecordedEvent>>(16, 0.75F, true) {
+
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, Consumer<RecordedEvent>> eldest) {
+              // Bound this map to prevent memory leaks with fast-cycling thread frameworks
+              return size() > 1024;
+            }
+          });
   private final ThreadGrouper grouper;
 
   protected AbstractThreadDispatchingHandler(ThreadGrouper grouper) {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/ThreadGrouper.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/ThreadGrouper.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17.internal;
 
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
@@ -14,13 +15,17 @@ import jdk.jfr.consumer.RecordedThread;
  * any time.
  */
 public final class ThreadGrouper {
+  private static final Pattern SIMILAR_THREAD_NAME_PATTERN = Pattern.compile("\\d+");
 
-  // FIXME doesn't actually do any grouping, but should be safe for now
+  // FIXME only handles substrings of contiguous digits -> a single `x`, but should be good
+  // enough for now
   @Nullable
   public String groupedName(RecordedEvent ev) {
     Object thisField = ev.getValue("eventThread");
     if (thisField instanceof RecordedThread) {
-      return ((RecordedThread) thisField).getJavaName();
+      return SIMILAR_THREAD_NAME_PATTERN
+          .matcher(((RecordedThread) thisField).getJavaName())
+          .replaceAll("x");
     }
     return null;
   }

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/cpu/LongLockHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/cpu/LongLockHandler.java
@@ -51,7 +51,7 @@ public final class LongLockHandler extends AbstractThreadDispatchingHandler {
 
   @Override
   public Consumer<RecordedEvent> createPerThreadSummarizer(String threadName) {
-    return new PerThreadLongLockHandler(histogram, threadName);
+    return new PerThreadLongLockHandler(histogram);
   }
 
   @Override
@@ -65,9 +65,9 @@ public final class LongLockHandler extends AbstractThreadDispatchingHandler {
     private final DoubleHistogram histogram;
     private final Attributes attributes;
 
-    public PerThreadLongLockHandler(DoubleHistogram histogram, String threadName) {
+    public PerThreadLongLockHandler(DoubleHistogram histogram) {
       this.histogram = histogram;
-      this.attributes = Attributes.of(Constants.ATTR_THREAD_NAME, threadName);
+      this.attributes = Attributes.empty();
     }
 
     @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ObjectAllocationInNewTlabHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ObjectAllocationInNewTlabHandler.java
@@ -50,7 +50,7 @@ public final class ObjectAllocationInNewTlabHandler extends AbstractThreadDispat
 
   @Override
   public Consumer<RecordedEvent> createPerThreadSummarizer(String threadName) {
-    return new PerThreadObjectAllocationInNewTlabHandler(histogram, threadName);
+    return new PerThreadObjectAllocationInNewTlabHandler(histogram);
   }
 
   /** This class aggregates all TLAB allocation JFR events for a single thread */
@@ -61,10 +61,9 @@ public final class ObjectAllocationInNewTlabHandler extends AbstractThreadDispat
     private final LongHistogram histogram;
     private final Attributes attributes;
 
-    public PerThreadObjectAllocationInNewTlabHandler(LongHistogram histogram, String threadName) {
+    public PerThreadObjectAllocationInNewTlabHandler(LongHistogram histogram) {
       this.histogram = histogram;
-      this.attributes =
-          Attributes.of(Constants.ATTR_THREAD_NAME, threadName, Constants.ATTR_ARENA_NAME, "TLAB");
+      this.attributes = Attributes.of(Constants.ATTR_ARENA_NAME, "TLAB");
     }
 
     @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ObjectAllocationOutsideTlabHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/memory/ObjectAllocationOutsideTlabHandler.java
@@ -50,7 +50,7 @@ public final class ObjectAllocationOutsideTlabHandler extends AbstractThreadDisp
 
   @Override
   public Consumer<RecordedEvent> createPerThreadSummarizer(String threadName) {
-    return new PerThreadObjectAllocationOutsideTlabHandler(histogram, threadName);
+    return new PerThreadObjectAllocationOutsideTlabHandler(histogram);
   }
 
   /** This class aggregates all non-TLAB allocation JFR events for a single thread */
@@ -61,10 +61,9 @@ public final class ObjectAllocationOutsideTlabHandler extends AbstractThreadDisp
     private final LongHistogram histogram;
     private final Attributes attributes;
 
-    public PerThreadObjectAllocationOutsideTlabHandler(LongHistogram histogram, String threadName) {
+    public PerThreadObjectAllocationOutsideTlabHandler(LongHistogram histogram) {
       this.histogram = histogram;
-      this.attributes =
-          Attributes.of(Constants.ATTR_THREAD_NAME, threadName, Constants.ATTR_ARENA_NAME, "Main");
+      this.attributes = Attributes.of(Constants.ATTR_ARENA_NAME, "Main");
     }
 
     @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/network/NetworkReadHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/network/NetworkReadHandler.java
@@ -56,7 +56,7 @@ public final class NetworkReadHandler extends AbstractThreadDispatchingHandler {
 
   @Override
   public Consumer<RecordedEvent> createPerThreadSummarizer(String threadName) {
-    return new PerThreadNetworkReadHandler(bytesHistogram, durationHistogram, threadName);
+    return new PerThreadNetworkReadHandler(bytesHistogram, durationHistogram);
   }
 
   private static class PerThreadNetworkReadHandler implements Consumer<RecordedEvent> {
@@ -67,15 +67,10 @@ public final class NetworkReadHandler extends AbstractThreadDispatchingHandler {
     private final Attributes attributes;
 
     public PerThreadNetworkReadHandler(
-        LongHistogram bytesHistogram, DoubleHistogram durationHistogram, String threadName) {
+        LongHistogram bytesHistogram, DoubleHistogram durationHistogram) {
       this.bytesHistogram = bytesHistogram;
       this.durationHistogram = durationHistogram;
-      this.attributes =
-          Attributes.of(
-              Constants.ATTR_THREAD_NAME,
-              threadName,
-              Constants.ATTR_NETWORK_MODE,
-              Constants.NETWORK_MODE_READ);
+      this.attributes = Attributes.of(Constants.ATTR_NETWORK_MODE, Constants.NETWORK_MODE_READ);
     }
 
     @Override

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/network/NetworkWriteHandler.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/internal/network/NetworkWriteHandler.java
@@ -74,7 +74,7 @@ public final class NetworkWriteHandler extends AbstractThreadDispatchingHandler 
 
   @Override
   public Consumer<RecordedEvent> createPerThreadSummarizer(String threadName) {
-    return new PerThreadNetworkWriteHandler(bytesHistogram, durationHistogram, threadName);
+    return new PerThreadNetworkWriteHandler(bytesHistogram, durationHistogram);
   }
 
   private static final class PerThreadNetworkWriteHandler implements Consumer<RecordedEvent> {
@@ -85,15 +85,10 @@ public final class NetworkWriteHandler extends AbstractThreadDispatchingHandler 
     private final Attributes attributes;
 
     private PerThreadNetworkWriteHandler(
-        LongHistogram bytesHistogram, DoubleHistogram durationHistogram, String threadName) {
+        LongHistogram bytesHistogram, DoubleHistogram durationHistogram) {
       this.bytesHistogram = bytesHistogram;
       this.durationHistogram = durationHistogram;
-      this.attributes =
-          Attributes.of(
-              Constants.ATTR_THREAD_NAME,
-              threadName,
-              Constants.ATTR_NETWORK_MODE,
-              Constants.NETWORK_MODE_WRITE);
+      this.attributes = Attributes.of(Constants.ATTR_NETWORK_MODE, Constants.NETWORK_MODE_WRITE);
     }
 
     @Override


### PR DESCRIPTION
As outlined in #13407 and #14047, the `thread.name` attribute can create very high cardinality in many cases, and also contributes to a memory leak in the collection mechanism of those metrics. This PR is aimed at fixing both issues.

 The affected metrics are:
* `jvm.memory.allocation`
* `jvm.cpu.longlock`
* `jvm.network.io`
* `jvm.network.time`