### PR TITLE
Fix hibernate testLatestDeps

### DIFF
--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/ProcedureCallTest.java
@@ -170,7 +170,9 @@ class ProcedureCallTest {
                                             "org.hibernate.exception.AuthException"),
                                         satisfies(
                                             AttributeKey.stringKey("exception.message"),
-                                            val -> val.startsWith("could not prepare statement")),
+                                            val ->
+                                                val.startsWithIgnoringCase(
+                                                    "could not prepare statement")),
                                         satisfies(
                                             AttributeKey.stringKey("exception.stacktrace"),
                                             val -> val.isNotNull())))


### PR DESCRIPTION
Test latest deps are failing due to a change in the exception message ([commit in hibernate](https://github.com/hibernate/hibernate-orm/commit/b20aa54cd5f5207a774568f10d0eacfd28dfb387)).

[build scan](https://scans.gradle.com/s/cwlrfklridtpo/tests/task/:instrumentation:hibernate:hibernate-6.0:javaagent:hibernate7Test/details/io.opentelemetry.javaagent.instrumentation.hibernate.v7_0.ProcedureCallTest/testFailingProcedureCall()?top-execution=2)

```

java.lang.AssertionError: [STRING attribute 'exception.message'] |  
-- | --
Expecting actual: |  
"Could not prepare statement [user lacks privilege or object not found] [{call TEST_PROC(?)}]" |  
to start with: |  
"could not prepare statement"
```

