### PR TITLE
Kafka metadata typo

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
@@ -1,2 +1,2 @@
 description: >
-  This instrumentation provides a library integeration that enables messaging spans and metrics for Apache Kafka 2.6+ clients.
+  This instrumentation provides a library integration that enables messaging spans and metrics for Apache Kafka 2.6+ clients.


### PR DESCRIPTION
This also propagated into the `instrumentation-list.yaml` file, but that file is apparently generated so I didn't edit it. Should I run something to update that too or?