### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -150,7 +150,7 @@ Some notes when writing descriptions:
   "This instrumentation **enables** HTTP server spans and HTTP server metrics for the ActiveJ" instead
   of something like "This instrumentation **provides** HTTP server spans and HTTP server metrics for the ActiveJ".
 * Explicitly state whether the instrumentation generates new telemetry (spans, metrics, logs).
-  * If it doesn't generate new telemetry, clearly explain what it's purpose is, for example whether it
+  * If it doesn't generate new telemetry, clearly explain what its purpose is, for example whether it
     augments or enriches existing telemetry produced by other instrumentations (e.g., by adding
     attributes or ensuring context propagation).
 * When describing the functionality of the instrumentation and the telemetry, specify using

--- a/instrumentation/rxjava/rxjava-2.0/testing/src/main/java/io/opentelemetry/instrumentation/rxjava/v2_0/RxJava2ConcurrencyTestHelper.java
+++ b/instrumentation/rxjava/rxjava-2.0/testing/src/main/java/io/opentelemetry/instrumentation/rxjava/v2_0/RxJava2ConcurrencyTestHelper.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  * This test creates the specified number of traces with three spans: 1) Outer (root) span 2) Middle
  * span, child of outer, created in success handler of the chain subscribed to in the context of the
  * outer span (with some delay and map thrown in for good measure) 3) Inner span, child of middle,
- * created in the success handler of a new chain started and subscribed to in the the middle span
+ * created in the success handler of a new chain started and subscribed to in the middle span
  *
  * <p>The varying delays between the stages where each span is created should guarantee that
  * scheduler threads handling various stages of the chain will have to alternate between contexts

--- a/instrumentation/rxjava/rxjava-3-common/testing/src/main/java/io/opentelemetry/instrumentation/rxjava/v3/common/RxJava3ConcurrencyTestHelper.java
+++ b/instrumentation/rxjava/rxjava-3-common/testing/src/main/java/io/opentelemetry/instrumentation/rxjava/v3/common/RxJava3ConcurrencyTestHelper.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  * This test creates the specified number of traces with three spans: 1) Outer (root) span 2) Middle
  * span, child of outer, created in success handler of the chain subscribed to in the context of the
  * outer span (with some delay and map thrown in for good measure) 3) Inner span, child of middle,
- * created in the success handler of a new chain started and subscribed to in the the middle span
+ * created in the success handler of a new chain started and subscribed to in the middle span
  *
  * <p>The varying delays between the stages where each span is created should guarantee that
  * scheduler threads handling various stages of the chain will have to alternate between contexts

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceTransformer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceTransformer.java
@@ -534,7 +534,7 @@ class AdviceTransformer {
             Type[] argumentTypes = ga.getArgumentTypes();
 
             if (isEnterAdvice) {
-              // we have changed the type fo method arguments annotated with @Advice.Local to Object
+              // we have changed the type of method arguments annotated with @Advice.Local to Object
               // here we'll load the argument, cast it to its actual type, and store it back
               for (AdviceLocal adviceLocal : adviceLocals) {
                 ga.loadArg(adviceLocal.adviceIndex);


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help