### PR TITLE
Remove references to ExtendedTextMapGetter

### DIFF
--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerRequestGetter.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerRequestGetter.java
@@ -9,14 +9,14 @@ import io.activej.http.HttpHeader;
 import io.activej.http.HttpHeaderValue;
 import io.activej.http.HttpHeaders;
 import io.activej.http.HttpRequest;
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-enum ActivejHttpServerRequestGetter implements ExtendedTextMapGetter<HttpRequest> {
+enum ActivejHttpServerRequestGetter implements TextMapGetter<HttpRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerHeaders.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerHeaders.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
 import akka.http.javadsl.model.HttpHeader;
 import akka.http.scaladsl.model.HttpRequest;
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-enum AkkaHttpServerHeaders implements ExtendedTextMapGetter<HttpRequest> {
+enum AkkaHttpServerHeaders implements TextMapGetter<HttpRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/RequestContextGetter.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/RequestContextGetter.java
@@ -7,13 +7,13 @@ package io.opentelemetry.instrumentation.armeria.v1_3.internal;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.netty.util.AsciiString;
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-enum RequestContextGetter implements ExtendedTextMapGetter<ServiceRequestContext> {
+enum RequestContextGetter implements TextMapGetter<ServiceRequestContext> {
   INSTANCE;
 
   @Override

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpRequestHeadersGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpRequestHeadersGetter.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.grizzly;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 import org.glassfish.grizzly.http.HttpRequestPacket;
 
-enum HttpRequestHeadersGetter implements ExtendedTextMapGetter<HttpRequestPacket> {
+enum HttpRequestHeadersGetter implements TextMapGetter<HttpRequestPacket> {
   INSTANCE;
 
   @Override

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequestGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequestGetter.java
@@ -8,11 +8,11 @@ package io.opentelemetry.instrumentation.grpc.v1_6;
 import static java.util.Collections.emptyIterator;
 
 import io.grpc.Metadata;
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 import javax.annotation.Nullable;
 
-enum GrpcRequestGetter implements ExtendedTextMapGetter<GrpcRequest> {
+enum GrpcRequestGetter implements TextMapGetter<GrpcRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/java-http-server/library/src/main/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerExchangeGetter.java
+++ b/instrumentation/java-http-server/library/src/main/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerExchangeGetter.java
@@ -9,12 +9,12 @@ import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
 
 import com.sun.net.httpserver.HttpExchange;
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
 
-enum JavaHttpServerExchangeGetter implements ExtendedTextMapGetter<HttpExchange> {
+enum JavaHttpServerExchangeGetter implements TextMapGetter<HttpExchange> {
   INSTANCE;
 
   @Override

--- a/instrumentation/jetty/jetty-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12TextMapGetter.java
+++ b/instrumentation/jetty/jetty-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12TextMapGetter.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jetty.v12_0;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import java.util.Iterator;
 import org.eclipse.jetty.server.Request;
 
-enum Jetty12TextMapGetter implements ExtendedTextMapGetter<Request> {
+enum Jetty12TextMapGetter implements TextMapGetter<Request> {
   INSTANCE;
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.stream.Collectors;
@@ -13,7 +13,7 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.kafka.common.header.Header;
 
-enum KafkaConsumerRecordGetter implements ExtendedTextMapGetter<KafkaProcessRequest> {
+enum KafkaConsumerRecordGetter implements TextMapGetter<KafkaProcessRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/ApplicationRequestGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/ApplicationRequestGetter.kt
@@ -6,10 +6,10 @@
 package io.opentelemetry.instrumentation.ktor.v1_0
 
 import io.ktor.request.*
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter
+import io.opentelemetry.context.propagation.TextMapGetter
 import java.util.Collections
 
-internal object ApplicationRequestGetter : ExtendedTextMapGetter<ApplicationRequest> {
+internal object ApplicationRequestGetter : TextMapGetter<ApplicationRequest> {
   override fun keys(carrier: ApplicationRequest): Iterable<String> = carrier.headers.names()
 
   override fun get(carrier: ApplicationRequest?, name: String): String? = carrier?.headers?.get(name)

--- a/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/ApplicationRequestGetter.kt
+++ b/instrumentation/ktor/ktor-2-common/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/common/ApplicationRequestGetter.kt
@@ -6,10 +6,10 @@
 package io.opentelemetry.instrumentation.ktor.v2_0.common
 
 import io.ktor.server.request.*
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter
+import io.opentelemetry.context.propagation.TextMapGetter
 import java.util.Collections
 
-internal object ApplicationRequestGetter : ExtendedTextMapGetter<ApplicationRequest> {
+internal object ApplicationRequestGetter : TextMapGetter<ApplicationRequest> {
   override fun keys(carrier: ApplicationRequest): Iterable<String> = carrier.headers.names()
 
   override fun get(carrier: ApplicationRequest?, name: String): String? = carrier?.headers?.get(name)

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherRequestGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherRequestGetter.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 
-enum LibertyDispatcherRequestGetter implements ExtendedTextMapGetter<LibertyRequest> {
+enum LibertyDispatcherRequestGetter implements TextMapGetter<LibertyRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHeadersGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHeadersGetter.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
 import java.util.Iterator;
 import javax.annotation.Nullable;
 
-enum NettyHeadersGetter implements ExtendedTextMapGetter<HttpRequestAndChannel> {
+enum NettyHeadersGetter implements TextMapGetter<HttpRequestAndChannel> {
   INSTANCE;
 
   @Override

--- a/instrumentation/netty/netty-common-4.0/library/src/main/java/io/opentelemetry/instrumentation/netty/common/v4_0/internal/server/HttpRequestHeadersGetter.java
+++ b/instrumentation/netty/netty-common-4.0/library/src/main/java/io/opentelemetry/instrumentation/netty/common/v4_0/internal/server/HttpRequestHeadersGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.netty.common.v4_0.internal.server;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.netty.common.v4_0.HttpRequestAndChannel;
 import java.util.Collections;
 import java.util.Iterator;
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public enum HttpRequestHeadersGetter implements ExtendedTextMapGetter<HttpRequestAndChannel> {
+public enum HttpRequestHeadersGetter implements TextMapGetter<HttpRequestAndChannel> {
   INSTANCE;
 
   @Override

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoHttpServerHeaders.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoHttpServerHeaders.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.stream.StreamSupport;
 import org.apache.pekko.http.javadsl.model.HttpHeader;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 
-enum PekkoHttpServerHeaders implements ExtendedTextMapGetter<HttpRequest> {
+enum PekkoHttpServerHeaders implements TextMapGetter<HttpRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7.internal;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Collections;
 import java.util.Iterator;
 import javax.annotation.Nullable;
@@ -15,7 +15,7 @@ import ratpack.http.Request;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-enum RatpackGetter implements ExtendedTextMapGetter<Request> {
+enum RatpackGetter implements TextMapGetter<Request> {
   INSTANCE;
 
   @Override

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/RestletHeadersGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/internal/RestletHeadersGetter.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.restlet.v1_1.internal;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 import org.restlet.data.Form;
 import org.restlet.data.Message;
 import org.restlet.data.Parameter;
 import org.restlet.data.Request;
 
-enum RestletHeadersGetter implements ExtendedTextMapGetter<Request> {
+enum RestletHeadersGetter implements TextMapGetter<Request> {
   INSTANCE;
 
   @Override

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHeadersGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHeadersGetter.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.restlet.v2_0.internal;
 
 import static java.util.Collections.emptySet;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -21,7 +21,7 @@ import org.restlet.Message;
 import org.restlet.Request;
 import org.restlet.util.Series;
 
-final class RestletHeadersGetter implements ExtendedTextMapGetter<Request> {
+final class RestletHeadersGetter implements TextMapGetter<Request> {
 
   private static final MethodHandle GET_ATTRIBUTES;
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestGetter.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 
 public class ServletRequestGetter<REQUEST>
-    implements ExtendedTextMapGetter<ServletRequestContext<REQUEST>> {
+    implements TextMapGetter<ServletRequestContext<REQUEST>> {
   protected final ServletAccessor<REQUEST, ?> accessor;
 
   public ServletRequestGetter(ServletAccessor<REQUEST, ?> accessor) {

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxTextMapGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxTextMapGetter.java
@@ -7,13 +7,13 @@ package io.opentelemetry.instrumentation.spring.webflux.v5_3;
 
 import static java.util.Collections.emptyIterator;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.web.server.ServerWebExchange;
 
-enum WebfluxTextMapGetter implements ExtendedTextMapGetter<ServerWebExchange> {
+enum WebfluxTextMapGetter implements TextMapGetter<ServerWebExchange> {
   INSTANCE;
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/JavaxHttpServletRequestGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/JavaxHttpServletRequestGetter.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc.v5_3;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import java.util.Collections;
 import java.util.Iterator;
 import javax.servlet.http.HttpServletRequest;
 
-enum JavaxHttpServletRequestGetter implements ExtendedTextMapGetter<HttpServletRequest> {
+enum JavaxHttpServletRequestGetter implements TextMapGetter<HttpServletRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/JakartaHttpServletRequestGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/JakartaHttpServletRequestGetter.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc.v6_0;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.Iterator;
 
-enum JakartaHttpServletRequestGetter implements ExtendedTextMapGetter<HttpServletRequest> {
+enum JakartaHttpServletRequestGetter implements TextMapGetter<HttpServletRequest> {
   INSTANCE;
 
   @Override

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatRequestGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatRequestGetter.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.common;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import java.util.Collections;
 import java.util.Iterator;
 import org.apache.coyote.Request;
 
-enum TomcatRequestGetter implements ExtendedTextMapGetter<Request> {
+enum TomcatRequestGetter implements TextMapGetter<Request> {
   INSTANCE;
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowExchangeGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowExchangeGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.HttpString;
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Collectors;
 
-enum UndertowExchangeGetter implements ExtendedTextMapGetter<HttpServerExchange> {
+enum UndertowExchangeGetter implements TextMapGetter<HttpServerExchange> {
   INSTANCE;
 
   @Override

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/server/http/RequestContextGetter.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/server/http/RequestContextGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.test.server.http;
 
-import io.opentelemetry.context.propagation.internal.ExtendedTextMapGetter;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.testing.internal.armeria.server.ServiceRequestContext;
 import io.opentelemetry.testing.internal.io.netty.util.AsciiString;
 import java.util.Collections;
@@ -13,7 +13,7 @@ import java.util.Iterator;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-public enum RequestContextGetter implements ExtendedTextMapGetter<ServiceRequestContext> {
+public enum RequestContextGetter implements TextMapGetter<ServiceRequestContext> {
   INSTANCE;
 
   @Override


### PR DESCRIPTION
Now that the new method has been stabilized and moved to TextMapGetter.