### PR TITLE
Switch approach to asserting not null when using satisfies()

### DIFF
--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
@@ -33,6 +33,7 @@ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import java.util.ArrayList;
 import java.util.List;
+import org.assertj.core.api.AbstractAssert;
 
 class AwsSpanAssertions {
 
@@ -106,12 +107,10 @@ class AwsSpanAssertions {
         attributeAssertions.add(equalTo(MESSAGING_OPERATION, "receive"));
       } else if (spanName.endsWith("process")) {
         attributeAssertions.add(equalTo(MESSAGING_OPERATION, "process"));
-        attributeAssertions.add(
-            satisfies(MESSAGING_MESSAGE_ID, val -> assertThat(val).isNotNull()));
+        attributeAssertions.add(satisfies(MESSAGING_MESSAGE_ID, AbstractAssert::isNotNull));
       } else if (spanName.endsWith("publish")) {
         attributeAssertions.add(equalTo(MESSAGING_OPERATION, "publish"));
-        attributeAssertions.add(
-            satisfies(MESSAGING_MESSAGE_ID, val -> assertThat(val).isNotNull()));
+        attributeAssertions.add(satisfies(MESSAGING_MESSAGE_ID, AbstractAssert::isNotNull));
       }
     }
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
@@ -246,7 +247,7 @@ public abstract class AbstractGrpcStreamingTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .satisfies(
                                 spanData ->
                                     assertThat(spanData.getEvents())

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -70,6 +70,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -175,7 +176,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -328,7 +329,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -493,7 +494,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -626,7 +627,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).isNotEmpty();
@@ -765,7 +766,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).hasSize(2);
@@ -1002,7 +1003,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1120,7 +1121,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1235,7 +1236,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1336,7 +1337,7 @@ public abstract class AbstractGrpcTest {
                                 equalTo(SERVER_PORT, server.getPort()),
                                 equalTo(NETWORK_TYPE, "ipv4"),
                                 equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                                satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()))
+                                satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1595,7 +1596,7 @@ public abstract class AbstractGrpcTest {
     if (Boolean.getBoolean("testLatestDeps")) {
       result.add(equalTo(NETWORK_TYPE, "ipv4"));
       result.add(equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
-      result.add(satisfies(NETWORK_PEER_PORT, val -> assertThat(val).isNotNull()));
+      result.add(satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull));
     }
     return result;
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/boot/SpringBootBasedTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/boot/SpringBootBasedTest.java
@@ -12,7 +12,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.spring.webmvc.boot.AbstractSpringBootBasedTest;
@@ -25,6 +24,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.Map;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -86,7 +86,7 @@ class SpringBootBasedTest extends AbstractSpringBootBasedTest {
                           equalTo(
                               EXCEPTION_TYPE,
                               "org.springframework.web.servlet.resource.NoResourceFoundException"),
-                          satisfies(EXCEPTION_MESSAGE, val -> assertThat(val).isNotNull()),
+                          satisfies(EXCEPTION_MESSAGE, AbstractAssert::isNotNull),
                           satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
       return span;
     } else {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/filter/ServletFilterTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/filter/ServletFilterTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.Map;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -70,7 +71,7 @@ class ServletFilterTest extends AbstractServletFilterTest {
                           equalTo(
                               EXCEPTION_TYPE,
                               "org.springframework.web.servlet.resource.NoResourceFoundException"),
-                          satisfies(EXCEPTION_MESSAGE, val -> assertThat(val).isNotNull()),
+                          satisfies(EXCEPTION_MESSAGE, AbstractAssert::isNotNull),
                           satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
       return span;
     } else {


### PR DESCRIPTION
While working on metadata for couchbase, I found that some of the assertions weren't working correctly. [These assertions ](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/Couchbase26Util.java#L54-L57)should have actually failed because the test suite wasn't setting the flag to enable experimental attributes.

In this example, it doesn't work as expected because `val` is an `StringAssert` object and is never null, so the test passes:

```java
  @Test
  void test() {
    testing().runWithSpan("test", () -> {});

    testing().waitAndAssertTraces(
        traceAssert -> traceAssert.hasSpansSatisfyingExactly(
            span -> span.hasName("test")
                .hasAttributesSatisfyingExactly(
                    satisfies(
                        stringKey("couchbase.local.address"),
                        val -> assertThat(val).isNotNull()))));
  }
```

You would need to use `val -> assertThat(val.actual()).isNotNull())` to get it to fail as expected, or more simply we can use `AbstractAssert::isNotNull`, like in:

```java
  @Test
  void test() {
    testing().runWithSpan("test", () -> {});

    testing().waitAndAssertTraces(
        traceAssert -> traceAssert.hasSpansSatisfyingExactly(
            span -> span.hasName("test")
                .hasAttributesSatisfyingExactly(
                    satisfies(
                        stringKey("couchbase.local.address"),
                        AbstractAssert::isNotNull))));
  }
```

This PR cleans up all usages except couchbase, because the couchbase ones require a bit more of a refactor, so that will come in a followup.