### PR TITLE
Revert "Use faster machine for release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     permissions:
       contents: write # for creating the release
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: ubuntu-latest
     needs:
       - common
     outputs:


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java-instrumentation#14073

Well, I was wrong, the worst case was breaking the release (`gh` command isn't available on the self-hosted runner)