### PR TITLE
markdown link check -- remove github.token which is the default

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -16,5 +16,4 @@ jobs:
         with:
           args: >
             --config ./lychee.toml
-            --github-token ${{ github.token }}
             .


### PR DESCRIPTION
According to https://github.com/lycheeverse/lychee-action/blob/master/action.yml#L41 it seems like the argument was never spelled `--github-token` and the default is just `github.token` anyway, and core omits it, so this should be fine.

I'm running across the main java repos and making the markdown link check more consistent. This will align with [contrib #1986](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1986). 