### PR TITLE
Update links to not use search.maven.org

### DIFF
--- a/instrumentation/apache-dbcp-2.0/library/README.md
+++ b/instrumentation/apache-dbcp-2.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Apache DBCP](https://commons.apache.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-apache-dbcp-2.0).
+release](https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-apache-dbcp-2.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/README.md
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Apache Http Client 5.2](https://hc.a
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-apache-httpclient-5.2).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-apache-httpclient-5.2).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/README.md
@@ -50,7 +50,7 @@ link to tracing information provided by Lambda itself. To do so, add a dependenc
 `io.opentelemetry.contrib:opentelemetry-aws-xray-propagator`.
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.contrib/opentelemetry-aws-xray-propagator).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-aws-xray-propagator).
 
 Gradle:
 

--- a/instrumentation/c3p0-0.9/library/README.md
+++ b/instrumentation/c3p0-0.9/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [C3P0](https://www.mchange.com/projec
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-c3p0-0.9).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-c3p0-0.9).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/graphql-java/graphql-java-12.0/library/README.md
+++ b/instrumentation/graphql-java/graphql-java-12.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [GraphQL Java](https://www.graphql-ja
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-graphql-java-12.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-graphql-java-12.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/graphql-java/graphql-java-20.0/library/README.md
+++ b/instrumentation/graphql-java/graphql-java-20.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [GraphQL Java](https://www.graphql-ja
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-graphql-java-12.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-graphql-java-12.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/grpc-1.6/library/README.md
+++ b/instrumentation/grpc-1.6/library/README.md
@@ -6,7 +6,7 @@ Provides OpenTelemetry instrumentation for [gRPC](https://grpc.io/).
 
 ### Add the following dependencies to your project
 
-Replace `OPENTELEMETRY_VERSION` with the [latest release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6).
+Replace `OPENTELEMETRY_VERSION` with the [latest release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6).
 
 For Maven, add the following to your `pom.xml` dependencies:
 

--- a/instrumentation/hikaricp-3.0/library/README.md
+++ b/instrumentation/hikaricp-3.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [HikariCP](https://github.com/brettwo
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-hikaricp-3.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-hikaricp-3.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/java-http-client/library/README.md
+++ b/instrumentation/java-http-client/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Java HTTP Client](https://openjdk.or
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-java-http-client).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-java-http-client).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/java-http-server/library/README.md
+++ b/instrumentation/java-http-server/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Java HTTP Server](https://docs.oracl
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-java-http-server).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-java-http-server).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/jdbc/library/README.md
+++ b/instrumentation/jdbc/library/README.md
@@ -8,7 +8,7 @@ Provides OpenTelemetry instrumentation for
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-jdbc).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-jdbc).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/README.md
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/README.md
@@ -5,7 +5,7 @@
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/ktor/ktor-1.0/library/README.md
+++ b/instrumentation/ktor/ktor-1.0/library/README.md
@@ -8,7 +8,7 @@ Currently, only server instrumentation is supported.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-1.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-1.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/ktor/ktor-2.0/library/README.md
+++ b/instrumentation/ktor/ktor-2.0/library/README.md
@@ -8,7 +8,7 @@ Server and client instrumentations are supported.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-2.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-2.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/ktor/ktor-3.0/library/README.md
+++ b/instrumentation/ktor/ktor-3.0/library/README.md
@@ -8,7 +8,7 @@ Server and client instrumentations are supported.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-3.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-ktor-3.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -9,7 +9,7 @@ which forwards Log4j2 log events to the
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-log4j-appender-2.17).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-log4j-appender-2.17).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
@@ -8,7 +8,7 @@ into log context.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-log4j-context-data-2.17-autoconfigure).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-log4j-context-data-2.17-autoconfigure).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/logback/logback-appender-1.0/library/README.md
+++ b/instrumentation/logback/logback-appender-1.0/library/README.md
@@ -9,7 +9,7 @@ forwards Logback log events to the
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/logback/logback-mdc-1.0/library/README.md
+++ b/instrumentation/logback/logback-mdc-1.0/library/README.md
@@ -8,7 +8,7 @@ mounted span using a custom Logback appender.
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-mdc-1.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-mdc-1.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -9,7 +9,7 @@ sends Micrometer metrics to the
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-micrometer-1.5).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-micrometer-1.5).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/okhttp/okhttp-3.0/library/README.md
+++ b/instrumentation/okhttp/okhttp-3.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/ok
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-okhttp-3.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-okhttp-3.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/openai/openai-java-1.1/library/README.md
+++ b/instrumentation/openai/openai-java-1.1/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [openai-java](https://github.com/open
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-openai-java-1.1).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-openai-java-1.1).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/oracle-ucp-11.2/library/README.md
+++ b/instrumentation/oracle-ucp-11.2/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Oracle UCP](https://docs.oracle.com/
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-oracle-ucp-11.2).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-oracle-ucp-11.2).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/oshi/README.md
+++ b/instrumentation/oshi/README.md
@@ -6,4 +6,4 @@
 
 # Using OSHI with OpenTelemetry Java agent
 
