### PR TITLE
Fix codeql failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version-file: 11
+          java-version: 11
 
       - name: Set up JDK for running Gradle
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,12 @@ jobs:
 
       # don't need to free disk space (which takes time) since running on larger machine
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version-file: 11
+
       - name: Set up JDK for running Gradle
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:


### PR DESCRIPTION
Since automatic provisioning of jdks currently doesn't work correctly we can install the jdk 11 that appears to be required.