### PR TITLE
Fix non-lowercase messaging headers

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/CapturedMessageHeadersUtil.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/CapturedMessageHeadersUtil.java
@@ -5,31 +5,21 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-import static java.util.Collections.unmodifiableList;
-
 import io.opentelemetry.api.common.AttributeKey;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
 final class CapturedMessageHeadersUtil {
 
   private static final ConcurrentMap<String, AttributeKey<List<String>>> attributeKeysCache =
       new ConcurrentHashMap<>();
 
-  static List<String> lowercase(List<String> names) {
-    return unmodifiableList(
-        names.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList()));
-  }
-
   static AttributeKey<List<String>> attributeKey(String headerName) {
     return attributeKeysCache.computeIfAbsent(headerName, n -> createKey(n));
   }
 
   private static AttributeKey<List<String>> createKey(String headerName) {
-    // headerName is always lowercase, see MessagingAttributesExtractor
     String key = "messaging.header." + headerName.replace('-', '_');
     return AttributeKey.stringArrayKey(key);
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -13,6 +13,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -85,7 +86,7 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       List<String> capturedHeaders) {
     this.getter = getter;
     this.operation = operation;
-    this.capturedHeaders = CapturedMessageHeadersUtil.lowercase(capturedHeaders);
+    this.capturedHeaders = new ArrayList<>(capturedHeaders);
   }
 
   @Override

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -30,8 +30,8 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * Configures the messaging headers that will be captured as span attributes.
    *
    * <p>The messaging header values will be captured under the {@code messaging.header.<name>}
