### PR TITLE
Be consistent with excluding boot libs

### DIFF
--- a/examples/distro/agent/build.gradle
+++ b/examples/distro/agent/build.gradle
@@ -75,7 +75,10 @@ tasks {
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory
     dependencies {
       exclude("io.opentelemetry:opentelemetry-api")
+      exclude("io.opentelemetry:opentelemetry-common")
       exclude("io.opentelemetry:opentelemetry-context")
+      exclude("io.opentelemetry.semconv:opentelemetry-semconv")
+      exclude("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
       // events API and metrics advice API
       exclude("io.opentelemetry:opentelemetry-api-incubator")
     }

--- a/examples/distro/testing/agent-for-testing/build.gradle
+++ b/examples/distro/testing/agent-for-testing/build.gradle
@@ -70,7 +70,10 @@ tasks {
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory
     dependencies {
       exclude("io.opentelemetry:opentelemetry-api")
+      exclude("io.opentelemetry:opentelemetry-common")
       exclude("io.opentelemetry:opentelemetry-context")
+      exclude("io.opentelemetry.semconv:opentelemetry-semconv")
+      exclude("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
       // events API and metrics advice API
       exclude("io.opentelemetry:opentelemetry-api-incubator")
     }

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -39,6 +39,8 @@ val javaagentLibs by configurations.creating {
 listOf(baseJavaagentLibs, javaagentLibs).forEach {
   it.run {
     exclude("io.opentelemetry", "opentelemetry-api")
+    exclude("io.opentelemetry", "opentelemetry-common")
+    exclude("io.opentelemetry", "opentelemetry-context")
     exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
     exclude("io.opentelemetry.semconv", "opentelemetry-semconv-incubating")
     // events API and metrics advice API


### PR DESCRIPTION
Classes that are placed in boot loader shouldn't be in the agent loader. As far as I can tell these extra rules aren't necessary here, but they are necessary in the custom distro I'm working on. I think it is better to use the same set of rules everywhere even when the build produces the correct result without having some of them.