### PR TITLE
Change branch name used in metadata update github action

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
-          BRANCH_NAME="metadata-update-main"
+          BRANCH_NAME="otelbot/metadata-update-main"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
           if git ls-remote --exit-code --heads origin "$BRANCH_NAME"; then
             git fetch origin "$BRANCH_NAME"


### PR DESCRIPTION
[Last night's run failed](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/17169551141/job/48716520045) with:

```
Run BRANCH_NAME="metadata-update-main"
[metadata-update-main b2dd798] chore: update instrumentation list [automated]
 1 file changed, 8 insertions(+)
remote: error: GH013: Repository rule violations found for refs/heads/metadata-update-main.        
remote: Review all repository rules at https://github.com/open-telemetry/opentelemetry-java-instrumentation/rules?ref=refs%2Fheads%2Fmetadata-update-main        
remote: 
remote: - Required status check "EasyCLA" is expected.        
remote: 
To https://github.com/open-telemetry/opentelemetry-java-instrumentation
 ! [remote rejected] metadata-update-main -> metadata-update-main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/open-telemetry/opentelemetry-java-instrumentation'
Error: Process completed with exit code 1.
```

Added `otelbot/` to the branch name to follow the pattern used elsewhere to bypass this check