### PR TITLE
Fix resource leak in PortAllocator canBind method

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/PortAllocator.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/PortAllocator.java
@@ -118,9 +118,7 @@ class PortAllocator {
     }
 
     boolean canBind(int port) {
-      try {
-        ServerSocket socket = new ServerSocket(port);
-        socket.close();
+      try (ServerSocket socket = new ServerSocket(port)) {
         return true;
       } catch (IOException exception) {
         return false;


### PR DESCRIPTION
## Summary
Fixed a potential resource leak in the `canBind` method of `PortAllocator` class.

## Problem
The original implementation manually created and closed `ServerSocket` instances, which could lead to resource leaks if an exception occurred between socket creation and the explicit `close()` call.

```java
// Original code with potential leak
try {
    ServerSocket socket = new ServerSocket(port);
    socket.close();  // If exception thrown here, socket won't be closed
    return true;
} catch (IOException exception) {
    return false;
}
```

## Solution
Replaced manual resource management with try-with-resources statement to ensure automatic cleanup:

```java
// Fixed code with automatic resource management
try (ServerSocket socket = new ServerSocket(port)) {
    return true;  // Socket automatically closed regardless of outcome
} catch (IOException exception) {
    return false;
}
```

## Benefits
- **Prevents resource leaks**: Socket handles are guaranteed to be released
- **Cleaner code**: Removes manual resource management boilerplate
- **Exception safety**: Resources cleaned up even if unexpected exceptions occur

## Test plan
- [x] Verified code compiles without errors
- [x] Confirmed try-with-resources follows Java best practices
- [x] No functional changes to the method behavior