### PR TITLE
Metadata Telemetry scope allowlist

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -784,6 +784,37 @@ libraries:
     target_versions:
       javaagent:
       - com.linecorp.armeria:armeria-grpc:[1.14.0,)
+    telemetry:
+    - when: default
+      spans:
+      - span_kind: CLIENT
+        attributes:
+        - name: rpc.grpc.status_code
+          type: LONG
+        - name: rpc.method
+          type: STRING
+        - name: rpc.service
+          type: STRING
+        - name: rpc.system
+          type: STRING
+        - name: server.address
+          type: STRING
+        - name: server.port
+          type: LONG
+      - span_kind: SERVER
+        attributes:
+        - name: rpc.grpc.status_code
+          type: LONG
+        - name: rpc.method
+          type: STRING
+        - name: rpc.service
+          type: STRING
+        - name: rpc.system
+          type: STRING
+        - name: server.address
+          type: STRING
+        - name: server.port
+          type: LONG
   async:
   - name: async-http-client-1.9
     description: This instrumentation enables CLIENT spans and metrics for version

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
@@ -20,7 +20,7 @@ import java.util.Set;
  * This class is responsible for parsing metric files from the `.telemetry` directory of an
  * instrumentation module and filtering them by scope.
  */
-public class MetricParser {
+public class MetricParser extends TelemetryParser {
 
   /**
    * Retrieves metrics for a given instrumentation module, filtered by scope.
@@ -109,7 +109,10 @@ public class MetricParser {
           aggregatedMetrics.computeIfAbsent(when, k -> new HashMap<>());
 
       for (EmittedMetrics.MetricsByScope metricsByScope : metrics.getMetricsByScope()) {
-        if (metricsByScope.getScope().equals(targetScopeName)) {
+        if (metricsByScope.getScope().equals(targetScopeName)
+            || scopeAllowList
+                .getOrDefault(targetScopeName, Set.of())
+                .contains(metricsByScope.getScope())) {
           for (EmittedMetrics.Metric metric : metricsByScope.getMetrics()) {
             AggregatedMetricInfo aggInfo =
                 metricKindMap.computeIfAbsent(

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/MetricParser.java
@@ -20,7 +20,7 @@ import java.util.Set;
  * This class is responsible for parsing metric files from the `.telemetry` directory of an
  * instrumentation module and filtering them by scope.
  */
-public class MetricParser extends TelemetryParser {
+public class MetricParser {
 
   /**
    * Retrieves metrics for a given instrumentation module, filtered by scope.
@@ -109,10 +109,7 @@ public class MetricParser extends TelemetryParser {
           aggregatedMetrics.computeIfAbsent(when, k -> new HashMap<>());
 
       for (EmittedMetrics.MetricsByScope metricsByScope : metrics.getMetricsByScope()) {
-        if (metricsByScope.getScope().equals(targetScopeName)
-            || scopeAllowList
-                .getOrDefault(targetScopeName, Set.of())
-                .contains(metricsByScope.getScope())) {
+        if (TelemetryParser.scopeIsValid(metricsByScope.getScope(), targetScopeName)) {
           for (EmittedMetrics.Metric metric : metricsByScope.getMetrics()) {
             AggregatedMetricInfo aggInfo =
                 metricKindMap.computeIfAbsent(

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * This class is responsible for parsing span files from the `.telemetry` directory of an
  * instrumentation module and filtering them by scope.
  */
-public class SpanParser {
+public class SpanParser extends TelemetryParser {
 
   // We want to ignore test related attributes
   private static final List<String> EXCLUDED_ATTRIBUTES =
@@ -87,7 +87,10 @@ public class SpanParser {
           aggregatedAttributes.computeIfAbsent(when, k -> new HashMap<>());
 
       for (EmittedSpans.SpansByScope spansByScope : spans.getSpansByScope()) {
-        if (spansByScope.getScope().equals(targetScopeName)) {
+        if (spansByScope.getScope().equals(targetScopeName)
+            || scopeAllowList
+                .getOrDefault(targetScopeName, Set.of())
+                .contains(spansByScope.getScope())) {
           processSpansForScope(spansByScope, spanKindMap);
         }
       }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * This class is responsible for parsing span files from the `.telemetry` directory of an
  * instrumentation module and filtering them by scope.
  */
-public class SpanParser extends TelemetryParser {
+public class SpanParser {
 
   // We want to ignore test related attributes
   private static final List<String> EXCLUDED_ATTRIBUTES =
@@ -87,10 +87,7 @@ public class SpanParser extends TelemetryParser {
           aggregatedAttributes.computeIfAbsent(when, k -> new HashMap<>());
 
       for (EmittedSpans.SpansByScope spansByScope : spans.getSpansByScope()) {
-        if (spansByScope.getScope().equals(targetScopeName)
-            || scopeAllowList
-                .getOrDefault(targetScopeName, Set.of())
-                .contains(spansByScope.getScope())) {
+        if (TelemetryParser.scopeIsValid(spansByScope.getScope(), targetScopeName)) {
           processSpansForScope(spansByScope, spanKindMap);
         }
       }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import java.util.Map;
+import java.util.Set;
+
+abstract class TelemetryParser {
+
+  // If an instrumentation module uses an instrumenter or telemetry class from another module, it
+  // might report telemetry with a different scope name, resulting in us excluding it. There are
+  // cases where we want to include this data, so we provide this way to override that exclusion
+  // filter. The key is the scope of the module being analyzed, the value is a set of additional
+  // allowed scopes.
+  protected static final Map<String, Set<String>> scopeAllowList =
+      Map.of("io.opentelemetry.armeria-grpc-1.14", Set.of("io.opentelemetry.grpc-1.6"));
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
@@ -8,13 +8,28 @@ package io.opentelemetry.instrumentation.docs.parsers;
 import java.util.Map;
 import java.util.Set;
 
-abstract class TelemetryParser {
+class TelemetryParser {
 
-  // If an instrumentation module uses an instrumenter or telemetry class from another module, it
-  // might report telemetry with a different scope name, resulting in us excluding it. There are
-  // cases where we want to include this data, so we provide this way to override that exclusion
-  // filter. The key is the scope of the module being analyzed, the value is a set of additional
-  // allowed scopes.
-  protected static final Map<String, Set<String>> scopeAllowList =
+  // Key is the scope of the module being analyzed, value is a set of additional allowed scopes.
+  private static final Map<String, Set<String>> scopeAllowList =
       Map.of("io.opentelemetry.armeria-grpc-1.14", Set.of("io.opentelemetry.grpc-1.6"));
+
+  /**
+   * Checks if the given telemetry scope is valid for the specified module scope.
+   *
+   * <p>If an instrumentation module uses an instrumenter or telemetry class from another module, it
+   * might report telemetry with a different scope name, resulting in us excluding it. There are
+   * cases where we want to include this data, so we provide this way to override that exclusion
+   * filter.
+   *
+   * @param telemetryScope the scope of the telemetry signal
+   * @param moduleScope the scope of the module being analyzed
+   * @return true if the telemetry scope is valid for the module, false otherwise
+   */
+  static boolean scopeIsValid(String telemetryScope, String moduleScope) {
+    return telemetryScope.equals(moduleScope)
+        || scopeAllowList.getOrDefault(moduleScope, Set.of()).contains(telemetryScope);
+  }
+
+  private TelemetryParser() {}
 }


### PR DESCRIPTION
Related to #13468 

There are some instrumentations that use instrumenters or Telemetry classes from other instrumentation modules, and the resulting telemetry has a scope that does not match the instrumentation name. For example, the `armeria-grpc-1.14` instrumentation installs [Client](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcClientBuilderInstrumentation.java#L40) and server interceptors from the [grpc-1.6](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/grpc-1.6) instrumenation library, and therefore the resulting spans have a scope of `io.opentelemetry.grpc-1.6`

This causes issues with the `SpanParser` when trying to show telemetry emitted, because we are filtering out all telemetry signals that don't match the scope of the instrumentation module we are processing.

I think in cases like this, it's useful to have that telemetry documented, even if the scope doesn't match, since it is `armeria-grpc-1.14` installing those filters and enabling the telemetry.

So I added a new capability to specify a `scopeAllowList` so that you can define additional scopes to include in telemetry collection for a given scope (for example to allow showing the telemetry from `grpc-1.6` for `armeria-grpc-1.14`).