### PR TITLE
Avoid NPE in smoke tests that failed to start

### DIFF
--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/SmokeTestRunner.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/SmokeTestRunner.java
@@ -42,7 +42,9 @@ public class SmokeTestRunner extends InstrumentationTestRunner {
 
   @Override
   public void clearAllExportedData() {
-    telemetryRetriever.clearTelemetry();
+    if (telemetryRetriever != null) {
+      telemetryRetriever.clearTelemetry();
+    }
   }
 
   @Override


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14930
NPE while cleaning up a smoke test that failed before telemetry retriever was set
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/18364728236/job/52315366155
```
    java.lang.NullPointerException
        at io.opentelemetry.smoketest.SmokeTestRunner.clearAllExportedData(SmokeTestRunner.java:45)
        at io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension.afterAll(InstrumentationExtension.java:64)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```