### PR TITLE
Enable strict context check for kotlinx coroutines

### DIFF
--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/build.gradle.kts
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/build.gradle.kts
@@ -41,7 +41,3 @@ kotlin {
     jvmTarget.set(JvmTarget.JVM_1_8)
   }
 }
-
-tasks.withType<Test>().configureEach {
-  jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
-}


### PR DESCRIPTION
Related to #3916 