### PR TITLE
fix invalid jmx state metrics empty unit

### DIFF
--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/UnitConverter.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/UnitConverter.java
@@ -33,17 +33,12 @@ class UnitConverter {
    * @param sourceUnit a source unit supported by requested converter
    * @param targetUnit a target unit supported by requested converter
    * @return an instance of converter, or {@literal null} if {@code sourceUnit} is {@literal null}
-   *     or empty, which means that there is no conversion needed.
-   * @throws IllegalArgumentException if {@code targetUnit} is empty, or matching converter was not
-   *     found for provided units.
+   *     or empty or if {@code targetUnit} is empty, which means that there is no conversion needed.
+   * @throws IllegalArgumentException if matching converter was not found for provided units.
    */
   @Nullable
   public static UnitConverter getInstance(@Nullable String sourceUnit, String targetUnit) {
-    if (targetUnit.isEmpty()) {
-      throw new IllegalArgumentException("Non empty targetUnit must be provided");
-    }
-
-    if (sourceUnit == null || sourceUnit.isEmpty()) {
+    if (sourceUnit == null || sourceUnit.isEmpty() || targetUnit.isEmpty()) {
       // No conversion is needed
       return null;
     }

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/UnitConverterTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/engine/UnitConverterTest.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.instrumentation.jmx.engine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,10 +58,11 @@ class UnitConverterTest {
   @CsvSource({
     ", s", // null -> "s"
     "'', s", // "" -> "s"
+    "1, ''", // empty target unit
   })
   void shouldSkipConversionWhenSourceUnitNotSpecified(String sourceUnit, String targetUnit) {
     UnitConverter converter = UnitConverter.getInstance(sourceUnit, targetUnit);
-    assertNull(converter);
+    assertThat(converter).isNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes #14190

The addition of metrics unit conversion in JMX metrics (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13448) combined with using empty unit for 
state metrics (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13796) introduced a regression in 2.17.0 as the `UnitConverter.getInstance(...)` call throws an exception when called with an empty target unit, which is now always the case with state metrics.

An exception was thrown which probably makes the JMX bean detection fail silently, this behavior was not explicitly tested so the simplest approach is probably to return `null` unit converter instance when we use it with an empty unit.