### PR TITLE
Update documentation audit schedule

### DIFF
--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -2,7 +2,7 @@ name: Documentation Synchronization Audit (opentelemetry.io)
 
 on:
   schedule:
-    - cron: "30 1 * * *" # daily at 1:30 UTC
+    - cron: "30 1 * * 1" # every Monday at 1:30 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This doesn't need to run every night, considering it probably makes sense to wait until the next release to document changes to instrumentations on the documentation site. I'm currently waiting until we get a little closer to the next release to add the new failsafe instrumentation to the other site, for example. 

Changing this to run weekly instead