### PR TITLE
Add task dependency to quarkus smoke test image

### DIFF
--- a/smoke-tests/images/quarkus/build.gradle.kts
+++ b/smoke-tests/images/quarkus/build.gradle.kts
@@ -62,6 +62,10 @@ tasks {
     dependsOn(quarkusBuild)
   }
 
+  compileJava {
+    dependsOn(compileQuarkusGeneratedSourcesJava)
+  }
+
   sourcesJar {
     dependsOn(quarkusGenerateCode, compileQuarkusGeneratedSourcesJava)
   }


### PR DESCRIPTION
Gradle 9 requires adding an extra task dependency