### PR TITLE
Flaky test reporter: don't parse empty files

### DIFF
--- a/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
+++ b/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
@@ -201,7 +201,7 @@ public class FlakyTestReporter {
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
             String name = file.getFileName().toString();
-            if (name.startsWith("TEST-") && name.endsWith(".xml")) {
+            if (name.startsWith("TEST-") && name.endsWith(".xml") && file.toFile().length() > 0) {
               scanTestFile(file);
             }
 


### PR DESCRIPTION
Hopefully avoids failures like
```
> Task :test-report:reportFlakyTests FAILED
Scanning for flaky tests in /home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation
[Fatal Error] TEST-io.opentelemetry.javaagent.instrumentation.hystrix.HystrixObservableChainTest.xml:1:1: Premature end of file.
Error: Exception in thread "main" java.lang.IllegalStateException: failed to parse test report /home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation/instrumentation/hystrix-1.4/javaagent/build/test-results/testExperimental/TEST-io.opentelemetry.javaagent.instrumentation.hystrix.HystrixObservableChainTest.xml
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.parse(FlakyTestReporter.java:70)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.scanTestFile(FlakyTestReporter.java:76)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter$1.visitFile(FlakyTestReporter.java:205)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter$1.visitFile(FlakyTestReporter.java:200)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2799)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2870)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.scanTestResults(FlakyTestReporter.java:198)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter$2.preVisitDirectory(FlakyTestReporter.java:222)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter$2.preVisitDirectory(FlakyTestReporter.java:217)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2805)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2870)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.scan(FlakyTestReporter.java:215)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.main(FlakyTestReporter.java:310)
Caused by: org.xml.sax.SAXParseException; systemId: file:/home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation/instrumentation/hystrix-1.4/javaagent/build/test-results/testExperimental/TEST-io.opentelemetry.javaagent.instrumentation.hystrix.HystrixObservableChainTest.xml; lineNumber: 1; columnNumber: 1; Premature end of file.
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:262)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:342)
	at java.xml/javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:206)
	at io.opentelemetry.instrumentation.testreport.FlakyTestReporter.parse(FlakyTestReporter.java:68)
	... 12 more
```