### PR TITLE
Update smoke test app server patch versions

### DIFF
--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -25,10 +25,10 @@ val latestJava = "25" // renovate: datasource=java-version
 // Dockerfile name, args key passes raw arguments to docker build
 val targets = mapOf(
   "jetty" to listOf(
-    ImageTarget(listOf("9.4.53"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava), mapOf("sourceVersion" to "9.4.53.v20231009")),
-    ImageTarget(listOf("10.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("sourceVersion" to "10.0.19")),
-    ImageTarget(listOf("11.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("sourceVersion" to "11.0.19"), "servlet-5.0"),
-    ImageTarget(listOf("12.0.6"), listOf("hotspot", "openj9"), listOf("17", "21", latestJava), mapOf("sourceVersion" to "12.0.6"), "servlet-5.0"),
+    ImageTarget(listOf("9.4.58"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava), mapOf("sourceVersion" to "9.4.58.v20250814")),
+    ImageTarget(listOf("10.0.26"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("sourceVersion" to "10.0.26")),
+    ImageTarget(listOf("11.0.26"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("sourceVersion" to "11.0.26"), "servlet-5.0"),
+    ImageTarget(listOf("12.0.28"), listOf("hotspot", "openj9"), listOf("17", "21", latestJava), mapOf("sourceVersion" to "12.0.28"), "servlet-5.0"),
   ),
   "liberty" to listOf(
     ImageTarget(listOf("20.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11"), mapOf("release" to "2020-11-11_0736")),
@@ -47,13 +47,13 @@ val targets = mapOf(
   "tomcat" to listOf(
     ImageTarget(listOf("7.0.109"), listOf("hotspot", "openj9"), listOf("8"), mapOf("majorVersion" to "7")),
     ImageTarget(listOf("8.5.98"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava), mapOf("majorVersion" to "8")),
-    ImageTarget(listOf("9.0.85"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava), mapOf("majorVersion" to "9")),
-    ImageTarget(listOf("10.1.18"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("majorVersion" to "10"), "servlet-5.0"),
+    ImageTarget(listOf("9.0.111"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava), mapOf("majorVersion" to "9")),
+    ImageTarget(listOf("10.1.48"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), mapOf("majorVersion" to "10"), "servlet-5.0"),
   ),
   "tomee" to listOf(
     ImageTarget(listOf("7.0.9", "7.1.4"), listOf("hotspot", "openj9"), listOf("8")),
     ImageTarget(listOf("8.0.16"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21", latestJava)),
-    ImageTarget(listOf("9.1.2"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), war = "servlet-5.0"),
+    ImageTarget(listOf("9.1.3"), listOf("hotspot", "openj9"), listOf("11", "17", "21", latestJava), war = "servlet-5.0"),
   ),
   "websphere" to listOf(
     ImageTarget(listOf("8.5.5.22", "9.0.5.14"), listOf("openj9"), listOf("8"), windows = false),


### PR DESCRIPTION
I'll update https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#application-servers in the PR that updates the tests to run against these new images