### PR TITLE
Instrument openai async client

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/metadata.yaml
@@ -1,2 +1,2 @@
 description: >
-  This instrumentation provides a library integeration that enables messaging spans and metrics for Apache Kafka 2.6+ clients.
+  This instrumentation provides a library integration that enables messaging spans and metrics for Apache Kafka 2.6+ clients.

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiClientAsyncInstrumentation.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiClientAsyncInstrumentation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
+
+import static io.opentelemetry.javaagent.instrumentation.openai.v1_1.OpenAiSingletons.TELEMETRY;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+import com.openai.client.OpenAIClientAsync;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class OpenAiClientAsyncInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.openai.client.okhttp.OpenAIOkHttpClientAsync$Builder");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("build").and(returns(named("com.openai.client.OpenAIClientAsync"))),
+        OpenAiClientAsyncInstrumentation.class.getName() + "$BuildAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class BuildAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Advice.AssignReturned.ToReturned
+    public static OpenAIClientAsync onExit(@Advice.Return OpenAIClientAsync client) {
+      return TELEMETRY.wrap(client);
+    }
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiInstrumentationModule.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiInstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -27,6 +27,6 @@ public class OpenAiInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new OpenAiClientInstrumentation());
+    return asList(new OpenAiClientInstrumentation(), new OpenAiClientAsyncInstrumentation());
   }
 }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
 
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import io.opentelemetry.instrumentation.openai.v1_1.AbstractChatTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -28,6 +29,11 @@ class ChatTest extends AbstractChatTest {
 
   @Override
   protected OpenAIClient wrap(OpenAIClient client) {
+    return client;
+  }
+
+  @Override
+  protected OpenAIClientAsync wrap(OpenAIClientAsync client) {
     return client;
   }
 

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionEventsHelper.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionEventsHelper.java
@@ -35,7 +35,7 @@ final class ChatCompletionEventsHelper {
   private static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
 
   public static void emitPromptLogEvents(
-      Context ctx,
+      Context context,
       Logger eventLogger,
       ChatCompletionCreateParams request,
       boolean captureMessageContent) {
@@ -86,7 +86,7 @@ final class ChatCompletionEventsHelper {
       } else {
         continue;
       }
-      newEvent(eventLogger, eventType).setContext(ctx).setBody(Value.of(body)).emit();
+      newEvent(eventLogger, eventType).setContext(context).setBody(Value.of(body)).emit();
     }
   }
 
@@ -162,7 +162,10 @@ final class ChatCompletionEventsHelper {
   }
 
   public static void emitCompletionLogEvents(
-      Context ctx, Logger eventLogger, ChatCompletion completion, boolean captureMessageContent) {
+      Context context,
+      Logger eventLogger,
+      ChatCompletion completion,
+      boolean captureMessageContent) {
     for (ChatCompletion.Choice choice : completion.choices()) {
       ChatCompletionMessage choiceMsg = choice.message();
       Map<String, Value<?>> message = new HashMap<>();
@@ -181,12 +184,16 @@ final class ChatCompletionEventsHelper {
                             .collect(Collectors.toList())));
               });
       emitCompletionLogEvent(
-          ctx, eventLogger, choice.index(), choice.finishReason().toString(), Value.of(message));
+          context,
+          eventLogger,
+          choice.index(),
+          choice.finishReason().toString(),
+          Value.of(message));
     }
   }
 
   public static void emitCompletionLogEvent(
-      Context ctx,
+      Context context,
       Logger eventLogger,
       long index,
       String finishReason,
@@ -195,7 +202,7 @@ final class ChatCompletionEventsHelper {
     body.put("finish_reason", Value.of(finishReason));
     body.put("index", Value.of(index));
     body.put("message", eventMessageObject);
-    newEvent(eventLogger, "gen_ai.choice").setContext(ctx).setBody(Value.of(body)).emit();
+    newEvent(eventLogger, "gen_ai.choice").setContext(context).setBody(Value.of(body)).emit();
   }
 
   private static LogRecordBuilder newEvent(Logger eventLogger, String name) {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/CompletableFutureWrapper.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/CompletableFutureWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.concurrent.CompletableFuture;
+
+final class CompletableFutureWrapper {
+  private CompletableFutureWrapper() {}
+
+  public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, Context context) {
+    CompletableFuture<T> result = new CompletableFuture<>();
+    future.whenComplete(
+        (T value, Throwable throwable) -> {
+          try (Scope ignored = context.makeCurrent()) {
+            if (throwable != null) {
+              result.completeExceptionally(throwable);
+            } else {
+              result.complete(value);
+            }
+          }
+        });
+
+    return result;
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/CompletableFutureWrapper.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/CompletableFutureWrapper.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 final class CompletableFutureWrapper {
   private CompletableFutureWrapper() {}
 
-  public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, Context context) {
+  static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, Context context) {
     CompletableFuture<T> result = new CompletableFuture<>();
     future.whenComplete(
         (T value, Throwable throwable) -> {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionServiceAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionServiceAsync.java
@@ -92,7 +92,7 @@ final class InstrumentedChatCompletionServiceAsync
     future =
         future.whenComplete(
             (res, t) -> instrumenter.end(context, chatCompletionCreateParams, res, t));
-    return CompletableFutureWrapper.wrap(future, context);
+    return CompletableFutureWrapper.wrap(future, parentContext);
   }
 
   private CompletableFuture<ChatCompletion> createWithLogs(

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatService.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatService.java
@@ -19,7 +19,7 @@ final class InstrumentedChatService
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
-  public InstrumentedChatService(
+  InstrumentedChatService(
       ChatService delegate,
       Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
       Logger eventLogger,

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
@@ -5,48 +5,43 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
-import com.openai.client.OpenAIClient;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.services.async.ChatServiceAsync;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.lang.reflect.Method;
 
-final class InstrumentedOpenAiClient
-    extends DelegatingInvocationHandler<OpenAIClient, InstrumentedOpenAiClient> {
+final class InstrumentedChatServiceAsync
+    extends DelegatingInvocationHandler<ChatServiceAsync, InstrumentedChatServiceAsync> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter;
+  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
-  InstrumentedOpenAiClient(
-      OpenAIClient delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter,
+  public InstrumentedChatServiceAsync(
+      ChatServiceAsync delegate,
+      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
     super(delegate);
-    this.chatInstrumenter = chatInstrumenter;
+    this.instrumenter = instrumenter;
     this.eventLogger = eventLogger;
     this.captureMessageContent = captureMessageContent;
   }
 
   @Override
-  protected Class<OpenAIClient> getProxyType() {
-    return OpenAIClient.class;
+  protected Class<ChatServiceAsync> getProxyType() {
+    return ChatServiceAsync.class;
   }
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
     String methodName = method.getName();
     Class<?>[] parameterTypes = method.getParameterTypes();
-    if (methodName.equals("chat") && parameterTypes.length == 0) {
-      return new InstrumentedChatService(
-              delegate.chat(), chatInstrumenter, eventLogger, captureMessageContent)
-          .createProxy();
-    }
-    if (methodName.equals("async") && parameterTypes.length == 0) {
-      return new InstrumentedOpenAiClientAsync(
-              delegate.async(), chatInstrumenter, eventLogger, captureMessageContent)
+    if (methodName.equals("completions") && parameterTypes.length == 0) {
+      return new InstrumentedChatCompletionServiceAsync(
+              delegate.completions(), instrumenter, eventLogger, captureMessageContent)
           .createProxy();
     }
     return super.invoke(proxy, method, args);

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
@@ -19,7 +19,7 @@ final class InstrumentedChatServiceAsync
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
-  public InstrumentedChatServiceAsync(
+  InstrumentedChatServiceAsync(
       ChatServiceAsync delegate,
       Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
       Logger eventLogger,

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClientAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClientAsync.java
@@ -5,22 +5,22 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
-import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.lang.reflect.Method;
 
-final class InstrumentedOpenAiClient
-    extends DelegatingInvocationHandler<OpenAIClient, InstrumentedOpenAiClient> {
+final class InstrumentedOpenAiClientAsync
+    extends DelegatingInvocationHandler<OpenAIClientAsync, InstrumentedOpenAiClientAsync> {
 
   private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
-  InstrumentedOpenAiClient(
-      OpenAIClient delegate,
+  InstrumentedOpenAiClientAsync(
+      OpenAIClientAsync delegate,
       Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
@@ -31,8 +31,8 @@ final class InstrumentedOpenAiClient
   }
 
   @Override
-  protected Class<OpenAIClient> getProxyType() {
-    return OpenAIClient.class;
+  protected Class<OpenAIClientAsync> getProxyType() {
+    return OpenAIClientAsync.class;
   }
 
   @Override
@@ -40,13 +40,13 @@ final class InstrumentedOpenAiClient
     String methodName = method.getName();
     Class<?>[] parameterTypes = method.getParameterTypes();
     if (methodName.equals("chat") && parameterTypes.length == 0) {
-      return new InstrumentedChatService(
+      return new InstrumentedChatServiceAsync(
               delegate.chat(), chatInstrumenter, eventLogger, captureMessageContent)
           .createProxy();
     }
-    if (methodName.equals("async") && parameterTypes.length == 0) {
-      return new InstrumentedOpenAiClientAsync(
-              delegate.async(), chatInstrumenter, eventLogger, captureMessageContent)
+    if (methodName.equals("sync") && parameterTypes.length == 0) {
+      return new InstrumentedOpenAiClient(
+              delegate.sync(), chatInstrumenter, eventLogger, captureMessageContent)
           .createProxy();
     }
     return super.invoke(proxy, method, args);

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetry.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetry.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.openai.v1_1;
 
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import io.opentelemetry.api.OpenTelemetry;
@@ -45,6 +46,13 @@ public final class OpenAITelemetry {
   /** Wraps the provided OpenAIClient, enabling telemetry for it. */
   public OpenAIClient wrap(OpenAIClient client) {
     return new InstrumentedOpenAiClient(
+            client, chatInstrumenter, eventLogger, captureMessageContent)
+        .createProxy();
+  }
+
+  /** Wraps the provided OpenAIClientAsync, enabling telemetry for it. */
+  public OpenAIClientAsync wrap(OpenAIClientAsync client) {
+    return new InstrumentedOpenAiClientAsync(
             client, chatInstrumenter, eventLogger, captureMessageContent)
         .createProxy();
   }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionChunk;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.completions.CompletionUsage;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+final class StreamListener {
+
+  private final Context parentCtx;
+  private final ChatCompletionCreateParams request;
+  private final List<StreamedMessageBuffer> choiceBuffers;
+
+  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Logger eventLogger;
+  private final boolean captureMessageContent;
+  private final boolean newSpan;
+  private final AtomicBoolean hasEnded;
+
+  @Nullable private CompletionUsage usage;
+  @Nullable private String model;
+  @Nullable private String responseId;
+
+  StreamListener(
+      Context parentCtx,
+      ChatCompletionCreateParams request,
+      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      Logger eventLogger,
+      boolean captureMessageContent,
+      boolean newSpan) {
+    this.parentCtx = parentCtx;
+    this.request = request;
+    this.instrumenter = instrumenter;
+    this.eventLogger = eventLogger;
+    this.captureMessageContent = captureMessageContent;
+    this.newSpan = newSpan;
+    choiceBuffers = new ArrayList<>();
+    hasEnded = new AtomicBoolean();
+  }
+
+  void onChunk(ChatCompletionChunk chunk) {
+    model = chunk.model();
+    responseId = chunk.id();
+    chunk.usage().ifPresent(u -> usage = u);
+
+    for (ChatCompletionChunk.Choice choice : chunk.choices()) {
+      while (choiceBuffers.size() <= choice.index()) {
+        choiceBuffers.add(null);
+      }
+      StreamedMessageBuffer buffer = choiceBuffers.get((int) choice.index());
+      if (buffer == null) {
+        buffer = new StreamedMessageBuffer(choice.index(), captureMessageContent);
+        choiceBuffers.set((int) choice.index(), buffer);
+      }
+      buffer.append(choice.delta());
+      if (choice.finishReason().isPresent()) {
+        buffer.finishReason = choice.finishReason().get().toString();
+
+        // message has ended, let's emit
+        ChatCompletionEventsHelper.emitCompletionLogEvent(
+            parentCtx, eventLogger, choice.index(), buffer.finishReason, buffer.toEventBody());
+      }
+    }
+  }
+
+  void endSpan(@Nullable Throwable error) {
+    // Use an atomic operation since close() type of methods are exposed to the user
+    // and can come from any thread.
+    if (!hasEnded.compareAndSet(false, true)) {
+      return;
+    }
+
+    if (model == null || responseId == null) {
+      // Only happens if we got no chunks, so we have no response.
+      if (newSpan) {
+        instrumenter.end(parentCtx, request, null, error);
+      }
+      return;
+    }
+
+    ChatCompletion.Builder result =
+        ChatCompletion.builder()
+            .created(0)
+            .model(model)
+            .id(responseId)
+            .choices(
+                choiceBuffers.stream()
+                    .map(StreamedMessageBuffer::toChoice)
+                    .collect(Collectors.toList()));
+
+    if (usage != null) {
+      result.usage(usage);
+    }
+
+    if (newSpan) {
+      instrumenter.end(parentCtx, request, result.build(), error);
+    }
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 final class StreamListener {
 
-  private final Context parentCtx;
+  private final Context context;
   private final ChatCompletionCreateParams request;
   private final List<StreamedMessageBuffer> choiceBuffers;
 
@@ -35,13 +35,13 @@ final class StreamListener {
   @Nullable private String responseId;
 
   StreamListener(
-      Context parentCtx,
+      Context context,
       ChatCompletionCreateParams request,
       Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent,
       boolean newSpan) {
-    this.parentCtx = parentCtx;
+    this.context = context;
     this.request = request;
     this.instrumenter = instrumenter;
     this.eventLogger = eventLogger;
@@ -71,7 +71,7 @@ final class StreamListener {
 
         // message has ended, let's emit
         ChatCompletionEventsHelper.emitCompletionLogEvent(
-            parentCtx, eventLogger, choice.index(), buffer.finishReason, buffer.toEventBody());
+            context, eventLogger, choice.index(), buffer.finishReason, buffer.toEventBody());
       }
     }
   }
@@ -86,7 +86,7 @@ final class StreamListener {
     if (model == null || responseId == null) {
       // Only happens if we got no chunks, so we have no response.
       if (newSpan) {
-        instrumenter.end(parentCtx, request, null, error);
+        instrumenter.end(context, request, null, error);
       }
       return;
     }
@@ -106,7 +106,7 @@ final class StreamListener {
     }
 
     if (newSpan) {
-      instrumenter.end(parentCtx, request, result.build(), error);
+      instrumenter.end(context, request, result.build(), error);
     }
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/TracingAsyncStreamedResponse.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/TracingAsyncStreamedResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import com.openai.core.http.AsyncStreamResponse;
+import com.openai.models.chat.completions.ChatCompletionChunk;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+final class TracingAsyncStreamedResponse implements AsyncStreamResponse<ChatCompletionChunk> {
+
+  private final AsyncStreamResponse<ChatCompletionChunk> delegate;
+  private final StreamListener listener;
+
+  TracingAsyncStreamedResponse(
+      AsyncStreamResponse<ChatCompletionChunk> delegate, StreamListener listener) {
+    this.delegate = delegate;
+    this.listener = listener;
+  }
+
+  @Override
+  public void close() {
+    listener.endSpan(null);
+    delegate.close();
+  }
+
+  @Override
+  public AsyncStreamResponse<ChatCompletionChunk> subscribe(
+      Handler<? super ChatCompletionChunk> handler) {
+    delegate.subscribe(new TracingHandler(handler));
+    return this;
+  }
+
+  @Override
+  public AsyncStreamResponse<ChatCompletionChunk> subscribe(
+      Handler<? super ChatCompletionChunk> handler, Executor executor) {
+    delegate.subscribe(new TracingHandler(handler), executor);
+    return this;
+  }
+
+  @Override
+  public CompletableFuture<Void> onCompleteFuture() {
+    return delegate.onCompleteFuture();
+  }
+
+  private class TracingHandler implements Handler<ChatCompletionChunk> {
+
+    private final Handler<? super ChatCompletionChunk> delegate;
+
+    private TracingHandler(Handler<? super ChatCompletionChunk> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onNext(ChatCompletionChunk chunk) {
+      listener.onChunk(chunk);
+      delegate.onNext(chunk);
+    }
+
+    @Override
+    public void onComplete(Optional<Throwable> error) {
+      listener.endSpan(error.orElse(null));
+      delegate.onComplete(error);
+    }
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -33,9 +33,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.openai.client.OpenAIClient;
+import com.openai.client.OpenAIClientAsync;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
 import com.openai.core.JsonObject;
 import com.openai.core.JsonValue;
+import com.openai.core.http.AsyncStreamResponse;
 import com.openai.core.http.StreamResponse;
 import com.openai.errors.OpenAIIoException;
 import com.openai.models.FunctionDefinition;
@@ -67,12 +70,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.EnumSource;
 
+@ParameterizedClass
+@EnumSource(AbstractChatTest.TestType.class)
 public abstract class AbstractChatTest {
+  enum TestType {
+    SYNC,
+    SYNC_FROM_ASYNC,
+    ASYNC,
+    ASYNC_FROM_SYNC,
+  }
+
   protected static final String INSTRUMENTATION_NAME = "io.opentelemetry.openai-java-1.1";
 
   private static final String API_URL = "https://api.openai.com/v1";
@@ -90,7 +106,9 @@ public abstract class AbstractChatTest {
 
   protected abstract OpenAIClient wrap(OpenAIClient client);
 
-  protected OpenAIClient getRawClient() {
+  protected abstract OpenAIClientAsync wrap(OpenAIClientAsync client);
+
+  protected final OpenAIClient getRawClient() {
     OpenAIOkHttpClient.Builder builder =
         OpenAIOkHttpClient.builder().baseUrl("http://localhost:" + recording.getPort());
     if (recording.isRecording()) {
@@ -101,12 +119,95 @@ public abstract class AbstractChatTest {
     return builder.build();
   }
 
-  protected OpenAIClient getClient() {
+  protected final OpenAIClientAsync getRawClientAsync() {
+    OpenAIOkHttpClientAsync.Builder builder =
+        OpenAIOkHttpClientAsync.builder().baseUrl("http://localhost:" + recording.getPort());
+    if (recording.isRecording()) {
+      builder.apiKey(System.getenv("OPENAI_API_KEY"));
+    } else {
+      builder.apiKey("unused");
+    }
+    return builder.build();
+  }
+
+  protected final OpenAIClient getClient() {
     return wrap(getRawClient());
+  }
+
+  protected final OpenAIClientAsync getClientAsync() {
+    return wrap(getRawClientAsync());
   }
 
   protected abstract List<Consumer<SpanDataAssert>> maybeWithTransportSpan(
       Consumer<SpanDataAssert> span);
+
+  @Parameter TestType testType;
+
+  protected final ChatCompletion doCompletions(ChatCompletionCreateParams params) {
+    return doCompletions(params, getClient(), getClientAsync());
+  }
+
+  protected final ChatCompletion doCompletions(
+      ChatCompletionCreateParams params, OpenAIClient client, OpenAIClientAsync clientAsync) {
+    switch (testType) {
+      case SYNC:
+        return client.chat().completions().create(params);
+      case SYNC_FROM_ASYNC:
+        return clientAsync.sync().chat().completions().create(params);
+      case ASYNC:
+      case ASYNC_FROM_SYNC:
+        OpenAIClientAsync cl = testType == TestType.ASYNC ? clientAsync : client.async();
+        try {
+          return cl.chat().completions().create(params).join();
+        } catch (CompletionException e) {
+          if (e.getCause() instanceof OpenAIIoException) {
+            throw ((OpenAIIoException) e.getCause());
+          }
+          throw e;
+        }
+    }
+    throw new AssertionError();
+  }
+
+  protected final List<ChatCompletionChunk> doCompletionsStreaming(
+      ChatCompletionCreateParams params) {
+    return doCompletionsStreaming(params, getClient(), getClientAsync());
+  }
+
+  protected final List<ChatCompletionChunk> doCompletionsStreaming(
+      ChatCompletionCreateParams params, OpenAIClient client, OpenAIClientAsync clientAsync) {
+    switch (testType) {
+      case SYNC:
+        try (StreamResponse<ChatCompletionChunk> result =
+            client.chat().completions().createStreaming(params)) {
+          return result.stream().collect(Collectors.toList());
+        }
+      case SYNC_FROM_ASYNC:
+        try (StreamResponse<ChatCompletionChunk> result =
+            clientAsync.sync().chat().completions().createStreaming(params)) {
+          return result.stream().collect(Collectors.toList());
+        }
+      case ASYNC:
+      case ASYNC_FROM_SYNC:
+        {
+          OpenAIClientAsync cl = testType == TestType.ASYNC ? clientAsync : client.async();
+          AsyncStreamResponse<ChatCompletionChunk> stream =
+              cl.chat().completions().createStreaming(params);
+          List<ChatCompletionChunk> result = new ArrayList<>();
+          stream.subscribe(result::add);
+          try {
+            stream.onCompleteFuture().join();
+          } catch (CompletionException e) {
+            if (e.getCause() instanceof OpenAIIoException) {
+              throw ((OpenAIIoException) e.getCause());
+            }
+            throw e;
+          }
+          return result;
+        }
+    }
+    throw new AssertionError();
+  }
 
   @Test
   void basic() {
@@ -116,7 +217,7 @@ public abstract class AbstractChatTest {
             .model(TEST_CHAT_MODEL)
             .build();
 
-    ChatCompletion response = getClient().chat().completions().create(params);
+    ChatCompletion response = doCompletions(params);
     String content = "Atlantic Ocean";
     assertThat(response.choices().get(0).message().content()).hasValue(content);
 
@@ -217,7 +318,7 @@ public abstract class AbstractChatTest {
             .model(TEST_CHAT_MODEL)
             .build();
 
-    ChatCompletion response = getClient().chat().completions().create(params);
+    ChatCompletion response = doCompletions(params);
     String content = "Tomato.";
     assertThat(response.choices().get(0).message().content()).hasValue(content);
 
@@ -271,7 +372,7 @@ public abstract class AbstractChatTest {
             .responseFormat(ResponseFormatText.builder().build())
             .build();
 
-    ChatCompletion response = getClient().chat().completions().create(params);
+    ChatCompletion response = doCompletions(params);
     String content = "Southern Ocean.";
     assertThat(response.choices().get(0).message().content()).hasValue(content);
 
@@ -376,7 +477,7 @@ public abstract class AbstractChatTest {
             .n(2)
             .build();
 
-    ChatCompletion response = getClient().chat().completions().create(params);
+    ChatCompletion response = doCompletions(params);
     String content1 = "South Atlantic Ocean.";
     assertThat(response.choices().get(0).message().content()).hasValue(content1);
     String content2 = "Atlantic Ocean.";
@@ -489,7 +590,7 @@ public abstract class AbstractChatTest {
             .addTool(buildGetWeatherToolDefinition())
             .build();
 
-    ChatCompletion response = getClient().chat().completions().create(params);
+    ChatCompletion response = doCompletions(params);
 
     assertThat(response.choices().get(0).message().content()).isEmpty();
 
@@ -815,6 +916,13 @@ public abstract class AbstractChatTest {
                 .apiKey("testing")
                 .maxRetries(0)
                 .build());
+    OpenAIClientAsync clientAsync =
+        wrap(
+            OpenAIOkHttpClientAsync.builder()
+                .baseUrl("http://localhost:9999/v5")
+                .apiKey("testing")
+                .maxRetries(0)
+                .build());
 
     ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()
@@ -822,7 +930,7 @@ public abstract class AbstractChatTest {
             .model(TEST_CHAT_MODEL)
             .build();
 
-    Throwable thrown = catchThrowable(() -> client.chat().completions().create(params));
+    Throwable thrown = catchThrowable(() -> doCompletions(params, client, clientAsync));
     assertThat(thrown).isInstanceOf(OpenAIIoException.class);
 
     getTesting()
@@ -873,11 +981,7 @@ public abstract class AbstractChatTest {
             .model(TEST_CHAT_MODEL)
             .build();
 
-    List<ChatCompletionChunk> chunks;
-    try (StreamResponse<ChatCompletionChunk> result =
-        getClient().chat().completions().createStreaming(params)) {
-      chunks = result.stream().collect(Collectors.toList());
-    }
+    List<ChatCompletionChunk> chunks = doCompletionsStreaming(params);
 
     String fullMessage =
         chunks.stream()
@@ -962,11 +1066,7 @@ public abstract class AbstractChatTest {
             .streamOptions(ChatCompletionStreamOptions.builder().includeUsage(true).build())
             .build();
 
-    List<ChatCompletionChunk> chunks;
-    try (StreamResponse<ChatCompletionChunk> result =
-        getClient().chat().completions().createStreaming(params)) {
-      chunks = result.stream().collect(Collectors.toList());
-    }
+    List<ChatCompletionChunk> chunks = doCompletionsStreaming(params);
 
     String fullMessage =
         chunks.stream()
@@ -1078,11 +1178,7 @@ public abstract class AbstractChatTest {
             .n(2)
             .build();
 
-    List<ChatCompletionChunk> chunks;
-    try (StreamResponse<ChatCompletionChunk> result =
-        getClient().chat().completions().createStreaming(params)) {
-      chunks = result.stream().collect(Collectors.toList());
-    }
+    List<ChatCompletionChunk> chunks = doCompletionsStreaming(params);
 
     StringBuilder content1Builder = new StringBuilder();
     StringBuilder content2Builder = new StringBuilder();
@@ -1188,11 +1284,7 @@ public abstract class AbstractChatTest {
             .addTool(buildGetWeatherToolDefinition())
             .build();
 
-    List<ChatCompletionChunk> chunks;
-    try (StreamResponse<ChatCompletionChunk> result =
-        getClient().chat().completions().createStreaming(params)) {
-      chunks = result.stream().collect(Collectors.toList());
-    }
+    List<ChatCompletionChunk> chunks = doCompletionsStreaming(params);
 
     List<ChatCompletionMessageToolCall> toolCalls = new ArrayList<>();
 
@@ -1363,10 +1455,7 @@ public abstract class AbstractChatTest {
             .addTool(buildGetWeatherToolDefinition())
             .build();
 
-    try (StreamResponse<ChatCompletionChunk> result =
-        getClient().chat().completions().createStreaming(params)) {
-      chunks = result.stream().collect(Collectors.toList());
-    }
+    chunks = doCompletionsStreaming(params);
 
     String finalAnswer =
         chunks.stream()
@@ -1510,6 +1599,13 @@ public abstract class AbstractChatTest {
                 .apiKey("testing")
                 .maxRetries(0)
                 .build());
+    OpenAIClientAsync clientAsync =
+        wrap(
+            OpenAIOkHttpClientAsync.builder()
+                .baseUrl("http://localhost:9999/v5")
+                .apiKey("testing")
+                .maxRetries(0)
+                .build());
 
     ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()
@@ -1517,7 +1613,7 @@ public abstract class AbstractChatTest {
             .model(TEST_CHAT_MODEL)
             .build();
 
-    Throwable thrown = catchThrowable(() -> client.chat().completions().createStreaming(params));
+    Throwable thrown = catchThrowable(() -> doCompletionsStreaming(params, client, clientAsync));
     assertThat(thrown).isInstanceOf(OpenAIIoException.class);
 
     getTesting()


### PR DESCRIPTION
Continues openai instrumentation, adding support for async client. The types work out that the proxy entry points need to basically be duplicated but the telemetry is still mostly contained in the instrumentation API usage, and streaming handling was refactored to a sharable class.

Also passes context to logs in all cases which is required for async, and will be a bit faster in sync anyways.

/cc @codefromthecrypt