### PR TITLE
Try to work around openj9 crash

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -339,6 +339,14 @@ val resourceClassesCsv = resourceNames.joinToString(",") { "io.opentelemetry.sdk
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
 
+  // work around jvm crash on openJ9 8 after updating armeria to 1.33.1
+  val testJavaVersion = gradle.startParameter.projectProperties["testJavaVersion"]?.let(JavaVersion::toVersion)
+  val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
+    ?: false
+  if (useJ9 && testJavaVersion != null && testJavaVersion.isJava8) {
+    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.setLong*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf._setLong*}")
+  }
+
   // There's no real harm in setting this for all tests even if any happen to not be using context
   // propagation.
   jvmArgs("-Dio.opentelemetry.context.enableStrictContext=${rootProject.findProperty("enableStrictContext") ?: true}")

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -344,7 +344,7 @@ tasks.withType<Test>().configureEach {
   val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
     ?: false
   if (useJ9 && testJavaVersion != null && testJavaVersion.isJava8) {
-    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*}")
+    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/AbstractByteBuf.*}")
   }
 
   // There's no real harm in setting this for all tests even if any happen to not be using context

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -344,7 +344,7 @@ tasks.withType<Test>().configureEach {
   val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
     ?: false
   if (useJ9 && testJavaVersion != null && testJavaVersion.isJava8) {
-    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.setLong*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf._setLong*}")
+    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*}")
   }
 
   // There's no real harm in setting this for all tests even if any happen to not be using context


### PR DESCRIPTION
After merging https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14430 openj9 jdk8 test crash while compiling certain netty methods. This PR disables jit compilation of the problematic methods. Alternative would be to revert the armeria update.