### PR TITLE
Move around benchmark git config

### DIFF
--- a/.github/workflows/overhead-benchmark-daily.yml
+++ b/.github/workflows/overhead-benchmark-daily.yml
@@ -51,12 +51,11 @@ jobs:
       - name: Copy results back to gh-pages branch
         run: rsync -avv benchmark-overhead/results/ gh-pages/benchmark-overhead/results/ && rm -rf benchmark-overhead/results
 
-      - name: Use CLA approved bot
-        run: .github/scripts/use-cla-approved-bot.sh
-
       - name: Commit updated results
         working-directory: ./gh-pages
         run: |
+          git config user.name otelbot
+          git config user.email 197425009+otelbot@users.noreply.github.com
           git add benchmark-overhead/results
           git commit -m "update test result data"
           git push


### PR DESCRIPTION
Fixes #14818

The `.github/scripts/use-cla-approved-bot.sh` script was being run from a differnt directory from where the benchmark git operations are being done (`./gh-pages`), so moving the config commands directly into the script that runs in that other directory


Fixes the error:
```
Run git add benchmark-overhead/results
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@runnervm3ublj.3xvpnnmqe0pufide3cozgi5fjc.cx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```