### PR TITLE
Update references to spankind in descriptions

### DIFF
--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -86,33 +86,33 @@ At a minimum, every instrumentation metadata file should include a `description`
 
 Some example descriptions:
 
-* This instrumentation enables SERVER spans and metrics for the ActiveJ HTTP server.
+* This instrumentation enables HTTP server spans and HTTP server metrics for the ActiveJ HTTP server.
 * This instrumentation provides context propagation for Akka actors, it does not emit any telemetry
   on its own.
 * The Alibaba Druid instrumentation generates database connection pool metrics for druid data sources.
-* The Apache Dubbo instrumentation provides CLIENT and SERVER spans
-  for Apache Dubbo RPC calls. Each call produces a span named after the Dubbo
-  method, enriched with standard RPC attributes (system, service, method), network
-  attributes, and error details if an exception occurs.
+* The Apache Dubbo instrumentation provides RPC client spans and RPC server spans for Apache Dubbo
+  RPC calls. Each call produces a span named after the Dubbo method, enriched with standard RPC
+  attributes (system, service, method), network attributes, and error details if an exception
+  occurs.
 
 Some notes when writing descriptions:
 
 * You don't always need to explicitly name the instrumentation, and you can start with "This
   instrumentation..."
 * Prefer the convention of using the word "enables" when describing what the instrumentation does,
-  "This instrumentation enables SERVER spans and metrics for the ActiveJ" instead of something like
-  "This instrumentation provides SERVER spans and metrics for the ActiveJ".
+  "This instrumentation **enables** HTTP server spans and HTTP server metrics for the ActiveJ" instead
+  of something like "This instrumentation **provides** HTTP server spans and HTTP server metrics for the ActiveJ".
 * Explicitly state whether the instrumentation generates new telemetry (spans, metrics, logs).
   * If it doesn't generate new telemetry, clearly explain what it's purpose is, for example whether it
     augments or enriches existing telemetry produced by other instrumentations (e.g., by adding
     attributes or ensuring context propagation).
