### PR TITLE
Enable strict context check for rxjava libraries

### DIFF
--- a/instrumentation/rxjava/rxjava-2.0/library/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-2.0/library/build.gradle.kts
@@ -14,6 +14,4 @@ tasks.withType<Test>().configureEach {
   // required on jdk17, uses spock Mock that needs access to jdk internals
   jvmArgs("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
-
-  jvmArgs("-Dio.opentelemetry.context.enableStrictContext=false")
 }

--- a/instrumentation/rxjava/rxjava-3.0/library/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-3.0/library/build.gradle.kts
@@ -11,7 +11,3 @@ dependencies {
 
   latestDepTestLibrary("io.reactivex.rxjava3:rxjava:3.1.0") // see rxjava-3.1.1 module
 }
-
-tasks.withType<Test>().configureEach {
-  jvmArgs("-Dio.opentelemetry.context.enableStrictContext=false")
-}


### PR DESCRIPTION
Related to #3916 