### PR TITLE
Fix nullaway convention plugin

### DIFF
--- a/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
@@ -19,8 +19,9 @@ nullaway {
 tasks {
   withType<JavaCompile>().configureEach {
     if (name.contains("test", ignoreCase = true)) {
-      options.errorprone.nullaway {
-        enabled = false
+      // For test compilation tasks, disable errorprone entirely to avoid nullaway issues
+      options.errorprone {
+        isEnabled.set(false)
       }
     } else {
       options.errorprone.nullaway {

--- a/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
@@ -18,20 +18,16 @@ nullaway {
 
 tasks {
   withType<JavaCompile>().configureEach {
-    if (name.contains("test", ignoreCase = true)) {
-      // For test compilation tasks, disable errorprone entirely to avoid nullaway issues
-      options.errorprone {
-        isEnabled.set(false)
-      }
-    } else {
-      options.errorprone.nullaway {
-        severity.set(CheckSeverity.ERROR)
-      }
-    }
     options.errorprone.nullaway {
+      if (name.contains("test", ignoreCase = true)) {
+        disable()
+      } else {
+        error()
+      }
       customInitializerAnnotations.add("org.openjdk.jmh.annotations.Setup")
       excludedFieldAnnotations.add("org.mockito.Mock")
       excludedFieldAnnotations.add("org.mockito.InjectMocks")
     }
   }
 }
+

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ManualTelemetryTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ManualTelemetryTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.docs;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -142,40 +143,11 @@ class ManualTelemetryTest {
 
     InstrumentationMetadata actualMetadata = YamlHelper.metaDataParser(yamlContent);
 
-    ManualTelemetryEntry defaultEntry =
-        new ManualTelemetryEntry(
-            "default",
-            List.of(
-                new ManualTelemetryEntry.ManualMetric(
-                    "system.disk.io",
-                    "System disk IO",
-                    "LONG_SUM",
-                    "By",
-                    List.of(
-                        new TelemetryAttribute("device", "STRING"),
-                        new TelemetryAttribute("direction", "STRING")))),
-            List.of(
-                new ManualTelemetryEntry.ManualSpan(
-                    "CLIENT", List.of(new TelemetryAttribute("custom.operation", "STRING")))));
-
-    ManualTelemetryEntry experimentalEntry =
-        new ManualTelemetryEntry(
-            "experimental",
-            List.of(
-                new ManualTelemetryEntry.ManualMetric(
-                    "experimental.feature.usage",
-                    "Usage of experimental features",
-                    "HISTOGRAM",
-                    "s",
-                    List.of(new TelemetryAttribute("feature.name", "STRING")))),
-            List.of());
-
     InstrumentationMetadata expectedMetadata =
         new InstrumentationMetadata.Builder()
-            .description("Example instrumentation with manual telemetry documentation")
-            .libraryLink("https://example.com/library")
+            .description("Example without manual telemetry")
             .semanticConventions(List.of(SemanticConvention.HTTP_CLIENT_SPANS))
-            .additionalTelemetry(List.of(defaultEntry, experimentalEntry))
+            .additionalTelemetry(emptyList())
             .overrideTelemetry(false)
             .build();
 


### PR DESCRIPTION
Fixes #14771

While doing some development locally I realized that changes I was making to test code was not being reflected, and I noticed that we had an actual test failure merged in `main` that was not failing in CI.

I think previously we were disabling the entire module instead of just nullaway/errorprone. This change fixes that.

I think every module that uses nullaway might not be actually executing tests as of right now. This should fix it.
