### PR TITLE
Remove INTERNAL span descriptor in metadata

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -2581,7 +2581,7 @@ libraries:
       - io.dropwizard:dropwizard-views:(,3.0.0)
     configurations:
     - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-      description: Enables the creation of experimental view (INTERNAL) spans.
+      description: Enables the creation of experimental view spans.
       type: boolean
       default: false
     telemetry:
@@ -3344,7 +3344,7 @@ libraries:
   grails:
   - name: grails-3.0
     description: |
-      This instrumentation enriches existing HTTP server spans with HTTP route information, and optionally enables experimental controller (INTERNAL) spans for Grails applications.
+      This instrumentation enriches existing HTTP server spans with HTTP route information, and optionally enables experimental controller spans for Grails applications.
     library_link: https://grails.apache.org/
     source_path: instrumentation/grails-3.0
     scope:
@@ -3354,7 +3354,7 @@ libraries:
       - org.grails:grails-web-url-mappings:[3.0,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     telemetry:
@@ -3850,7 +3850,7 @@ libraries:
   hibernate:
   - name: hibernate-3.3
     description: |
-      This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
+      This instrumentation enables the generation of spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
     library_link: https://github.com/hibernate/hibernate-orm
     source_path: instrumentation/hibernate/hibernate-3.3
     scope:
@@ -3877,7 +3877,7 @@ libraries:
           type: STRING
   - name: hibernate-4.0
     description: |
-      This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
+      This instrumentation enables the generation of spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
     library_link: https://github.com/hibernate/hibernate-orm
     source_path: instrumentation/hibernate/hibernate-4.0
     scope:
@@ -3904,7 +3904,7 @@ libraries:
           type: STRING
   - name: hibernate-6.0
     description: |
-      This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
+      This instrumentation enables the generation of spans for Hibernate operations, including session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
     library_link: https://github.com/hibernate/hibernate-orm
     source_path: instrumentation/hibernate/hibernate-6.0
     minimum_java_version: 11
@@ -3931,8 +3931,8 @@ libraries:
         - name: hibernate.session_id
           type: STRING
   - name: hibernate-procedure-call-4.3
-    description: This instrumentation enables the generation of INTERNAL spans for
-      Hibernate stored procedure calls.
+    description: This instrumentation enables the generation of spans for Hibernate
+      stored procedure calls.
     library_link: https://github.com/hibernate/hibernate-orm
     source_path: instrumentation/hibernate/hibernate-procedure-call-4.3
     scope:
@@ -4184,8 +4184,8 @@ libraries:
           type: STRING
   hystrix:
   - name: hystrix-1.4
-    description: This instrumentation enables the generation of INTERNAL spans for
-      Hystrix command executions and fallbacks.
+    description: This instrumentation enables the generation of spans for Hystrix
+      command executions and fallbacks.
     library_link: https://github.com/Netflix/Hystrix
     source_path: instrumentation/hystrix-1.4
     scope:
@@ -4460,7 +4460,7 @@ libraries:
       - javax.ws.rs:jsr311-api:[0.5,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     telemetry:
@@ -4485,7 +4485,7 @@ libraries:
       - javax.ws.rs:javax.ws.rs-api:[,]
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4515,7 +4515,7 @@ libraries:
       - org.apache.cxf:cxf-rt-frontend-jaxrs:[3.2,4)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4555,7 +4555,7 @@ libraries:
       - org.glassfish.jersey.containers:jersey-container-servlet:[2.0,3.0.0)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4595,7 +4595,7 @@ libraries:
       - org.jboss.resteasy:resteasy-jaxrs:[3.5.0.Final,4)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4635,7 +4635,7 @@ libraries:
       - org.jboss.resteasy:resteasy-core:[4.0.0.Final,6)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4674,7 +4674,7 @@ libraries:
       - jakarta.ws.rs:jakarta.ws.rs-api:[3.0.0,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4704,7 +4704,7 @@ libraries:
       - org.glassfish.jersey.core:jersey-server:[3.0.0,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -4744,7 +4744,7 @@ libraries:
       - org.jboss.resteasy:resteasy-core:[6.0.0.Final,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.jaxrs.experimental-span-attributes
@@ -6910,8 +6910,8 @@ libraries:
       - com.sparkjava:spark-core:[2.3,)
   spring:
   - name: spring-batch-3.0
-    description: This instrumentation enables INTERNAL spans for jobs run by the Spring
-      Batch framework.
+    description: This instrumentation enables spans for jobs run by the Spring Batch
+      framework.
     library_link: https://spring.io/projects/spring-batch
     disabled_by_default: true
     source_path: instrumentation/spring/spring-batch-3.0
@@ -7439,7 +7439,7 @@ libraries:
       - org.springframework:spring-web:[6.0.0,)
   - name: spring-webflux-5.0
     description: |
-      This instrumentation enables HTTP client spans and metrics for Spring WebFlux 5.0. It also optionally enables experimental controller (INTERNAL) spans.
+      This instrumentation enables HTTP client spans and metrics for Spring WebFlux 5.0. It also optionally enables experimental controller spans.
     library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html
     source_path: instrumentation/spring/spring-webflux/spring-webflux-5.0
     scope:
@@ -7451,7 +7451,7 @@ libraries:
       - io.projectreactor.netty:reactor-netty:[0.8.0.RELEASE,)
     configurations:
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     telemetry:
@@ -7575,7 +7575,7 @@ libraries:
           type: STRING
   - name: spring-webmvc-3.1
     description: |
-      This instrumentation enables optional Controller and View (INTERNAL) spans for Spring WebMVC 3.1+.
+      This instrumentation enables optional Controller and View spans for Spring WebMVC 3.1+.
     library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html
     source_path: instrumentation/spring/spring-webmvc/spring-webmvc-3.1
     scope:
@@ -7590,11 +7590,11 @@ libraries:
       type: boolean
       default: false
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-      description: Enables the creation of experimental view (INTERNAL) spans.
+      description: Enables the creation of experimental view spans.
       type: boolean
       default: false
     telemetry:
@@ -7676,7 +7676,7 @@ libraries:
           type: STRING
   - name: spring-webmvc-6.0
     description: |
-      This instrumentation enables optional Controller and View (INTERNAL) spans for Spring WebMVC 6.0+.
+      This instrumentation enables optional Controller and View spans for Spring WebMVC 6.0+.
     library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html
     source_path: instrumentation/spring/spring-webmvc/spring-webmvc-6.0
     minimum_java_version: 17
@@ -7692,11 +7692,11 @@ libraries:
       type: boolean
       default: false
     - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      description: Enables the creation of experimental controller (INTERNAL) spans.
+      description: Enables the creation of experimental controller spans.
       type: boolean
       default: false
     - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-      description: Enables the creation of experimental view (INTERNAL) spans.
+      description: Enables the creation of experimental view spans.
       type: boolean
       default: false
     telemetry:

--- a/instrumentation/dropwizard/dropwizard-views-0.7/metadata.yaml
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/metadata.yaml
@@ -2,6 +2,6 @@ description: This instrumentation enables the creation of spans for Dropwizard v
 library_link: https://www.dropwizard.io/en/latest/manual/views.html
 configurations:
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    description: Enables the creation of experimental view (INTERNAL) spans.
+    description: Enables the creation of experimental view spans.
     type: boolean
     default: false

--- a/instrumentation/grails-3.0/metadata.yaml
+++ b/instrumentation/grails-3.0/metadata.yaml
@@ -1,9 +1,9 @@
 description: >
   This instrumentation enriches existing HTTP server spans with HTTP route information, and
-  optionally enables experimental controller (INTERNAL) spans for Grails applications.
+  optionally enables experimental controller spans for Grails applications.
 library_link: https://grails.apache.org/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false

--- a/instrumentation/hibernate/hibernate-3.3/metadata.yaml
+++ b/instrumentation/hibernate/hibernate-3.3/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including
+  This instrumentation enables the generation of spans for Hibernate operations, including
   session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
 library_link: https://github.com/hibernate/hibernate-orm
 configurations:

--- a/instrumentation/hibernate/hibernate-4.0/metadata.yaml
+++ b/instrumentation/hibernate/hibernate-4.0/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including
+  This instrumentation enables the generation of spans for Hibernate operations, including
   session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
 library_link: https://github.com/hibernate/hibernate-orm
 configurations:

--- a/instrumentation/hibernate/hibernate-6.0/metadata.yaml
+++ b/instrumentation/hibernate/hibernate-6.0/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enables the generation of INTERNAL spans for Hibernate operations, including
+  This instrumentation enables the generation of spans for Hibernate operations, including
   session methods (e.g., `save`, `update`, `delete`), transaction commits, and query executions.
 library_link: https://github.com/hibernate/hibernate-orm
 configurations:

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/metadata.yaml
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables the generation of INTERNAL spans for Hibernate stored procedure calls.
+description: This instrumentation enables the generation of spans for Hibernate stored procedure calls.
 library_link: https://github.com/hibernate/hibernate-orm
 configurations:
   - name: otel.instrumentation.hibernate.experimental-span-attributes

--- a/instrumentation/hystrix-1.4/metadata.yaml
+++ b/instrumentation/hystrix-1.4/metadata.yaml
@@ -1,4 +1,4 @@
-description: This instrumentation enables the generation of INTERNAL spans for Hystrix command executions and fallbacks.
+description: This instrumentation enables the generation of spans for Hystrix command executions and fallbacks.
 library_link: https://github.com/Netflix/Hystrix
 configurations:
   - name: otel.instrumentation.hystrix.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
@@ -5,6 +5,6 @@ description: >
 library_link: https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/package-summary.html
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/package-summary.html
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://cxf.apache.org/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://eclipse-ee4j.github.io/jersey/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://resteasy.dev/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://resteasy.dev/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://jakarta.ee/specifications/restful-ws/3.0/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://eclipse-ee4j.github.io/jersey/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0/metadata.yaml
@@ -5,7 +5,7 @@ description: >
 library_link: https://resteasy.dev/
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.jaxrs.experimental-span-attributes

--- a/instrumentation/spring/spring-batch-3.0/metadata.yaml
+++ b/instrumentation/spring/spring-batch-3.0/metadata.yaml
@@ -1,5 +1,5 @@
 disabled_by_default: true
-description: This instrumentation enables INTERNAL spans for jobs run by the Spring Batch framework.
+description: This instrumentation enables spans for jobs run by the Spring Batch framework.
 library_link: https://spring.io/projects/spring-batch
 configurations:
   - name: otel.instrumentation.spring-batch.experimental-span-attributes

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/metadata.yaml
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/metadata.yaml
@@ -1,9 +1,9 @@
 description: > 
   This instrumentation enables HTTP client spans and metrics for Spring WebFlux 5.0. It also
-  optionally enables experimental controller (INTERNAL) spans.
+  optionally enables experimental controller spans.
 library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/metadata.yaml
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enables optional Controller and View (INTERNAL) spans for Spring WebMVC 3.1+.
+  This instrumentation enables optional Controller and View spans for Spring WebMVC 3.1+.
 library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html
 configurations:
   - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
@@ -9,10 +9,10 @@ configurations:
       Enables the capture of experimental span attributes `spring-webmvc-view-name` and
       `spring-webmvc.view.type`.
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    description: Enables the creation of experimental view (INTERNAL) spans.
+    description: Enables the creation of experimental view spans.
     type: boolean
     default: false

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/metadata.yaml
@@ -1,5 +1,5 @@
 description: >
-  This instrumentation enables optional Controller and View (INTERNAL) spans for Spring WebMVC 6.0+.
+  This instrumentation enables optional Controller and View spans for Spring WebMVC 6.0+.
 configurations:
   - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
     type: boolean
@@ -8,11 +8,11 @@ configurations:
       Enables the capture of experimental span attributes `spring-webmvc-view-name` and
       `spring-webmvc.view.type`.
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    description: Enables the creation of experimental controller (INTERNAL) spans.
+    description: Enables the creation of experimental controller spans.
     type: boolean
     default: false
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    description: Enables the creation of experimental view (INTERNAL) spans.
+    description: Enables the creation of experimental view spans.
     type: boolean
     default: false
 library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html


### PR DESCRIPTION
We've determined that indicating the span type, especially when its INTERNAL, is not really useful to users.

See [comment](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14864#discussion_r2416390401).