### PR TITLE
Add display_name support to metadata

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -5,6 +5,7 @@
 libraries:
   activej:
   - name: activej-http-6.0
+    display_name: ActiveJ
     description: This instrumentation enables HTTP server spans and HTTP server metrics
       for the ActiveJ HTTP server.
     library_link: https://activej.io/
@@ -60,6 +61,7 @@ libraries:
           type: STRING
   akka:
   - name: akka-actor-2.3
+    display_name: Akka Actors
     description: This instrumentation provides context propagation for Akka actors,
       it does not emit any telemetry on its own.
     library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html
@@ -72,6 +74,7 @@ libraries:
       - com.typesafe.akka:akka-actor_2.12:[2.3,)
       - com.typesafe.akka:akka-actor_2.13:[2.3,)
   - name: akka-actor-fork-join-2.5
+    display_name: Akka Actors
     description: This instrumentation provides context propagation for the Akka Fork-Join
       Pool, it does not emit any telemetry on its own.
     library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html
@@ -84,6 +87,7 @@ libraries:
       - com.typesafe.akka:akka-actor_2.13:[2.5.23,2.6)
       - com.typesafe.akka:akka-actor_2.11:[2.5,)
   - name: akka-http-10.0
+    display_name: Akka HTTP
     description: |
       This instrumentation enables HTTP client spans and metrics for the Akka HTTP client, and HTTP server spans and metrics for the Akka HTTP server.
     library_link: https://doc.akka.io/docs/akka-http/current/index.html

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.docs;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetaData;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.parsers.GradleParser;
@@ -58,7 +58,7 @@ class InstrumentationAnalyzer {
   }
 
   private void enrichModule(InstrumentationModule module) throws IOException {
-    InstrumentationMetaData metaData = getMetadata(module);
+    InstrumentationMetadata metaData = getMetadata(module);
     if (metaData != null) {
       module.setMetadata(metaData);
     }
@@ -69,7 +69,7 @@ class InstrumentationAnalyzer {
   }
 
   @Nullable
-  private InstrumentationMetaData getMetadata(InstrumentationModule module)
+  private InstrumentationMetadata getMetadata(InstrumentationModule module)
       throws JsonProcessingException {
     String metadataFile = fileManager.getMetaDataFile(module.getSrcPath());
     if (metadataFile == null) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetadata.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetadata.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.docs.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -16,7 +17,7 @@ import javax.annotation.Nullable;
  * Represents the data in a metadata.yaml file. This class is internal and is hence not for public
  * use. Its APIs are unstable and can change at any time.
  */
-public class InstrumentationMetaData {
+public class InstrumentationMetadata {
   @Nullable private String description;
 
   @JsonProperty("disabled_by_default")
@@ -29,28 +30,43 @@ public class InstrumentationMetaData {
   @Nullable
   private String libraryLink;
 
+  @JsonProperty("display_name")
+  @Nullable
+  private String displayName;
+
   private List<ConfigurationOption> configurations = Collections.emptyList();
 
-  public InstrumentationMetaData() {
+  public InstrumentationMetadata() {
     this.classification = InstrumentationClassification.LIBRARY.toString();
   }
 
-  public InstrumentationMetaData(
+  public InstrumentationMetadata(
       @Nullable String description,
-      String classification,
       @Nullable Boolean disabledByDefault,
+      String classification,
       @Nullable String libraryLink,
+      @Nullable String displayName,
       @Nullable List<ConfigurationOption> configurations) {
     this.classification = classification;
     this.disabledByDefault = disabledByDefault;
     this.description = description;
     this.libraryLink = libraryLink;
+    this.displayName = displayName;
     this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
   }
 
   @Nullable
   public String getDescription() {
     return description;
+  }
+
+  public void setDisplayName(@Nullable String displayName) {
+    this.displayName = displayName;
+  }
+
+  @Nullable
+  public String getDisplayName() {
+    return displayName;
   }
 
   @Nonnull
@@ -91,5 +107,67 @@ public class InstrumentationMetaData {
 
   public void setLibraryLink(@Nullable String libraryLink) {
     this.libraryLink = libraryLink;
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class Builder {
+
+    @Nullable private String description;
+    @Nullable private Boolean disabledByDefault;
+    @Nullable private String classification;
+    @Nullable private String libraryLink;
+    @Nullable private String displayName;
+    private List<ConfigurationOption> configurations = Collections.emptyList();
+
+    @CanIgnoreReturnValue
+    public Builder description(@Nullable String description) {
+      this.description = description;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder disabledByDefault(@Nullable Boolean disabledByDefault) {
+      this.disabledByDefault = disabledByDefault;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder classification(@Nullable String classification) {
+      this.classification = classification;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder libraryLink(@Nullable String libraryLink) {
+      this.libraryLink = libraryLink;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder displayName(@Nullable String displayName) {
+      this.displayName = displayName;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder configurations(@Nullable List<ConfigurationOption> configurations) {
+      this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
+      return this;
+    }
+
+    public InstrumentationMetadata build() {
+      return new InstrumentationMetadata(
+          description,
+          disabledByDefault,
+          classification != null
+              ? classification
+              : InstrumentationClassification.LIBRARY.toString(),
+          libraryLink,
+          displayName,
+          configurations);
+    }
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetadata.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationMetadata.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.instrumentation.docs.internal;
 
+import static java.util.Collections.emptyList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -34,10 +35,10 @@ public class InstrumentationMetadata {
   @Nullable
   private String displayName;
 
-  private List<ConfigurationOption> configurations = Collections.emptyList();
+  private List<ConfigurationOption> configurations = emptyList();
 
   public InstrumentationMetadata() {
-    this.classification = InstrumentationClassification.LIBRARY.toString();
+    this.classification = InstrumentationClassification.LIBRARY.name();
   }
 
   public InstrumentationMetadata(
@@ -52,7 +53,7 @@ public class InstrumentationMetadata {
     this.description = description;
     this.libraryLink = libraryLink;
     this.displayName = displayName;
-    this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
+    this.configurations = Objects.requireNonNullElse(configurations, emptyList());
   }
 
   @Nullable
@@ -97,7 +98,7 @@ public class InstrumentationMetadata {
   }
 
   public void setConfigurations(@Nullable List<ConfigurationOption> configurations) {
-    this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
+    this.configurations = Objects.requireNonNullElse(configurations, emptyList());
   }
 
   @Nullable
@@ -120,7 +121,7 @@ public class InstrumentationMetadata {
     @Nullable private String classification;
     @Nullable private String libraryLink;
     @Nullable private String displayName;
-    private List<ConfigurationOption> configurations = Collections.emptyList();
+    private List<ConfigurationOption> configurations = emptyList();
 
     @CanIgnoreReturnValue
     public Builder description(@Nullable String description) {
@@ -154,7 +155,7 @@ public class InstrumentationMetadata {
 
     @CanIgnoreReturnValue
     public Builder configurations(@Nullable List<ConfigurationOption> configurations) {
-      this.configurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
+      this.configurations = Objects.requireNonNullElse(configurations, emptyList());
       return this;
     }
 
@@ -162,9 +163,7 @@ public class InstrumentationMetadata {
       return new InstrumentationMetadata(
           description,
           disabledByDefault,
-          classification != null
-              ? classification
-              : InstrumentationClassification.LIBRARY.toString(),
+          classification != null ? classification : InstrumentationClassification.LIBRARY.name(),
           libraryLink,
           displayName,
           configurations);

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
@@ -35,7 +35,7 @@ public class InstrumentationModule {
 
   @Nullable private Integer minJavaVersion;
 
-  @Nullable private InstrumentationMetaData metadata;
+  @Nullable private InstrumentationMetadata metadata;
 
   /**
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -79,9 +79,9 @@ public class InstrumentationModule {
     return scopeInfo;
   }
 
-  public InstrumentationMetaData getMetadata() {
+  public InstrumentationMetadata getMetadata() {
     if (metadata == null) {
-      metadata = new InstrumentationMetaData();
+      metadata = new InstrumentationMetadata();
     }
 
     return metadata;
@@ -109,7 +109,7 @@ public class InstrumentationModule {
     this.targetVersions = targetVersions;
   }
 
-  public void setMetadata(InstrumentationMetaData metadata) {
+  public void setMetadata(InstrumentationMetadata metadata) {
     this.metadata = metadata;
   }
 
@@ -135,7 +135,7 @@ public class InstrumentationModule {
     @Nullable private String namespace;
     @Nullable private String group;
     @Nullable private Integer minJavaVersion;
-    @Nullable private InstrumentationMetaData metadata;
+    @Nullable private InstrumentationMetadata metadata;
     @Nullable private Map<InstrumentationType, Set<String>> targetVersions;
     @Nullable private Map<String, List<EmittedMetrics.Metric>> metrics;
     @Nullable private Map<String, List<EmittedSpans.Span>> spans;
@@ -171,7 +171,7 @@ public class InstrumentationModule {
     }
 
     @CanIgnoreReturnValue
-    public Builder metadata(InstrumentationMetaData metadata) {
+    public Builder metadata(InstrumentationMetadata metadata) {
       this.metadata = metadata;
       return this;
     }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -13,7 +13,7 @@ import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetaData;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
 import java.io.BufferedWriter;
@@ -195,6 +195,9 @@ public class YamlHelper {
   private static void addMetadataProperties(
       InstrumentationModule module, Map<String, Object> moduleMap) {
     if (module.getMetadata() != null) {
+      if (module.getMetadata().getDisplayName() != null) {
+        moduleMap.put("display_name", module.getMetadata().getDisplayName());
+      }
       if (module.getMetadata().getDescription() != null) {
         moduleMap.put("description", module.getMetadata().getDescription());
       }
@@ -290,9 +293,9 @@ public class YamlHelper {
     return innerMetricMap;
   }
 
-  public static InstrumentationMetaData metaDataParser(String input)
+  public static InstrumentationMetadata metaDataParser(String input)
       throws JsonProcessingException {
-    return mapper.readValue(input, InstrumentationMetaData.class);
+    return mapper.readValue(input, InstrumentationMetadata.class);
   }
 
   public static EmittedMetrics emittedMetricsParser(String input) throws JsonProcessingException {

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -42,7 +42,7 @@ class YamlHelperTest {
         new InstrumentationMetadata.Builder()
             .description("Spring Web 6.0 instrumentation")
             .displayName("Spring Web")
-            .classification(InstrumentationClassification.LIBRARY.toString())
+            .classification(InstrumentationClassification.LIBRARY.name())
             .disabledByDefault(true)
             .build();
 
@@ -114,7 +114,7 @@ class YamlHelperTest {
     InstrumentationMetadata springMetadata =
         new InstrumentationMetadata.Builder()
             .description("Spring Web 6.0 instrumentation")
-            .classification(InstrumentationClassification.LIBRARY.toString())
+            .classification(InstrumentationClassification.LIBRARY.name())
             .disabledByDefault(false)
             .configurations(
                 List.of(
@@ -138,7 +138,7 @@ class YamlHelperTest {
 
     InstrumentationMetadata internalMetadata =
         new InstrumentationMetadata.Builder()
-            .classification(InstrumentationClassification.INTERNAL.toString())
+            .classification(InstrumentationClassification.INTERNAL.name())
             .build();
 
     modules.add(
@@ -153,7 +153,7 @@ class YamlHelperTest {
 
     InstrumentationMetadata customMetadata =
         new InstrumentationMetadata.Builder()
-            .classification(InstrumentationClassification.CUSTOM.toString())
+            .classification(InstrumentationClassification.CUSTOM.name())
             .build();
 
     Map<InstrumentationType, Set<String>> externalAnnotationsVersions =
@@ -516,7 +516,7 @@ class YamlHelperTest {
     InstrumentationMetadata metadataWithLink =
         new InstrumentationMetadata.Builder()
             .description("Test library instrumentation with link")
-            .classification(InstrumentationClassification.LIBRARY.toString())
+            .classification(InstrumentationClassification.LIBRARY.name())
             .disabledByDefault(false)
             .libraryLink("https://example.com/test-library-docs")
             .build();
@@ -534,7 +534,7 @@ class YamlHelperTest {
     InstrumentationMetadata metadataWithoutLink =
         new InstrumentationMetadata.Builder()
             .description("Test library instrumentation without link")
-            .classification(InstrumentationClassification.LIBRARY.toString())
+            .classification(InstrumentationClassification.LIBRARY.name())
             .disabledByDefault(false)
             .build();
 

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -14,7 +14,7 @@ import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
-import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetaData;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
@@ -38,13 +38,13 @@ class YamlHelperTest {
         InstrumentationType.JAVAAGENT,
         new HashSet<>(List.of("org.springframework:spring-web:[6.0.0,)")));
 
-    InstrumentationMetaData springMetadata =
-        new InstrumentationMetaData(
-            "Spring Web 6.0 instrumentation",
-            InstrumentationClassification.LIBRARY.toString(),
-            true,
-            null,
-            null);
+    InstrumentationMetadata springMetadata =
+        new InstrumentationMetadata.Builder()
+            .description("Spring Web 6.0 instrumentation")
+            .displayName("Spring Web")
+            .classification(InstrumentationClassification.LIBRARY.toString())
+            .disabledByDefault(true)
+            .build();
 
     modules.add(
         new InstrumentationModule.Builder()
@@ -82,6 +82,7 @@ class YamlHelperTest {
             libraries:
               spring:
               - name: spring-web-6.0
+                display_name: Spring Web
                 description: Spring Web 6.0 instrumentation
                 disabled_by_default: true
                 source_path: instrumentation/spring/spring-web/spring-web-6.0
@@ -110,18 +111,19 @@ class YamlHelperTest {
     Map<InstrumentationType, Set<String>> springTargetVersions =
         Map.of(InstrumentationType.JAVAAGENT, Set.of("org.springframework:spring-web:[6.0.0,)"));
 
-    InstrumentationMetaData springMetadata =
-        new InstrumentationMetaData(
-            "Spring Web 6.0 instrumentation",
-            InstrumentationClassification.LIBRARY.toString(),
-            false,
-            null,
-            List.of(
-                new ConfigurationOption(
-                    "otel.instrumentation.spring-web-6.0.enabled",
-                    "Enables or disables Spring Web 6.0 instrumentation.",
-                    "true",
-                    ConfigurationType.BOOLEAN)));
+    InstrumentationMetadata springMetadata =
+        new InstrumentationMetadata.Builder()
+            .description("Spring Web 6.0 instrumentation")
+            .classification(InstrumentationClassification.LIBRARY.toString())
+            .disabledByDefault(false)
+            .configurations(
+                List.of(
+                    new ConfigurationOption(
+                        "otel.instrumentation.spring-web-6.0.enabled",
+                        "Enables or disables Spring Web 6.0 instrumentation.",
+                        "true",
+                        ConfigurationType.BOOLEAN)))
+            .build();
 
     modules.add(
         new InstrumentationModule.Builder()
@@ -134,9 +136,10 @@ class YamlHelperTest {
             .minJavaVersion(11)
             .build());
 
-    InstrumentationMetaData internalMetadata =
-        new InstrumentationMetaData(
-            null, InstrumentationClassification.INTERNAL.toString(), null, null, null);
+    InstrumentationMetadata internalMetadata =
+        new InstrumentationMetadata.Builder()
+            .classification(InstrumentationClassification.INTERNAL.toString())
+            .build();
 
     modules.add(
         new InstrumentationModule.Builder()
@@ -148,9 +151,10 @@ class YamlHelperTest {
             .targetVersions(new HashMap<>())
             .build());
 
-    InstrumentationMetaData customMetadata =
-        new InstrumentationMetaData(
-            null, InstrumentationClassification.CUSTOM.toString(), null, null, null);
+    InstrumentationMetadata customMetadata =
+        new InstrumentationMetadata.Builder()
+            .classification(InstrumentationClassification.CUSTOM.toString())
+            .build();
 
     Map<InstrumentationType, Set<String>> externalAnnotationsVersions =
         Map.of(
@@ -224,7 +228,7 @@ class YamlHelperTest {
                 default: true
             """;
 
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
 
     ConfigurationOption config = metadata.getConfigurations().get(0);
     assertThat(config.name())
@@ -242,7 +246,7 @@ class YamlHelperTest {
   @Test
   void testMetadataParserWithOnlyLibraryEntry() throws JsonProcessingException {
     String input = "classification: internal";
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
     assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.INTERNAL);
     assertThat(metadata.getDescription()).isNull();
     assertThat(metadata.getLibraryLink()).isNull();
@@ -253,7 +257,7 @@ class YamlHelperTest {
   @Test
   void testMetadataParserWithOnlyLibraryLink() throws JsonProcessingException {
     String input = "library_link: https://example.com/only-link";
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
     assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
     assertThat(metadata.getDescription()).isNull();
     assertThat(metadata.getLibraryLink()).isEqualTo("https://example.com/only-link");
@@ -264,7 +268,7 @@ class YamlHelperTest {
   @Test
   void testMetadataParserWithOnlyDescription() throws JsonProcessingException {
     String input = "description: false";
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
     assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
     assertThat(metadata.getDisabledByDefault()).isFalse();
     assertThat(metadata.getConfigurations()).isEmpty();
@@ -273,7 +277,7 @@ class YamlHelperTest {
   @Test
   void testMetadataParserWithOnlyDisabledByDefault() throws JsonProcessingException {
     String input = "disabled_by_default: true";
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
     assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
     assertThat(metadata.getDescription()).isNull();
     assertThat(metadata.getDisabledByDefault()).isTrue();
@@ -290,7 +294,7 @@ class YamlHelperTest {
                 type: boolean
                 default: true
         """;
-    InstrumentationMetaData metadata = YamlHelper.metaDataParser(input);
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
     ConfigurationOption config = metadata.getConfigurations().get(0);
 
     assertThat(metadata.getClassification()).isEqualTo(InstrumentationClassification.LIBRARY);
@@ -509,13 +513,13 @@ class YamlHelperTest {
     targetVersions.put(
         InstrumentationType.JAVAAGENT, new HashSet<>(List.of("com.example:test-library:[1.0.0,)")));
 
-    InstrumentationMetaData metadataWithLink =
-        new InstrumentationMetaData(
-            "Test library instrumentation with link",
-            InstrumentationClassification.LIBRARY.toString(),
-            false,
-            "https://example.com/test-library-docs",
-            emptyList());
+    InstrumentationMetadata metadataWithLink =
+        new InstrumentationMetadata.Builder()
+            .description("Test library instrumentation with link")
+            .classification(InstrumentationClassification.LIBRARY.toString())
+            .disabledByDefault(false)
+            .libraryLink("https://example.com/test-library-docs")
+            .build();
 
     modules.add(
         new InstrumentationModule.Builder()
@@ -527,13 +531,12 @@ class YamlHelperTest {
             .metadata(metadataWithLink)
             .build());
 
-    InstrumentationMetaData metadataWithoutLink =
-        new InstrumentationMetaData(
-            "Test library instrumentation without link",
-            InstrumentationClassification.LIBRARY.toString(),
-            false,
-            null,
-            emptyList());
+    InstrumentationMetadata metadataWithoutLink =
+        new InstrumentationMetadata.Builder()
+            .description("Test library instrumentation without link")
+            .classification(InstrumentationClassification.LIBRARY.toString())
+            .disabledByDefault(false)
+            .build();
 
     modules.add(
         new InstrumentationModule.Builder()

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -1,2 +1,3 @@
+display_name: ActiveJ
 description: This instrumentation enables HTTP server spans and HTTP server metrics for the ActiveJ HTTP server.
 library_link: https://activej.io/

--- a/instrumentation/akka/akka-actor-2.3/metadata.yaml
+++ b/instrumentation/akka/akka-actor-2.3/metadata.yaml
@@ -1,2 +1,3 @@
+display_name: Akka Actors
 description: This instrumentation provides context propagation for Akka actors, it does not emit any telemetry on its own.
 library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html

--- a/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/metadata.yaml
@@ -1,2 +1,3 @@
+display_name: Akka Actors
 description: This instrumentation provides context propagation for the Akka Fork-Join Pool, it does not emit any telemetry on its own.
 library_link: https://doc.akka.io/libraries/akka-core/current/typed/index.html

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -1,3 +1,4 @@
+display_name: Akka HTTP
 description: >
   This instrumentation enables HTTP client spans and metrics for the Akka HTTP client, and HTTP
   server spans and metrics for the Akka HTTP server.


### PR DESCRIPTION
Closes #14623 
Closes #14643 

Adds `display_name` support to the metadata file and adds it to the instrumentation-list.yaml output. 

Also added a builder for the `InstrumentationMetadata` class since it has so many attributes now.

Added a few display names for some instrumentations, matching what they are on the [supported libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md) page. I will have followups where I populate more of them to avoid bloating this PR.