### PR TITLE
Rename lambda instrumentation helper class

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.flushTimeout;
-import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.functionInstrumenter;
+import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaSingletons.flushTimeout;
+import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaSingletons.functionInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestStreamHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestStreamHandlerInstrumentation.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.flushTimeout;
-import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.functionInstrumenter;
+import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaSingletons.flushTimeout;
+import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaSingletons.functionInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaSingletons.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaSingletons.java
@@ -3,26 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
+package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenter;
+import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenterFactory;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrapperConfiguration;
-import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaEventsInstrumenterFactory;
-import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaSqsInstrumenterFactory;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import java.time.Duration;
 
-public final class AwsLambdaInstrumentationHelper {
+public final class AwsLambdaSingletons {
 
   private static final AwsLambdaFunctionInstrumenter FUNCTION_INSTRUMENTER =
-      AwsLambdaEventsInstrumenterFactory.createInstrumenter(
-          GlobalOpenTelemetry.get(), AgentCommonConfig.get().getKnownHttpRequestMethods());
-  private static final Instrumenter<SQSEvent, Void> MESSAGE_TRACER =
-      AwsLambdaSqsInstrumenterFactory.forEvent(GlobalOpenTelemetry.get());
+      AwsLambdaFunctionInstrumenterFactory.createInstrumenter(GlobalOpenTelemetry.get());
   private static final Duration FLUSH_TIMEOUT =
       Duration.ofMillis(
           AgentInstrumentationConfig.get()
@@ -34,13 +27,9 @@ public final class AwsLambdaInstrumentationHelper {
     return FUNCTION_INSTRUMENTER;
   }
 
-  public static Instrumenter<SQSEvent, Void> messageInstrumenter() {
-    return MESSAGE_TRACER;
-  }
-
   public static Duration flushTimeout() {
     return FLUSH_TIMEOUT;
   }
 
-  private AwsLambdaInstrumentationHelper() {}
+  private AwsLambdaSingletons() {}
 }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
@@ -36,10 +36,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AwsLambdaStreamHandlerTest {
+class AwsLambdaStreamHandlerTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class AwsLambdaTest extends AbstractAwsLambdaTest {
+class AwsLambdaTest extends AbstractAwsLambdaTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @Override
   protected RequestHandler<String, String> handler() {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
@@ -44,10 +44,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
     key = WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY,
     value =
         "io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaStreamWrapperHttpPropagationTest$TestRequestHandler::handleRequest")
-public class AwsLambdaStreamWrapperHttpPropagationTest {
+class AwsLambdaStreamWrapperHttpPropagationTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
@@ -43,10 +43,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
     key = WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY,
     value =
         "io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaStreamWrapperTest$TestRequestHandler::handleRequest")
-public class AwsLambdaStreamWrapperTest {
+class AwsLambdaStreamWrapperTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
@@ -12,10 +12,10 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class AwsLambdaTest extends AbstractAwsLambdaTest {
+class AwsLambdaTest extends AbstractAwsLambdaTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Override
   protected RequestHandler<String, String> handler() {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequestTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequestTest.java
@@ -30,7 +30,7 @@ class ApiGatewayProxyRequestTest {
   }
 
   @Test
-  public void shouldCreateNoopRequestIfNoPropagatorsSet() throws IOException {
+  void shouldCreateNoopRequestIfNoPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
     GlobalOpenTelemetry.set(OpenTelemetry.noop());
@@ -42,7 +42,7 @@ class ApiGatewayProxyRequestTest {
   }
 
   @Test
-  public void shouldCreateNoopRequestIfXrayPropagatorsSet() throws IOException {
+  void shouldCreateNoopRequestIfXrayPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
     GlobalOpenTelemetry.set(
@@ -55,7 +55,7 @@ class ApiGatewayProxyRequestTest {
   }
 
   @Test
-  public void shouldUseStreamMarkingIfHttpPropagatorsSet() throws IOException {
+  void shouldUseStreamMarkingIfHttpPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
     when(mock.markSupported()).thenReturn(true);
@@ -70,7 +70,7 @@ class ApiGatewayProxyRequestTest {
   }
 
   @Test
-  public void shouldUseNoopIfMarkingNotAvailableAndHttpPropagatorsSet() throws IOException {
+  void shouldUseNoopIfMarkingNotAvailableAndHttpPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
     when(mock.markSupported()).thenReturn(false);

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactoryTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactoryTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class HeadersFactoryTest {
 
   @Test
-  public void shouldReadHeadersFromStream() {
+  void shouldReadHeadersFromStream() {
     // given
     String json =
         "{"
@@ -40,7 +40,7 @@ class HeadersFactoryTest {
   }
 
   @Test
-  public void shouldReturnNullIfNoHeadersInStream() {
+  void shouldReturnNullIfNoHeadersInStream() {
     // given
     String json = "{\"something\" : \"else\"}";
     InputStream inputStream = new ByteArrayInputStream(json.getBytes(Charset.defaultCharset()));

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/InstrumenterExtractionTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/InstrumenterExtractionTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 class InstrumenterExtractionTest {
   @Test
-  public void useCustomContext() {
+  void useCustomContext() {
     AwsLambdaFunctionInstrumenter instr =
         AwsLambdaFunctionInstrumenterFactory.createInstrumenter(
             OpenTelemetry.propagating(

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaRequestStreamHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaRequestStreamHandlerInstrumentation.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2.AwsLambdaInstrumentationHelper.flushTimeout;
+import static io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2.AwsLambdaSingletons.flushTimeout;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -62,15 +62,13 @@ public class AwsLambdaRequestStreamHandlerInstrumentation implements TypeInstrum
       Map<String, String> headers = Collections.emptyMap();
       otelInput = AwsLambdaRequest.create(context, input, headers);
       io.opentelemetry.context.Context parentContext =
-          AwsLambdaInstrumentationHelper.functionInstrumenter().extract(otelInput);
+          AwsLambdaSingletons.functionInstrumenter().extract(otelInput);
 
-      if (!AwsLambdaInstrumentationHelper.functionInstrumenter()
-          .shouldStart(parentContext, otelInput)) {
+      if (!AwsLambdaSingletons.functionInstrumenter().shouldStart(parentContext, otelInput)) {
         return;
       }
 
-      otelContext =
-          AwsLambdaInstrumentationHelper.functionInstrumenter().start(parentContext, otelInput);
+      otelContext = AwsLambdaSingletons.functionInstrumenter().start(parentContext, otelInput);
       otelScope = otelContext.makeCurrent();
     }
 
@@ -82,8 +80,7 @@ public class AwsLambdaRequestStreamHandlerInstrumentation implements TypeInstrum
         @Advice.Local("otelScope") Scope functionScope) {
       if (functionScope != null) {
         functionScope.close();
-        AwsLambdaInstrumentationHelper.functionInstrumenter()
-            .end(functionContext, input, null, throwable);
+        AwsLambdaSingletons.functionInstrumenter().end(functionContext, input, null, throwable);
       }
 
       OpenTelemetrySdkAccess.forceFlush(flushTimeout().toNanos(), TimeUnit.NANOSECONDS);

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSingletons.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSingletons.java
@@ -3,19 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
+package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenter;
-import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionInstrumenterFactory;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrapperConfiguration;
+import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaEventsInstrumenterFactory;
+import io.opentelemetry.instrumentation.awslambdaevents.v2_2.internal.AwsLambdaSqsInstrumenterFactory;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import java.time.Duration;
 
-public final class AwsLambdaInstrumentationHelper {
+public final class AwsLambdaSingletons {
 
   private static final AwsLambdaFunctionInstrumenter FUNCTION_INSTRUMENTER =
-      AwsLambdaFunctionInstrumenterFactory.createInstrumenter(GlobalOpenTelemetry.get());
+      AwsLambdaEventsInstrumenterFactory.createInstrumenter(
+          GlobalOpenTelemetry.get(), AgentCommonConfig.get().getKnownHttpRequestMethods());
+  private static final Instrumenter<SQSEvent, Void> MESSAGE_TRACER =
+      AwsLambdaSqsInstrumenterFactory.forEvent(GlobalOpenTelemetry.get());
   private static final Duration FLUSH_TIMEOUT =
       Duration.ofMillis(
           AgentInstrumentationConfig.get()
@@ -27,9 +34,13 @@ public final class AwsLambdaInstrumentationHelper {
     return FUNCTION_INSTRUMENTER;
   }
 
+  public static Instrumenter<SQSEvent, Void> messageInstrumenter() {
+    return MESSAGE_TRACER;
+  }
+
   public static Duration flushTimeout() {
     return FLUSH_TIMEOUT;
   }
 
-  private AwsLambdaInstrumentationHelper() {}
+  private AwsLambdaSingletons() {}
 }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
@@ -35,10 +35,10 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class AwsLambdaApiGatewayHandlerTest {
+class AwsLambdaApiGatewayHandlerTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
@@ -13,10 +13,10 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest {
+class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @Override
   protected RequestHandler<SQSEvent, Void> handler() {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
@@ -36,10 +36,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AwsLambdaStreamHandlerTest {
+class AwsLambdaStreamHandlerTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayWrapperTest.java
@@ -38,10 +38,10 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class AwsLambdaApiGatewayWrapperTest {
+class AwsLambdaApiGatewayWrapperTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
@@ -13,10 +13,10 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest {
+class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Override
   protected RequestHandler<SQSEvent, Void> handler() {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventWrapperTest.java
@@ -37,10 +37,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
     key = WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY,
     value =
         "io.opentelemetry.instrumentation.awslambdaevents.v2_2.AwsLambdaSqsEventWrapperTest$TestRequestHandler::handleRequest")
-public class AwsLambdaSqsEventWrapperTest {
+class AwsLambdaSqsEventWrapperTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMessageHandlerTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AwsLambdaSqsMessageHandlerTest {
+class AwsLambdaSqsMessageHandlerTest {
 
   private static final String AWS_TRACE_HEADER1 =
       "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
@@ -45,7 +45,7 @@ public class AwsLambdaSqsMessageHandlerTest {
       "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad9;Sampled=1";
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaWrapperTest.java
@@ -30,10 +30,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AwsLambdaWrapperTest {
+class AwsLambdaWrapperTest {
 
   @RegisterExtension
-  public static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Mock private Context context;
 


### PR DESCRIPTION
I was reading the code in these modules and noticed they didn't follow the standard pattern of using a `Singletons` class for the instrumenters, so I renamed the helper classes to follow that pattern. Also cleaned up some test code visibility.