### PR TITLE
Quarkus image build fix

### DIFF
--- a/smoke-tests/images/quarkus/build.gradle.kts
+++ b/smoke-tests/images/quarkus/build.gradle.kts
@@ -69,4 +69,8 @@ tasks {
   javadoc {
     dependsOn(compileQuarkusGeneratedSourcesJava)
   }
+
+  checkstyleMain {
+    dependsOn(compileQuarkusGeneratedSourcesJava)
+  }
 }


### PR DESCRIPTION
```
* What went wrong:
Some problems were found with the configuration of task ':smoke-tests:images:quarkus:checkstyleMain' (type 'Checkstyle').
  - Gradle detected a problem with the following location: '/Users/ltulmin/dev/opentelemetry-java-instrumentation/smoke-tests/images/quarkus/build/classes/java/quarkus-generated-sources'.

    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.14.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/ltulmin/dev/opentelemetry-java-instrumentation/smoke-tests/images/quarkus/build/classes/java/quarkus-generated-sources/grpc'.

    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.14.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/ltulmin/dev/opentelemetry-java-instrumentation/smoke-tests/images/quarkus/build/classes/java/quarkus-generated-sources/avdl'.

    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.14.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/ltulmin/dev/opentelemetry-java-instrumentation/smoke-tests/images/quarkus/build/classes/java/quarkus-generated-sources/avpr'.

    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.14.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/ltulmin/dev/opentelemetry-java-instrumentation/smoke-tests/images/quarkus/build/classes/java/quarkus-generated-sources/avsc'.

    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.14.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

* Try:
> Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'
> Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn
> Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter
```