### PR TITLE
Rename akka fork join instrumentation package

### DIFF
--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaActorForkJoinInstrumentationModule.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaActorForkJoinInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.akkaactor;
+package io.opentelemetry.javaagent.instrumentation.akkaforkjoin;
 
 import static java.util.Arrays.asList;
 

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinPoolInstrumentation.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinPoolInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.akkaactor;
+package io.opentelemetry.javaagent.instrumentation.akkaforkjoin;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinTaskInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.akkaactor;
+package io.opentelemetry.javaagent.instrumentation.akkaforkjoin;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/VirtualFields.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/VirtualFields.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.akkaactor;
+package io.opentelemetry.javaagent.instrumentation.akkaforkjoin;
 
 import akka.dispatch.forkjoin.ForkJoinTask;
 import io.opentelemetry.instrumentation.api.util.VirtualField;

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaAsyncChild.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaAsyncChild.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.akkaactor;
+package io.opentelemetry.instrumentation.akkaforkjoin;
 
 import akka.dispatch.forkjoin.ForkJoinTask;
 import io.opentelemetry.api.GlobalOpenTelemetry;

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaExecutorInstrumentationTest.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaExecutorInstrumentationTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.akkaactor;
+package io.opentelemetry.instrumentation.akkaforkjoin;
 
 import akka.dispatch.forkjoin.ForkJoinPool;
 import akka.dispatch.forkjoin.ForkJoinTask;


### PR DESCRIPTION
Currently we have 2 classes with the same fully qualified name `io.opentelemetry.javaagent.instrumentation.akkaactor.VirtualFields`. This means that one of the instrumentations is broken since it will see the wrong class.