### PR TITLE
Remove pluralization of failsafe metric namespace

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -3069,7 +3069,7 @@ libraries:
           type: STRING
         - name: failsafe.circuit_breaker.outcome
           type: STRING
-      - name: failsafe.circuit_breaker.state_changes.count
+      - name: failsafe.circuit_breaker.state_change.count
         description: Count of circuit breaker state changes.
         type: LONG_SUM
         unit: execution

--- a/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
+++ b/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
@@ -57,7 +57,7 @@ public final class FailsafeTelemetry {
             .build();
     LongCounter stateChangesCounter =
         meter
-            .counterBuilder("failsafe.circuit_breaker.state_changes.count")
+            .counterBuilder("failsafe.circuit_breaker.state_change.count")
             .setDescription("Count of circuit breaker state changes.")
             .setUnit("{execution}")
             .build();

--- a/instrumentation/failsafe-3.0/library/src/test/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetryTest.java
+++ b/instrumentation/failsafe-3.0/library/src/test/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetryTest.java
@@ -67,7 +67,7 @@ final class FailsafeTelemetryTest {
         "io.opentelemetry.failsafe-3.0",
         metricAssert ->
             metricAssert
-                .hasName("failsafe.circuit_breaker.state_changes.count")
+                .hasName("failsafe.circuit_breaker.state_change.count")
                 .hasLongSumSatisfying(
                     sum ->
                         sum.isMonotonic()


### PR DESCRIPTION
Renames `failsafe.circuit_breaker.state_changes.count` to `failsafe.circuit_breaker.state_change.count`.

Follow-up to #14057

cc @onurkybsi