-   * attribute key. The {@code <name>} part in the attribute key is the normalized header name:
-   * lowercase, with dashes replaced by underscores.
+   * attribute key. The {@code <name>} part in the attribute key is the header name with dashes
+   * replaced by underscores.
    *
    * @param capturedHeaders A list of messaging header names.
    */

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("otel.instrumentation.aws-sdk.experimental-span-attributes", "true")
-    systemProperty("otel.instrumentation.messaging.experimental.capture-headers", "test-message-header")
+    systemProperty("otel.instrumentation.messaging.experimental.capture-headers", "Test-Message-Header")
   }
 
   val testReceiveSpansDisabled by registering(Test::class) {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
@@ -28,7 +28,7 @@ class SqsTracingTest extends AbstractSqsTracingTest {
         AwsSdkTelemetry.builder(testing().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
             .setMessagingReceiveInstrumentationEnabled(true)
-            .setCapturedHeaders(singletonList("test-message-header"))
+            .setCapturedHeaders(singletonList("Test-Message-Header"))
             .build()
             .newRequestHandler());
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -106,7 +106,7 @@ public abstract class AbstractSqsTracingTest {
 
     if (testCaptureHeaders) {
       sendMessageRequest.addMessageAttributesEntry(
-          "test-message-header",
+          "Test-Message-Header",
           new MessageAttributeValue().withDataType("String").withStringValue("test"));
     }
     sqsClient.sendMessage(sendMessageRequest);
@@ -114,7 +114,7 @@ public abstract class AbstractSqsTracingTest {
     ReceiveMessageRequest receiveMessageRequest =
         new ReceiveMessageRequest("http://localhost:" + sqsPort + "/000000000000/testSdkSqs");
     if (testCaptureHeaders) {
-      receiveMessageRequest.withMessageAttributeNames("test-message-header");
+      receiveMessageRequest.withMessageAttributeNames("Test-Message-Header");
     }
     ReceiveMessageResult receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
 
@@ -182,7 +182,7 @@ public abstract class AbstractSqsTracingTest {
                       if (testCaptureHeaders) {
                         attributes.add(
                             satisfies(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 val -> val.isEqualTo(singletonList("test"))));
                       }
 
@@ -222,7 +222,7 @@ public abstract class AbstractSqsTracingTest {
                       if (testCaptureHeaders) {
                         attributes.add(
                             satisfies(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 val -> val.isEqualTo(singletonList("test"))));
                       }
 
@@ -261,7 +261,7 @@ public abstract class AbstractSqsTracingTest {
                       if (testCaptureHeaders) {
                         attributes.add(
                             satisfies(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 val -> val.isEqualTo(singletonList("test"))));
                       }
                       span.hasName("testSdkSqs process")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -28,7 +28,7 @@ tasks {
   withType<Test>().configureEach {
     systemProperty("otel.instrumentation.aws-sdk.experimental-span-attributes", true)
     systemProperty("otel.instrumentation.aws-sdk.experimental-record-individual-http-error", true)
-    systemProperty("otel.instrumentation.messaging.experimental.capture-headers", "test-message-header")
+    systemProperty("otel.instrumentation.messaging.experimental.capture-headers", "Test-Message-Header")
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
@@ -33,7 +33,7 @@ abstract class Aws2SqsTracingTest extends AbstractAws2SqsTracingTest {
         AwsSdkTelemetry.builder(getTesting().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
             .setMessagingReceiveInstrumentationEnabled(true)
-            .setCapturedHeaders(singletonList("test-message-header"));
+            .setCapturedHeaders(singletonList("Test-Message-Header"));
 
     configure(telemetryBuilder);
     telemetry = telemetryBuilder.build();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                       if (captureHeaders) {
                         attributes.add(
                             satisfies(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 v -> v.isEqualTo(ImmutableList.of("test"))));
                       }
                       span.hasName("testSdkSqs publish")
@@ -163,7 +163,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                         if (captureHeaders) {
                           attributes.add(
                               satisfies(
-                                  stringArrayKey("messaging.header.test_message_header"),
+                                  stringArrayKey("messaging.header.Test_Message_Header"),
                                   v -> v.isEqualTo(ImmutableList.of("test"))));
                         }
 
@@ -201,7 +201,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                         if (captureHeaders) {
                           attributes.add(
                               satisfies(
-                                  stringArrayKey("messaging.header.test_message_header"),
+                                  stringArrayKey("messaging.header.Test_Message_Header"),
                                   v -> v.isEqualTo(singletonList("test"))));
                         }
 
@@ -238,13 +238,13 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
         sendMessageRequest.toBuilder()
             .messageAttributes(
                 Collections.singletonMap(
-                    "test-message-header",
+                    "Test-Message-Header",
                     MessageAttributeValue.builder().dataType("String").stringValue("test").build()))
             .build();
     client.sendMessage(newSendMessageRequest);
 
     ReceiveMessageRequest newReceiveMessageRequest =
-        receiveMessageRequest.toBuilder().messageAttributeNames("test-message-header").build();
+        receiveMessageRequest.toBuilder().messageAttributeNames("Test-Message-Header").build();
     ReceiveMessageResponse response = client.receiveMessage(newReceiveMessageRequest);
 
     assertThat(response.messages().size()).isEqualTo(1);

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -177,8 +177,8 @@ abstract class AbstractJms1Test {
     // given
     Destination destination = destinationFactory.create(session);
     TextMessage sentMessage = session.createTextMessage("a message");
-    sentMessage.setStringProperty("test_message_header", "test");
-    sentMessage.setIntProperty("test_message_int_header", 1234);
+    sentMessage.setStringProperty("Test_Message_Header", "test");
+    sentMessage.setIntProperty("Test_Message_Int_Header", 1234);
 
     MessageProducer producer = session.createProducer(destination);
     cleanup.deferCleanup(producer::close);
@@ -215,10 +215,10 @@ abstract class AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
                     span.hasName(destinationName + " process")
@@ -231,10 +231,10 @@ abstract class AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -191,8 +191,8 @@ abstract class AbstractJms3Test {
     // given
     Destination destination = destinationFactory.create(session);
     TextMessage sentMessage = session.createTextMessage("hello there");
-    sentMessage.setStringProperty("test_message_header", "test");
-    sentMessage.setIntProperty("test_message_int_header", 1234);
+    sentMessage.setStringProperty("Test_Message_Header", "test");
+    sentMessage.setIntProperty("Test_Message_Int_Header", 1234);
 
     MessageProducer producer = session.createProducer(destination);
     cleanup.deferCleanup(producer);
@@ -232,10 +232,10 @@ abstract class AbstractJms3Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
                     span.hasName(actualDestinationName + " process")
@@ -247,10 +247,10 @@ abstract class AbstractJms3Test {
                             equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -49,7 +49,7 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           if (testHeaders) {
             producerRecord
                 .headers()
-                .add("test-message-header", "test".getBytes(StandardCharsets.UTF_8));
+                .add("Test-Message-Header", "test".getBytes(StandardCharsets.UTF_8));
           }
           producer
               .send(
@@ -214,7 +214,7 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         () -> {
           ProducerRecord<Integer, String> producerRecord =
               new ProducerRecord<>(SHARED_TOPIC, 10, greeting);
-          producerRecord.headers().add("test-message-header", null);
+          producerRecord.headers().add("Test-Message-Header", null);
           producer
               .send(
                   producerRecord,
@@ -238,7 +238,7 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           () -> {
             assertThat(record.key()).isEqualTo(10);
             assertThat(record.value()).isEqualTo(greeting);
-            assertThat(record.headers().lastHeader("test-message-header").value()).isNull();
+            assertThat(record.headers().lastHeader("Test-Message-Header").value()).isNull();
           });
     }
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
@@ -188,7 +188,7 @@ public abstract class KafkaClientBaseTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -211,7 +211,7 @@ public abstract class KafkaClientBaseTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -249,7 +249,7 @@ public abstract class KafkaClientBaseTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
@@ -34,7 +34,7 @@ abstract class AbstractWrapperTest extends KafkaClientBaseTest {
   void testWrappers(boolean testHeaders) throws InterruptedException {
     KafkaTelemetryBuilder telemetryBuilder =
         KafkaTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedHeaders(singletonList("test-message-header"))
+            .setCapturedHeaders(singletonList("Test-Message-Header"))
             // TODO run tests both with and without experimental span attributes
             .setCaptureExperimentalSpanAttributes(true);
     configure(telemetryBuilder);
@@ -50,7 +50,7 @@ abstract class AbstractWrapperTest extends KafkaClientBaseTest {
           if (testHeaders) {
             producerRecord
                 .headers()
-                .add("test-message-header", "test".getBytes(StandardCharsets.UTF_8));
+                .add("Test-Message-Header", "test".getBytes(StandardCharsets.UTF_8));
           }
           wrappedProducer.send(
               producerRecord,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -73,7 +73,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -100,7 +100,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -96,7 +96,7 @@ class WrapperTest extends AbstractWrapperTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -123,7 +123,7 @@ class WrapperTest extends AbstractWrapperTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -143,7 +143,7 @@ class WrapperTest extends AbstractWrapperTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -363,7 +363,7 @@ abstract class AbstractPulsarClientTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     int partitionIndex = TopicName.getPartitionIndex(destination);
@@ -399,7 +399,7 @@ abstract class AbstractPulsarClientTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     if (isBatch) {
@@ -426,7 +426,7 @@ abstract class AbstractPulsarClientTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     int partitionIndex = TopicName.getPartitionIndex(destination);

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
@@ -215,7 +215,7 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
     MessageId msgId =
         testing.runWithSpan(
             "parent",
-            () -> producer.newMessage().value(msg).property("test-message-header", "test").send());
+            () -> producer.newMessage().value(msg).property("Test-Message-Header", "test").send());
 
     latch.await(1, TimeUnit.MINUTES);
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -431,7 +431,7 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     MessageId msgId =
         testing.runWithSpan(
             "parent",
-            () -> producer.newMessage().value(msg).property("test-message-header", "test").send());
+            () -> producer.newMessage().value(msg).property("Test-Message-Header", "test").send());
 
     latch.await(1, TimeUnit.MINUTES);
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqTest.java
@@ -513,7 +513,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
   void captureMessageHeaderAsSpanAttributes() throws IOException, InterruptedException {
     String queueName = channel.queueDeclare().getQueue();
     Map<String, Object> headers = new java.util.HashMap<>();
-    headers.put("test-message-header", "test");
+    headers.put("Test_Message_Header", "test");
     AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder().headers(headers).build();
     channel.basicPublish(
         "", queueName, properties, "Hello, world!".getBytes(Charset.defaultCharset()));
@@ -555,7 +555,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                                   List<String> verifyHeaders =
                                       attrs.get(
                                           AttributeKey.stringArrayKey(
-                                              "messaging.header.test_message_header"));
+                                              "messaging.header.Test_Message_Header"));
                                   assertNotNull(verifyHeaders);
                                   assertTrue(verifyHeaders.contains("test"));
                                 });
@@ -579,7 +579,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                                   List<String> verifyHeaders =
                                       attrs.get(
                                           AttributeKey.stringArrayKey(
-                                              "messaging.header.test_message_header"));
+                                              "messaging.header.Test_Message_Header"));
                                   assertNotNull(verifyHeaders);
                                   assertTrue(verifyHeaders.contains("test"));
                                 });

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqClientTest.java
@@ -31,7 +31,7 @@ class RocketMqClientTest extends AbstractRocketMqClientTest {
         .getDefaultMQProducerImpl()
         .registerSendMessageHook(
             RocketMqTelemetry.builder(testing.getOpenTelemetry())
-                .setCapturedHeaders(singletonList("test-message-header"))
+                .setCapturedHeaders(singletonList("Test-Message-Header"))
                 .setCaptureExperimentalSpanAttributes(true)
                 .build()
                 .newTracingSendMessageHook());
@@ -45,7 +45,7 @@ class RocketMqClientTest extends AbstractRocketMqClientTest {
         .getDefaultMQPushConsumerImpl()
         .registerConsumeMessageHook(
             RocketMqTelemetry.builder(testing.getOpenTelemetry())
-                .setCapturedHeaders(singletonList("test-message-header"))
+                .setCapturedHeaders(singletonList("Test-Message-Header"))
                 .setCaptureExperimentalSpanAttributes(true)
                 .build()
                 .newTracingConsumeMessageHook());

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
@@ -377,7 +377,7 @@ abstract class AbstractRocketMqClientTest {
               Message msg =
                   new Message(
                       sharedTopic, "TagA", "Hello RocketMQ".getBytes(Charset.defaultCharset()));
-              msg.putUserProperty("test-message-header", "test");
+              msg.putUserProperty("Test-Message-Header", "test");
               SendResult sendResult = producer.send(msg);
               assertEquals(
                   SendStatus.SEND_OK, sendResult.getSendStatus(), "Send status should be SEND_OK");
@@ -409,7 +409,7 @@ abstract class AbstractRocketMqClientTest {
                                     "SEND_OK"),
                                 equalTo(
                                     AttributeKey.stringArrayKey(
-                                        "messaging.header.test_message_header"),
+                                        "messaging.header.Test_Message_Header"),
                                     singletonList("test"))),
                     span ->
                         span.hasName(sharedTopic + " process")
@@ -436,7 +436,7 @@ abstract class AbstractRocketMqClientTest {
                                     val -> val.isInstanceOf(Long.class)),
                                 equalTo(
                                     AttributeKey.stringArrayKey(
-                                        "messaging.header.test_message_header"),
+                                        "messaging.header.Test_Message_Header"),
                                     singletonList("test"))),
                     span ->
                         span.hasName("messageListener")

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -348,7 +348,7 @@ public abstract class AbstractRocketMqClientTest {
             .setTag(tag)
             .setKeys(keys)
             .setBody(body)
-            .addProperty("test-message-header", "test")
+            .addProperty("Test-Message-Header", "test")
             .build();
 
     SendReceipt sendReceipt =
@@ -372,7 +372,7 @@ public abstract class AbstractRocketMqClientTest {
                               sendReceipt,
                               equalTo(
                                   AttributeKey.stringArrayKey(
-                                      "messaging.header.test_message_header"),
+                                      "messaging.header.Test_Message_Header"),
                                   Collections.singletonList("test")))
                           .hasParent(trace.getSpan(0)));
               sendSpanData.set(trace.getSpan(1));
@@ -392,7 +392,7 @@ public abstract class AbstractRocketMqClientTest {
                                 sendReceipt,
                                 equalTo(
                                     AttributeKey.stringArrayKey(
-                                        "messaging.header.test_message_header"),
+                                        "messaging.header.Test_Message_Header"),
                                     Collections.singletonList("test")))
                             // As the child of receive span.
                             .hasParent(trace.getSpan(0)),

--- a/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/GlobalInterceptorSpringConfig.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/GlobalInterceptorSpringConfig.java
@@ -21,7 +21,7 @@ class GlobalInterceptorSpringConfig {
   @Bean
   ChannelInterceptor otelInterceptor() {
     return SpringIntegrationTelemetry.builder(GlobalOpenTelemetry.get())
-        .setCapturedHeaders(singletonList("test-message-header"))
+        .setCapturedHeaders(singletonList("Test-Message-Header"))
         .build()
         .newChannelInterceptor();
   }

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
@@ -182,7 +182,7 @@ abstract class AbstractSpringIntegrationTracingTest {
     channel.subscribe(messageHandler);
 
     channel.send(
-        MessageBuilder.withPayload("test").setHeader("test-message-header", "test").build());
+        MessageBuilder.withPayload("test").setHeader("Test-Message-Header", "test").build());
 
     Message<?> capturedMessage = messageHandler.join();
 

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
@@ -224,8 +224,8 @@ class SpringTemplateTest extends AbstractJmsTest {
         new MessagePostProcessor() {
           @Override
           public @NotNull Message postProcessMessage(@NotNull Message message) throws JMSException {
-            message.setStringProperty("test_message_header", "test");
-            message.setIntProperty("test_message_int_header", 1234);
+            message.setStringProperty("Test_Message_Header", "test");
+            message.setIntProperty("Test_Message_Int_Header", 1234);
             return message;
           }
         });

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
@@ -53,11 +53,11 @@ public abstract class AbstractJmsTest {
     if (testHeaders) {
       attributeAssertions.add(
           equalTo(
-              stringArrayKey("messaging.header.test_message_header"),
+              stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
       attributeAssertions.add(
           equalTo(
-              stringArrayKey("messaging.header.test_message_int_header"),
+              stringArrayKey("messaging.header.Test_Message_Int_Header"),
               Collections.singletonList("1234")));
     }
     return attributeAssertions;
@@ -105,11 +105,11 @@ public abstract class AbstractJmsTest {
     if (testHeaders) {
       attributeAssertions.add(
           equalTo(
-              stringArrayKey("messaging.header.test_message_header"),
+              stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
       attributeAssertions.add(
           equalTo(
-              stringArrayKey("messaging.header.test_message_int_header"),
+              stringArrayKey("messaging.header.Test_Message_Int_Header"),
               Collections.singletonList("1234")));
     }
     return attributeAssertions;

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -104,8 +104,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                 "spring-jms-listener",
                 message,
                 jmsMessage -> {
-                  jmsMessage.setStringProperty("test_message_header", "test");
-                  jmsMessage.setIntProperty("test_message_int_header", 1234);
+                  jmsMessage.setStringProperty("Test_Message_Header", "test");
+                  jmsMessage.setIntProperty("Test_Message_Int_Header", 1234);
                   return jmsMessage;
                 }));
 
@@ -129,10 +129,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             equalTo(MESSAGING_OPERATION, "publish"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234")))),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -146,10 +146,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             equalTo(MESSAGING_OPERATION, "receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
                     span.hasName("spring-jms-listener process")
@@ -161,10 +161,10 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_header"),
+                                stringArrayKey("messaging.header.Test_Message_Header"),
                                 singletonList("test")),
                             equalTo(
-                                stringArrayKey("messaging.header.test_message_int_header"),
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -130,7 +130,7 @@ public class SpringRabbitMqTest {
     if (testHeaders) {
       assertions.add(
           equalTo(
-              AttributeKey.stringArrayKey("messaging.header.test_message_header"),
+              AttributeKey.stringArrayKey("messaging.header.Test_Message_Header"),
               Collections.singletonList("test")));
     }
     return assertions;
@@ -151,7 +151,7 @@ public class SpringRabbitMqTest {
                         ConsumerConfig.TEST_QUEUE,
                         "test",
                         message -> {
-                          message.getMessageProperties().setHeader("test-message-header", "test");
+                          message.getMessageProperties().setHeader("Test-Message-Header", "test");
                           return message;
                         });
               } else {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/messaging/CapturedMessagingHeadersTestConfigSupplier.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/messaging/CapturedMessagingHeadersTestConfigSupplier.java
@@ -25,10 +25,10 @@ public class CapturedMessagingHeadersTestConfigSupplier
     Map<String, String> testConfig = new HashMap<>();
     testConfig.put(
         "otel.instrumentation.messaging.experimental.capture-headers",
-        // most tests use "test-message-header", "test_message_header" is used for JMS2+ because
+        // most tests use "Test-Message-Header". "Test_Message_Header" is used for JMS2+ because
         // '-' is not allowed in a JMS property name. JMS property name should be a valid java
         // identifier.
-        "test-message-header, test-message-int-header, test_message_header, test_message_int_header");
+        "Test-Message-Header, Test-Message-Int-Header, Test_Message_Header, Test_Message_Int_Header");
     return testConfig;
   }
 }


### PR DESCRIPTION
Resolves #14473

While HTTP headers are case insensitive by the HTTP specification, I don't believe messaging headers are.

I don't think removing the case normalization is breaking since it doesn't seem like non-lowercase messaging headers ever worked at all previously.

Probably we should also remove `-` to `_` normalization (similar to what was done for HTTP headers), but that would be breaking so may want to wait for 3.0 for that.