### PR TITLE
Fix muzzle2 task failure in restlet-1.1 module

### DIFF
--- a/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
@@ -9,7 +9,7 @@ muzzle {
     versions.set("[1.1.0, 1.2-M1)")
     extraDependency("com.noelios.restlet:com.noelios.restlet")
     // missing dependencies
-    skip("2.5.0", "2.5.1", "2.5.2")
+    skip("2.5.0", "2.5.1", "2.5.2", "2.6.0")
     assertInverse.set(true)
   }
 }


### PR DESCRIPTION
fix [muzzle2 task failure in restlet-1.1 module](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/15961934111/job/45015751297?pr=14158)

Meanwhile, I have two questions


- The current `inverseOf()` function completely copies all configurations from the original directive, including `extraDependency`. However, some extraDependency entries may only exist within specific version ranges. Should we modify the logic so that implicitly generated fail tasks don't copy extraDependency settings, or add a version range restriction mechanism for extraDependency ?

- `assertInverse.set(true)` dynamically generates implicit fail directives, but the detailed configurations of these directives are not visible in error build logs. Should we print these implicitly generated fail task configurations during the build process to help developers better understand and troubleshoot issues?

recurrence #14113