### PR TITLE
Reduce log level for main jar detection

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ManifestResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ManifestResourceProvider.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.resources;
 
-import static java.util.logging.Level.WARNING;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
@@ -73,7 +73,7 @@ public final class ManifestResourceProvider extends AttributeResourceProvider<Ma
     try (JarFile jarFile = new JarFile(jarPath.toFile(), false)) {
       return Optional.of(jarFile.getManifest());
     } catch (IOException exception) {
-      logger.log(WARNING, "Error reading manifest", exception);
+      logger.log(FINE, "Error reading manifest", exception);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14523

Main jar detection is best effort on jdk8. https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14523 presents a scenario where we misdetect the main jar and fail parsing it.