### PR TITLE
Metadata for instrumentations starting with G

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -2873,20 +2873,94 @@ libraries:
           type: STRING
   geode:
   - name: geode-1.4
+    description: This instrumentation enables database CLIENT spans and metrics for
+      Apache Geode cache operations.
     source_path: instrumentation/geode-1.4
     scope:
       name: io.opentelemetry.geode-1.4
     target_versions:
       javaagent:
       - org.apache.geode:geode-core:[1.4.0,)
+    configurations:
+    - name: otel.instrumentation.common.db-statement-sanitizer.enabled
+      description: Enables statement sanitization for database queries.
+      type: boolean
+      default: true
+    telemetry:
+    - when: default
+      spans:
+      - span_kind: CLIENT
+        attributes:
+        - name: db.name
+          type: STRING
+        - name: db.operation
+          type: STRING
+        - name: db.statement
+          type: STRING
+        - name: db.system
+          type: STRING
+    - when: otel.semconv-stability.opt-in=database
+      metrics:
+      - name: db.client.operation.duration
+        description: Duration of database client operations.
+        type: HISTOGRAM
+        unit: s
+        attributes:
+        - name: db.namespace
+          type: STRING
+        - name: db.operation.name
+          type: STRING
+        - name: db.system.name
+          type: STRING
+      spans:
+      - span_kind: CLIENT
+        attributes:
+        - name: db.namespace
+          type: STRING
+        - name: db.operation.name
+          type: STRING
+        - name: db.query.text
+          type: STRING
+        - name: db.system.name
+          type: STRING
   google:
   - name: google-http-client-1.19
+    description: This instrumentation enables HTTP CLIENT spans and metrics for Google
+      HTTP Client requests.
     source_path: instrumentation/google-http-client-1.19
     scope:
       name: io.opentelemetry.google-http-client-1.19
     target_versions:
       javaagent:
       - com.google.http-client:google-http-client:[1.19.0,)
+    configurations:
+    - name: otel.instrumentation.http.known-methods
+      description: |
+        Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+      type: list
+      default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+    - name: otel.instrumentation.http.client.capture-request-headers
+      description: List of HTTP request headers to capture in HTTP client telemetry.
+      type: list
+      default: ''
+    - name: otel.instrumentation.http.client.capture-response-headers
+      description: List of HTTP response headers to capture in HTTP client telemetry.
+      type: list
+      default: ''
+    - name: otel.instrumentation.common.peer-service-mapping
+      description: Used to specify a mapping from host names or IP addresses to peer
+        services.
+      type: map
+      default: ''
+    - name: otel.instrumentation.http.client.emit-experimental-telemetry
+      description: |
+        Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+      type: boolean
+      default: false
+    - name: otel.instrumentation.http.client.experimental.redact-query-parameters
+      description: Redact sensitive URL parameters. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+      type: boolean
+      default: true
     telemetry:
     - when: default
       metrics:
@@ -2920,12 +2994,24 @@ libraries:
           type: STRING
   grails:
   - name: grails-3.0
+    description: |
+      This instrumentation enriches existing SERVER spans with route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
     source_path: instrumentation/grails-3.0
     scope:
       name: io.opentelemetry.grails-3.0
     target_versions:
       javaagent:
       - org.grails:grails-web-url-mappings:[3.0,)
+    configurations:
+    - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+      description: Enables the creation of experimental controller (INTERNAL) spans.
+      type: boolean
+      default: false
+    telemetry:
+    - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+      spans:
+      - span_kind: INTERNAL
+        attributes: []
   graphql:
   - name: graphql-java-12.0
     source_path: instrumentation/graphql-java/graphql-java-12.0
@@ -2948,12 +3034,85 @@ libraries:
       - com.graphql-java:graphql-java:20.0
   grizzly:
   - name: grizzly-2.3
+    description: This instrumentation enables HTTP SERVER spans and metrics for Grizzly
+      applications.
     source_path: instrumentation/grizzly-2.3
     scope:
       name: io.opentelemetry.grizzly-2.3
     target_versions:
       javaagent:
       - org.glassfish.grizzly:grizzly-http:[2.3,)
