### PR TITLE
Give actions/stale needed permissions

### DIFF
--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -13,6 +13,7 @@ jobs:
   stale:
     permissions:
       contents: read
+      actions: write # because actions/stale deletes its old cache before saving new one
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest


### PR DESCRIPTION
Per https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions

I hope this is why we're seeing issues still:

> Failed to save: Unable to reserve cache with key _state, another job may be creating this cache.