### PR TITLE
Add attribute to camel aws SNS assertions

### DIFF
--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_REQUEST_ID;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SNS_TOPIC_ARN;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
@@ -139,16 +140,18 @@ class AwsSpanAssertions {
                         v -> val.isInstanceOf(Number.class), v -> assertThat(v).isNull())));
   }
 
-  static SpanDataAssert sns(SpanDataAssert span, String spanName, String topicArn) {
+  static SpanDataAssert sns(
+      SpanDataAssert span, String spanName, String topicArn, String destinationName) {
     return span.hasName(spanName)
         .hasKind(CLIENT)
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("aws.agent"), "java-aws-sdk"),
             satisfies(AWS_REQUEST_ID, val -> val.isInstanceOf(String.class)),
+            equalTo(AWS_SNS_TOPIC_ARN, topicArn),
             equalTo(RPC_SYSTEM, "aws-api"),
             equalTo(RPC_METHOD, spanName.substring(4)),
             equalTo(RPC_SERVICE, "AmazonSNS"),
-            equalTo(MESSAGING_DESTINATION_NAME, topicArn),
+            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
             equalTo(HTTP_REQUEST_METHOD, "POST"),
             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
             satisfies(URL_FULL, val -> val.isInstanceOf(String.class)),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SnsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SnsCamelTest.java
@@ -55,10 +55,12 @@ class SnsCamelTest {
                 span -> AwsSpanAssertions.sqs(span, "SQS.ListQueues").hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sns(span, "SNS.ListTopics", null).hasNoParent()),
+                span -> AwsSpanAssertions.sns(span, "SNS.ListTopics", null, null).hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sns(span, "SNS.Publish", metaData.topicArn).hasNoParent(),
+                span ->
+                    AwsSpanAssertions.sns(span, "SNS.Publish", metaData.topicArn, metaData.topicArn)
+                        .hasNoParent(),
                 span ->
                     AwsSpanAssertions.sqs(
                             span,
@@ -107,13 +109,13 @@ class SnsCamelTest {
                 span -> AwsSpanAssertions.sqs(span, "SQS.ListQueues").hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sns(span, "SNS.ListTopics", null).hasNoParent()),
+                span -> AwsSpanAssertions.sns(span, "SNS.ListTopics", null, null).hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> CamelSpanAssertions.direct(span, "input"),
                 span -> CamelSpanAssertions.snsPublish(span, topicName).hasParent(trace.getSpan(0)),
                 span ->
-                    AwsSpanAssertions.sns(span, "SNS.Publish", metaData.topicArn)
+                    AwsSpanAssertions.sns(span, "SNS.Publish", metaData.topicArn, metaData.topicArn)
                         .hasParent(trace.getSpan(1)),
                 span ->
                     AwsSpanAssertions.sqs(
@@ -150,10 +152,13 @@ class SnsCamelTest {
                     AwsSpanAssertions.sqs(span, "SQS.SetQueueAttributes", queueUrl).hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sns(span, "SNS.CreateTopic", null).hasNoParent()),
+                span ->
+                    AwsSpanAssertions.sns(span, "SNS.CreateTopic", topicArn, null).hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sns(span, "SNS.Subscribe", topicArn).hasNoParent()));
+                span ->
+                    AwsSpanAssertions.sns(span, "SNS.Subscribe", topicArn, topicArn)
+                        .hasNoParent()));
     testing.clearData();
   }
 


### PR DESCRIPTION
#14035 added a new aws attribute, which are emitted by the camel tests. This SNS test is disabled, so our automation didn't pick up on the failure.

It was failing with: 

```
java.lang.AssertionError: [span [SNS.CreateTopic] attribute keys] 
Expecting actual:
  [aws.agent,
    aws.request_id,
    aws.sns.topic.arn,
    http.request.method,
    http.response.status_code,
    network.protocol.version,
    rpc.method,
    rpc.service,
    rpc.system,
    server.address,
    url.full]
to contain exactly in any order:
  [aws.agent,
    url.full,
    rpc.system,
    aws.request_id,
    server.address,
    rpc.service,
    http.response.status_code,
    http.request.method,
    rpc.method,
    network.protocol.version]
but the following elements were unexpected:
  [aws.sns.topic.arn]
```

Now passes locally:
<img width="488" height="121" alt="image" src="https://github.com/user-attachments/assets/ae97e0c8-ac2b-4f91-914b-3db39a9bde24" />