+* When describing the functionality of the instrumentation and the telemetry, specify using
+  [semantic convention categories](https://opentelemetry.io/docs/specs/semconv/) when possible
+  (e.g., "database client spans", "RPC server metrics", "consumer messaging spans").
 * Do not include specific method names, class names, or other low-level implementation details in
   the description unless they are essential to understanding the purpose of the instrumentation.
 * It is not usually necessary to include specific library or framework version numbers in the
   description, unless that context is significant in some way.
-* When an instrumentation generates spans, be specific about the SpanKind (e.g., SERVER, CLIENT,
-  PRODUCER, CONSUMER, INTERNAL).
-  * Capitalize SpanKind values (e.g., SERVER, CLIENT) when used in descriptions.
 
 
 ### Configurations

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -5,8 +5,8 @@
 libraries:
   activej:
   - name: activej-http-6.0
-    description: This instrumentation enables SERVER spans and metrics for the ActiveJ
-      HTTP server.
+    description: This instrumentation enables HTTP server spans and HTTP server metrics
+      for the ActiveJ HTTP server.
     source_path: instrumentation/activej-http-6.0
     minimum_java_version: 17
     scope:
@@ -81,8 +81,8 @@ libraries:
       - com.typesafe.akka:akka-actor_2.13:[2.5.23,2.6)
       - com.typesafe.akka:akka-actor_2.11:[2.5,)
   - name: akka-http-10.0
-    description: This instrumentation enables CLIENT and SERVER spans and metrics
-      for the Akka HTTP client and server.
+    description: |
+      This instrumentation enables HTTP client spans and metrics for the Akka HTTP client, and HTTP server spans and metrics for the Akka HTTP server.
     source_path: instrumentation/akka/akka-http-10.0
     scope:
       name: io.opentelemetry.akka-http-10.0
@@ -342,10 +342,10 @@ libraries:
         - name: db.client.connection.pool.name
           type: STRING
   - name: apache-dubbo-2.7
-    description: The Apache Dubbo instrumentation provides client and server spans
-      for Apache Dubbo RPC calls. Each call produces a span named after the Dubbo
-      method, enriched with standard RPC attributes (system, service, method), network
-      attributes, and error details if an exception occurs.
+    description: The Apache Dubbo instrumentation provides RPC client spans and RPC
+      server spans for Apache Dubbo RPC calls. Each call produces a span named after
+      the Dubbo method, enriched with standard RPC attributes (system, service, method),
+      network attributes, and error details if an exception occurs.
     source_path: instrumentation/apache-dubbo-2.7
     scope:
       name: io.opentelemetry.apache-dubbo-2.7
@@ -386,8 +386,8 @@ libraries:
         - name: rpc.system
           type: STRING
   - name: apache-httpasyncclient-4.1
-    description: This instrumentation enables CLIENT spans and metrics for the Apache
-      HttpAsyncClient.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for the Apache HttpAsyncClient.
     source_path: instrumentation/apache-httpasyncclient-4.1
     scope:
       name: io.opentelemetry.apache-httpasyncclient-4.1
@@ -432,8 +432,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: apache-httpclient-2.0
-    description: This instrumentation enables CLIENT spans and metrics for versions
-      2 and 3 of the Apache HttpClient.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for versions 2 and 3 of the Apache HttpClient.
     source_path: instrumentation/apache-httpclient/apache-httpclient-2.0
     scope:
       name: io.opentelemetry.apache-httpclient-2.0
@@ -476,8 +476,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: apache-httpclient-4.0
-    description: This instrumentation enables CLIENT spans and metrics for version
-      4 of the Apache HttpClient.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for version 4 of the Apache HttpClient.
     source_path: instrumentation/apache-httpclient/apache-httpclient-4.0
     scope:
       name: io.opentelemetry.apache-httpclient-4.0
@@ -524,7 +524,7 @@ libraries:
           type: STRING
   - name: apache-httpclient-4.3
     description: This instrumentation provides a library integration that enables
-      CLIENT spans and metrics for the Apache HttpClient.
+      HTTP client spans and HTTP client metrics for the Apache HttpClient.
     source_path: instrumentation/apache-httpclient/apache-httpclient-4.3
     scope:
       name: io.opentelemetry.apache-httpclient-4.3
@@ -571,8 +571,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: apache-httpclient-5.0
-    description: This instrumentation enables CLIENT spans and metrics for version
-      5 of the Apache HttpClient.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for version 5 of the Apache HttpClient.
     source_path: instrumentation/apache-httpclient/apache-httpclient-5.0
     scope:
       name: io.opentelemetry.apache-httpclient-5.0
@@ -618,7 +618,7 @@ libraries:
           type: STRING
   - name: apache-httpclient-5.2
     description: This instrumentation provides a library integration that enables
-      CLIENT spans and metrics for the Apache HttpClient.
+      HTTP client spans and HTTP client metrics for the Apache HttpClient.
     source_path: instrumentation/apache-httpclient/apache-httpclient-5.2
     scope:
       name: io.opentelemetry.apache-httpclient-5.2
@@ -666,7 +666,7 @@ libraries:
           type: STRING
   - name: apache-shenyu-2.4
     description: |
-      This instrumentation does not emit telemetry on its own. Instead, it augments existing SERVER spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
+      This instrumentation does not emit telemetry on its own. Instead, it augments existing server spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
     source_path: instrumentation/apache-shenyu-2.4
     scope:
       name: io.opentelemetry.apache-shenyu-2.4
@@ -681,8 +681,8 @@ libraries:
       default: false
   armeria:
   - name: armeria-1.3
-    description: This instrumentation enables CLIENT and SERVER spans and metrics
-      for the Armeria HTTP client and server.
+    description: |
+      This instrumentation enables HTTP client spans and metrics for the Armeria HTTP client, and HTTP server spans and metrics for the Armeria HTTP server.
     source_path: instrumentation/armeria/armeria-1.3
     scope:
       name: io.opentelemetry.armeria-1.3
@@ -776,8 +776,8 @@ libraries:
         - name: user_agent.original
           type: STRING
   - name: armeria-grpc-1.14
-    description: This instrumentation enables CLIENT and SERVER spans and metrics
-      for the Armeria gRPC client and server.
+    description: |
+      This instrumentation enables RPC client spans and metrics for the Armeria gRPC client, and RPC server spans and metrics for the Armeria gRPC server.
     source_path: instrumentation/armeria/armeria-grpc-1.14
     scope:
       name: io.opentelemetry.armeria-grpc-1.14
@@ -817,8 +817,8 @@ libraries:
           type: LONG
   async:
   - name: async-http-client-1.9
-    description: This instrumentation enables CLIENT spans and metrics for version
-      1 of the AsyncHttpClient (AHC) HTTP client.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for version 1 of the AsyncHttpClient (AHC) HTTP client.
     source_path: instrumentation/async-http-client/async-http-client-1.9
     scope:
       name: io.opentelemetry.async-http-client-1.9
@@ -859,8 +859,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: async-http-client-2.0
-    description: This instrumentation enables CLIENT spans and metrics for version
-      2 of the AsyncHttpClient (AHC) HTTP client.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for version 2 of the AsyncHttpClient (AHC) HTTP client.
     source_path: instrumentation/async-http-client/async-http-client-2.0
     scope:
       name: io.opentelemetry.async-http-client-2.0
@@ -911,7 +911,7 @@ libraries:
   avaje:
   - name: avaje-jex-3.0
     description: |
-      This instrumentation does not emit telemetry on its own. Instead, it hooks into the Avaje Jex Context to extract the HTTP route and attach it to existing SERVER spans and HTTP server metrics.
+      This instrumentation does not emit telemetry on its own. Instead, it hooks into the Avaje Jex Context to extract the HTTP route and attach it to existing HTTP server spans and HTTP server metrics.
     source_path: instrumentation/avaje-jex-3.0
     minimum_java_version: 21
     scope:
@@ -922,7 +922,7 @@ libraries:
   aws:
   - name: aws-lambda-core-1.0
     description: |
-      Provides lightweight instrumentation of the Lambda core library, supporting all versions. It generates FaaS SERVER spans with the `faas.invocation_id` attribute. Use this package if you only use `RequestStreamHandler` or know you don't use any event classes from `aws-lambda-java-events`. This also includes when you are using `aws-serverless-java-container` to run e.g., a Spring Boot application on Lambda.
+      Provides lightweight instrumentation of the Lambda core library, supporting all versions. It generates FaaS server spans with the `faas.invocation_id` attribute. Use this package if you only use `RequestStreamHandler` or know you don't use any event classes from `aws-lambda-java-events`. This also includes when you are using `aws-serverless-java-container` to run e.g., a Spring Boot application on Lambda.
       For custom wrappers when using library instrumentation, you can configure the `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` environment variable to contain your lambda handler method (in the format `package.ClassName::methodName`) and use one of wrappers as your lambda `Handler`.
     source_path: instrumentation/aws-lambda/aws-lambda-core-1.0
     scope:
@@ -2135,7 +2135,7 @@ libraries:
   couchbase:
   - name: couchbase-2.0
     description: |
-      This instrumentation enables database CLIENT spans and metrics for Couchbase 2.0 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
+      This instrumentation enables database client spans and database client metrics for Couchbase 2.0 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
     source_path: instrumentation/couchbase/couchbase-2.0
     scope:
       name: io.opentelemetry.couchbase-2.0
@@ -2179,7 +2179,7 @@ libraries:
           type: STRING
   - name: couchbase-2.6
     description: |
-      This instrumentation enables database CLIENT spans and metrics for Couchbase 2.6 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
+      This instrumentation enables database client spans and database client metrics for Couchbase 2.6 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
     source_path: instrumentation/couchbase/couchbase-2.6
     scope:
       name: io.opentelemetry.couchbase-2.6
@@ -2395,8 +2395,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: elasticsearch-rest-5.0
-    description: This instrumentation enables database CLIENT spans and metrics for
-      Elasticsearch REST clients.
+    description: This instrumentation enables database client spans and database client
+      metrics for Elasticsearch REST clients.
     source_path: instrumentation/elasticsearch/elasticsearch-rest-5.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-5.0
@@ -2457,8 +2457,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: elasticsearch-rest-6.4
-    description: This instrumentation enables database CLIENT spans and metrics for
-      Elasticsearch REST clients.
+    description: This instrumentation enables database client spans and database client
+      metrics for Elasticsearch REST clients.
     source_path: instrumentation/elasticsearch/elasticsearch-rest-6.4
     scope:
       name: io.opentelemetry.elasticsearch-rest-6.4
@@ -2518,8 +2518,8 @@ libraries:
         - name: url.full
           type: STRING
   - name: elasticsearch-rest-7.0
-    description: This instrumentation enables database CLIENT spans and metrics for
-      Elasticsearch REST clients.
+    description: This instrumentation enables database client spans and database client
+      metrics for Elasticsearch REST clients.
     source_path: instrumentation/elasticsearch/elasticsearch-rest-7.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-7.0
@@ -2582,7 +2582,7 @@ libraries:
           type: STRING
   - name: elasticsearch-transport-5.0
     description: |
-      This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+      This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
     source_path: instrumentation/elasticsearch/elasticsearch-transport-5.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.0
@@ -2674,7 +2674,7 @@ libraries:
           type: LONG
   - name: elasticsearch-transport-5.3
     description: |
-      This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+      This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
     source_path: instrumentation/elasticsearch/elasticsearch-transport-5.3
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.3
@@ -2771,7 +2771,7 @@ libraries:
           type: LONG
   - name: elasticsearch-transport-6.0
     description: |
-      This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+      This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
     source_path: instrumentation/elasticsearch/elasticsearch-transport-6.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-6.0
@@ -2917,8 +2917,8 @@ libraries:
           type: STRING
   geode:
   - name: geode-1.4
-    description: This instrumentation enables database CLIENT spans and metrics for
-      Apache Geode cache operations.
+    description: This instrumentation enables database client spans and database client
+      metrics for Apache Geode cache operations.
     source_path: instrumentation/geode-1.4
     scope:
       name: io.opentelemetry.geode-1.4
@@ -2969,8 +2969,8 @@ libraries:
           type: STRING
   google:
   - name: google-http-client-1.19
-    description: This instrumentation enables HTTP CLIENT spans and metrics for Google
-      HTTP Client requests.
+    description: This instrumentation enables HTTP client spans and HTTP client metrics
+      for Google HTTP Client requests.
     source_path: instrumentation/google-http-client-1.19
     scope:
       name: io.opentelemetry.google-http-client-1.19
@@ -3039,7 +3039,7 @@ libraries:
   grails:
   - name: grails-3.0
     description: |
-      This instrumentation enriches existing SERVER spans with route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
+      This instrumentation enriches existing server spans with route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
     source_path: instrumentation/grails-3.0
     scope:
       name: io.opentelemetry.grails-3.0
@@ -3147,8 +3147,8 @@ libraries:
           type: STRING
   grizzly:
   - name: grizzly-2.3
-    description: This instrumentation enables HTTP SERVER spans and metrics for Grizzly
-      applications.
+    description: This instrumentation enables HTTP server spans and HTTP server metrics
+      for Grizzly applications.
     source_path: instrumentation/grizzly-2.3
     scope:
       name: io.opentelemetry.grizzly-2.3
@@ -3228,8 +3228,8 @@ libraries:
           type: STRING
   grpc:
   - name: grpc-1.6
-    description: This instrumentation enables RPC CLIENT and SERVER spans and metrics
-      for gRPC version 1.6 and above.
+    description: This instrumentation enables RPC client spans and metrics, and RPC
+      server spans and metrics for gRPC version 1.6 and above.
     source_path: instrumentation/grpc-1.6
     scope:
       name: io.opentelemetry.grpc-1.6
@@ -3426,7 +3426,7 @@ libraries:
       - com.google.guava:guava:10.0
   gwt:
   - name: gwt-2.0
-    description: This instrumentation enables SERVER spans for GWT RPC requests.
+    description: This instrumentation enables RPC server spans for GWT RPC requests.
     source_path: instrumentation/gwt-2.0
     scope:
       name: io.opentelemetry.gwt-2.0
@@ -5776,7 +5776,7 @@ libraries:
   spark:
   - name: spark-2.3
     description: |
-      This instrumentation does not emit telemetry on its own. Instead, it extracts the HTTP route and attaches it to SERVER spans and HTTP server metrics.
+      This instrumentation does not emit telemetry on its own. Instead, it extracts the HTTP route and attaches it to HTTP server spans and HTTP server metrics.
     source_path: instrumentation/spark-2.3
     scope:
       name: io.opentelemetry.spark-2.3
@@ -5896,8 +5896,8 @@ libraries:
         - name: code.namespace
           type: STRING
   - name: spring-integration-4.1
-    description: This instrumentation enables PRODUCER and CONSUMER spans for Spring
-      Integration.
+    description: This instrumentation enables producer and consumer messaging spans
+      for Spring Integration.
     source_path: instrumentation/spring/spring-integration-4.1
     scope:
       name: io.opentelemetry.spring-integration-4.1
@@ -5938,8 +5938,8 @@ libraries:
         - name: messaging.operation
           type: STRING
   - name: spring-jms-2.0
-    description: This instrumentation enables the generation of CONSUMER spans for
-      Spring JMS.
+    description: This instrumentation enables the generation of consumer messaging
+      spans for Spring JMS.
     source_path: instrumentation/spring/spring-jms/spring-jms-2.0
     scope:
       name: io.opentelemetry.spring-jms-2.0
@@ -5970,8 +5970,8 @@ libraries:
         - name: messaging.system
           type: STRING
   - name: spring-jms-6.0
-    description: This instrumentation enables the generation of CONSUMER spans for
-      Spring JMS.
+    description: This instrumentation enables the generation of consumer messaging
+      spans for Spring JMS.
     source_path: instrumentation/spring/spring-jms/spring-jms-6.0
     minimum_java_version: 17
     scope:
@@ -6003,7 +6003,8 @@ libraries:
         - name: messaging.system
           type: STRING
   - name: spring-kafka-2.7
-    description: This instrumentation enables CONSUMER spans for Spring Kafka listeners.
+    description: This instrumentation enables consumer messaging spans for Spring
+      Kafka listeners.
     source_path: instrumentation/spring/spring-kafka-2.7
     scope:
       name: io.opentelemetry.spring-kafka-2.7
@@ -6076,7 +6077,8 @@ libraries:
         - name: messaging.system
           type: STRING
   - name: spring-pulsar-1.0
-    description: This instrumentation enables CONSUMER spans for Spring Pulsar listeners.
+    description: This instrumentation enables consumer messaging spans for Spring
+      Pulsar listeners.
     source_path: instrumentation/spring/spring-pulsar-1.0
     minimum_java_version: 17
     scope:
@@ -6115,7 +6117,8 @@ libraries:
         - name: messaging.system
           type: STRING
   - name: spring-rabbit-1.0
-    description: This instrumentation enables CONSUMER spans for Spring RabbitMQ listeners.
+    description: This instrumentation enables consumer messaging spans for Spring
+      RabbitMQ listeners.
     source_path: instrumentation/spring/spring-rabbit-1.0
     scope:
       name: io.opentelemetry.spring-rabbit-1.0
@@ -6141,8 +6144,8 @@ libraries:
         - name: messaging.system
           type: STRING
   - name: spring-rmi-4.0
-    description: This instrumentation enables CLIENT and SERVER spans for Spring RMI
-      applications.
+    description: This instrumentation enables RPC client and RPC server spans for
+      Spring RMI applications.
     source_path: instrumentation/spring/spring-rmi-4.0
     scope:
       name: io.opentelemetry.spring-rmi-4.0

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -666,7 +666,7 @@ libraries:
           type: STRING
   - name: apache-shenyu-2.4
     description: |
-      This instrumentation does not emit telemetry on its own. Instead, it augments existing server spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
+      This instrumentation does not emit telemetry on its own. Instead, it augments existing HTTP server spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
     source_path: instrumentation/apache-shenyu-2.4
     scope:
       name: io.opentelemetry.apache-shenyu-2.4
@@ -3039,7 +3039,7 @@ libraries:
   grails:
   - name: grails-3.0
     description: |
-      This instrumentation enriches existing server spans with route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
+      This instrumentation enriches existing HTTP server spans with HTTP route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
     source_path: instrumentation/grails-3.0
     scope:
       name: io.opentelemetry.grails-3.0

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables SERVER spans and metrics for the ActiveJ HTTP server.
+description: This instrumentation enables HTTP server spans and HTTP server metrics for the ActiveJ HTTP server.

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -1,1 +1,3 @@
-description: This instrumentation enables CLIENT and SERVER spans and metrics for the Akka HTTP client and server.
+description: >
+  This instrumentation enables HTTP client spans and metrics for the Akka HTTP client, and HTTP
+  server spans and metrics for the Akka HTTP server.

--- a/instrumentation/apache-dubbo-2.7/metadata.yaml
+++ b/instrumentation/apache-dubbo-2.7/metadata.yaml
@@ -1,7 +1,7 @@
-description: The Apache Dubbo instrumentation provides client and server spans for Apache Dubbo
-  RPC calls. Each call produces a span named after the Dubbo method, enriched with standard RPC
-  attributes (system, service, method), network attributes, and error details if an exception
-  occurs.
+description: The Apache Dubbo instrumentation provides RPC client spans and RPC server spans for
+  Apache Dubbo RPC calls. Each call produces a span named after the Dubbo method, enriched with
+  standard RPC attributes (system, service, method), network attributes, and error details if an
+  exception occurs.
 configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for the Apache HttpAsyncClient.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for the Apache HttpAsyncClient.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for versions 2 and 3 of the Apache HttpClient.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for versions 2 and 3 of the Apache HttpClient.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for version 4 of the Apache HttpClient.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for version 4 of the Apache HttpClient.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation provides a library integration that enables CLIENT spans and metrics for the Apache HttpClient.
+description: This instrumentation provides a library integration that enables HTTP client spans and HTTP client metrics for the Apache HttpClient.

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for version 5 of the Apache HttpClient.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for version 5 of the Apache HttpClient.

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation provides a library integration that enables CLIENT spans and metrics for the Apache HttpClient.
+description: This instrumentation provides a library integration that enables HTTP client spans and HTTP client metrics for the Apache HttpClient.

--- a/instrumentation/apache-shenyu-2.4/metadata.yaml
+++ b/instrumentation/apache-shenyu-2.4/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation does not emit telemetry on its own. Instead, it augments existing server
+  This instrumentation does not emit telemetry on its own. Instead, it augments existing HTTP server
   spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
 configurations:
   - name: otel.instrumentation.apache-shenyu.experimental-span-attributes

--- a/instrumentation/apache-shenyu-2.4/metadata.yaml
+++ b/instrumentation/apache-shenyu-2.4/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation does not emit telemetry on its own. Instead, it augments existing SERVER
+  This instrumentation does not emit telemetry on its own. Instead, it augments existing server
   spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
 configurations:
   - name: otel.instrumentation.apache-shenyu.experimental-span-attributes

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -1,1 +1,3 @@
-description: This instrumentation enables CLIENT and SERVER spans and metrics for the Armeria HTTP client and server.
+description: >
+  This instrumentation enables HTTP client spans and metrics for the Armeria HTTP client, and HTTP
+  server spans and metrics for the Armeria HTTP server.

--- a/instrumentation/armeria/armeria-grpc-1.14/metadata.yaml
+++ b/instrumentation/armeria/armeria-grpc-1.14/metadata.yaml
@@ -1,1 +1,3 @@
-description: This instrumentation enables CLIENT and SERVER spans and metrics for the Armeria gRPC client and server.
+description: >
+  This instrumentation enables RPC client spans and metrics for the Armeria gRPC client, and RPC
+  server spans and metrics for the Armeria gRPC server.

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for version 1 of the AsyncHttpClient (AHC) HTTP client.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for version 1 of the AsyncHttpClient (AHC) HTTP client.

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT spans and metrics for version 2 of the AsyncHttpClient (AHC) HTTP client.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for version 2 of the AsyncHttpClient (AHC) HTTP client.

--- a/instrumentation/avaje-jex-3.0/metadata.yaml
+++ b/instrumentation/avaje-jex-3.0/metadata.yaml
@@ -1,4 +1,4 @@
 description: >
   This instrumentation does not emit telemetry on its own. Instead, it hooks into the Avaje Jex
-  Context to extract the HTTP route and attach it to existing SERVER spans and HTTP server
+  Context to extract the HTTP route and attach it to existing HTTP server spans and HTTP server
   metrics.

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/metadata.yaml
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/metadata.yaml
@@ -1,6 +1,6 @@
 description: >
   Provides lightweight instrumentation of the Lambda core library, supporting all versions. It
-  generates FaaS SERVER spans with the `faas.invocation_id` attribute. Use this package if you only
+  generates FaaS server spans with the `faas.invocation_id` attribute. Use this package if you only
   use `RequestStreamHandler` or know you don't use any event classes from `aws-lambda-java-events`.
   This also includes when you are using `aws-serverless-java-container` to run e.g., a Spring Boot
   application on Lambda.

--- a/instrumentation/couchbase/couchbase-2.0/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.0/metadata.yaml
@@ -1,4 +1,4 @@
 description: >
-  This instrumentation enables database CLIENT spans and metrics for Couchbase 2.0 operations.
-  It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL
-  queries, and cluster management operations.
+  This instrumentation enables database client spans and database client metrics for Couchbase 2.0
+  operations. It automatically traces key-value operations (get, upsert, replace, remove), view
+  queries, N1QL queries, and cluster management operations.

--- a/instrumentation/couchbase/couchbase-2.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.6/metadata.yaml
@@ -1,7 +1,7 @@
 description: >
-  This instrumentation enables database CLIENT spans and metrics for Couchbase 2.6 operations.
-  It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL
-  queries, and cluster management operations.
+  This instrumentation enables database client spans and database client metrics for Couchbase 2.6
+  operations. It automatically traces key-value operations (get, upsert, replace, remove), view
+  queries, N1QL queries, and cluster management operations.
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables database CLIENT spans and metrics for Elasticsearch REST clients.
+description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables database CLIENT spans and metrics for Elasticsearch REST clients.
+description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables database CLIENT spans and metrics for Elasticsearch REST clients.
+description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/metadata.yaml
@@ -1,7 +1,7 @@
 description: >
-  This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests.
-  Each call produces a span named after the Elasticsearch action, enriched with transport-specific
-  attributes.
+  This instrumentation enables database client spans and database client metrics for Elasticsearch
+  transport client requests. Each call produces a span named after the Elasticsearch action,
+  enriched with transport-specific attributes.
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/metadata.yaml
@@ -1,7 +1,7 @@
 description: >
-  This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests.
-  Each call produces a span named after the Elasticsearch action, enriched with transport-specific
-  attributes.
+  This instrumentation enables database client spans and database client metrics for Elasticsearch
+  transport client requests. Each call produces a span named after the Elasticsearch action,
+  enriched with transport-specific attributes.
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/metadata.yaml
@@ -1,7 +1,7 @@
 description: >
-  This instrumentation enables CLIENT spans and metrics for Elasticsearch transport client requests.
-  Each call produces a span named after the Elasticsearch action, enriched with transport-specific
-  attributes.
+  This instrumentation enables database client spans and database client metrics for Elasticsearch
+  transport client requests. Each call produces a span named after the Elasticsearch action,
+  enriched with transport-specific attributes.
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables database CLIENT spans and metrics for Apache Geode cache operations.
+description: This instrumentation enables database client spans and database client metrics for Apache Geode cache operations.
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables HTTP CLIENT spans and metrics for Google HTTP Client requests.
+description: This instrumentation enables HTTP client spans and HTTP client metrics for Google HTTP Client requests.
 configurations:
   - name: otel.instrumentation.http.known-methods
     description: >

--- a/instrumentation/grails-3.0/metadata.yaml
+++ b/instrumentation/grails-3.0/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enriches existing SERVER spans with route information, and optionally enables
+  This instrumentation enriches existing server spans with route information, and optionally enables
   experimental controller (INTERNAL) spans for Grails applications.
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled

--- a/instrumentation/grails-3.0/metadata.yaml
+++ b/instrumentation/grails-3.0/metadata.yaml
@@ -1,6 +1,6 @@
 description: >
-  This instrumentation enriches existing server spans with route information, and optionally enables
-  experimental controller (INTERNAL) spans for Grails applications.
+  This instrumentation enriches existing HTTP server spans with HTTP route information, and
+  optionally enables experimental controller (INTERNAL) spans for Grails applications.
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
     description: Enables the creation of experimental controller (INTERNAL) spans.

--- a/instrumentation/grizzly-2.3/metadata.yaml
+++ b/instrumentation/grizzly-2.3/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables HTTP SERVER spans and metrics for Grizzly applications.
+description: This instrumentation enables HTTP server spans and HTTP server metrics for Grizzly applications.
 configurations:
   - name: otel.instrumentation.http.known-methods
     description: >

--- a/instrumentation/grpc-1.6/metadata.yaml
+++ b/instrumentation/grpc-1.6/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables RPC CLIENT and SERVER spans and metrics for gRPC version 1.6 and above.
+description: This instrumentation enables RPC client spans and metrics, and RPC server spans and metrics for gRPC version 1.6 and above.
 configurations:
   - name: otel.instrumentation.grpc.emit-message-events
     type: boolean

--- a/instrumentation/gwt-2.0/metadata.yaml
+++ b/instrumentation/gwt-2.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables SERVER spans for GWT RPC requests.
+description: This instrumentation enables RPC server spans for GWT RPC requests.

--- a/instrumentation/spark-2.3/metadata.yaml
+++ b/instrumentation/spark-2.3/metadata.yaml
@@ -1,3 +1,3 @@
 description: > 
   This instrumentation does not emit telemetry on its own. Instead, it extracts the HTTP route and
-  attaches it to SERVER spans and HTTP server metrics.
+  attaches it to HTTP server spans and HTTP server metrics.

--- a/instrumentation/spring/spring-integration-4.1/metadata.yaml
+++ b/instrumentation/spring/spring-integration-4.1/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables PRODUCER and CONSUMER spans for Spring Integration.
+description: This instrumentation enables producer and consumer messaging spans for Spring Integration.
 configurations:
   - name: otel.instrumentation.spring-integration.producer.enabled
     type: boolean

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/metadata.yaml
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables the generation of CONSUMER spans for Spring JMS.
+description: This instrumentation enables the generation of consumer messaging spans for Spring JMS.
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables the generation of CONSUMER spans for Spring JMS.
+description: This instrumentation enables the generation of consumer messaging spans for Spring JMS.
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >

--- a/instrumentation/spring/spring-kafka-2.7/metadata.yaml
+++ b/instrumentation/spring/spring-kafka-2.7/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables CONSUMER spans for Spring Kafka listeners.
+description: This instrumentation enables consumer messaging spans for Spring Kafka listeners.
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >

--- a/instrumentation/spring/spring-pulsar-1.0/metadata.yaml
+++ b/instrumentation/spring/spring-pulsar-1.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables CONSUMER spans for Spring Pulsar listeners.
+description: This instrumentation enables consumer messaging spans for Spring Pulsar listeners.
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >

--- a/instrumentation/spring/spring-rabbit-1.0/metadata.yaml
+++ b/instrumentation/spring/spring-rabbit-1.0/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables CONSUMER spans for Spring RabbitMQ listeners.
+description: This instrumentation enables consumer messaging spans for Spring RabbitMQ listeners.
 configurations:
   - name: otel.instrumentation.messaging.experimental.capture-headers
     description: A comma-separated list of header names to capture as span attributes.

--- a/instrumentation/spring/spring-rmi-4.0/metadata.yaml
+++ b/instrumentation/spring/spring-rmi-4.0/metadata.yaml
@@ -1,1 +1,1 @@
-description: This instrumentation enables CLIENT and SERVER spans for Spring RMI applications.
+description: This instrumentation enables RPC client and RPC server spans for Spring RMI applications.


### PR DESCRIPTION
Related to #13468 

From [this discussion](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14603#discussion_r2330532924).

I had originally thought that capitalizing the span kind helped highlight which type of instrumentation it was, but I don't see this capitalized convention being done in the documentation or spec. So I lowercased all the uppercased SpanKinds, and added descriptors where applicable (**HTTP** client/ **RPC** server etc)