### PR TITLE
Exclude okhttp5 public suffix database

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -178,8 +178,7 @@ tasks {
 
     excludeBootstrapClasses()
     // remove MPL licensed content
-    exclude("okhttp3/internal/publicsuffix/NOTICE")
-    exclude("okhttp3/internal/publicsuffix/publicsuffixes.gz")
+    exclude("okhttp3/internal/publicsuffix/PublicSuffixDatabase.list")
 
     duplicatesStrategy = DuplicatesStrategy.FAIL
 


### PR DESCRIPTION
okhttp has switched to a different public suffix list, but as far as I can tell, it is still generated from https://publicsuffix.org/list/public_suffix_list.dat Idk whether that allows us to stop removing it.