### PR TITLE
add experimental option to avoid lettuce noisy span events

### DIFF
--- a/instrumentation/lettuce/README.md
+++ b/instrumentation/lettuce/README.md
@@ -1,6 +1,7 @@
 # Settings for the Lettuce instrumentation
 
-| System property                                             | Type    | Default | Description                                         |
-|-------------------------------------------------------------|---------|---------|-----------------------------------------------------|
-| `otel.instrumentation.lettuce.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
-| `otel.instrumentation.lettuce.connection-telemetry.enabled` | Boolean | `false` | Enable the creation of Connect spans.               |
+| System property                                                          | Type    | Default | Description                                         |
+|--------------------------------------------------------------------------|---------|---------|-----------------------------------------------------|
+| `otel.instrumentation.lettuce.experimental-span-attributes`              | Boolean | `false` | Enable the capture of experimental span attributes. |
+| `otel.instrumentation.lettuce.connection-telemetry.enabled`              | Boolean | `false` | Enable the creation of Connect spans.               |
+| `otel.instrumentation.lettuce.experimental.encoding-span-events.enabled` | Boolean | `true`  | Allows to toggle span encoding events.              |

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/TracingHolder.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/TracingHolder.java
@@ -9,12 +9,19 @@ import io.lettuce.core.tracing.Tracing;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.lettuce.v5_1.LettuceTelemetry;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 
 public final class TracingHolder {
+
+  private static final boolean CAPTURE_ENCODING_SPAN_EVENTS =
+      AgentInstrumentationConfig.get()
+          .getBoolean(
+              "otel.instrumentation.lettuce.experimental.encoding-span-events.enabled", true);
 
   public static final Tracing TRACING =
       LettuceTelemetry.builder(GlobalOpenTelemetry.get())
           .setStatementSanitizationEnabled(AgentCommonConfig.get().isStatementSanitizationEnabled())
+          .setEncodingSpanEventsEnabled(CAPTURE_ENCODING_SPAN_EVENTS)
           .build()
           .newTracing();
 

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetry.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetry.java
@@ -33,10 +33,12 @@ public final class LettuceTelemetry {
   private final Tracer tracer;
   private final RedisCommandSanitizer sanitizer;
   private final OperationListener metrics;
+  private final boolean encodingEventsEnabled;
 
   LettuceTelemetry(
       OpenTelemetry openTelemetry,
       boolean statementSanitizationEnabled,
+      boolean encodingEventsEnabled,
       OperationListener metrics) {
     this.metrics = metrics;
     TracerBuilder tracerBuilder = openTelemetry.tracerBuilder(INSTRUMENTATION_NAME);
@@ -46,6 +48,7 @@ public final class LettuceTelemetry {
     }
     tracer = tracerBuilder.build();
     sanitizer = RedisCommandSanitizer.create(statementSanitizationEnabled);
+    this.encodingEventsEnabled = encodingEventsEnabled;
   }
 
   /**
@@ -53,6 +56,6 @@ public final class LettuceTelemetry {
    * io.lettuce.core.resource.ClientResources.Builder#tracing(Tracing)}.
    */
   public Tracing newTracing() {
-    return new OpenTelemetryTracing(tracer, sanitizer, metrics);
+    return new OpenTelemetryTracing(tracer, sanitizer, metrics, encodingEventsEnabled);
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
@@ -18,6 +18,8 @@ public final class LettuceTelemetryBuilder {
 
   private boolean statementSanitizationEnabled = true;
 
+  private boolean encodingEventsEnabled = true;
+
   LettuceTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
   }
@@ -35,6 +37,16 @@ public final class LettuceTelemetryBuilder {
   }
 
   /**
+   * Sets whether the {@code redis.encode.start} and {@code redis.encode.end} span events should be
+   * emitted by the constructed {@link LettuceTelemetry}. Enabled by default.
+   */
+  @CanIgnoreReturnValue
+  public LettuceTelemetryBuilder setEncodingSpanEventsEnabled(boolean encodingEventsEnabled) {
+    this.encodingEventsEnabled = encodingEventsEnabled;
+    return this;
+  }
+
+  /**
    * Returns a new {@link LettuceTelemetry} with the settings of this {@link
    * LettuceTelemetryBuilder}.
    */
@@ -42,6 +54,7 @@ public final class LettuceTelemetryBuilder {
     return new LettuceTelemetry(
         openTelemetry,
         statementSanitizationEnabled,
+        encodingEventsEnabled,
         DbClientMetrics.get().create(openTelemetry.getMeterProvider().get(INSTRUMENTATION_NAME)));
   }
 }


### PR DESCRIPTION
When using `lettuce`, the current instrumentation produces lots `redis.encode.start` and `redis.encode.end` span events which can be noisy.

- adds a new `otel.instrumentation.lettuce.experimental.encoding-span-events.enabled` configuration option, default to `true` to preserve current behavior by default.
- filters the span events as they are produced in [`TracedCommand`](https://github.com/redis/lettuce/blob/83125aaee919c9bec656051499d4e965c757b097/src/main/java/io/lettuce/core/protocol/TracedCommand.java#L14) lettuce class

This solves the same issue that was reported in [ApplicationInsights-Java#1586](https://github.com/microsoft/ApplicationInsights-Java/issues/1586) and [elastic-otel-java#796](https://github.com/elastic/elastic-otel-java/issues/796), for now the workaround is to post-process and filter the span events at the collector level.