### PR TITLE
add missing configurations to the kafka documents

### DIFF
--- a/instrumentation/kafka/README.md
+++ b/instrumentation/kafka/README.md
@@ -1,9 +1,6 @@
 # Settings for the Kafka instrumentation
 
-| System property                                           | Type    | Default | Description                                                                |
-|-----------------------------------------------------------|---------|---------|----------------------------------------------------------------------------|
-| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                        |
-| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                     |
-| `otel.instrumentation.messaging.experimental.capture-headers` | List    | Empty   | Enable the capture of experimental headers in messaging systems.           |
-| `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | Boolean | `false` | Enable the capture of experimental receive telemetry in messaging systems. |
----------
+| System property                                           | Type    | Default | Description                                                                                                                    |
+|-----------------------------------------------------------| ------- |---------|--------------------------------------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                                                                            |
+| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                                                                         |1

--- a/instrumentation/kafka/README.md
+++ b/instrumentation/kafka/README.md
@@ -1,6 +1,9 @@
 # Settings for the Kafka instrumentation
 
-| System property                                           | Type    | Default | Description                                                                                                                    |
-|-----------------------------------------------------------| ------- |---------|--------------------------------------------------------------------------------------------------------------------------------|
-| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                                                                            |
-| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                                                                         |
+| System property                                           | Type    | Default | Description                                                                |
+|-----------------------------------------------------------|---------|---------|----------------------------------------------------------------------------|
+| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                        |
+| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                     |
+| `otel.instrumentation.messaging.experimental.capture-headers` | List    | Empty   | Enable the capture of experimental headers in messaging systems.           |
+| `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | Boolean | `false` | Enable the capture of experimental receive telemetry in messaging systems. |
+---------

--- a/instrumentation/kafka/README.md
+++ b/instrumentation/kafka/README.md
@@ -3,4 +3,4 @@
 | System property                                           | Type    | Default | Description                                                                                                                    |
 |-----------------------------------------------------------| ------- |---------|--------------------------------------------------------------------------------------------------------------------------------|
 | `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.                                                                            |
-| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                                                                         |1
+| `otel.instrumentation.kafka.producer-propagation.enabled` | Boolean | `true`  | Enable context propagation for kafka message producer.                                                                         |

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
@@ -1,3 +1,6 @@
+description: >
+  This instrumentation provides producer and consumer spans and metrics for Apache Kafka 0.11 clients.
+  It automatically traces message production and consumption, propagates context, and emits metrics for production and consumption.
 configurations:
   - name: otel.instrumentation.kafka.producer-propagation.enabled
     description: Enable context propagation for kafka message producers.
@@ -5,5 +8,13 @@ configurations:
     default: true
   - name: otel.instrumentation.kafka.experimental-span-attributes
     description: Enables the capture of the experimental consumer attribute "kafka.record.queue_time_ms"
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    description: Allows configuring headers to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    description: Enables experimental receive telemetry for AWS SDK instrumentation.
     type: boolean
     default: false

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation provides producer and consumer spans and metrics for Apache Kafka 0.11 clients.
+  This instrumentation provides messaging spans and metrics for Apache Kafka 0.11 clients.
   It automatically traces message production and consumption, propagates context, and emits metrics for production and consumption.
 configurations:
   - name: otel.instrumentation.kafka.producer-propagation.enabled
@@ -11,10 +11,10 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.messaging.experimental.capture-headers
-    description: Allows configuring headers to capture as span attributes.
+    description: A comma-separated list of header names to capture as span attributes.
     type: list
     default: ''
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    description: Enables experimental receive telemetry for AWS SDK instrumentation.
+    description: Enables experimental receive telemetry for Kafka instrumentation.
     type: boolean
     default: false

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
@@ -1,0 +1,2 @@
+description: >
+  This instrumentation provides a library integeration that enables producer and consumer spans and metrics for Apache Kafka 2.6+ clients.

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
@@ -1,2 +1,2 @@
 description: >
-  This instrumentation provides a library integeration that enables producer and consumer spans and metrics for Apache Kafka 2.6+ clients.
+  This instrumentation provides a library integeration that enables messaging spans and metrics for Apache Kafka 2.6+ clients.


### PR DESCRIPTION
As part of [this issue](https://github.com/orgs/open-telemetry/projects/153?pane=issue&itemId=116369612&issue=open-telemetry%7Copentelemetry-java-instrumentation%7C14096), I add missing configurations and a description to the metadata for Kafka 0.11, and write the metadata for Kafka 2.6.

Kafka 0.11 instrumentation is a Java agent module, so its metadata includes a configurations section. In contrast, Kafka 2.6 instrumentation is just a library, so I don’t include any configurations there.

While going through the Kafka README.md, I notice that a few configurations are missing, so I add them as well.