### PR TITLE
Add additional issue and pr automation

### DIFF
--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7
           days-before-close: 7
           only-labels: "needs author feedback"
@@ -38,11 +37,11 @@ jobs:
           days-before-close: 0
           close-issue-label: stale
           close-issue-message: >
-            We would welcome a contribution for this enhancement, but since there has been no activity on it for the past year we are closing it to help maintain our backlog.
+            Since there has been no activity on this enhancement for the past year we are closing it to help maintain our backlog.
             Anyone who would like to work on it is still welcome to do so, and we can re-open it at that time.
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          only-labels: "enhancement,contribution welcome"
+          only-labels: "enhancement"
           exempt-issue-labels: "stale" # so that it won't close issues labeled as stale by "needs author feedback"
 
       - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0


### PR DESCRIPTION
Closes #9289

* For PRs that have been open for 1 year with no activity, mark as stale and add comment, close if still no activity after 7 days
* For issues with the tags: "enhancement" or "contribution welcome" that have no activity for 1 year, add a comment and a "needs author feedback" label
* For issues that have the "needs repro" label that have had no activity for 1 month, add "needs author feedback" label