### PR TITLE
Use fixed `service.version` in spring boot smoke test

### DIFF
--- a/smoke-tests/images/spring-boot/build.gradle.kts
+++ b/smoke-tests/images/spring-boot/build.gradle.kts
@@ -42,6 +42,9 @@ java {
 
 springBoot {
   buildInfo {
+    properties {
+      version = "1.2.3"
+    }
   }
 }
 


### PR DESCRIPTION
So we don't need to update it each time we update the image:

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/2edb854cafe765e1dc5393a00b568ffe98ea8473/smoke-tests/src/test/java/io/opentelemetry/smoketest/SpringBootSmokeTest.java#L61-L63