### PR TITLE
Add support for library links in metadata

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -143,7 +143,7 @@ abstract class NettyAlignmentRule : ComponentMetadataRule {
     with(ctx.details) {
       if (id.group == "io.netty" && id.name != "netty") {
         if (id.version.startsWith("4.1.")) {
-          belongsTo("io.netty:netty-bom:4.1.126.Final", false)
+          belongsTo("io.netty:netty-bom:4.1.127.Final", false)
         } else if (id.version.startsWith("4.0.")) {
           belongsTo("io.netty:netty-bom:4.0.56.Final", false)
         }

--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -80,6 +80,20 @@ Each instrumentation should have a `metadata.yaml` file in the root of the instr
 (`instrumentation/{some instrumentation}/metadata.yaml`) that contains structured metadata about the
 instrumentation.
 
+Example:
+
+```yaml
+description: "This instrumentation enables..."
+disabled_by_default: true
+classification: library
+library_link: "https://..."
+configurations:
+  - name: otel.instrumentation.common.db-statement-sanitizer.enabled
+    description: Enables statement sanitization for database queries.
+    type: boolean
+    default: true
+```
+
 ### Description (required)
 
 At a minimum, every instrumentation metadata file should include a `description`.
@@ -114,6 +128,10 @@ Some notes when writing descriptions:
 * It is not usually necessary to include specific library or framework version numbers in the
   description, unless that context is significant in some way.
 
+### Library Link
+
+For library instrumentations, include a `library_link` field with a URL to the library or framework's
+main website or documentation, or if those don't exist, the GitHub repository.
 
 ### Configurations
 

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -7,7 +7,7 @@ libraries:
   - name: activej-http-6.0
     description: This instrumentation enables HTTP server spans and HTTP server metrics
       for the ActiveJ HTTP server.
-    library_link: https://activej.io/
+    library_link: https://github.com/activej/activej
     source_path: instrumentation/activej-http-6.0
     minimum_java_version: 17
     scope:
@@ -62,7 +62,7 @@ libraries:
   - name: akka-actor-2.3
     description: This instrumentation provides context propagation for Akka actors,
       it does not emit any telemetry on its own.
-    library_link: https://doc.akka.io/docs/akka/current/typed/index.html
+    library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html
     source_path: instrumentation/akka/akka-actor-2.3
     scope:
       name: io.opentelemetry.akka-actor-2.3
@@ -74,7 +74,7 @@ libraries:
   - name: akka-actor-fork-join-2.5
     description: This instrumentation provides context propagation for the Akka Fork-Join
       Pool, it does not emit any telemetry on its own.
-    library_link: https://doc.akka.io/docs/akka/current/typed/index.html
+    library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html
     source_path: instrumentation/akka/akka-actor-fork-join-2.5
     scope:
       name: io.opentelemetry.akka-actor-fork-join-2.5
@@ -271,6 +271,7 @@ libraries:
     description: |
       This instrumentation enables database connection pools metrics for Apache DBCP.
       The instrumentation uses `MBeanRegistration` methods for lifecycle detection, therefore it only activates if the `BasicDataSource` is registered to an `MBeanServer`. If using Spring Boot, this happens automatically as all Spring beans that support JMX registration are automatically registered by default.
+    library_link: https://commons.apache.org/proper/commons-dbcp/
     source_path: instrumentation/apache-dbcp-2.0
     scope:
       name: io.opentelemetry.apache-dbcp-2.0
@@ -351,6 +352,7 @@ libraries:
       server spans for Apache Dubbo RPC calls. Each call produces a span named after
       the Dubbo method, enriched with standard RPC attributes (system, service, method),
       network attributes, and error details if an exception occurs.
+    library_link: https://github.com/apache/dubbo/
     source_path: instrumentation/apache-dubbo-2.7
     scope:
       name: io.opentelemetry.apache-dubbo-2.7
@@ -393,6 +395,7 @@ libraries:
   - name: apache-httpasyncclient-4.1
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for the Apache HttpAsyncClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpasyncclient-4.1
     scope:
       name: io.opentelemetry.apache-httpasyncclient-4.1
@@ -439,6 +442,7 @@ libraries:
   - name: apache-httpclient-2.0
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for versions 2 and 3 of the Apache HttpClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpclient/apache-httpclient-2.0
     scope:
       name: io.opentelemetry.apache-httpclient-2.0
@@ -483,6 +487,7 @@ libraries:
   - name: apache-httpclient-4.0
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for version 4 of the Apache HttpClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpclient/apache-httpclient-4.0
     scope:
       name: io.opentelemetry.apache-httpclient-4.0
@@ -530,6 +535,7 @@ libraries:
   - name: apache-httpclient-4.3
     description: This instrumentation provides a library integration that enables
       HTTP client spans and HTTP client metrics for the Apache HttpClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpclient/apache-httpclient-4.3
     scope:
       name: io.opentelemetry.apache-httpclient-4.3
@@ -578,6 +584,7 @@ libraries:
   - name: apache-httpclient-5.0
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for version 5 of the Apache HttpClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpclient/apache-httpclient-5.0
     scope:
       name: io.opentelemetry.apache-httpclient-5.0
@@ -624,6 +631,7 @@ libraries:
   - name: apache-httpclient-5.2
     description: This instrumentation provides a library integration that enables
       HTTP client spans and HTTP client metrics for the Apache HttpClient.
+    library_link: https://hc.apache.org/index.html
     source_path: instrumentation/apache-httpclient/apache-httpclient-5.2
     scope:
       name: io.opentelemetry.apache-httpclient-5.2
@@ -672,6 +680,7 @@ libraries:
   - name: apache-shenyu-2.4
     description: |
       This instrumentation does not emit telemetry on its own. Instead, it augments existing HTTP server spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
+    library_link: https://shenyu.apache.org/
     source_path: instrumentation/apache-shenyu-2.4
     scope:
       name: io.opentelemetry.apache-shenyu-2.4
@@ -688,6 +697,7 @@ libraries:
   - name: armeria-1.3
     description: |
       This instrumentation enables HTTP client spans and metrics for the Armeria HTTP client, and HTTP server spans and metrics for the Armeria HTTP server.
+    library_link: https://armeria.dev/
     source_path: instrumentation/armeria/armeria-1.3
     scope:
       name: io.opentelemetry.armeria-1.3
@@ -783,6 +793,7 @@ libraries:
   - name: armeria-grpc-1.14
     description: |
       This instrumentation enables RPC client spans and metrics for the Armeria gRPC client, and RPC server spans and metrics for the Armeria gRPC server.
+    library_link: https://armeria.dev/
     source_path: instrumentation/armeria/armeria-grpc-1.14
     scope:
       name: io.opentelemetry.armeria-grpc-1.14
@@ -824,6 +835,7 @@ libraries:
   - name: async-http-client-1.9
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for version 1 of the AsyncHttpClient (AHC) HTTP client.
+    library_link: https://github.com/AsyncHttpClient/async-http-client
     source_path: instrumentation/async-http-client/async-http-client-1.9
     scope:
       name: io.opentelemetry.async-http-client-1.9
@@ -866,6 +878,7 @@ libraries:
   - name: async-http-client-2.0
     description: This instrumentation enables HTTP client spans and HTTP client metrics
       for version 2 of the AsyncHttpClient (AHC) HTTP client.
+    library_link: https://github.com/AsyncHttpClient/async-http-client
     source_path: instrumentation/async-http-client/async-http-client-2.0
     scope:
       name: io.opentelemetry.async-http-client-2.0
@@ -917,6 +930,7 @@ libraries:
   - name: avaje-jex-3.0
     description: |
       This instrumentation does not emit telemetry on its own. Instead, it hooks into the Avaje Jex Context to extract the HTTP route and attach it to existing HTTP server spans and HTTP server metrics.
+    library_link: https://avaje.io/jex/
     source_path: instrumentation/avaje-jex-3.0
     minimum_java_version: 21
     scope:
@@ -929,6 +943,7 @@ libraries:
     description: |
       Provides lightweight instrumentation of the Lambda core library, supporting all versions. It generates FaaS server spans with the `faas.invocation_id` attribute. Use this package if you only use `RequestStreamHandler` or know you don't use any event classes from `aws-lambda-java-events`. This also includes when you are using `aws-serverless-java-container` to run e.g., a Spring Boot application on Lambda.
       For custom wrappers when using library instrumentation, you can configure the `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` environment variable to contain your lambda handler method (in the format `package.ClassName::methodName`) and use one of wrappers as your lambda `Handler`.
+    library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
     source_path: instrumentation/aws-lambda/aws-lambda-core-1.0
     scope:
       name: io.opentelemetry.aws-lambda-core-1.0
@@ -952,6 +967,7 @@ libraries:
   - name: aws-lambda-events-2.2
     description: |
       This version of the library instrumentation is deprecated, please use the `aws-lambda-events-3.11` library instrumentation instead. This instrumentation builds on top of the `aws-lambda-core-1.0` instrumentation, expanding support to cover the Lambda library, including standard and custom event types.
+    library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
     source_path: instrumentation/aws-lambda/aws-lambda-events-2.2
     scope:
       name: io.opentelemetry.aws-lambda-events-2.2
@@ -997,6 +1013,7 @@ libraries:
   - name: aws-lambda-events-3.11
     description: |
       This instrumentation builds on top of the `aws-lambda-core-1.0` instrumentation, expanding support to cover the Lambda library, including standard and custom event types.
+    library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
     source_path: instrumentation/aws-lambda/aws-lambda-events-3.11
     scope:
       name: io.opentelemetry.aws-lambda-events-3.11
@@ -1043,6 +1060,7 @@ libraries:
   - name: aws-sdk-1.11
     description: |
       This instrumentation covers the AWS SDK 1.11+ client library, enabling messaging and client spans and metrics for calls to AWS services including DynamoDB, EC2, Kinesis, Lambda, RDS, S3, secrets manager, SNS/SQS and step functions.
+    library_link: https://aws.amazon.com/sdk-for-java/
     source_path: instrumentation/aws-sdk/aws-sdk-1.11
     scope:
       name: io.opentelemetry.aws-sdk-1.11
@@ -1270,6 +1288,7 @@ libraries:
   - name: aws-sdk-2.2
     description: |
       This instrumentation covers the AWS SDK 2.2+ client library, enabling messaging and client spans and metrics for calls to AWS services including DynamoDB, EC2, Kinesis, Lambda, RDS, S3, SNS/SQS and Bedrock.
+    library_link: https://aws.amazon.com/sdk-for-java/
     source_path: instrumentation/aws-sdk/aws-sdk-2.2
     scope:
       name: io.opentelemetry.aws-sdk-2.2
@@ -1628,6 +1647,7 @@ libraries:
   - name: azure-core-1.14
     description: This instrumentation enables context propagation for the Azure Core
       library, it does not emit any telemetry on its own.
+    library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable
     source_path: instrumentation/azure-core/azure-core-1.14
     scope:
       name: io.opentelemetry.azure-core-1.14
@@ -1637,6 +1657,7 @@ libraries:
   - name: azure-core-1.19
     description: This instrumentation enables context propagation for the Azure Core
       library, it does not emit any telemetry on its own.
+    library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable
     source_path: instrumentation/azure-core/azure-core-1.19
     scope:
       name: io.opentelemetry.azure-core-1.19
@@ -1646,6 +1667,7 @@ libraries:
   - name: azure-core-1.36
     description: This instrumentation enables context propagation for the Azure Core
       library, it does not emit any telemetry on its own.
+    library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable
     source_path: instrumentation/azure-core/azure-core-1.36
     scope:
       name: io.opentelemetry.azure-core-1.36
@@ -1709,6 +1731,7 @@ libraries:
   - name: camel-2.20
     description: |
       This instrumentation enables tracing for Apache Camel 2.x applications by generating spans for each route execution. For Camel versions 3.5 and newer, users should instead use the native 'camel-opentelemetry' component provided directly by the Camel project.
+    library_link: https://camel.apache.org/
     source_path: instrumentation/camel-2.20
     scope:
       name: io.opentelemetry.camel-2.20
@@ -1834,6 +1857,7 @@ libraries:
   - name: cassandra-3.0
     description: |
       Instruments the Cassandra database client, providing database client spans and metrics for Cassandra queries.
+    library_link: https://github.com/apache/cassandra-java-driver
     source_path: instrumentation/cassandra/cassandra-3.0
     scope:
       name: io.opentelemetry.cassandra-3.0
@@ -1897,6 +1921,7 @@ libraries:
   - name: cassandra-4.0
     description: |
       Instruments the Cassandra database client, providing database client spans and metrics for Cassandra queries.
+    library_link: https://github.com/apache/cassandra-java-driver
     source_path: instrumentation/cassandra/cassandra-4.0
     scope:
       name: io.opentelemetry.cassandra-4.0
@@ -1984,6 +2009,7 @@ libraries:
   - name: cassandra-4.4
     description: |
       Instruments the Cassandra database client, providing database client spans and metrics for Cassandra queries.
+    library_link: https://github.com/apache/cassandra-java-driver
     source_path: instrumentation/cassandra/cassandra-4.4
     scope:
       name: io.opentelemetry.cassandra-4.4
@@ -2074,6 +2100,7 @@ libraries:
   - name: clickhouse-client-0.5
     description: Instruments the V1 ClickHouseClient, providing database client spans
       and metrics.
+    library_link: https://github.com/ClickHouse/clickhouse-java
     source_path: instrumentation/clickhouse-client-0.5
     scope:
       name: io.opentelemetry.clickhouse-client-0.5
@@ -2142,6 +2169,7 @@ libraries:
   - name: couchbase-2.0
     description: |
       This instrumentation enables database client spans and database client metrics for Couchbase 2.0 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
+    library_link: https://github.com/couchbase/couchbase-java-client
     source_path: instrumentation/couchbase/couchbase-2.0
     scope:
       name: io.opentelemetry.couchbase-2.0
@@ -2186,6 +2214,7 @@ libraries:
   - name: couchbase-2.6
     description: |
       This instrumentation enables database client spans and database client metrics for Couchbase 2.6 operations. It automatically traces key-value operations (get, upsert, replace, remove), view queries, N1QL queries, and cluster management operations.
+    library_link: https://github.com/couchbase/couchbase-java-client
     source_path: instrumentation/couchbase/couchbase-2.6
     scope:
       name: io.opentelemetry.couchbase-2.6
@@ -2274,6 +2303,7 @@ libraries:
   - name: couchbase-3.1
     description: |
       Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation automatically configures the instrumentation provided by the Couchbase library.
+    library_link: https://github.com/couchbase/couchbase-java-client
     source_path: instrumentation/couchbase/couchbase-3.1
     scope:
       name: io.opentelemetry.couchbase-3.1
@@ -2283,6 +2313,7 @@ libraries:
   - name: couchbase-3.1.6
     description: |
       Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation automatically configures the instrumentation provided by the Couchbase library.
+    library_link: https://github.com/couchbase/couchbase-java-client
     source_path: instrumentation/couchbase/couchbase-3.1.6
     scope:
       name: io.opentelemetry.couchbase-3.1.6
@@ -2292,6 +2323,7 @@ libraries:
   - name: couchbase-3.2
     description: |
       Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation automatically configures the instrumentation provided by the Couchbase library.
+    library_link: https://github.com/couchbase/couchbase-java-client
     source_path: instrumentation/couchbase/couchbase-3.2
     scope:
       name: io.opentelemetry.couchbase-3.2
@@ -2303,6 +2335,7 @@ libraries:
     description: |
       The dropwizard-metrics instrumentation for the dropwizard/codahale metrics library produces OpenTelemetry compliant versions of the metrics generated by the Dropwizard MetricRegistry.
       The Dropwizard metrics API does not have a concept of metric labels/tags/attributes, thus the data produced by this integration might be of very low quality, depending on how the API is used in the instrumented application.
+    library_link: https://metrics.dropwizard.io/4.2.0/
     disabled_by_default: true
     source_path: instrumentation/dropwizard/dropwizard-metrics-4.0
     scope:
@@ -2318,6 +2351,7 @@ libraries:
   - name: dropwizard-views-0.7
     description: This instrumentation enables the creation of spans for Dropwizard
       views.
+    library_link: https://www.dropwizard.io/en/latest/manual/views.html
     source_path: instrumentation/dropwizard/dropwizard-views-0.7
     scope:
       name: io.opentelemetry.dropwizard-views-0.7
@@ -2337,7 +2371,8 @@ libraries:
   elasticsearch:
   - name: elasticsearch-api-client-7.16
     description: |
-      This instrumentation extends the elasticsearch-rest-7.0 instrumentation by adding additional `db.elasticsearch.path_parts.id` and `db.elasticsearch.path_parts.index` attributes to Elasticsearch CLIENT spans. Versions 8.10 and later of the client have native support for OpenTelemetry.
+      This instrumentation extends the elasticsearch-rest-7.0 instrumentation by adding additional `db.elasticsearch.path_parts.id` and `db.elasticsearch.path_parts.index` attributes to Elasticsearch database client spans. Versions 8.10 and later of the client have native support for OpenTelemetry.
+    library_link: https://www.elastic.co/docs/reference/elasticsearch/clients/java
     source_path: instrumentation/elasticsearch/elasticsearch-api-client-7.16
     scope:
       name: io.opentelemetry.elasticsearch-api-client-7.16
@@ -2403,6 +2438,7 @@ libraries:
   - name: elasticsearch-rest-5.0
     description: This instrumentation enables database client spans and database client
       metrics for Elasticsearch REST clients.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
     source_path: instrumentation/elasticsearch/elasticsearch-rest-5.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-5.0
@@ -2465,6 +2501,7 @@ libraries:
   - name: elasticsearch-rest-6.4
     description: This instrumentation enables database client spans and database client
       metrics for Elasticsearch REST clients.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
     source_path: instrumentation/elasticsearch/elasticsearch-rest-6.4
     scope:
       name: io.opentelemetry.elasticsearch-rest-6.4
@@ -2526,6 +2563,7 @@ libraries:
   - name: elasticsearch-rest-7.0
     description: This instrumentation enables database client spans and database client
       metrics for Elasticsearch REST clients.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
     source_path: instrumentation/elasticsearch/elasticsearch-rest-7.0
     scope:
       name: io.opentelemetry.elasticsearch-rest-7.0
@@ -2589,6 +2627,7 @@ libraries:
   - name: elasticsearch-transport-5.0
     description: |
       This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
     source_path: instrumentation/elasticsearch/elasticsearch-transport-5.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.0
@@ -2681,6 +2720,7 @@ libraries:
   - name: elasticsearch-transport-5.3
     description: |
       This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
     source_path: instrumentation/elasticsearch/elasticsearch-transport-5.3
     scope:
       name: io.opentelemetry.elasticsearch-transport-5.3
@@ -2778,6 +2818,7 @@ libraries:
   - name: elasticsearch-transport-6.0
     description: |
       This instrumentation enables database client spans and database client metrics for Elasticsearch transport client requests. Each call produces a span named after the Elasticsearch action, enriched with transport-specific attributes.
+    library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
     source_path: instrumentation/elasticsearch/elasticsearch-transport-6.0
     scope:
       name: io.opentelemetry.elasticsearch-transport-6.0

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -1651,6 +1651,7 @@ libraries:
   - name: c3p0-0.9
     description: The c3p0 instrumentation provides connection pool metrics for c3p0
       data sources.
+    library_link: https://github.com/swaldman/c3p0
     source_path: instrumentation/c3p0-0.9
     scope:
       name: io.opentelemetry.c3p0-0.9
@@ -2971,6 +2972,7 @@ libraries:
   - name: google-http-client-1.19
     description: This instrumentation enables HTTP CLIENT spans and metrics for Google
       HTTP Client requests.
+    library_link: https://github.com/googleapis/google-http-java-client
     source_path: instrumentation/google-http-client-1.19
     scope:
       name: io.opentelemetry.google-http-client-1.19
@@ -3059,6 +3061,7 @@ libraries:
   graphql:
   - name: graphql-java-12.0
     description: This instrumentation enables spans for GraphQL Java operations.
+    library_link: https://www.graphql-java.com/
     source_path: instrumentation/graphql-java/graphql-java-12.0
     scope:
       name: io.opentelemetry.graphql-java-12.0

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -114,6 +114,9 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 * name
   * Identifier for instrumentation module, used to enable/disable
   * Configured in `InstrumentationModule` code for each module
+* library_link
+  * URL to the library or framework's main website or documentation, or if those don't exist, the
+  GitHub repository.
 * source_path
   * Path to the source code of the instrumentation module
 * minimum_java_version
@@ -145,9 +148,10 @@ additional information about the instrumentation module.
 As of now, the following fields are supported, all of which are optional:
 
 ```yaml
-description: "Instruments..."   # Description of the instrumentation module
-disabled_by_default: true       # Defaults to `false`
-classification: internal        # instrumentation classification: library | internal | custom
+description: "This instrumentation enables..."    # Description of the instrumentation module
+disabled_by_default: true                         # Defaults to `false`
+classification: internal                          # instrumentation classification: library | internal | custom
+library_link: "https://..."                       # URL to the library or framework's main website or documentation
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetaData.java
@@ -25,6 +25,10 @@ public class InstrumentationMetaData {
 
   private String classification;
 
+  @JsonProperty("library_link")
+  @Nullable
+  private String libraryLink;
+
   private List<ConfigurationOption> configurations = Collections.emptyList();
 
   public InstrumentationMetaData() {
@@ -35,10 +39,12 @@ public class InstrumentationMetaData {
       @Nullable String description,
       String classification,
       @Nullable Boolean disabledByDefault,
+      @Nullable String libraryLink,
       @Nullable List<ConfigurationOption> configurations) {
     this.classification = classification;
     this.disabledByDefault = disabledByDefault;
     this.description = description;
+    this.libraryLink = libraryLink;
     this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
   }
 
@@ -76,5 +82,14 @@ public class InstrumentationMetaData {
 
   public void setConfigurations(@Nullable List<ConfigurationOption> configurations) {
     this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
+  }
+
+  @Nullable
+  public String getLibraryLink() {
+    return libraryLink;
+  }
+
+  public void setLibraryLink(@Nullable String libraryLink) {
+    this.libraryLink = libraryLink;
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -198,6 +198,9 @@ public class YamlHelper {
       if (module.getMetadata().getDescription() != null) {
         moduleMap.put("description", module.getMetadata().getDescription());
       }
+      if (module.getMetadata().getLibraryLink() != null) {
+        moduleMap.put("library_link", module.getMetadata().getLibraryLink());
+      }
       if (module.getMetadata().getDisabledByDefault()) {
         moduleMap.put("disabled_by_default", module.getMetadata().getDisabledByDefault());
       }

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables SERVER spans and metrics for the ActiveJ HTTP server.
+library_link: https://activej.io/

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -1,2 +1,2 @@
 description: This instrumentation enables HTTP server spans and HTTP server metrics for the ActiveJ HTTP server.
-library_link: https://activej.io/
+library_link: https://github.com/activej/activej

--- a/instrumentation/akka/akka-actor-2.3/metadata.yaml
+++ b/instrumentation/akka/akka-actor-2.3/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation provides context propagation for Akka actors, it does not emit any telemetry on its own.
+library_link: https://doc.akka.io/docs/akka/current/typed/index.html

--- a/instrumentation/akka/akka-actor-2.3/metadata.yaml
+++ b/instrumentation/akka/akka-actor-2.3/metadata.yaml
@@ -1,2 +1,2 @@
 description: This instrumentation provides context propagation for Akka actors, it does not emit any telemetry on its own.
-library_link: https://doc.akka.io/docs/akka/current/typed/index.html
+library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html

--- a/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
@@ -1,2 +1,2 @@
 description: This instrumentation provides context propagation for the Akka Fork-Join Pool, it does not emit any telemetry on its own.
-library_link: https://doc.akka.io/docs/akka/current/typed/index.html
+library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html

--- a/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation provides context propagation for the Akka Fork-Join Pool, it does not emit any telemetry on its own.
+library_link: https://doc.akka.io/docs/akka/current/typed/index.html

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables CLIENT and SERVER spans and metrics for the Akka HTTP client and server.
+library_link: https://doc.akka.io/docs/akka-http/current/index.html

--- a/instrumentation/alibaba-druid-1.0/metadata.yaml
+++ b/instrumentation/alibaba-druid-1.0/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   The Alibaba Druid instrumentation generates database connection pool metrics for druid data
   sources.
+library_link: https://github.com/alibaba/druid

--- a/instrumentation/apache-dbcp-2.0/metadata.yaml
+++ b/instrumentation/apache-dbcp-2.0/metadata.yaml
@@ -5,3 +5,4 @@ description: >
   only activates if the `BasicDataSource` is registered to an `MBeanServer`. If using Spring Boot,
   this happens automatically as all Spring beans that support JMX registration are automatically
   registered by default.
+library_link: https://commons.apache.org/proper/commons-dbcp/

--- a/instrumentation/apache-dubbo-2.7/metadata.yaml
+++ b/instrumentation/apache-dubbo-2.7/metadata.yaml
@@ -2,6 +2,7 @@ description: The Apache Dubbo instrumentation provides RPC client spans and RPC 
   Apache Dubbo RPC calls. Each call produces a span named after the Dubbo method, enriched with
   standard RPC attributes (system, service, method), network attributes, and error details if an
   exception occurs.
+library_link: https://github.com/apache/dubbo/
 configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for the Apache HttpAsyncClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for versions 2 and 3 of the Apache HttpClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for version 4 of the Apache HttpClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation provides a library integration that enables HTTP client spans and HTTP client metrics for the Apache HttpClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for version 5 of the Apache HttpClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables CLIENT spans and metrics for the Apache HttpAsyncClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation provides a library integration that enables HTTP client spans and HTTP client metrics for the Apache HttpClient.
+library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-shenyu-2.4/metadata.yaml
+++ b/instrumentation/apache-shenyu-2.4/metadata.yaml
@@ -1,6 +1,7 @@
 description: >
   This instrumentation does not emit telemetry on its own. Instead, it augments existing HTTP server
   spans and HTTP server metrics with the HTTP route and Shenyu specific attributes.
+library_link: https://shenyu.apache.org/
 configurations:
   - name: otel.instrumentation.apache-shenyu.experimental-span-attributes
     description: > 

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   This instrumentation enables HTTP client spans and metrics for the Armeria HTTP client, and HTTP
   server spans and metrics for the Armeria HTTP server.
+library_link: https://armeria.dev/

--- a/instrumentation/armeria/armeria-grpc-1.14/metadata.yaml
+++ b/instrumentation/armeria/armeria-grpc-1.14/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   This instrumentation enables RPC client spans and metrics for the Armeria gRPC client, and RPC
   server spans and metrics for the Armeria gRPC server.
+library_link: https://armeria.dev/

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for version 1 of the AsyncHttpClient (AHC) HTTP client.
+library_link: https://github.com/AsyncHttpClient/async-http-client

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables HTTP client spans and HTTP client metrics for version 2 of the AsyncHttpClient (AHC) HTTP client.
+library_link: https://github.com/AsyncHttpClient/async-http-client

--- a/instrumentation/avaje-jex-3.0/metadata.yaml
+++ b/instrumentation/avaje-jex-3.0/metadata.yaml
@@ -2,3 +2,4 @@ description: >
   This instrumentation does not emit telemetry on its own. Instead, it hooks into the Avaje Jex
   Context to extract the HTTP route and attach it to existing HTTP server spans and HTTP server
   metrics.
+library_link: https://avaje.io/jex/

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/metadata.yaml
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/metadata.yaml
@@ -8,6 +8,7 @@ description: >
   For custom wrappers when using library instrumentation, you can configure the `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER`
   environment variable to contain your lambda handler method (in the format `package.ClassName::methodName`) and use
   one of wrappers as your lambda `Handler`.
+library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
 configurations:
   - name: otel.instrumentation.aws-lambda.flush-timeout
     type: int

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/metadata.yaml
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This version of the library instrumentation is deprecated, please use the `aws-lambda-events-3.11`
   library instrumentation instead. This instrumentation builds on top of the `aws-lambda-core-1.0`
   instrumentation, expanding support to cover the Lambda library, including standard and custom event types.
+library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
 configurations:
   - name: otel.instrumentation.aws-lambda.flush-timeout
     type: int

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/metadata.yaml
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/metadata.yaml
@@ -1,6 +1,7 @@
 description: >
   This instrumentation builds on top of the `aws-lambda-core-1.0` instrumentation, expanding support
   to cover the Lambda library, including standard and custom event types.
+library_link: https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
 configurations:
   - name: otel.instrumentation.aws-lambda.flush-timeout
     type: int

--- a/instrumentation/aws-sdk/aws-sdk-1.11/metadata.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation covers the AWS SDK 1.11+ client library, enabling messaging and client spans
   and metrics for calls to AWS services including DynamoDB, EC2, Kinesis, Lambda, RDS, S3, secrets
   manager, SNS/SQS and step functions.
+library_link: https://aws.amazon.com/sdk-for-java/
 configurations:
   - name: otel.instrumentation.aws-sdk.experimental-span-attributes
     description: >

--- a/instrumentation/aws-sdk/aws-sdk-2.2/metadata.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation covers the AWS SDK 2.2+ client library, enabling messaging and client spans
   and metrics for calls to AWS services including DynamoDB, EC2, Kinesis, Lambda, RDS, S3, SNS/SQS
   and Bedrock.
+library_link: https://aws.amazon.com/sdk-for-java/
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >

--- a/instrumentation/azure-core/azure-core-1.14/metadata.yaml
+++ b/instrumentation/azure-core/azure-core-1.14/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables context propagation for the Azure Core library, it does not emit any telemetry on its own.
+library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable

--- a/instrumentation/azure-core/azure-core-1.19/metadata.yaml
+++ b/instrumentation/azure-core/azure-core-1.19/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables context propagation for the Azure Core library, it does not emit any telemetry on its own.
+library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable

--- a/instrumentation/azure-core/azure-core-1.36/metadata.yaml
+++ b/instrumentation/azure-core/azure-core-1.36/metadata.yaml
@@ -1,1 +1,2 @@
 description: This instrumentation enables context propagation for the Azure Core library, it does not emit any telemetry on its own.
+library_link: https://learn.microsoft.com/en-us/java/api/overview/azure/core-readme?view=azure-java-stable

--- a/instrumentation/c3p0-0.9/metadata.yaml
+++ b/instrumentation/c3p0-0.9/metadata.yaml
@@ -1,1 +1,2 @@
 description: The c3p0 instrumentation provides connection pool metrics for c3p0 data sources.
+library_link: https://github.com/swaldman/c3p0

--- a/instrumentation/camel-2.20/metadata.yaml
+++ b/instrumentation/camel-2.20/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation enables tracing for Apache Camel 2.x applications by generating spans for
   each route execution. For Camel versions 3.5 and newer, users should instead use the native
   'camel-opentelemetry' component provided directly by the Camel project.
+library_link: https://camel.apache.org/
 configurations:
   - name: otel.instrumentation.camel.experimental-span-attributes
     description: >

--- a/instrumentation/cassandra/cassandra-3.0/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-3.0/metadata.yaml
@@ -1,6 +1,7 @@
 description: >
   Instruments the Cassandra database client, providing database client spans and metrics for
   Cassandra queries.
+library_link: https://github.com/apache/cassandra-java-driver
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation/cassandra/cassandra-4.0/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-4.0/metadata.yaml
@@ -1,6 +1,7 @@
 description: >
   Instruments the Cassandra database client, providing database client spans and metrics for
   Cassandra queries.
+library_link: https://github.com/apache/cassandra-java-driver
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation/cassandra/cassandra-4.4/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-4.4/metadata.yaml
@@ -1,6 +1,7 @@
 description: >
   Instruments the Cassandra database client, providing database client spans and metrics for
   Cassandra queries.
+library_link: https://github.com/apache/cassandra-java-driver
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation/clickhouse-client-0.5/metadata.yaml
+++ b/instrumentation/clickhouse-client-0.5/metadata.yaml
@@ -1,4 +1,5 @@
 description: Instruments the V1 ClickHouseClient, providing database client spans and metrics.
+library_link: https://github.com/ClickHouse/clickhouse-java
 configurations:
   - name: otel.instrumentation.common.db-statement-sanitizer.enabled
     description: Enables statement sanitization for database queries.

--- a/instrumentation/couchbase/couchbase-2.0/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.0/metadata.yaml
@@ -2,3 +2,4 @@ description: >
   This instrumentation enables database client spans and database client metrics for Couchbase 2.0
   operations. It automatically traces key-value operations (get, upsert, replace, remove), view
   queries, N1QL queries, and cluster management operations.
+library_link: https://github.com/couchbase/couchbase-java-client

--- a/instrumentation/couchbase/couchbase-2.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.6/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation enables database client spans and database client metrics for Couchbase 2.6
   operations. It automatically traces key-value operations (get, upsert, replace, remove), view
   queries, N1QL queries, and cluster management operations.
+library_link: https://github.com/couchbase/couchbase-java-client
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     description: >

--- a/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation
   automatically configures the instrumentation provided by the Couchbase library.
+library_link: https://github.com/couchbase/couchbase-java-client

--- a/instrumentation/couchbase/couchbase-3.1/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation
   automatically configures the instrumentation provided by the Couchbase library.
+library_link: https://github.com/couchbase/couchbase-java-client

--- a/instrumentation/couchbase/couchbase-3.2/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.2/metadata.yaml
@@ -1,3 +1,4 @@
 description: >
   Couchbase instrumentation is owned by the Couchbase project for versions 3+. This instrumentation
   automatically configures the instrumentation provided by the Couchbase library.
+library_link: https://github.com/couchbase/couchbase-java-client

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/metadata.yaml
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/metadata.yaml
@@ -5,6 +5,7 @@ description: >
   The Dropwizard metrics API does not have a concept of metric labels/tags/attributes, thus the data
   produced by this integration might be of very low quality, depending on how the API is used in the
   instrumented application.
+library_link: https://metrics.dropwizard.io/4.2.0/
 disabled_by_default: true
 configurations:
   - name: otel.instrumentation.dropwizard-metrics.enabled

--- a/instrumentation/dropwizard/dropwizard-views-0.7/metadata.yaml
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables the creation of spans for Dropwizard views.
+library_link: https://www.dropwizard.io/en/latest/manual/views.html
 configurations:
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
     description: Enables the creation of experimental view (INTERNAL) spans.

--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/metadata.yaml
@@ -1,5 +1,6 @@
 description: >
   This instrumentation extends the elasticsearch-rest-7.0 instrumentation by adding
   additional `db.elasticsearch.path_parts.id` and `db.elasticsearch.path_parts.index` attributes to
-  Elasticsearch CLIENT spans. Versions 8.10 and later of the client have native support for
+  Elasticsearch database client spans. Versions 8.10 and later of the client have native support for
   OpenTelemetry.
+library_link: https://www.elastic.co/docs/reference/elasticsearch/clients/java

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables database client spans and database client metrics for Elasticsearch REST clients.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-rest
 configurations:
   - name: otel.instrumentation.elasticsearch.capture-search-query
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation enables database client spans and database client metrics for Elasticsearch
   transport client requests. Each call produces a span named after the Elasticsearch action,
   enriched with transport-specific attributes.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation enables database client spans and database client metrics for Elasticsearch
   transport client requests. Each call produces a span named after the Elasticsearch action,
   enriched with transport-specific attributes.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/metadata.yaml
@@ -2,6 +2,7 @@ description: >
   This instrumentation enables database client spans and database client metrics for Elasticsearch
   transport client requests. Each call produces a span named after the Elasticsearch action,
   enriched with transport-specific attributes.
+library_link: https://www.elastic.co/guide/en/elasticsearch/client/java-api/
 configurations:
   - name: otel.instrumentation.elasticsearch.experimental-span-attributes
     description: >

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables HTTP CLIENT spans and metrics for Google HTTP Client requests.
+library_link: https://github.com/googleapis/google-http-java-client
 configurations:
   - name: otel.instrumentation.http.known-methods
     description: >

--- a/instrumentation/graphql-java/graphql-java-12.0/metadata.yaml
+++ b/instrumentation/graphql-java/graphql-java-12.0/metadata.yaml
@@ -1,4 +1,5 @@
 description: This instrumentation enables spans for GraphQL Java operations.
+library_link: https://www.graphql-java.com/
 configurations:
   - name: otel.instrumentation.graphql.query-sanitizer.enabled
     description: Enables sanitization of sensitive information from queries so they aren't added as span attributes.


### PR DESCRIPTION
Related to #13468 

Closes #14233

Referenced the links used in the [Supported Libraries page](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md)

I will continue populating the remaining metadata files in followup PRs as to not bloat this changeset too much more