### PR TITLE
Fix: Snapshot Publishing

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -43,7 +43,7 @@ testing {
       dependencies {
         implementation(project())
         implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
-        version = if (testLatestDeps) "latest.release" else "1.12.80"
+        val version = if (testLatestDeps) "latest.release" else "1.12.80"
         implementation("com.amazonaws:aws-java-sdk-secretsmanager:$version")
       }
     }


### PR DESCRIPTION
Use a local variable `version` instead of overwriting `project.version`

This was tested locally before and after using a throw-away version dump task e.g.:
```
tasks.register("checkVersion") {
    doLast {
      println(project.version as String)
  }
}
```

Fixes: #14169