### PR TITLE
Use Renovate to keep smoke test Java versions up-to-date

### DIFF
--- a/.github/workflows/reusable-pr-smoke-test-images.yml
+++ b/.github/workflows/reusable-pr-smoke-test-images.yml
@@ -22,12 +22,6 @@ on:
       skip-java-11:
         type: boolean
         required: false
-      skip-java-17:
-        type: boolean
-        required: false
-      skip-java-21:
-        type: boolean
-        required: false
 
 permissions:
   contents: read
@@ -35,6 +29,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      LATEST_JAVA_VERSION: 23 # renovate: datasource=java-version
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -64,13 +60,10 @@ jobs:
         run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 17 Docker image
-        if: "!inputs.skip-java-17"
         run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 21 Docker image
-        if: "!inputs.skip-java-21"
         run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
 
-      - name: Build Java 23 Docker image
-        if: "!inputs.skip-java-23"
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=23 -Djib.httpTimeout=120000 -Djib.console=plain
+      - name: Build Java ${{ env.LATEST_JAVA_VERSION }} Docker image
+        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=${{ env.LATEST_JAVA_VERSION }} -Djib.httpTimeout=120000 -Djib.console=plain

--- a/.github/workflows/reusable-publish-smoke-test-images.yml
+++ b/.github/workflows/reusable-publish-smoke-test-images.yml
@@ -22,12 +22,6 @@ on:
       skip-java-11:
         type: boolean
         required: false
-      skip-java-17:
-        type: boolean
-        required: false
-      skip-java-21:
-        type: boolean
-        required: false
 
 permissions:
   contents: read
@@ -38,6 +32,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      LATEST_JAVA_VERSION: 23 # renovate: datasource=java-version
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -74,13 +70,10 @@ jobs:
         run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 17 Docker image
-        if: "!inputs.skip-java-17"
         run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 21 Docker image
-        if: "!inputs.skip-java-21"
         run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
 
-      - name: Build Java 23 Docker image
-        if: "!inputs.skip-java-23"
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=23 -Djib.httpTimeout=120000 -Djib.console=plain
+      - name: Build Java ${{ env.LATEST_JAVA_VERSION }} Docker image
+        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=${{ env.LATEST_JAVA_VERSION }} -Djib.httpTimeout=120000 -Djib.console=plain


### PR DESCRIPTION
Intentionally leaving it as Java 23 for now to make sure Renovate updates it right away.