### PR TITLE
Refactor out camel ContextWithScope into a bootstrap package so it can be referenced by multiple ClassLoaders.

### DIFF
--- a/instrumentation/camel-2.20/bootstrap/build.gradle.kts
+++ b/instrumentation/camel-2.20/bootstrap/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+  id("otel.javaagent-bootstrap")
+}

--- a/instrumentation/camel-2.20/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/apachecamel/ContextWithScope.java
+++ b/instrumentation/camel-2.20/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/apachecamel/ContextWithScope.java
@@ -1,0 +1,43 @@
+package io.opentelemetry.javaagent.bootstrap.apachecamel;
+
+import javax.annotation.Nullable;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+  
+public class ContextWithScope {
+  @Nullable private final ContextWithScope parent;
+  @Nullable private final Context context;
+  @Nullable private final Scope scope;
+
+  public ContextWithScope(
+      ContextWithScope parent, Context context, Scope scope) {
+    this.parent = parent;
+    this.context = context;
+    this.scope = scope;
+  }
+
+  public static ContextWithScope activate(ContextWithScope parent, Context context) {
+    Scope scope = context != null ? context.makeCurrent() : null;
+    return new ContextWithScope(parent, context, scope);
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public ContextWithScope getParent() {
+    return parent;
+  }
+
+  public void deactivate() {
+    if (scope == null) {
+      return;
+    }
+    scope.close();
+  }
+
+  @Override
+  public String toString() {
+    return "ContextWithScope [context=" + context + ", scope=" + scope + "]";
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
+  bootstrap(project(":instrumentation:camel-2.20:bootstrap"))
 
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-3.0:javaagent"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -180,6 +180,7 @@ include(":instrumentation:azure-core:azure-core-1.36:library-instrumentation-sha
 include(":instrumentation:c3p0-0.9:javaagent")
 include(":instrumentation:c3p0-0.9:library")
 include(":instrumentation:c3p0-0.9:testing")
+include(":instrumentation:camel-2.20:bootstrap")
 include(":instrumentation:camel-2.20:javaagent")
 include(":instrumentation:camel-2.20:javaagent-unit-tests")
 include(":instrumentation:cassandra:cassandra-3.0:javaagent")


### PR DESCRIPTION
As mentioned in #14238 there was an issue when using the Apache Camel instrumentation inside a blueprint container where some of the instrumentation classes were loaded by different classloaders at different times. This led to a loss of context, and many orphaned spans on a trace.