### PR TITLE
chore: add workflow for surveys of non-members

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,0 +1,44 @@
+name: Survey on Merged PR by Non-Member
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+env:
+  PR_NUM: ${{ github.event.pull_request.number }}
+  SURVEY_URL: https://docs.google.com/forms/d/e/1FAIpQLSf2FfCsW-DimeWzdQgfl0KDzT2UEAqu69_f7F2BVPSxVae1cQ/viewform?entry.1540511742=open-telemetry/opentelemetry-java-instrumentation
+
+jobs:
+  comment-on-pr:
+    name: Add survey to PR if author is not a member
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check if user is a member of the org
+        id: check-membership
+        run: |
+          USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
+          ORG="${{ github.repository_owner }}"
+          STATUS=$(gh api "orgs/$ORG/members/$USERNAME" --silent && echo "true" || echo "false")
+          if [[ "$STATUS" == "true" ]]; then
+            echo "MEMBER_FOUND=true" >> $GITHUB_ENV
+          else
+            echo "MEMBER_FOUND=false" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+
+      - name: Add comment to PR if author is not a member
+        if: env.MEMBER_FOUND == 'false'
+        run: |
+          USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
+          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry-java-instrumentation --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The Contributor Experience group created a survey to help understand challenges and feedback from new contributors. We have this survey running for a few months on opentelemetry.io and the JS repo, with helpful feedback, so now adding to more repos.

Example of message: https://github.com/open-telemetry/opentelemetry-js/pull/5884#issuecomment-3237568813