### PR TITLE
[release/v2.17.x] Don't auto-release to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        run: ./gradlew assemble spdxSbom publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew assemble spdxSbom publishToSonatype closeSonatypeStagingRepository
 
       - name: Build and publish gradle plugins
         env:
@@ -111,7 +111,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         # Don't use publishToSonatype since we don't want to publish the marker artifact
-        run: ./gradlew build publishPlugins publishPluginMavenPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew build publishPlugins publishPluginMavenPublicationToSonatypeRepository closeSonatypeStagingRepository
         working-directory: gradle-plugins
 
       - name: Collect SBOMs


### PR DESCRIPTION
This will give us a chance to check the staging repositories before releasing to Maven Central, so we can troubleshoot if the same issue occurs again that happened with the 2.17.0 release.