### PR TITLE
[release/v2.20.x] Backport: Fix post-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           message="Post-release updates for $VERSION"
-          body="Post-release updates for `$VERSION`."
+          body="Post-release updates for \`$VERSION\`."
           branch="otelbot/update-apidiff-baseline-to-released-version-${VERSION}"
 
           git checkout -b $branch


### PR DESCRIPTION
Clean cherry-pick of #14727

(couldn't use backport automation because it lacks permissions to update workflow files)