### PR TITLE
Url template

### DIFF
--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
@@ -109,7 +109,8 @@ enum SpringWebHttpAttributesGetter
     return httpRequest.getURI().getPort();
   }
 
-  private static final String URI_TEMPLATE_ATTRIBUTE = "org.springframework.web.client.RestClient.uriTemplate";
+  private static final String URI_TEMPLATE_ATTRIBUTE =
+      "org.springframework.web.client.RestClient.uriTemplate";
   @Nullable private static final MethodHandle GET_ATTRIBUTES;
 
   static {
@@ -127,9 +128,7 @@ enum SpringWebHttpAttributesGetter
       try {
         getAttributes =
             lookup.findVirtual(
-                httpRequestClass,
-                "getAttributes",
-                MethodType.methodType(java.util.Map.class));
+                httpRequestClass, "getAttributes", MethodType.methodType(java.util.Map.class));
       } catch (NoSuchMethodException | IllegalAccessException ignored) {
         // ignored
       }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
@@ -24,7 +24,6 @@ public enum WebClientHttpAttributesGetter
     implements HttpClientExperimentalAttributesGetter<ClientRequest, ClientResponse> {
   INSTANCE;
 
-
   private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
   private static final Pattern PATTERN_BEFORE_PATH = Pattern.compile("^https?://[^/]+/");
 
@@ -91,6 +90,4 @@ public enum WebClientHttpAttributesGetter
     }
     return null;
   }
-
-
 }


### PR DESCRIPTION
This implements `url.template` for WebClient and RestClient.
Attributes was first introduced in RestClient beginning with [Spring 6.2](https://github.com/spring-projects/spring-framework/commit/60b5bbe33466e905dee828804e3f19b344b47861).

I access it using reflection using a similar pattern to how the status code is accessed.

The other alternatives are:
 * Hook into the Spring client observability framework. I'm not sure whether this is compatible with the Otel framework.
 * Duplicate the `spring-web-3-1/library` to provide a `spring-web-6-2/library`
