### PR TITLE
Remove span status description from Lettuce 5.1 instrumentation

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -298,7 +298,7 @@ final class OpenTelemetryTracing implements Tracing {
               if (output != null) {
                 String error = output.getError();
                 if (error != null) {
-                  span.setStatus(StatusCode.ERROR, error);
+                  span.setStatus(StatusCode.ERROR);
                 }
               }
 


### PR DESCRIPTION
Lettuce 5.1 appears to be the only instrumentation in the entire repo that sets span status description.

I think this is ok to do in a minor version bump, but I could also hide it behind database stability opt-in.

Noticed this while reviewing https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8422, which shows the sensitive data showing up in `otel.status_description` (in addition to `exception.message`).

Related to

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6710#issuecomment-1259241361
- https://github.com/open-telemetry/opentelemetry-specification/issues/3496

Specifically motivated by https://github.com/open-telemetry/opentelemetry-specification/issues/3496#issuecomment-3366843990

> It may be a bit easier to explain to users that there's just one place (`exception.message`) where this shows up and that users may need to redact `exception.message` (which will likely be going to log pipeline in the future by default), as opposed to showing up in two places / signals.