### PR TITLE
Let instrumentations fill db.query.summary attribute

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -48,6 +49,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
     if (SemconvStability.emitStableDatabaseSemconv()) {
       internalSet(attributes, DB_QUERY_TEXT, getter.getDbQueryText(request));
       internalSet(attributes, DB_OPERATION_NAME, getter.getDbOperationName(request));
+      internalSet(attributes, DB_QUERY_SUMMARY, getter.getDbQuerySummary(request));
     }
     if (SemconvStability.emitOldDatabaseSemconv()) {
       internalSet(attributes, DB_STATEMENT, getter.getDbQueryText(request));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
@@ -36,6 +36,12 @@ public interface DbClientAttributesGetter<REQUEST, RESPONSE>
     return getStatement(request);
   }
 
+  // TODO: make this required to implement
+  @Nullable
+  default String getDbQuerySummary(REQUEST request) {
+    return null;
+  }
+
   /**
    * @deprecated Use {@link #getDbOperationName(REQUEST)} instead.
    */

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 class DbClientAttributesExtractorTest {
@@ -51,6 +52,12 @@ class DbClientAttributesExtractorTest {
       return map.get("db.statement");
     }
 
+    @Nullable
+    @Override
+    public String getDbQuerySummary(Map<String, String> map) {
+      return map.get("db.query_summary");
+    }
+
     @Override
     public String getDbOperationName(Map<String, String> map) {
       return map.get("db.operation");
@@ -67,6 +74,7 @@ class DbClientAttributesExtractorTest {
     request.put("db.name", "potatoes");
     request.put("db.connection_string", "mydb:///potatoes");
     request.put("db.statement", "SELECT * FROM potato");
+    request.put("db.query_summary", "SELECT potato");
     request.put("db.operation", "SELECT");
 
     Context context = Context.root();
@@ -94,6 +102,7 @@ class DbClientAttributesExtractorTest {
               entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
               entry(DbAttributes.DB_NAMESPACE, "potatoes"),
               entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato"),
+              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"),
               entry(DbAttributes.DB_OPERATION_NAME, "SELECT"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
@@ -110,6 +119,7 @@ class DbClientAttributesExtractorTest {
               entry(DbAttributes.DB_SYSTEM_NAME, "myDb"),
               entry(DbAttributes.DB_NAMESPACE, "potatoes"),
               entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato"),
+              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"),
               entry(DbAttributes.DB_OPERATION_NAME, "SELECT"));
     }
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12608
This PR only adds the getter and filling the attribute to the `DbClientAttributesExtractor`. It does not implement filling the query summary attribute for the jdbc or other instrumentations.