### PR TITLE
Fix executor context propagation race with stateless lambdas

### DIFF
--- a/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingCallable.java
+++ b/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingCallable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.bootstrap.executors;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.internal.ContextPropagationDebug;
+import java.util.concurrent.Callable;
+
+public final class ContextPropagatingCallable<T> implements Callable<T> {
+
+  public static <T> boolean shouldDecorateCallable(Callable<T> task) {
+    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
+    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+    // note: it is always safe to decorate lambdas since downstream code cannot be expecting a
+    // specific runnable implementation anyways
+    return task.getClass().getName().contains("/") && !(task instanceof ContextPropagatingCallable);
+  }
+
+  public static <T> Callable<T> propagateContext(Callable<T> task, Context context) {
+    return new ContextPropagatingCallable<T>(task, context);
+  }
+
+  private final Callable<T> delegate;
+  private final Context context;
+
+  private ContextPropagatingCallable(Callable<T> delegate, Context context) {
+    this.delegate = delegate;
+    this.context = ContextPropagationDebug.addDebugInfo(context, delegate);
+  }
+
+  @Override
+  public T call() throws Exception {
+    try (Scope ignored = context.makeCurrent()) {
+      return delegate.call();
+    }
+  }
+}

--- a/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/LambdaContextPropagationTest.java
+++ b/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/LambdaContextPropagationTest.java
@@ -9,29 +9,148 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.context.Scope;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-// regression test for #9175
+// regression test for:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9175
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14805
 class LambdaContextPropagationTest {
 
   // must be static! the lambda that uses that must be non-capturing
   private static final AtomicInteger failureCounter = new AtomicInteger();
 
+  @BeforeEach
+  void reset() {
+    failureCounter.set(0);
+  }
+
   @Test
-  void shouldCorrectlyPropagateContextToRunnables() {
+  void propagateContextExecuteRunnable() throws InterruptedException {
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
     Baggage baggage = Baggage.builder().put("test", "test").build();
     try (Scope ignored = baggage.makeCurrent()) {
       for (int i = 0; i < 20; i++) {
-        // must text execute() -- other methods like submit() decorate the Runnable with a
-        // FutureTask
         executor.execute(LambdaContextPropagationTest::assertBaggage);
       }
     }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  @Test
+  void propagateContextSubmitRunnable() throws InterruptedException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        executor.submit(LambdaContextPropagationTest::assertBaggage);
+      }
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  @Test
+  void propagateContextSubmitRunnableAndResult() throws InterruptedException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        executor.submit(LambdaContextPropagationTest::assertBaggage, null);
+      }
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  @Test
+  void propagateContextSubmitCallable() throws InterruptedException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        Callable<?> callable =
+            () -> {
+              assertBaggage();
+              return null;
+            };
+        executor.submit(callable);
+      }
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  @Test
+  void propagateContextInvokeAll() throws InterruptedException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        Callable<Void> callable =
+            () -> {
+              assertBaggage();
+              return null;
+            };
+        List<Callable<Void>> callables = new ArrayList<>();
+        for (int j = 0; j < 20; j++) {
+          callables.add(callable);
+        }
+        executor.invokeAll(callables);
+      }
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  @Test
+  void propagateContextInvokeAny() throws InterruptedException, ExecutionException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        Callable<?> callable =
+            () -> {
+              assertBaggage();
+              return null;
+            };
+        executor.invokeAny(Collections.singletonList(callable));
+      }
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
 
     assertThat(failureCounter).hasValue(0);
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14805
When the same instance is passed to executor multiple times the context propagation virtual field gets overwritten and reset  which makes context propagation unreliable. This issue is now easier to trigger after https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14546 because previously some executor methods would wrap the given instance into another runnable that would also carry context. Even when the original shared instance had the context reset the wrapper still carried it. https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14546 disabled propagating the context into the wrapper. We have previously already fixed this issue for `execute(Runnable)`. This PR applies the same approach to other methods like `submit(Runnable)` and `submit(Callable)`. Note that this fix only applies to tasks that are stateless lambdas. If a regular singleton is passed to executor it will have the same issue. To fix that we'd need to wrap all tasks similarly to what was proposed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9325 I don't remember why that PR was never merged.