### PR TITLE
Fix restlet muzzle error

### DIFF
--- a/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
@@ -9,7 +9,7 @@ muzzle {
     versions.set("[1.1.0, 1.2-M1)")
     extraDependency("com.noelios.restlet:com.noelios.restlet")
     // missing dependencies
-    skip("2.5.0", "2.5.1")
+    skip("2.5.0", "2.5.1", "2.5.2")
     assertInverse.set(true)
   }
 }


### PR DESCRIPTION
This should solve [one of our build failures](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/15814723109/job/44571467717) at least.

Error was:

```
Execution failed for task ':instrumentation:restlet:restlet-1.1:javaagent:muzzle-AssertFail-org.restlet-org.restlet-2.5.2'.
> Could not resolve all files for configuration ':instrumentation:restlet:restlet-1.1:javaagent:muzzle-AssertFail-org.restlet-org.restlet-2.5.2'.
   > Could not resolve all dependencies for configuration ':instrumentation:restlet:restlet-1.1:javaagent:muzzle-AssertFail-org.restlet-org.restlet-2.5.2'.
      > Could not find com.noelios.restlet:com.noelios.restlet:2.5.2.
        Searched in the following locations:
          - https://repo.maven.apache.org/maven2/com/noelios/restlet/com.noelios.restlet/2.5.2/com.noelios.restlet-2.5.2.pom
          - https://maven.restlet.talend.com/com/noelios/restlet/com.noelios.restlet/2.5.2/com.noelios.restlet-2.5.2.pom
          - file:/home/runner/.m2/repository/com/noelios/restlet/com.noelios.restlet/2.5.2/com.noelios.restlet-2.5.2.pom
        Required by:
            project :instrumentation:restlet:restlet-1.1:javaagent
```


