### PR TITLE
Remove StringUtils usage from build script

### DIFF
--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
-import org.apache.commons.lang.StringUtils
 
 plugins {
   id("otel.spotless-conventions")
@@ -105,7 +104,7 @@ tasks {
           continue
         }
         println(server)
-        val serverName = StringUtils.capitalize(server)
+        val serverName = server.replaceFirstChar(Char::uppercase)
         for (entry in matrices) {
           for (version in entry.version) {
             val dotIndex = version.indexOf('.')


### PR DESCRIPTION
StringUtils from commons lang being available in build script is a coincidence. I'll remove it in a separate PR.