### PR TITLE
Tools linked

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,9 +66,9 @@ jobs:
         uses: github/codeql-action/init@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.8
         with:
           languages: ${{ matrix.language }}
-          # using "latest" helps to keep up with the latest Kotlin support
+          # using "linked" helps to keep up with the linked Kotlin support
           # see https://github.com/github/codeql-action/issues/1555#issuecomment-1452228433
-          tools: latest
+          tools: linked
 
       - name: Assemble
         if: matrix.language == 'java'


### PR DESCRIPTION
CodeQL is reporting:

```
`tools: latest` has been renamed to `tools: linked`, but the old name is still supported.
```