### PR TITLE
Add AWS_LAMBDA_RESOURCE_MAPPING_ID Semantic Convention Support for AWS Lambda SDK

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-ec2:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-lambda:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-rds:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-s3:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/LambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/LambdaClientTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import io.opentelemetry.instrumentation.awssdk.v1_11.AbstractLambdaClientTest;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class LambdaClientTest extends AbstractLambdaClientTest {
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder clientBuilder) {
+    return clientBuilder;
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-ec2:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
+  testLibrary("com.amazonaws:aws-java-sdk-lambda:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-rds:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-s3:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkAttributesExtractor.java
@@ -26,6 +26,8 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
   // Copied from AwsIncubatingAttributes
   private static final AttributeKey<String> AWS_SECRETSMANAGER_SECRET_ARN =
       stringKey("aws.secretsmanager.secret.arn");
+  private static final AttributeKey<String> AWS_LAMBDA_RESOURCE_MAPPING_ID =
+      stringKey("aws.lambda.resource_mapping.id");
   private static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
   private static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
       stringKey("aws.step_functions.activity.arn");
@@ -46,6 +48,11 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
     Object originalRequest = request.getOriginalRequest();
+    setAttribute(
+        attributes,
+        AWS_LAMBDA_RESOURCE_MAPPING_ID,
+        originalRequest,
+        RequestAccess::getLambdaResourceMappingId);
     setAttribute(attributes, AWS_SNS_TOPIC_ARN, originalRequest, RequestAccess::getSnsTopicArn);
     setAttribute(
         attributes,
@@ -69,6 +76,11 @@ class AwsSdkAttributesExtractor implements AttributesExtractor<Request<?>, Respo
     Object awsResp = getAwsResponse(response);
     if (awsResp != null) {
       setAttribute(attributes, AWS_SECRETSMANAGER_SECRET_ARN, awsResp, RequestAccess::getSecretArn);
+      setAttribute(
+          attributes,
+          AWS_LAMBDA_RESOURCE_MAPPING_ID,
+          awsResp,
+          RequestAccess::getLambdaResourceMappingId);
       setAttribute(attributes, AWS_SNS_TOPIC_ARN, awsResp, RequestAccess::getSnsTopicArn);
       setAttribute(
           attributes,

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AGENT;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BUCKET_NAME;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_URL;
 import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_NAME;
@@ -35,6 +37,7 @@ class AwsSdkExperimentalAttributesExtractor
     setRequestAttribute(attributes, AWS_QUEUE_NAME, originalRequest, RequestAccess::getQueueName);
     setRequestAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
     setRequestAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
+    setRequestAttribute(attributes, AWS_LAMBDA_NAME, originalRequest, RequestAccess::getLambdaName);
   }
 
   private static void setRequestAttribute(
@@ -54,5 +57,17 @@ class AwsSdkExperimentalAttributesExtractor
       Context context,
       Request<?> request,
       @Nullable Response<?> response,
-      @Nullable Throwable error) {}
+      @Nullable Throwable error) {
+    Object awsResponse = getAwsResponse(response);
+    if (awsResponse != null) {
+      setRequestAttribute(attributes, AWS_LAMBDA_ARN, awsResponse, RequestAccess::getLambdaArn);
+    }
+  }
+
+  private static Object getAwsResponse(Response<?> response) {
+    if (response == null) {
+      return null;
+    }
+    return response.getAwsResponse();
+  }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/LambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/LambdaClientTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class LambdaClientTest extends AbstractLambdaClientTest {
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Override
+  protected InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  public AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder clientBuilder) {
+    return clientBuilder.withRequestHandlers(
+        AwsSdkTelemetry.builder(testing().getOpenTelemetry())
+            .setCaptureExperimentalSpanAttributes(true)
+            .build()
+            .newRequestHandler());
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   compileOnly("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-ec2:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
+  compileOnly("com.amazonaws:aws-java-sdk-lambda:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-rds:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-s3:1.11.106")
   compileOnly("com.amazonaws:aws-java-sdk-secretsmanager:1.12.80")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_LAMBDA_RESOURCE_MAPPING_ID;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import com.amazonaws.services.lambda.model.CreateEventSourceMappingRequest;
+import com.amazonaws.services.lambda.model.GetEventSourceMappingRequest;
+import com.amazonaws.services.lambda.model.GetFunctionRequest;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+import io.opentelemetry.testing.internal.armeria.common.MediaType;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public abstract class AbstractLambdaClientTest extends AbstractBaseAwsClientTest {
+  private static final String lambdaCreateEventSourceMappingResponseBody =
+      "{"
+          + "\"UUID\": \"e31def54-5e5d-4c1b-8e0f-bf1b11c137b7\","
+          + "\"BatchSize\": 10,"
+          + "\"MaximumBatchingWindowInSeconds\": 0,"
+          + "\"EventSourceArn\": \"arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo\","
+          + "\"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:myFn01-Temp\","
+          + "\"LastModified\": \"1.754882043E9\","
+          + "\"State\": \"Creating\","
+          + "\"StateTransitionReason\": \"USER_INITIATED\","
+          + "\"FunctionResponseTypes\": [],"
+          + "\"EventSourceMappingArn\": \"arn:aws:lambda:us-west-2:123456789012:event-source-mapping:e31def54-5e5d-4c1b-8e0f-bf1b11c137b7\""
+          + "}";
+
+  private static final String lambdaGetEventSourceMappingResponseBody =
+      "{"
+          + "\"UUID\": \"e31def54-5e5d-4c1b-8e0f-bf1b11c138c8\","
+          + "\"BatchSize\": 10,"
+          + "\"MaximumBatchingWindowInSeconds\": 0,"
+          + "\"EventSourceArn\": \"arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo\","
+          + "\"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:myFn01-Temp\","
+          + "\"LastModified\": \"1.755054843E9\","
+          + "\"State\": \"Enabled\","
+          + "\"StateTransitionReason\": \"USER_INITIATED\","
+          + "\"FunctionResponseTypes\": [],"
+          + "\"EventSourceMappingArn\": \"arn:aws:lambda:us-west-2:123456789012:event-source-mapping:e31def54-5e5d-4c1b-8e0f-bf1b11c138c8\""
+          + "}";
+
+  private static final String lambdaGetFunctionResponseBody =
+      "{"
+          + "\"Configuration\": {"
+          + "   \"FunctionName\": \"lambda-function-name-foo\","
+          + "   \"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:lambda-function-name-foo\","
+          + "   \"Runtime\": \"nodejs22.x\","
+          + "   \"Role\": \"arn:aws:iam::123456789012:role/service-role/Fn-role-pr7kt0bf\","
+          + "   \"Handler\": \"index.handler\","
+          + "   \"CodeSize\": 295,"
+          + "   \"Description\": \"\","
+          + "   \"Timeout\": 3,"
+          + "   \"MemorySize\": 128,"
+          + "   \"LastModified\": \"1.743573094E9\","
+          + "   \"CodeSha256\": \"q8E7Nexf5xxhKT9/d4bGpAYOXJYFAUjJ0UDj8OivK8E=\","
+          + "   \"Version\": \"$LATEST\","
+          + "   \"Environment\": {"
+          + "     \"Variables\": {"
+          + "         \"AWS_LAMBDA_EXEC_WRAPPER\": \"/opt/otel-instrument\""
+          + "}"
+          + "   },"
+          + "   \"TracingConfig\": {"
+          + "       \"Mode\": \"PassThrough\""
+          + "   },"
+          + "   \"RevisionId\": \"955247dc-c724-4653-8f8b-f702c6f9c389\","
+          + "   \"Layers\": ["
+          + "     {"
+          + "       \"Arn\": \"arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:6\","
+          + "       \"CodeSize\": 14455992"
+          + "     }"
+          + "   ],"
+          + "   \"State\": \"Active\","
+          + "   \"LastUpdateStatus\": \"Successful\","
+          + "   \"PackageType\": \"Zip\","
+          + "   \"Architectures\": ["
+          + "     \"x86_64\""
+          + "   ],"
+          + "   \"EphemeralStorage\": {"
+          + "     \"Size\": 512"
+          + "   },"
+          + "  \"SnapStart\": {"
+          + "     \"ApplyOn\": \"None\","
+          + "     \"OptimizationStatus\": \"Off\""
+          + "   },"
+          + "   \"RuntimeVersionConfig\": {"
+          + "       \"RuntimeVersionArn\": \"arn:aws:lambda:us-west-2::runtime:fd2e05b324f99edd3c6e17800b2535deb79bcce74b7506d595a94870b3d9bd2e\""
+          + "   },"
+          + "   \"LoggingConfig\": {"
+          + "       \"LogFormat\": \"Text\","
+          + "       \"LogGroup\": \"/aws/lambda/mlambda-function-name-foo\""
+          + "   }"
+          + " },"
+          + " \"Code\": {"
+          + "     \"RepositoryType\": \"S3\","
+          + "     \"Location\": \"https://awslambda-us-west-2-tasks.s3.us-west-2.amazonaws.com/snapshots/123456789012/lambda-function-name-foo-47425b12\""
+          + " }"
+          + "}";
+
+  public abstract AWSLambdaClientBuilder configureClient(AWSLambdaClientBuilder client);
+
+  @Override
+  protected boolean hasRequestId() {
+    return false;
+  }
+
+  private static Stream<Arguments> provideArguments() {
+    return Stream.of(
+        Arguments.of(
+            "CreateEventSourceMapping",
+            "POST",
+            lambdaCreateEventSourceMappingResponseBody,
+            asList(
+                equalTo(stringKey("aws.lambda.function.name"), "myFn01-Temp"),
+                equalTo(AWS_LAMBDA_RESOURCE_MAPPING_ID, "e31def54-5e5d-4c1b-8e0f-bf1b11c137b7")),
+            (Function<AWSLambda, Object>)
+                c ->
+                    c.createEventSourceMapping(
+                        new CreateEventSourceMappingRequest()
+                            .withFunctionName("myFn01-Temp")
+                            .withEventSourceArn(
+                                "arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo")
+                            .withEnabled(true)
+                            .withBatchSize(10))),
+        Arguments.of(
+            "GetEventSourceMapping",
+            "GET",
+            lambdaGetEventSourceMappingResponseBody,
+            singletonList(
+                equalTo(AWS_LAMBDA_RESOURCE_MAPPING_ID, "e31def54-5e5d-4c1b-8e0f-bf1b11c138c8")),
+            (Function<AWSLambda, Object>)
+                c ->
+                    c.getEventSourceMapping(
+                        new GetEventSourceMappingRequest()
+                            .withUUID("e31def54-5e5d-4c1b-8e0f-bf1b11c138c8"))),
+        Arguments.of(
+            "GetFunction",
+            "GET",
+            lambdaGetFunctionResponseBody,
+            asList(
+                equalTo(stringKey("aws.lambda.function.name"), "lambda-function-name-foo"),
+                equalTo(
+                    stringKey("aws.lambda.function.arn"),
+                    "arn:aws:lambda:us-west-2:123456789012:function:lambda-function-name-foo")),
+            (Function<AWSLambda, Object>)
+                c ->
+                    c.getFunction(
+                        new GetFunctionRequest().withFunctionName("lambda-function-name-foo"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArguments")
+  void testSendRequestWithMockedResponse(
+      String operation,
+      String method,
+      String responseBody,
+      List<AttributeAssertion> additionalAttributes,
+      Function<AWSLambda, Object> call)
+      throws Exception {
+    AWSLambdaClientBuilder clientBuilder = AWSLambdaClientBuilder.standard();
+    AWSLambda client =
+        configureClient(clientBuilder)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(credentialsProvider)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, responseBody));
+    Object response = call.apply(client);
+    assertRequestWithMockedResponse(
+        response, client, "AWSLambda", operation, method, additionalAttributes);
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:dynamodb:2.2.0")
   testLibrary("software.amazon.awssdk:ec2:2.2.0")
   testLibrary("software.amazon.awssdk:kinesis:2.2.0")
+  testLibrary("software.amazon.awssdk:lambda:2.2.0")
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:secretsmanager:2.2.0")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
@@ -3,20 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.awssdk.v1_11;
+package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
 
 final class AwsExperimentalAttributes {
-  static final AttributeKey<String> AWS_AGENT = stringKey("aws.agent");
-  static final AttributeKey<String> AWS_BUCKET_NAME = stringKey("aws.bucket.name");
-  static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
-  static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
-  static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
-  static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
-
   // Work is underway to add these two keys to the SemConv AWS registry, in line with other AWS
   // resources.
   // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/aws.md#amazon-lambda-attributes

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.BEDROCK_RUNTIME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.DYNAMODB;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.KINESIS;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.LAMBDA;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.S3;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SECRETSMANAGER;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.SNS;
@@ -37,6 +38,7 @@ enum AwsSdkRequest {
   SnsRequest(SNS, "SnsRequest"),
   SqsRequest(SQS, "SqsRequest"),
   KinesisRequest(KINESIS, "KinesisRequest"),
+  LambdaRequest(LAMBDA, "LambdaRequest"),
   SecretsManagerRequest(SECRETSMANAGER, "SecretsManagerRequest"),
   StepFunctionsRequest(STEPFUNCTIONS, "SfnRequest"),
   // specific requests

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
+import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.request;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.FieldMapping.response;
 
@@ -20,6 +22,11 @@ enum AwsSdkRequestType {
   KINESIS(request("aws.stream.name", "StreamName")),
   DYNAMODB(request("aws.table.name", "TableName")),
   BEDROCK_RUNTIME(),
+  LAMBDA(
+      request(AWS_LAMBDA_NAME.getKey(), "FunctionName"),
+      request(AttributeKeys.AWS_LAMBDA_RESOURCE_MAPPING_ID.getKey(), "UUID"),
+      response(AWS_LAMBDA_ARN.getKey(), "Configuration.FunctionArn"),
+      response(AttributeKeys.AWS_LAMBDA_RESOURCE_MAPPING_ID.getKey(), "UUID")),
   SECRETSMANAGER(response(AttributeKeys.AWS_SECRETSMANAGER_SECRET_ARN.getKey(), "ARN")),
   SNS(
       /*
@@ -47,6 +54,8 @@ enum AwsSdkRequestType {
 
   private static class AttributeKeys {
     // Copied from AwsIncubatingAttributes
+    private static final AttributeKey<String> AWS_LAMBDA_RESOURCE_MAPPING_ID =
+        stringKey("aws.lambda.resource_mapping.id");
     static final AttributeKey<String> AWS_SECRETSMANAGER_SECRET_ARN =
         stringKey("aws.secretsmanager.secret.arn");
     static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_LAMBDA_RESOURCE_MAPPING_ID;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_REQUEST_ID;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SECRETSMANAGER_SECRET_ARN;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SNS_TOPIC_ARN;
@@ -72,6 +73,13 @@ import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.kinesis.KinesisClientBuilder;
 import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClientBuilder;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.LambdaClientBuilder;
+import software.amazon.awssdk.services.lambda.model.CreateEventSourceMappingRequest;
+import software.amazon.awssdk.services.lambda.model.GetEventSourceMappingRequest;
+import software.amazon.awssdk.services.lambda.model.GetFunctionRequest;
 import software.amazon.awssdk.services.rds.RdsAsyncClient;
 import software.amazon.awssdk.services.rds.RdsAsyncClientBuilder;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -127,6 +135,91 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
           + " <publicIp>192.0.2.1</publicIp>"
           + " <domain>standard</domain>"
           + "</AllocateAddressResponse>";
+
+  private static final String lambdaCreateEventSourceMappingResponseBody =
+      "{"
+          + "\"UUID\": \"e31def54-5e5d-4c1b-8e0f-bf1b11c137b7\","
+          + "\"BatchSize\": 10,"
+          + "\"MaximumBatchingWindowInSeconds\": 0,"
+          + "\"EventSourceArn\": \"arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo\","
+          + "\"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:myFn01-Temp\","
+          + "\"LastModified\": \"1.754882043E9\","
+          + "\"State\": \"Creating\","
+          + "\"StateTransitionReason\": \"USER_INITIATED\","
+          + "\"FunctionResponseTypes\": [],"
+          + "\"EventSourceMappingArn\": \"arn:aws:lambda:us-west-2:123456789012:event-source-mapping:e31def54-5e5d-4c1b-8e0f-bf1b11c137b7\""
+          + "}";
+
+  private static final String lambdaGetEventSourceMappingResponseBody =
+      "{"
+          + "\"UUID\": \"e31def54-5e5d-4c1b-8e0f-bf1b11c138c8\","
+          + "\"BatchSize\": 10,"
+          + "\"MaximumBatchingWindowInSeconds\": 0,"
+          + "\"EventSourceArn\": \"arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo\","
+          + "\"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:myFn01-Temp\","
+          + "\"LastModified\": \"1.755054843E9\","
+          + "\"State\": \"Enabled\","
+          + "\"StateTransitionReason\": \"USER_INITIATED\","
+          + "\"FunctionResponseTypes\": [],"
+          + "\"EventSourceMappingArn\": \"arn:aws:lambda:us-west-2:123456789012:event-source-mapping:e31def54-5e5d-4c1b-8e0f-bf1b11c138c8\""
+          + "}";
+
+  private static final String lambdaGetFunctionResponseBody =
+      "{"
+          + "\"Configuration\": {"
+          + "   \"FunctionName\": \"lambda-function-name-foo\","
+          + "   \"FunctionArn\": \"arn:aws:lambda:us-west-2:123456789012:function:lambda-function-name-foo\","
+          + "   \"Runtime\": \"nodejs22.x\","
+          + "   \"Role\": \"arn:aws:iam::123456789012:role/service-role/Fn-role-pr7kt0bf\","
+          + "   \"Handler\": \"index.handler\","
+          + "   \"CodeSize\": 295,"
+          + "   \"Description\": \"\","
+          + "   \"Timeout\": 3,"
+          + "   \"MemorySize\": 128,"
+          + "   \"LastModified\": \"1.743573094E9\","
+          + "   \"CodeSha256\": \"q8E7Nexf5xxhKT9/d4bGpAYOXJYFAUjJ0UDj8OivK8E=\","
+          + "   \"Version\": \"$LATEST\","
+          + "   \"Environment\": {"
+          + "     \"Variables\": {"
+          + "         \"AWS_LAMBDA_EXEC_WRAPPER\": \"/opt/otel-instrument\""
+          + "}"
+          + "   },"
+          + "   \"TracingConfig\": {"
+          + "       \"Mode\": \"PassThrough\""
+          + "   },"
+          + "   \"RevisionId\": \"955247dc-c724-4653-8f8b-f702c6f9c389\","
+          + "   \"Layers\": ["
+          + "     {"
+          + "       \"Arn\": \"arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:6\","
+          + "       \"CodeSize\": 14455992"
+          + "     }"
+          + "   ],"
+          + "   \"State\": \"Active\","
+          + "   \"LastUpdateStatus\": \"Successful\","
+          + "   \"PackageType\": \"Zip\","
+          + "   \"Architectures\": ["
+          + "     \"x86_64\""
+          + "   ],"
+          + "   \"EphemeralStorage\": {"
+          + "     \"Size\": 512"
+          + "   },"
+          + "  \"SnapStart\": {"
+          + "     \"ApplyOn\": \"None\","
+          + "     \"OptimizationStatus\": \"Off\""
+          + "   },"
+          + "   \"RuntimeVersionConfig\": {"
+          + "       \"RuntimeVersionArn\": \"arn:aws:lambda:us-west-2::runtime:fd2e05b324f99edd3c6e17800b2535deb79bcce74b7506d595a94870b3d9bd2e\""
+          + "   },"
+          + "   \"LoggingConfig\": {"
+          + "       \"LogFormat\": \"Text\","
+          + "       \"LogGroup\": \"/aws/lambda/mlambda-function-name-foo\""
+          + "   }"
+          + " },"
+          + " \"Code\": {"
+          + "     \"RepositoryType\": \"S3\","
+          + "     \"Location\": \"https://awslambda-us-west-2-tasks.s3.us-west-2.amazonaws.com/snapshots/123456789012/lambda-function-name-foo-47425b12\""
+          + " }"
+          + "}";
 
   private static final String rdsBodyContent =
       "<DeleteOptionGroupResponse xmlns=\"http://rds.amazonaws.com/doc/2014-09-01/\">"
@@ -305,6 +398,31 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
           equalTo(
               AWS_SECRETSMANAGER_SECRET_ARN,
               "arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecretFromCLI-sNkBwD"));
+    }
+
+    if (service.equals("Lambda")) {
+      switch (operation) {
+        case "GetFunction":
+          attributes.add(
+              equalTo(stringKey("aws.lambda.function.name"), "lambda-function-name-foo"));
+          attributes.add(
+              equalTo(
+                  stringKey("aws.lambda.function.arn"),
+                  "arn:aws:lambda:us-west-2:123456789012:function:lambda-function-name-foo"));
+          break;
+        case "CreateEventSourceMapping":
+          attributes.add(equalTo(stringKey("aws.lambda.function.name"), "myFn01-Temp"));
+          attributes.add(
+              equalTo(AWS_LAMBDA_RESOURCE_MAPPING_ID, "e31def54-5e5d-4c1b-8e0f-bf1b11c137b7"));
+          break;
+        case "GetEventSourceMapping":
+          attributes.add(
+              equalTo(AWS_LAMBDA_RESOURCE_MAPPING_ID, "e31def54-5e5d-4c1b-8e0f-bf1b11c138c8"));
+          break;
+        default:
+          attributes.add(equalTo(AWS_LAMBDA_RESOURCE_MAPPING_ID, "Bug-Unknown-Lambda-Operation"));
+          break;
+      }
     }
 
     String evaluatedOperation;
@@ -947,5 +1065,121 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
     Object response =
         client.getSecretValue(GetSecretValueRequest.builder().secretId("MySecretFromCLI").build());
     clientAssertions("SecretsManager", "GetSecretValue", "POST", response, "UNKNOWN");
+  }
+
+  private static Stream<Arguments> provideLambdaArguments() {
+    return Stream.of(
+        Arguments.of(
+            (Function<LambdaClient, Object>)
+                c ->
+                    c.getFunction(
+                        GetFunctionRequest.builder()
+                            .functionName("lambda-function-name-foo")
+                            .build()),
+            "GetFunction",
+            "GET",
+            lambdaGetFunctionResponseBody,
+            "UNKNOWN"),
+        Arguments.of(
+            (Function<LambdaClient, Object>)
+                c ->
+                    c.createEventSourceMapping(
+                        CreateEventSourceMappingRequest.builder()
+                            .functionName("myFn01-Temp")
+                            .eventSourceArn("arn:aws:sqs:us-west-2:123456789012:MyTestQueue.fifo")
+                            .enabled(true)
+                            .batchSize(10)
+                            .build()),
+            "CreateEventSourceMapping",
+            "POST",
+            lambdaCreateEventSourceMappingResponseBody,
+            "UNKNOWN"),
+        Arguments.of(
+            (Function<LambdaClient, Object>)
+                c ->
+                    c.getEventSourceMapping(
+                        GetEventSourceMappingRequest.builder()
+                            .uuid("e31def54-5e5d-4c1b-8e0f-bf1b11c138c8")
+                            .build()),
+            "GetEventSourceMapping",
+            "GET",
+            lambdaGetEventSourceMappingResponseBody,
+            "UNKNOWN"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideLambdaArguments")
+  void testLambdaSendOperationRequestWithBuilder(
+      Function<LambdaClient, Object> call,
+      String operation,
+      String method,
+      String responseBody,
+      String requestId) {
+    LambdaClientBuilder builder = LambdaClient.builder();
+    configureSdkClient(builder);
+    LambdaClient client =
+        builder
+            .endpointOverride(clientUri)
+            .region(Region.AP_NORTHEAST_1)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, responseBody));
+    Object response = call.apply(client);
+    assertThat(response.getClass().getSimpleName())
+        .satisfiesAnyOf(
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model.GetFunctionResponse.class),
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model
+                            .CreateEventSourceMappingResponse.class),
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model.GetEventSourceMappingResponse
+                            .class));
+    clientAssertions("Lambda", operation, method, response, requestId);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideLambdaArguments")
+  void testLambdaAsyncSendOperationRequestWithBuilder(
+      Function<LambdaClient, Object> call,
+      String operation,
+      String method,
+      String responseBody,
+      String requestId) {
+    LambdaAsyncClientBuilder builder = LambdaAsyncClient.builder();
+    configureSdkClient(builder);
+    LambdaAsyncClient client =
+        builder
+            .endpointOverride(clientUri)
+            .region(Region.AP_NORTHEAST_1)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, responseBody));
+    Object response = call.apply(wrapClient(LambdaClient.class, LambdaAsyncClient.class, client));
+    assertThat(response.getClass().getSimpleName())
+        .satisfiesAnyOf(
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model.GetFunctionResponse.class),
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model
+                            .CreateEventSourceMappingResponse.class),
+            v ->
+                assertThat(response)
+                    .isInstanceOf(
+                        software.amazon.awssdk.services.lambda.model.GetEventSourceMappingResponse
+                            .class));
+    clientAssertions("Lambda", operation, method, response, requestId);
   }
 }


### PR DESCRIPTION
This PR adds support for the AWS_LAMBDA_RESOURCE_MAPPING_ID semantic convention attribute in the AWS Lambda SDK instrumentation library.

It also introduces the following two experimental attributes. Work is currently underway to add these keys to the AWS section of the Semantic Conventions (SemConv) registry:

aws.lambda.function.arn
aws.lambda.function.name

Name is extracted from request object.
ARN is extracted from response object.
Resource Mapping ID is extracted from both request and response objects. This behavior is covered by unit tests.

Tests Run:
./gradlew spotlessCheck
./gradlew instrumentation:check
./gradlew :smoke-tests:test

All newly added tests pass, and no regressions were found.

Backward Compatibility:
This change is fully backward compatible. It introduces instrumentation for an additional AWS resource without modifying existing behavior in the auto-instrumentation library.