### PR TITLE
DeclarativeConfigPropertiesBridge - Handling time unit in the Duration type properties

### DIFF
--- a/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeTest.java
+++ b/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeTest.java
@@ -72,8 +72,10 @@ class DeclarativeConfigPropertiesBridgeTest {
     assertThat(bridge.getInt("otel.instrumentation.example-instrumentation.int_key")).isEqualTo(1);
     assertThat(bridge.getLong("otel.instrumentation.example-instrumentation.int_key"))
         .isEqualTo(1L);
-    assertThat(bridge.getDuration("otel.instrumentation.example-instrumentation.int_key"))
-        .isEqualTo(Duration.ofMillis(1));
+    assertThat(bridge.getDuration("otel.instrumentation.example-instrumentation.duration_key1"))
+        .isEqualTo(Duration.ofMillis(123));
+    assertThat(bridge.getDuration("otel.instrumentation.example-instrumentation.duration_key2"))
+        .isEqualTo(Duration.ofNanos(987));
     assertThat(bridge.getDouble("otel.instrumentation.example-instrumentation.double_key"))
         .isEqualTo(1.1);
     assertThat(bridge.getList("otel.instrumentation.example-instrumentation.list_key"))

--- a/declarative-config-bridge/src/test/resources/config.yaml
+++ b/declarative-config-bridge/src/test/resources/config.yaml
@@ -14,6 +14,8 @@ instrumentation/development:
       bool_key: true
       int_key: 1
       double_key: 1.1
+      duration_key1: 123
+      duration_key2: 987ns
       list_key:
         - value1
         - value2


### PR DESCRIPTION
Current implementation of Duration type properties does't support time unit provided as a part of property value.
This PR adds a support of time units, as described in [Java doc of ConfigProperties::getDuration](https://github.com/open-telemetry/opentelemetry-java/blob/eb2b668e91c3e104a2ed29b6916e86236034f2fd/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java#L147)

The implementation is mostly based on the implementation from [DefaultConfigProperties class](https://github.com/open-telemetry/opentelemetry-java/blob/eb2b668e91c3e104a2ed29b6916e86236034f2fd/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java#L161).
It supports additionally 'us' and 'ns' time units besides the units mentioned in the [Java doc of ConfigProperties::getDuration](https://github.com/open-telemetry/opentelemetry-java/blob/eb2b668e91c3e104a2ed29b6916e86236034f2fd/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java#L147)