### PR TITLE
Fix markdown-link-check reliability by adding timeout and retry_wait_time configuration

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,5 @@
+timeout = 30
+retry_wait_time = 5
 max_retries = 6
 max_concurrency = 4
 


### PR DESCRIPTION

Sometimes when submitting PRs and running markdown-link-check, we encounter unexpected errors even though the links are valid (for example: [[markdown-link-check error](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/15926455689/job/44924744149?pr=14032#logs)). Referring to the lychee documentation [Lychee Network Error Troubleshooting](https://lychee.cli.rs/troubleshooting/network-errors/) and [Lychee Configuration Documentation](https://lychee.cli.rs/usage/config/), I wonder if we could add two parameters to try to avoid this issue:
- timeout = 30 (set timeout to 30 seconds)
- retry_wait_time = 5 (wait 5 seconds between retries)
