### PR TITLE
Make telemetry group ordering deterministic

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -4776,12 +4776,10 @@ libraries:
       type: boolean
       default: false
     telemetry:
-    - when: otel.instrumentation.kafka.experimental-span-attributes=true
+    - when: default
       spans:
       - span_kind: CONSUMER
         attributes:
-        - name: kafka.record.queue_time_ms
-          type: LONG
         - name: messaging.batch.message_count
           type: LONG
         - name: messaging.client_id
@@ -4802,10 +4800,12 @@ libraries:
           type: STRING
         - name: messaging.system
           type: STRING
-    - when: default
+    - when: otel.instrumentation.kafka.experimental-span-attributes=true
       spans:
       - span_kind: CONSUMER
         attributes:
+        - name: kafka.record.queue_time_ms
+          type: LONG
         - name: messaging.batch.message_count
           type: LONG
         - name: messaging.client_id

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.yaml.snakeyaml.DumperOptions;
@@ -143,7 +144,7 @@ public class YamlHelper {
     addConfigurations(module, moduleMap);
 
     // Get telemetry grouping lists
-    Set<String> telemetryGroups = new java.util.HashSet<>(module.getMetrics().keySet());
+    Set<String> telemetryGroups = new TreeSet<>(module.getMetrics().keySet());
     telemetryGroups.addAll(module.getSpans().keySet());
 
     if (!telemetryGroups.isEmpty()) {


### PR DESCRIPTION
To prevent random churn of the yaml file (see #14377), we need to make sure everything is ordered. The metrics/spans/attributes are already ordered, but now we will ensure the telemetry groups themselves are ordered as well by using a `TreeSet`.