+    configurations:
+    - name: otel.instrumentation.http.known-methods
+      description: |
+        Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+      type: list
+      default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+    - name: otel.instrumentation.http.server.capture-request-headers
+      description: List of HTTP request headers to capture in HTTP server telemetry.
+      type: list
+      default: ''
+    - name: otel.instrumentation.http.server.capture-response-headers
+      description: List of HTTP response headers to capture in HTTP server telemetry.
+      type: list
+      default: ''
+    - name: otel.instrumentation.common.peer-service-mapping
+      description: Used to specify a mapping from host names or IP addresses to peer
+        services.
+      type: map
+      default: ''
+    - name: otel.instrumentation.http.server.emit-experimental-telemetry
+      description: |
+        Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+      type: boolean
+      default: false
+    telemetry:
+    - when: default
+      metrics:
+      - name: http.server.request.duration
+        description: Duration of HTTP server requests.
+        type: HISTOGRAM
+        unit: s
+        attributes:
+        - name: http.request.method
+          type: STRING
+        - name: http.response.status_code
+          type: LONG
+        - name: network.protocol.version
+          type: STRING
+        - name: url.scheme
+          type: STRING
+      spans:
+      - span_kind: SERVER
+        attributes:
+        - name: client.address
+          type: STRING
+        - name: error.type
+          type: STRING
+        - name: http.request.method
+          type: STRING
+        - name: http.request.method_original
+          type: STRING
+        - name: http.response.status_code
+          type: LONG
+        - name: network.peer.address
+          type: STRING
+        - name: network.peer.port
+          type: LONG
+        - name: network.protocol.version
+          type: STRING
+        - name: server.address
+          type: STRING
+        - name: server.port
+          type: LONG
+        - name: url.path
+          type: STRING
+        - name: url.query
+          type: STRING
+        - name: url.scheme
+          type: STRING
+        - name: user_agent.original
+          type: STRING
   grpc:
   - name: grpc-1.6
     source_path: instrumentation/grpc-1.6
@@ -2976,6 +3135,7 @@ libraries:
       - com.google.guava:guava:10.0
   gwt:
   - name: gwt-2.0
+    description: This instrumentation enables SERVER spans for GWT RPC requests.
     source_path: instrumentation/gwt-2.0
     scope:
       name: io.opentelemetry.gwt-2.0
@@ -2983,6 +3143,17 @@ libraries:
       javaagent:
       - com.google.gwt:gwt-servlet:[2.0.0,)
       - org.gwtproject:gwt-servlet:[2.10.0,)
+    telemetry:
+    - when: default
+      spans:
+      - span_kind: SERVER
+        attributes:
+        - name: rpc.method
+          type: STRING
+        - name: rpc.service
+          type: STRING
+        - name: rpc.system
+          type: STRING
   hibernate:
   - name: hibernate-3.3
     source_path: instrumentation/hibernate/hibernate-3.3

--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -132,6 +132,11 @@ readonly INSTRUMENTATIONS=(
   "couchbase:couchbase-2.6:javaagent:testStableSemconv"
   "couchbase:couchbase-2.6:javaagent:testExperimental"
   "dropwizard:dropwizard-views-0.7:javaagent:test"
+  "geode-1.4:javaagent:test"
+  "geode-1.4:javaagent:testStableSemconv"
+  "grails-3.0:javaagent:test"
+  "grizzly-2.3:javaagent:test"
+  "gwt-2.0:javaagent:test"
 )
 
 #  Some instrumentation test suites don't run ARM, so we use colima to run them in an x86_64

--- a/instrumentation/geode-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/geode-1.4/javaagent/build.gradle.kts
@@ -17,9 +17,18 @@ dependencies {
   annotationProcessor("com.google.auto.value:auto-value")
 }
 
