### PR TITLE
Filter metrics by scope

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -2836,24 +2836,6 @@ libraries:
     target_versions:
       javaagent:
       - io.projectreactor.netty:reactor-netty:[0.8.2.RELEASE,1.0.0)
-    telemetry:
-    - when: default
-      metrics:
-      - name: http.client.request.duration
-        description: Duration of HTTP client requests.
-        type: HISTOGRAM
-        unit: s
-        attributes:
-        - name: http.request.method
-          type: STRING
-        - name: http.response.status_code
-          type: LONG
-        - name: network.protocol.version
-          type: STRING
-        - name: server.address
-          type: STRING
-        - name: server.port
-          type: LONG
   - name: reactor-netty-1.0
     source_path: instrumentation/reactor/reactor-netty/reactor-netty-1.0
     scope:
@@ -3214,21 +3196,6 @@ libraries:
           type: STRING
         - name: server.port
           type: LONG
-      - name: http.server.request.duration
-        description: Duration of HTTP server requests.
-        type: HISTOGRAM
-        unit: s
-        attributes:
-        - name: http.request.method
-          type: STRING
-        - name: http.response.status_code
-          type: LONG
-        - name: http.route
-          type: STRING
-        - name: network.protocol.version
-          type: STRING
-        - name: url.scheme
-          type: STRING
   - name: spring-webflux-5.3
     source_path: instrumentation/spring/spring-webflux/spring-webflux-5.3
     scope:

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/EmittedMetrics.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/EmittedMetrics.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.docs.internal;
 
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,16 +19,18 @@ import java.util.List;
 public class EmittedMetrics {
   // Condition in which the metrics are emitted (ex: default, or configuration option names).
   private String when;
-  private List<Metric> metrics;
+
+  @JsonProperty("metrics_by_scope")
+  private List<MetricsByScope> metricsByScope;
 
   public EmittedMetrics() {
     this.when = "";
-    this.metrics = new ArrayList<>();
+    this.metricsByScope = emptyList();
   }
 
-  public EmittedMetrics(String when, List<Metric> metrics) {
-    this.when = "";
-    this.metrics = metrics;
+  public EmittedMetrics(String when, List<MetricsByScope> metricsByScope) {
+    this.when = when;
+    this.metricsByScope = metricsByScope;
   }
 
   public String getWhen() {
@@ -36,12 +41,49 @@ public class EmittedMetrics {
     this.when = when;
   }
 
-  public List<Metric> getMetrics() {
-    return metrics;
+  @JsonProperty("metrics_by_scope")
+  public List<MetricsByScope> getMetricsByScope() {
+    return metricsByScope;
   }
 
-  public void setMetrics(List<Metric> metrics) {
-    this.metrics = metrics;
+  @JsonProperty("metrics_by_scope")
+  public void setMetricsByScope(List<MetricsByScope> metricsByScope) {
+    this.metricsByScope = metricsByScope;
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class MetricsByScope {
+    private String scope;
+    private List<Metric> metrics;
+
+    public MetricsByScope(String scope, List<Metric> metrics) {
+      this.scope = scope;
+      this.metrics = metrics;
+    }
+
+    public MetricsByScope() {
+      this.scope = "";
+      this.metrics = new ArrayList<>();
+    }
+
+    public String getScope() {
+      return scope;
+    }
+
+    public void setScope(String scope) {
+      this.scope = scope;
+    }
+
+    public List<Metric> getMetrics() {
+      return metrics;
+    }
+
+    public void setMetrics(List<Metric> metrics) {
+      this.metrics = metrics;
+    }
   }
 
   /**

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is responsible for parsing metric files from the `.telemetry` directory of an
+ * instrumentation module and filtering them by scope.
+ */
+public class MetricParser {
+
+  /**
+   * Retrieves metrics for a given instrumentation module, filtered by scope.
+   *
+   * @param module the instrumentation module
+   * @param fileManager the file manager to use for file operations
+   * @return a map where the key is the 'when' condition and the value is a list of metrics
+   */
+  public static Map<String, List<EmittedMetrics.Metric>> getMetrics(
+      InstrumentationModule module, FileManager fileManager) {
+    Map<String, EmittedMetrics> metrics =
+        EmittedMetricsParser.getMetricsFromFiles(fileManager.rootDir(), module.getSrcPath());
+
+    if (metrics.isEmpty()) {
+      return new HashMap<>();
+    }
+
+    String scopeName = module.getScopeInfo().getName();
+    return filterMetricsByScope(metrics, scopeName);
+  }
+
+  /**
+   * Filters metrics by scope and aggregates attributes for each metric kind.
+   *
+   * @param metricsByScope the map of metrics by scope
+   * @param scopeName the name of the scope to filter metrics for
+   * @return a map of filtered metrics by 'when'
+   */
+  private static Map<String, List<EmittedMetrics.Metric>> filterMetricsByScope(
+      Map<String, EmittedMetrics> metricsByScope, String scopeName) {
+
+    Map<String, Map<String, MetricAggregator.AggregatedMetricInfo>> aggregatedMetrics =
+        new HashMap<>();
+
+    for (Map.Entry<String, EmittedMetrics> entry : metricsByScope.entrySet()) {
+      if (!hasValidMetrics(entry.getValue())) {
+        continue;
+      }
+
+      String when = entry.getValue().getWhen();
+      Map<String, Map<String, MetricAggregator.AggregatedMetricInfo>> result =
+          MetricAggregator.aggregateMetrics(when, entry.getValue(), scopeName);
+
+      // Merge result into aggregatedMetrics
+      for (Map.Entry<String, Map<String, MetricAggregator.AggregatedMetricInfo>> e :
+          result.entrySet()) {
+        String whenKey = e.getKey();
+        Map<String, MetricAggregator.AggregatedMetricInfo> metricMap =
+            aggregatedMetrics.computeIfAbsent(whenKey, k -> new HashMap<>());
+
+        for (Map.Entry<String, MetricAggregator.AggregatedMetricInfo> metricEntry :
+            e.getValue().entrySet()) {
+          String metricName = metricEntry.getKey();
+          MetricAggregator.AggregatedMetricInfo newInfo = metricEntry.getValue();
+          MetricAggregator.AggregatedMetricInfo existingInfo = metricMap.get(metricName);
+          if (existingInfo == null) {
+            metricMap.put(metricName, newInfo);
+          } else {
+            existingInfo.attributes.addAll(newInfo.attributes);
+          }
+        }
+      }
+    }
+
+    return MetricAggregator.buildFilteredMetrics(aggregatedMetrics);
+  }
+
+  private static boolean hasValidMetrics(EmittedMetrics metrics) {
+    return metrics != null && metrics.getMetricsByScope() != null;
+  }
+
+  /** Helper class to aggregate metrics by scope and name. */
+  static class MetricAggregator {
+    /**
+     * Aggregates metrics for a given 'when' condition, metrics object, and target scope name.
+     *
+     * @param when the 'when' condition
+     * @param metrics the EmittedMetrics object
+     * @param targetScopeName the scope name to filter by
+     * @return a map of aggregated metrics by 'when' and metric name
+     */
+    public static Map<String, Map<String, AggregatedMetricInfo>> aggregateMetrics(
+        String when, EmittedMetrics metrics, String targetScopeName) {
+      Map<String, Map<String, AggregatedMetricInfo>> aggregatedMetrics = new HashMap<>();
+      Map<String, AggregatedMetricInfo> metricKindMap =
+          aggregatedMetrics.computeIfAbsent(when, k -> new HashMap<>());
+
+      for (EmittedMetrics.MetricsByScope metricsByScope : metrics.getMetricsByScope()) {
+        if (metricsByScope.getScope().equals(targetScopeName)) {
+          for (EmittedMetrics.Metric metric : metricsByScope.getMetrics()) {
+            AggregatedMetricInfo aggInfo =
+                metricKindMap.computeIfAbsent(
+                    metric.getName(),
+                    k ->
+                        new AggregatedMetricInfo(
+                            metric.getName(),
+                            metric.getDescription(),
+                            metric.getType(),
+                            metric.getUnit()));
+            if (metric.getAttributes() != null) {
+              for (TelemetryAttribute attr : metric.getAttributes()) {
+                aggInfo.attributes.add(new TelemetryAttribute(attr.getName(), attr.getType()));
+              }
+            }
+          }
+        }
+      }
+      return aggregatedMetrics;
+    }
+
+    /**
+     * Builds a filtered metrics map from aggregated metrics.
+     *
+     * @param aggregatedMetrics the aggregated metrics map
+     * @return a map where the key is the 'when' condition and the value is a list of metrics
+     */
+    public static Map<String, List<EmittedMetrics.Metric>> buildFilteredMetrics(
+        Map<String, Map<String, AggregatedMetricInfo>> aggregatedMetrics) {
+      Map<String, List<EmittedMetrics.Metric>> result = new HashMap<>();
+      for (Map.Entry<String, Map<String, AggregatedMetricInfo>> entry :
+          aggregatedMetrics.entrySet()) {
+        String when = entry.getKey();
+        List<EmittedMetrics.Metric> metrics = result.computeIfAbsent(when, k -> new ArrayList<>());
+        for (AggregatedMetricInfo aggInfo : entry.getValue().values()) {
+          metrics.add(
+              new EmittedMetrics.Metric(
+                  aggInfo.name,
+                  aggInfo.description,
+                  aggInfo.type,
+                  aggInfo.unit,
+                  new ArrayList<>(aggInfo.attributes)));
+        }
+      }
+      return result;
+    }
+
+    /** Data class to hold aggregated metric information. */
+    static class AggregatedMetricInfo {
+      final String name;
+      final String description;
+      final String type;
+      final String unit;
+      final Set<TelemetryAttribute> attributes = new HashSet<>();
+
+      AggregatedMetricInfo(String name, String description, String type, String unit) {
+        this.name = name;
+        this.description = description;
+        this.type = type;
+        this.unit = unit;
+      }
+    }
+
+    private MetricAggregator() {}
+  }
+
+  private MetricParser() {}
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -291,8 +291,8 @@ public class YamlHelper {
     return mapper.readValue(input, InstrumentationMetaData.class);
   }
 
-  public static EmittedMetrics emittedMetricsParser(String input) {
-    return new Yaml().loadAs(input, EmittedMetrics.class);
+  public static EmittedMetrics emittedMetricsParser(String input) throws JsonProcessingException {
+    return mapper.readValue(input, EmittedMetrics.class);
   }
 
   public static EmittedSpans emittedSpansParser(String input) throws JsonProcessingException {

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+@SuppressWarnings("NullAway")
+class EmittedMetricsParserTest {
+
+  @Test
+  void parseMetricsDeduplicatesMetricsByName() throws JsonProcessingException {
+    String input =
+        """
+        metrics_by_scope:
+          - scope: io.opentelemetry.alibaba-druid-1.0
+            metrics:
+              - name: metric1
+                type: counter
+              - name: metric1
+                type: counter
+              - name: metric2
+                type: gauge
+        """;
+
+    Map<String, StringBuilder> metricMap = new HashMap<>();
+    metricMap.put("default", new StringBuilder(input));
+
+    Map<String, EmittedMetrics> result = EmittedMetricsParser.parseMetrics(metricMap);
+    List<String> metricNames =
+        result.get("default").getMetricsByScope().get(0).getMetrics().stream()
+            .map(EmittedMetrics.Metric::getName)
+            .sorted()
+            .toList();
+
+    assertThat(metricNames).hasSize(2);
+    assertThat(metricNames).containsExactly("metric1", "metric2");
+  }
+
+  @Test
+  void parseMetricsHandlesEmptyInput() throws JsonProcessingException {
+    String input = "metrics_by_scope:\n";
+    Map<String, StringBuilder> metricMap = new HashMap<>();
+    metricMap.put("default", new StringBuilder(input));
+
+    Map<String, EmittedMetrics> result = EmittedMetricsParser.parseMetrics(metricMap);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getMetricsFromFilesCombinesFilesCorrectly(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    String file1Content =
+        """
+    when: default
+    metrics_by_scope:
+      - scope: io.opentelemetry.MetricParserTest
+        metrics:
+          - name: metric1
+            type: counter
+    """;
+
+    String file2Content =
+        """
+    when: default
+    metrics_by_scope:
+      - scope: io.opentelemetry.MetricParserTest
+        metrics:
+          - name: metric2
+            type: gauge
+    """;
+
+    Files.writeString(telemetryDir.resolve("metrics-1.yaml"), file1Content);
+    Files.writeString(telemetryDir.resolve("metrics-2.yaml"), file2Content);
+
+    // Create a non-metrics file that should be ignored
+    Files.writeString(telemetryDir.resolve("other-file.yaml"), "some content");
+
+    try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
+      fileManagerMock
+          .when(
+              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml").toString()))
+          .thenReturn(file1Content);
+      fileManagerMock
+          .when(
+              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml").toString()))
+          .thenReturn(file2Content);
+
+      Map<String, EmittedMetrics> result =
+          EmittedMetricsParser.getMetricsFromFiles(tempDir.toString(), "");
+
+      EmittedMetrics.MetricsByScope metrics =
+          result.get("default").getMetricsByScope().stream()
+              .filter(scope -> scope.getScope().equals("io.opentelemetry.MetricParserTest"))
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(metrics.getMetrics()).hasSize(2);
+      List<String> metricNames =
+          metrics.getMetrics().stream().map(EmittedMetrics.Metric::getName).sorted().toList();
+      assertThat(metricNames).containsExactly("metric1", "metric2");
+    }
+  }
+
+  @Test
+  void getMetricsFromFilesHandlesNonexistentDirectory() throws JsonProcessingException {
+    Map<String, EmittedMetrics> result =
+        EmittedMetricsParser.getMetricsFromFiles("/nonexistent", "path");
+    assertThat(result).isEmpty();
+  }
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
@@ -73,7 +73,7 @@ public final class AgentTestRunner extends InstrumentationTestRunner {
       }
       String path = Paths.get(resource.getPath()).toString();
 
-      MetaDataCollector.writeTelemetryToFiles(path, metrics, tracesByScope);
+      MetaDataCollector.writeTelemetryToFiles(path, metricsByScope, tracesByScope);
     }
 
     // additional library ignores are ignored during tests, because they can make it really

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
@@ -51,7 +51,7 @@ import org.awaitility.core.ConditionTimeoutException;
 public abstract class InstrumentationTestRunner {
 
   private final TestInstrumenters testInstrumenters;
-  protected Map<String, MetricData> metrics = new HashMap<>();
+  protected Map<InstrumentationScopeInfo, Map<String, MetricData>> metricsByScope = new HashMap<>();
 
   /**
    * Stores traces by scope, where each scope contains a map of span kinds to a map of attribute
@@ -205,8 +205,12 @@ public abstract class InstrumentationTestRunner {
 
   private void collectEmittedMetrics(List<MetricData> metrics) {
     for (MetricData metric : metrics) {
-      if (!this.metrics.containsKey(metric.getName())) {
-        this.metrics.put(metric.getName(), metric);
+      Map<String, MetricData> scopeMap =
+          this.metricsByScope.computeIfAbsent(
+              metric.getInstrumentationScopeInfo(), m -> new HashMap<>());
+
+      if (!scopeMap.containsKey(metric.getName())) {
+        scopeMap.put(metric.getName(), metric);
       }
     }
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
@@ -130,7 +130,7 @@ public final class LibraryTestRunner extends InstrumentationTestRunner {
       }
       String path = Paths.get(resource.getPath()).toString();
 
-      MetaDataCollector.writeTelemetryToFiles(path, metrics, tracesByScope);
+      MetaDataCollector.writeTelemetryToFiles(path, metricsByScope, tracesByScope);
     }
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/MetaDataCollector.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/MetaDataCollector.java
@@ -39,13 +39,13 @@ public final class MetaDataCollector {
 
   public static void writeTelemetryToFiles(
       String path,
-      Map<String, MetricData> metrics,
+      Map<InstrumentationScopeInfo, Map<String, MetricData>> metricsByScope,
       Map<InstrumentationScopeInfo, Map<SpanKind, Map<InternalAttributeKeyImpl<?>, AttributeType>>>
           spansByScopeAndKind)
       throws IOException {
 
     String moduleRoot = extractInstrumentationPath(path);
-    writeMetricData(moduleRoot, metrics);
+    writeMetricData(moduleRoot, metricsByScope);
     writeSpanData(moduleRoot, spansByScopeAndKind);
   }
 
@@ -125,10 +125,12 @@ public final class MetaDataCollector {
     }
   }
 
-  private static void writeMetricData(String instrumentationPath, Map<String, MetricData> metrics)
+  private static void writeMetricData(
+      String instrumentationPath,
+      Map<InstrumentationScopeInfo, Map<String, MetricData>> metricsByScope)
       throws IOException {
 
-    if (metrics.isEmpty()) {
+    if (metricsByScope.isEmpty()) {
       return;
     }
 
@@ -144,26 +146,36 @@ public final class MetaDataCollector {
 
       writer.write("when: " + when + "\n");
 
-      writer.write("metrics:\n");
-      for (MetricData metric : metrics.values()) {
-        writer.write("  - name: " + metric.getName() + "\n");
-        writer.write("    description: " + metric.getDescription() + "\n");
-        writer.write("    type: " + metric.getType().toString() + "\n");
-        writer.write("    unit: " + sanitizeUnit(metric.getUnit()) + "\n");
-        writer.write("    attributes: \n");
-        metric.getData().getPoints().stream()
-            .findFirst()
-            .get()
-            .getAttributes()
-            .forEach(
-                (key, value) -> {
-                  try {
-                    writer.write("      - name: " + key.getKey() + "\n");
-                    writer.write("        type: " + key.getType().toString() + "\n");
-                  } catch (IOException e) {
-                    throw new IllegalStateException(e);
-                  }
-                });
+      writer.write("metrics_by_scope:\n");
+
+      for (Map.Entry<InstrumentationScopeInfo, Map<String, MetricData>> entry :
+          metricsByScope.entrySet()) {
+        InstrumentationScopeInfo scope = entry.getKey();
+        Map<String, MetricData> metrics = entry.getValue();
+
+        writer.write("  - scope: " + scope.getName() + "\n");
+        writer.write("    metrics:\n");
+
+        for (MetricData metric : metrics.values()) {
+          writer.write("      - name: " + metric.getName() + "\n");
+          writer.write("        description: " + metric.getDescription() + "\n");
+          writer.write("        type: " + metric.getType().toString() + "\n");
+          writer.write("        unit: " + sanitizeUnit(metric.getUnit()) + "\n");
+          writer.write("        attributes: \n");
+          metric.getData().getPoints().stream()
+              .findFirst()
+              .get()
+              .getAttributes()
+              .forEach(
+                  (key, value) -> {
+                    try {
+                      writer.write("          - name: " + key.getKey() + "\n");
+                      writer.write("            type: " + key.getType().toString() + "\n");
+                    } catch (IOException e) {
+                      throw new IllegalStateException(e);
+                    }
+                  });
+        }
       }
     }
   }


### PR DESCRIPTION
Related to #14098 and #13468 

We implemented a scope filter for span data to avoid including telemetry emitted by other instrumentations during tests, this change brings that same approach to metrics. When we process the instrumentation module, we only include the metrics that match the instrumentation scope.

After applying this change, it caught and reverted two modules that were incorrectly reporting metrics that were actually from the `io.opentelemetry.netty-4.1` scope.

The new metrics file format groups the metrics under `metrics_by_scope`, for example:

```yaml
when: default
metrics_by_scope:
  - scope: io.opentelemetry.oracle-ucp-11.2
    metrics:
      - name: db.client.connections.usage
        description: The number of connections that are currently in state described by the state attribute.
        type: LONG_SUM
        unit: connections
        attributes: 
          - name: pool.name
            type: STRING
          - name: state
            type: STRING
```

