### PR TITLE
Update KafkaConsumerRecordGetter.java - safety getAll values from headers

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
@@ -40,7 +40,9 @@ enum KafkaConsumerRecordGetter implements ExtendedTextMapGetter<KafkaProcessRequ
   @Override
   public Iterator<String> getAll(@Nullable KafkaProcessRequest carrier, String key) {
     return StreamSupport.stream(carrier.getRecord().headers().headers(key).spliterator(), false)
-        .map(header -> new String(header.value(), StandardCharsets.UTF_8))
+        .map(Header::value)
+        .filter(Objects::nonNull)
+        .map(value -> new String(value, StandardCharsets.UTF_8))
         .iterator();
   }
 }


### PR DESCRIPTION
KafkaConsumerRecordGetter/getAll method uses stream and iterates each headers, to get value.
but, it is not safe for NPE case when header value is null. 