### PR TITLE
Rework how we release to central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,8 @@ jobs:
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        run: ./gradlew assemble spdxSbom publishToSonatype closeAndReleaseSonatypeStagingRepository
+        # run: ./gradlew assemble spdxSbom publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew assemble spdxSbom publishAllPublicationToReleaseRepoRepository generateReleaseBundle uploadReleaseBundle
 
       - name: Build and publish gradle plugins
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.asRequestBody
 import java.time.Duration
+import java.util.Base64
 
 plugins {
   id("idea")
@@ -14,6 +18,12 @@ plugins {
   See https://github.com/gradle/gradle/issues/17559#issuecomment-1327991512
    */
   id("org.graalvm.buildtools.native") apply false
+}
+
+buildscript {
+  dependencies {
+    classpath("com.squareup.okhttp3:okhttp:4.12.0")
+  }
 }
 
 apply(from = "version.gradle.kts")
@@ -111,6 +121,8 @@ if (gradle.startParameter.taskNames.contains("listTestsInPartition")) {
 }
 
 tasks {
+  val stableVersion = version.toString().replace("-alpha", "")
+
   val generateFossaConfiguration by registering {
     group = "Help"
     description = "Generate .fossa.yml configuration file"
@@ -139,6 +151,50 @@ tasks {
         writer.println("      # consumer will only be exposed to these dependencies")
         writer.println("      - runtimeClasspath")
       }
+    }
+  }
+
+  val generateReleaseBundle by registering(Zip::class) {
+    dependsOn(getTasksByName("publishAllPublicationToReleaseRepoRepository", true))
+    from("releaseRepo")
+
+    exclude("**/maven-metadata.*")
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    includeEmptyDirs = false
+    archiveFileName.set("release-bundle-$stableVersion.zip")
+  }
+
+  val uploadReleaseBundle by registering {
+    dependsOn(generateReleaseBundle)
+
+    val bundle = generateReleaseBundle.get().outputs.files.singleFile
+    val httpClient = OkHttpClient()
+    val username = System.getenv("SONATYPE_USER") ?: throw GradleException("Sonatype user not set")
+    val password = System.getenv("SONATYPE_KEY") ?: throw GradleException("Sonatype key not set")
+    val token = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+
+    var query = "?name=opentelemetry-java-instrumentation-$stableVersion"
+    // uncomment to automatically publish the release
+    // query += "&publishingType=AUTOMATIC"
+
+    val request = okhttp3.Request.Builder()
+      .url("https://central.sonatype.com/api/v1/publisher/upload$query")
+      .post(
+        okhttp3.MultipartBody.Builder().addFormDataPart(
+          "bundle",
+          bundle.name,
+          bundle.asRequestBody("application/zip".toMediaType())
+        ).build()
+      )
+      .header("authorization", "Bearer $token")
+      .build()
+    httpClient.newCall(request).execute().use { response ->
+      response.body!!.string()
+    }
+
+    httpClient.newCall(request).execute().use { response ->
+      if (response.code != 201) throw GradleException("Unexpected response status ${response.code} while uploading the release bundle")
+      println("Uploaded deployment ${response.body!!.string()}")
     }
   }
 }

--- a/conventions/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -65,6 +65,13 @@ publishing {
       }
     }
   }
+
+  repositories {
+    maven {
+      name = "ReleaseRepo"
+      url = File(project.rootDir.path, "releaseRepo").toURI()
+    }
+  }
 }
 
 fun artifactPrefix(p: Project, archivesBaseName: String): String {


### PR DESCRIPTION
Since the last release with OSSRH Staging API didn't go well we need an alternative way for future releases. We could either adopt JReleaser or one of the plugins from https://central.sonatype.org/publish/publish-portal-gradle/#alternatives or build our own solution.
To publish to central we first publish to a local maven repository named `ReleaseRepo` using `publishAllPublicationToReleaseRepoRepository` then we zip that repository using `generateReleaseBundle` (these 2 were tested when fixing the 2.17.0 release) and finally upload it with `uploadReleaseBundle` (this one is untested). We could test by failing the build at the end of `uploadReleaseBundle` and check whether the uploaded bundle is valid in the publisher portal.