### PR TITLE
Fix muzzle task failure in restlet-1.1 module

### DIFF
--- a/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
@@ -8,9 +8,20 @@ muzzle {
     module.set("org.restlet")
     versions.set("[1.1.0, 1.2-M1)")
     extraDependency("com.noelios.restlet:com.noelios.restlet")
-    // missing dependencies
-    skip("2.5.0", "2.5.1", "2.5.2", "2.6.0")
-    assertInverse.set(true)
+  }
+
+  // assertInverse was removed because extraDependency is not available in later versions (e.g., 2.5.x),
+  // which causes exception during muzzle. #14159
+  fail {
+    group.set("org.restlet")
+    module.set("org.restlet")
+    versions.set("[,1.1.0)")
+  }
+
+  fail {
+    group.set("org.restlet")
+    module.set("org.restlet")
+    versions.set("[1.2-M1,)")
   }
 }
 

--- a/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.1/javaagent/build.gradle.kts
@@ -9,7 +9,7 @@ muzzle {
     versions.set("[1.1.0, 1.2-M1)")
     extraDependency("com.noelios.restlet:com.noelios.restlet")
     // missing dependencies
-    skip("2.5.0", "2.5.1", "2.5.2")
+    skip("2.5.0", "2.5.1", "2.5.2", "2.6.0")
     assertInverse.set(true)
   }
 }


### PR DESCRIPTION
assertInverse was removed because extraDependency is not available in later versions (e.g., 2.5.x),which causes exception during muzzle. #14159

