### PR TITLE
Metadata - Add new header exclusion

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
@@ -25,7 +25,7 @@ public class SpanParser {
 
   // We want to ignore test related attributes
   private static final List<String> EXCLUDED_ATTRIBUTES =
-      List.of("x-test-", "test-baggage-", "test_message");
+      List.of("x-test-", "test-baggage-", "test_message", "Test_Message");
 
   /**
    * Pull spans from the `.telemetry` directory, filter them by scope, and set them in the module.


### PR DESCRIPTION
Some recent changes around case sensitivity added some new headers in tests that we need to exclude so we don't populate our output with them. 

This is what was being added that this PR fixes:
```
       spans:
       - span_kind: CONSUMER
         attributes:
+        - name: messaging.header.Test_Message_Header
+          type: STRING_ARRAY
         - name: messaging.operation
           type: STRING

....

         attributes:
         - name: messaging.destination.name
           type: STRING
+        - name: messaging.header.Test_Message_Int_Header
+          type: STRING_ARRAY
```