### PR TITLE
Metadata for graphql-java

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -3014,6 +3014,7 @@ libraries:
         attributes: []
   graphql:
   - name: graphql-java-12.0
+    description: This instrumentation enables spans for GraphQL Java operations.
     source_path: instrumentation/graphql-java/graphql-java-12.0
     scope:
       name: io.opentelemetry.graphql-java-12.0
@@ -3022,7 +3023,30 @@ libraries:
       - com.graphql-java:graphql-java:[12,20)
       library:
       - com.graphql-java:graphql-java:[12.0,19.+)
+    configurations:
+    - name: otel.instrumentation.graphql.query-sanitizer.enabled
+      description: Enables sanitization of sensitive information from queries so they
+        aren't added as span attributes.
+      type: boolean
+      default: true
+    - name: otel.instrumentation.graphql.add-operation-name-to-span-name.enabled
+      description: |
+        Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
+      type: boolean
+      default: false
+    telemetry:
+    - when: default
+      spans:
+      - span_kind: INTERNAL
+        attributes:
+        - name: graphql.document
+          type: STRING
+        - name: graphql.operation.name
+          type: STRING
+        - name: graphql.operation.type
+          type: STRING
   - name: graphql-java-20.0
+    description: This instrumentation enables spans for GraphQL Java operations.
     source_path: instrumentation/graphql-java/graphql-java-20.0
     minimum_java_version: 11
     scope:
@@ -3032,6 +3056,51 @@ libraries:
       - com.graphql-java:graphql-java:[20,)
       library:
       - com.graphql-java:graphql-java:20.0
+    configurations:
+    - name: otel.instrumentation.graphql.query-sanitizer.enabled
+      description: Enables sanitization of sensitive information from queries so they
+        aren't added as span attributes.
+      type: boolean
+      default: true
+    - name: otel.instrumentation.graphql.add-operation-name-to-span-name.enabled
+      description: |
+        Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
+      type: boolean
+      default: false
+    - name: otel.instrumentation.graphql.data-fetcher.enabled
+      description: Enables span generation for data fetchers.
+      type: boolean
+      default: false
+    - name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
+      description: Whether to create spans for trivial data fetchers. A trivial data
+        fetcher is one that simply maps data from an object to a field.
+      type: boolean
+      default: false
+    telemetry:
+    - when: default
+      spans:
+      - span_kind: INTERNAL
+        attributes:
+        - name: graphql.document
+          type: STRING
+        - name: graphql.operation.name
+          type: STRING
+        - name: graphql.operation.type
+          type: STRING
+    - when: otel.instrumentation.graphql.data-fetcher.enabled=true
+      spans:
+      - span_kind: INTERNAL
+        attributes:
+        - name: graphql.document
+          type: STRING
+        - name: graphql.field.name
+          type: STRING
+        - name: graphql.field.path
+          type: STRING
+        - name: graphql.operation.name
+          type: STRING
+        - name: graphql.operation.type
+          type: STRING
   grizzly:
   - name: grizzly-2.3
     description: This instrumentation enables HTTP SERVER spans and metrics for Grizzly

--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -137,6 +137,9 @@ readonly INSTRUMENTATIONS=(
   "grails-3.0:javaagent:test"
   "grizzly-2.3:javaagent:test"
   "gwt-2.0:javaagent:test"
+  "graphql-java:graphql-java-12.0:javaagent:test"
+  "graphql-java:graphql-java-20.0:javaagent:test"
+  "graphql-java:graphql-java-20.0:javaagent:testDataFetcher"
 )
 
 #  Some instrumentation test suites don't run ARM, so we use colima to run them in an x86_64

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/build.gradle.kts
@@ -27,4 +27,6 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.graphql.add-operation-name-to-span-name.enabled=true")
+
+  systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
 }

--- a/instrumentation/graphql-java/graphql-java-12.0/metadata.yaml
+++ b/instrumentation/graphql-java/graphql-java-12.0/metadata.yaml
@@ -1,0 +1,13 @@
+description: This instrumentation enables spans for GraphQL Java operations.
+configurations:
+  - name: otel.instrumentation.graphql.query-sanitizer.enabled
+    description: Enables sanitization of sensitive information from queries so they aren't added as span attributes.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.add-operation-name-to-span-name.enabled
+    description: >
+      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is
+      provided by the client and can have high cardinality. Use only when the server is not exposed to malicious
+      clients.
+    type: boolean
+    default: false

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
@@ -23,9 +23,20 @@ dependencies {
   testImplementation(project(":instrumentation:graphql-java:graphql-java-common:testing"))
 }
 
