### PR TITLE
Rework service file merging

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -7,12 +7,18 @@ plugins {
 // NOTE: any modifications below should also be made in
 //       io.opentelemetry.instrumentation.muzzle-check.gradle.kts
 tasks.withType<ShadowJar>().configureEach {
-  // mergeServiceFiles requires that duplicate strategy is set to include
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
+  // mergeServiceFiles requires that duplicate strategy is set to include
+  filesMatching("META-INF/services/**") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
   // Merge any AWS SDK service files that may be present (too bad they didn't just use normal
   // service loader...)
   mergeServiceFiles("software/amazon/awssdk/global/handlers")
+  // mergeServiceFiles requires that duplicate strategy is set to include
+  filesMatching("software/amazon/awssdk/global/handlers/**") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   exclude("**/module-info.class")
 

--- a/examples/distro/agent/build.gradle
+++ b/examples/distro/agent/build.gradle
@@ -41,8 +41,7 @@ CopySpec isolateClasses(Iterable<File> jars) {
       from(zipTree(it)) {
         into("inst")
         rename("^(.*)\\.class\$", "\$1.classdata")
-        // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
-        rename("^LICENSE\$", "LICENSE.renamed")
+        exclude("^LICENSE\$")
         exclude("META-INF/INDEX.LIST")
         exclude("META-INF/*.DSA")
         exclude("META-INF/*.SF")
@@ -66,9 +65,12 @@ tasks {
 
     archiveFileName.set("javaagentLibs-relocated.jar")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.FAIL
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     exclude("**/module-info.class")
     relocatePackages(it)
 
@@ -105,9 +107,12 @@ tasks {
 
     archiveClassifier.set("all")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     mergeServiceFiles("inst/META-INF/services")
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("inst/META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
     exclude("**/module-info.class")
     relocatePackages(it)

--- a/examples/distro/gradle/instrumentation.gradle
+++ b/examples/distro/gradle/instrumentation.gradle
@@ -36,9 +36,11 @@ dependencies {
 shadowJar {
   configurations = [project.configurations.runtimeClasspath, project.configurations.testInstrumentation]
 
-  // mergeServiceFiles requires that duplicate strategy is set to include
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
+  // mergeServiceFiles requires that duplicate strategy is set to include
+  filesMatching("inst/META-INF/services/**") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   archiveFileName = 'agent-testing.jar'
 

--- a/examples/distro/testing/agent-for-testing/build.gradle
+++ b/examples/distro/testing/agent-for-testing/build.gradle
@@ -61,9 +61,13 @@ tasks {
 
     archiveFileName.set("javaagentLibs-relocated.jar")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.FAIL
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
     exclude("**/module-info.class")
     relocatePackages(it)
 
@@ -100,9 +104,12 @@ tasks {
 
     archiveClassifier.set("")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     mergeServiceFiles("inst/META-INF/services")
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("inst/META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
     exclude("**/module-info.class")
     relocatePackages(it)

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -74,12 +74,18 @@ val shadowMuzzleBootstrap by tasks.registering(ShadowJar::class) {
 // this is a copied from io.opentelemetry.instrumentation.javaagent-shadowing for now at least to
 // avoid publishing io.opentelemetry.instrumentation.javaagent-shadowing publicly
 tasks.withType<ShadowJar>().configureEach {
-  // mergeServiceFiles requires that duplicate strategy is set to include
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   mergeServiceFiles()
+  // mergeServiceFiles requires that duplicate strategy is set to include
+  filesMatching("META-INF/services/**") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
   // Merge any AWS SDK service files that may be present (too bad they didn't just use normal
   // service loader...)
   mergeServiceFiles("software/amazon/awssdk/global/handlers")
+  // mergeServiceFiles requires that duplicate strategy is set to include
+  filesMatching("software/amazon/awssdk/global/handlers/**") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   exclude("**/module-info.class")
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id("otel.javaagent-instrumentation")
 }
@@ -226,11 +228,13 @@ tasks {
     systemProperty("collectMetadata", collectMetadata)
   }
 
-  withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>().configureEach {
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  withType<ShadowJar>().configureEach {
     mergeServiceFiles {
       include("software/amazon/awssdk/global/handlers/execution.interceptors")
+    }
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("software/amazon/awssdk/global/handlers/execution.interceptors") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
   }
 }

--- a/javaagent-internal-logging-simple/build.gradle.kts
+++ b/javaagent-internal-logging-simple/build.gradle.kts
@@ -22,10 +22,12 @@ dependencies {
 
 tasks {
   val shadowJar by existing(ShadowJar::class) {
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     // required for META-INF/services files relocation
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
     // Prevents configuration naming conflict with other SLF4J instances
     relocate("org.slf4j", "io.opentelemetry.javaagent.slf4j")

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -160,6 +160,15 @@ tasks {
 
     excludeBootstrapClasses()
 
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    // TODO: remove after updating contrib to 1.50.0
+    filesMatching("io/opentelemetry/contrib/gcp/resource/version.properties") {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+    exclude("META-INF/LICENSE")
+    exclude("META-INF/NOTICE")
+    exclude("META-INF/maven/**")
+
     archiveFileName.set("baseJavaagentLibs-relocated-tmp.jar")
   }
 
@@ -179,6 +188,18 @@ tasks {
     excludeBootstrapClasses()
     // remove MPL licensed content
     exclude("okhttp3/internal/publicsuffix/PublicSuffixDatabase.list")
+
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    // TODO: remove after updating contrib to 1.50.0
+    filesMatching("io/opentelemetry/contrib/gcp/resource/version.properties") {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+    filesMatching("META-INF/io/opentelemetry/instrumentation/**") {
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+    exclude("META-INF/LICENSE")
+    exclude("META-INF/NOTICE")
+    exclude("META-INF/maven/**")
 
     archiveFileName.set("javaagentLibs-relocated-tmp.jar")
   }
@@ -391,8 +412,8 @@ fun CopySpec.isolateClasses(jar: Provider<RegularFile>) {
     // important to keep prefix "inst" short, as it is prefixed to lots of strings in runtime mem
     into("inst")
     rename("(^.*)\\.class\$", "\$1.classdata")
-    // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
-    rename("""^LICENSE$""", "LICENSE.renamed")
+    exclude("""^LICENSE$""")
+    exclude("META-INF/LICENSE.txt")
     exclude("META-INF/INDEX.LIST")
     exclude("META-INF/*.DSA")
     exclude("META-INF/*.SF")

--- a/testing/armeria-shaded-for-testing/build.gradle.kts
+++ b/testing/armeria-shaded-for-testing/build.gradle.kts
@@ -37,9 +37,11 @@ tasks {
     relocate("org.HdrHistogram", "io.opentelemetry.testing.internal.org.hdrhistogram")
     relocate("org.LatencyUtils", "io.opentelemetry.testing.internal.org.latencyutils")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
   }
 
   val extractShadowJar by registering(Copy::class) {

--- a/testing/wiremock-shaded-for-testing/build.gradle.kts
+++ b/testing/wiremock-shaded-for-testing/build.gradle.kts
@@ -35,9 +35,11 @@ tasks {
     relocate("javax.servlet", "io.opentelemetry.testing.internal.servlet")
     relocate("org.yaml", "io.opentelemetry.testing.internal.yaml")
 
-    // mergeServiceFiles requires that duplicate strategy is set to include
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
   }
 
   val extractShadowJar by registering(Copy::class) {


### PR DESCRIPTION
Set duplicate strategy to include only for service files that are going to be merged.