+val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
+
 tasks {
   val testStableSemconv by registering(Test::class) {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
+
+    systemProperty("collectMetadata", collectMetadata)
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
+  }
+
+  test {
+    systemProperty("collectMetadata", collectMetadata)
   }
 
   check {

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/PutGetTest.java
@@ -5,12 +5,16 @@
 
 package io.opentelemetry.javaagent.instrumentation.geode;
 
+import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,6 +54,15 @@ class PutGetTest {
         Arguments.of("Humpty", "Dumpty"),
         Arguments.of(Integer.valueOf(1), "One"),
         Arguments.of("One", Integer.valueOf(1)));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void testDurationMetric() {
+    region.put("key", "value");
+
+    assertDurationMetric(
+        testing, "io.opentelemetry.geode-1.4", DB_SYSTEM_NAME, DB_NAMESPACE, DB_OPERATION_NAME);
   }
 
   @ParameterizedTest

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -1,0 +1,6 @@
+description: This instrumentation enables database CLIENT spans and metrics for Apache Geode cache operations.
+configurations:
+  - name: otel.instrumentation.common.db-statement-sanitizer.enabled
+    description: Enables statement sanitization for database queries.
+    type: boolean
+    default: true

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -1,0 +1,31 @@
+description: This instrumentation enables HTTP CLIENT spans and metrics for Google HTTP Client requests.
+configurations:
+  - name: otel.instrumentation.http.known-methods
+    description: >
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
+      other methods will be treated as `_OTHER`.
+    type: list
+    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - name: otel.instrumentation.http.client.capture-request-headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ""
+  - name: otel.instrumentation.http.client.capture-response-headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ""
+  - name: otel.instrumentation.common.peer-service-mapping
+    description: Used to specify a mapping from host names or IP addresses to peer services.
+    type: map
+    default: ""
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    description: >
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
+      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
+      `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.client.experimental.redact-query-parameters
+    description: Redact sensitive URL parameters. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: boolean
+    default: true

--- a/instrumentation/grails-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/grails-3.0/javaagent/build.gradle.kts
@@ -81,5 +81,8 @@ tasks {
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
     jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+
+    systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+    systemProperty("metadataConfig", "otel.instrumentation.common.experimental.controller-telemetry.enabled=true")
   }
 }

--- a/instrumentation/grails-3.0/metadata.yaml
+++ b/instrumentation/grails-3.0/metadata.yaml
@@ -1,0 +1,8 @@
+description: >
+  This instrumentation enriches existing SERVER spans with route information, and optionally enables
+  experimental controller (INTERNAL) spans for Grails applications.
+configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    description: Enables the creation of experimental controller (INTERNAL) spans.
+    type: boolean
+    default: false

--- a/instrumentation/grizzly-2.3/javaagent/build.gradle.kts
+++ b/instrumentation/grizzly-2.3/javaagent/build.gradle.kts
@@ -24,6 +24,7 @@ tasks {
     // required on jdk17
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+    systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
 }
 

--- a/instrumentation/grizzly-2.3/metadata.yaml
+++ b/instrumentation/grizzly-2.3/metadata.yaml
@@ -1,0 +1,27 @@
+description: This instrumentation enables HTTP SERVER spans and metrics for Grizzly applications.
+configurations:
+  - name: otel.instrumentation.http.known-methods
+    description: >
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
+      other methods will be treated as `_OTHER`.
+    type: list
+    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - name: otel.instrumentation.http.server.capture-request-headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ""
+  - name: otel.instrumentation.http.server.capture-response-headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ""
+  - name: otel.instrumentation.common.peer-service-mapping
+    description: Used to specify a mapping from host names or IP addresses to peer services.
+    type: map
+    default: ""
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    description: >
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and
+      `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
+      and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -120,4 +120,5 @@ tasks.withType<Test>().configureEach {
   // required on jdk17
   jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+  systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
 }

--- a/instrumentation/gwt-2.0/metadata.yaml
+++ b/instrumentation/gwt-2.0/metadata.yaml
@@ -1,0 +1,1 @@
+description: This instrumentation enables SERVER spans for GWT RPC requests.


### PR DESCRIPTION
Part of #13468 and #14096

Adds another batch of metadata/telemetry collection for more instrumentations. The other modules that begin with "G" will require some changes to the test suites, so I will handle those in a followup.