-Download oshi-core jar from https://mvnrepository.com/artifact/com.github.oshi/oshi-core and place it on the class path. OpenTelemetry Java agent uses system class loader to load classes from the oshi-core jar that are used for the metrics.
+Download oshi-core jar from  https://central.sonatype.com/artifact/com.github.oshi/oshi-core and place it on the class path. OpenTelemetry Java agent uses system class loader to load classes from the oshi-core jar that are used for the metrics.

--- a/instrumentation/r2dbc-1.0/library/README.md
+++ b/instrumentation/r2dbc-1.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [R2dbc](https://r2dbc.io/).
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-r2dbc-1.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-r2dbc-1.0).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/README.md
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/README.md
@@ -6,7 +6,7 @@ Provides OpenTelemetry instrumentation for [Apache RocketMQ](https://rocketmq.ap
 
 ### Add the following dependencies to your project
 
-Replace `OPENTELEMETRY_VERSION` with the [latest release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-rocketmq-client-4.8).
+Replace `OPENTELEMETRY_VERSION` with the [latest release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-rocketmq-client-4.8).
 
 For Maven, add the following to your `pom.xml` dependencies:
 

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/README.md
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/README.md
@@ -7,7 +7,7 @@ This module provides JVM runtime metrics as documented in the [semantic conventi
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-runtime-telemetry-java8).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-runtime-telemetry-java8).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/README.md
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/README.md
@@ -10,7 +10,7 @@ Replace `SPRING_VERSION` with the version of spring you're using.
 `Minimum version: 3.1`
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-web-3.1).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-web-3.1).
 
 For Maven, add to your `pom.xml` dependencies:
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/README.md
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/README.md
@@ -11,7 +11,7 @@ Replace `SPRING_VERSION` with the version of spring you're using.
 - `Minimum version: 5.3`
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-5.3).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-5.3).
 
 For Maven add the following to your `pom.xml`:
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/README.md
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/README.md
@@ -11,7 +11,7 @@ Replace `SPRING_VERSION` with the version of spring you're using.
 - `Minimum version: 6.0.0`
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-6.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-6.0).
 
 For Maven add the following to your `pom.xml`:
 

--- a/instrumentation/vibur-dbcp-11.0/library/README.md
+++ b/instrumentation/vibur-dbcp-11.0/library/README.md
@@ -7,7 +7,7 @@ Provides OpenTelemetry instrumentation for [Vibur DBCP](https://www.vibur.org/).
 ### Add these dependencies to your project
 
 Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-vibur-dbcp-11.0).
+release]( https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-vibur-dbcp-11.0).
 
 For Maven, add to your `pom.xml` dependencies:
 


### PR DESCRIPTION
Updating library artifact links to point to https://central.sonatype.com instead of search.maven.org until we are able to get search.maven working again with the latest artifacts and figure out the blocking of the link checker.

After the sonatype migration a few months earlier, we do not have updated artifacts in search.maven.org, the latest is currently 2.16

<img width="2788" height="1492" alt="image" src="https://github.com/user-attachments/assets/03130d10-aa02-4758-af9c-9d4b17d43e50" />

We are also regularly getting a lot of 403's in link checker jobs in builds

<img width="1427" height="794" alt="image" src="https://github.com/user-attachments/assets/9dc4424e-dd54-43d1-ba5d-8a851bfe908c" />

