### PR TITLE
Add experimental api for adding operation attributes

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -79,7 +79,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
   private final ContextCustomizer<? super REQUEST>[] contextCustomizers;
   private final OperationListener[] operationListeners;
   private final AttributesExtractor<? super REQUEST, ? super RESPONSE>[]
-      operationAttributesExtractors;
+      operationListenerAttributesExtractors;
   private final ErrorCauseExtractor errorCauseExtractor;
   private final boolean propagateOperationListenersToOnEnd;
   private final boolean enabled;
@@ -96,8 +96,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
     this.attributesExtractors = builder.attributesExtractors.toArray(new AttributesExtractor[0]);
     this.contextCustomizers = builder.contextCustomizers.toArray(new ContextCustomizer[0]);
     this.operationListeners = builder.buildOperationListeners().toArray(new OperationListener[0]);
-    this.operationAttributesExtractors =
-        builder.operationAttributesExtractors.toArray(new AttributesExtractor[0]);
+    this.operationListenerAttributesExtractors =
+        builder.operationListenerAttributesExtractors.toArray(new AttributesExtractor[0]);
     this.errorCauseExtractor = builder.errorCauseExtractor;
     this.propagateOperationListenersToOnEnd = builder.propagateOperationListenersToOnEnd;
     this.enabled = builder.enabled;
@@ -211,11 +211,11 @@ public class Instrumenter<REQUEST, RESPONSE> {
     context = context.with(span);
 
     if (operationListeners.length != 0) {
-      if (operationAttributesExtractors.length != 0) {
+      if (operationListenerAttributesExtractors.length != 0) {
         UnsafeAttributes operationAttributes = new UnsafeAttributes();
         operationAttributes.putAll(attributes.asMap());
         for (AttributesExtractor<? super REQUEST, ? super RESPONSE> extractor :
-            operationAttributesExtractors) {
+            operationListenerAttributesExtractors) {
           extractor.onStart(operationAttributes, parentContext, request);
         }
         attributes = operationAttributes;
@@ -272,11 +272,11 @@ public class Instrumenter<REQUEST, RESPONSE> {
       operationListeners = this.operationListeners;
     }
     if (operationListeners.length != 0) {
-      if (operationAttributesExtractors.length != 0) {
+      if (operationListenerAttributesExtractors.length != 0) {
         UnsafeAttributes operationAttributes = new UnsafeAttributes();
         operationAttributes.putAll(attributes.asMap());
         for (AttributesExtractor<? super REQUEST, ? super RESPONSE> extractor :
-            operationAttributesExtractors) {
+            operationListenerAttributesExtractors) {
           extractor.onEnd(operationAttributes, context, request, response, error);
         }
         attributes = operationAttributes;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -61,8 +61,8 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   final List<SpanLinksExtractor<? super REQUEST>> spanLinksExtractors = new ArrayList<>();
   final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>> attributesExtractors =
       new ArrayList<>();
-  final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>> operationAttributesExtractors =
-      new ArrayList<>();
+  final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>>
+      operationListenerAttributesExtractors = new ArrayList<>();
   final List<ContextCustomizer<? super REQUEST>> contextCustomizers = new ArrayList<>();
   private final List<OperationListener> operationListeners = new ArrayList<>();
   private final List<OperationMetrics> operationMetrics = new ArrayList<>();
@@ -77,10 +77,11 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   boolean enabled = true;
 
   {
-    Experimental.internalAddOperationAttributesExtractor(
-        (builder, operationAttributesExtractor) ->
-            this.operationAttributesExtractors.add(
-                requireNonNull(operationAttributesExtractor, "operationAttributesExtractor")));
+    Experimental.internalAddOperationListenerAttributesExtractor(
+        (builder, operationListenerAttributesExtractor) ->
+            this.operationListenerAttributesExtractors.add(
+                requireNonNull(
+                    operationListenerAttributesExtractor, "operationListenerAttributesExtractor")));
   }
 
   InstrumenterBuilder(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -21,6 +21,7 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterBuilderAccess;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.InternalInstrumenterCustomizer;
@@ -60,6 +61,8 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   final List<SpanLinksExtractor<? super REQUEST>> spanLinksExtractors = new ArrayList<>();
   final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>> attributesExtractors =
       new ArrayList<>();
+  final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>> operationAttributesExtractors =
+      new ArrayList<>();
   final List<ContextCustomizer<? super REQUEST>> contextCustomizers = new ArrayList<>();
   private final List<OperationListener> operationListeners = new ArrayList<>();
   private final List<OperationMetrics> operationMetrics = new ArrayList<>();
@@ -72,6 +75,13 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   boolean propagateOperationListenersToOnEnd = false;
   boolean enabled = true;
+
+  {
+    Experimental.internalAddOperationAttributesExtractor(
+        (builder, operationAttributesExtractor) ->
+            this.operationAttributesExtractors.add(
+                requireNonNull(operationAttributesExtractor, "operationAttributesExtractor")));
+  }
 
   InstrumenterBuilder(
       OpenTelemetry openTelemetry,

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
@@ -30,7 +30,7 @@ public final class Experimental {
 
   @Nullable
   private static volatile BiConsumer<InstrumenterBuilder<?, ?>, AttributesExtractor<?, ?>>
-      operationAttributesExtractorAdder;
+      operationListenerAttributesExtractorAdder;
 
   private Experimental() {}
 
@@ -68,20 +68,21 @@ public final class Experimental {
    * attributes to the metrics without adding them to the span. To add attributes to the span use
    * {@link InstrumenterBuilder#addAttributesExtractor(AttributesExtractor)}.
    */
-  public static <REQUEST, RESPONSE> void addOperationAttributesExtractor(
+  public static <REQUEST, RESPONSE> void addOperationListenerAttributesExtractor(
       InstrumenterBuilder<REQUEST, RESPONSE> builder,
       AttributesExtractor<? super REQUEST, ? super RESPONSE> attributesExtractor) {
-    if (operationAttributesExtractorAdder != null) {
-      operationAttributesExtractorAdder.accept(builder, attributesExtractor);
+    if (operationListenerAttributesExtractorAdder != null) {
+      operationListenerAttributesExtractorAdder.accept(builder, attributesExtractor);
     }
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public static <REQUEST, RESPONSE> void internalAddOperationAttributesExtractor(
+  public static <REQUEST, RESPONSE> void internalAddOperationListenerAttributesExtractor(
       BiConsumer<
               InstrumenterBuilder<REQUEST, RESPONSE>,
               AttributesExtractor<? super REQUEST, ? super RESPONSE>>
-          operationAttributesExtractorAdder) {
-    Experimental.operationAttributesExtractorAdder = (BiConsumer) operationAttributesExtractorAdder;
+          operationListenerAttributesExtractorAdder) {
+    Experimental.operationListenerAttributesExtractorAdder =
+        (BiConsumer) operationListenerAttributesExtractorAdder;
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -528,7 +528,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addOperationListener(operationListener)
             .addAttributesExtractor(new AttributesExtractor1());
-    Experimental.addOperationAttributesExtractor(builder, new AttributesExtractor2());
+    Experimental.addOperationListenerAttributesExtractor(builder, new AttributesExtractor2());
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         builder.buildServerInstrumenter(new MapGetter());
 


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14342 requires adding attributes to metrics that are not added to the span. While this could be overcome by modifying the spec to add these attributes to the span too in my opinion it really is a shortcoming of our current api. 