### PR TITLE
Catch exception when reactor netty response is not available

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -40,6 +40,7 @@ final class ReactorNettyHttpClientAttributesGetter
     }
   }
 
+  @Nullable
   @Override
   public Integer getHttpResponseStatusCode(
       HttpClientRequest request, HttpClientResponse response, @Nullable Throwable error) {


### PR DESCRIPTION
I got notified that our rector netty http client instrumentation occasionally produces IllegalStateExceptions from
https://github.com/reactor/reactor-netty/blob/52d87512c6de3ef3f2990641bbfe997d95ab9262/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java#L549 I wasn't able to reproduce this (didn't try too  hard). Looking at the code I got the impression that this could happen when the server responds with something that netty deems invalid (netty gets an exception while parsing the response).