-tasks.withType<Test>().configureEach {
-  jvmArgs("-Dotel.instrumentation.graphql.data-fetcher.enabled=true")
-  jvmArgs("-Dotel.instrumentation.graphql.add-operation-name-to-span-name.enabled=true")
+tasks {
+  withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.graphql.add-operation-name-to-span-name.enabled=true")
+    systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+  }
+
+  val testDataFetcher by registering(Test::class) {
+    jvmArgs("-Dotel.instrumentation.graphql.data-fetcher.enabled=true")
+    systemProperty("metadataConfig", "otel.instrumentation.graphql.data-fetcher.enabled=true")
+  }
+
+  check {
+    dependsOn(testDataFetcher)
+  }
 }
 
 if (findProperty("testLatestDeps") as Boolean) {

--- a/instrumentation/graphql-java/graphql-java-20.0/metadata.yaml
+++ b/instrumentation/graphql-java/graphql-java-20.0/metadata.yaml
@@ -1,0 +1,21 @@
+description: This instrumentation enables spans for GraphQL Java operations.
+configurations:
+  - name: otel.instrumentation.graphql.query-sanitizer.enabled
+    description: Enables sanitization of sensitive information from queries so they aren't added as span attributes.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.add-operation-name-to-span-name.enabled
+    description: >
+      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is
+      provided by the client and can have high cardinality. Use only when the server is not exposed to malicious
+      clients.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.graphql.data-fetcher.enabled
+    description: Enables span generation for data fetchers.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
+    description: Whether to create spans for trivial data fetchers. A trivial data fetcher is one that simply maps data from an object to a field.
+    type: boolean
+    default: false

--- a/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
@@ -44,6 +44,9 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractGraphqlTest {
 
+  private static final String DATA_FETCHER_PROPERTY =
+      "otel.instrumentation.graphql.data-fetcher.enabled";
+
   private final List<Map<String, String>> books = new ArrayList<>();
   private final List<Map<String, String>> authors = new ArrayList<>();
 
@@ -56,6 +59,10 @@ public abstract class AbstractGraphqlTest {
 
   protected boolean hasDataFetcherSpans() {
     return false;
+  }
+
+  private boolean includeDataFetcher() {
+    return Boolean.getBoolean(DATA_FETCHER_PROPERTY) && hasDataFetcherSpans();
   }
 
   @BeforeAll
@@ -162,7 +169,7 @@ public abstract class AbstractGraphqlTest {
                               normalizedQueryEqualsTo(
                                   GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
                                   "query findBookById { bookById(id: ?) { name } }")));
-              if (hasDataFetcherSpans()) {
+              if (includeDataFetcher()) {
                 assertions.add(
                     span ->
                         span.hasName("bookById")
@@ -174,7 +181,7 @@ public abstract class AbstractGraphqlTest {
               assertions.add(
                   span ->
                       span.hasName("fetchBookById")
-                          .hasParent(trace.getSpan(hasDataFetcherSpans() ? 1 : 0)));
+                          .hasParent(trace.getSpan(includeDataFetcher() ? 1 : 0)));
 
               trace.hasSpansSatisfyingExactly(assertions);
             });
@@ -207,7 +214,7 @@ public abstract class AbstractGraphqlTest {
                               normalizedQueryEqualsTo(
                                   AttributeKey.stringKey("graphql.document"),
                                   "{ bookById(id: ?) { name } }")));
-              if (hasDataFetcherSpans()) {
+              if (includeDataFetcher()) {
                 assertions.add(
                     span ->
                         span.hasName("bookById")
@@ -219,7 +226,7 @@ public abstract class AbstractGraphqlTest {
               assertions.add(
                   span ->
                       span.hasName("fetchBookById")
-                          .hasParent(trace.getSpan(hasDataFetcherSpans() ? 1 : 0)));
+                          .hasParent(trace.getSpan(includeDataFetcher() ? 1 : 0)));
               trace.hasSpansSatisfyingExactly(assertions);
             });
   }


### PR DESCRIPTION
Part of #14128 and #13468 

Along with descriptions and configs, I created separate test suites for the data fetcher configuration vs standard for `graphql-java-20.0` to separate the attributes