### PR TITLE
Revert "Expose values added by logback mdc instrumentation to the appender instrumentation (#14904)"

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
@@ -46,8 +46,6 @@ dependencies {
 
   implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
 
-  testInstrumentation(project(":instrumentation:logback:logback-mdc-1.0:javaagent"))
-
   testImplementation("org.awaitility:awaitility")
 }
 

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
@@ -17,7 +17,6 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -167,15 +166,6 @@ class LogbackTest {
                       equalTo(EXCEPTION_MESSAGE, "hello"),
                       satisfies(
                           EXCEPTION_STACKTRACE, v -> v.contains(LogbackTest.class.getName()))));
-            }
-            if (withParent) {
-              SpanContext spanContext = testing.spans().get(0).getSpanContext();
-              attributeAsserts.addAll(
-                  Arrays.asList(
-                      equalTo(AttributeKey.stringKey("trace_id"), spanContext.getTraceId()),
-                      equalTo(AttributeKey.stringKey("span_id"), spanContext.getSpanId()),
-                      equalTo(
-                          AttributeKey.stringKey("trace_flags"), TraceFlags.getSampled().asHex())));
             }
             logRecord.hasAttributesSatisfyingExactly(attributeAsserts);
           });

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/mdc/v1_0/LogbackMdcInstrumentationModule.java
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/mdc/v1_0/LogbackMdcInstrumentationModule.java
@@ -29,11 +29,4 @@ public class LogbackMdcInstrumentationModule extends InstrumentationModule
   public boolean isIndyReady() {
     return true;
   }
-
-  @Override
-  public int order() {
-    // run before logback appender instrumentation so that the appender instrumentation can observe
-    // the attributes added to the mdc by this instrumentation
-    return -1;
-  }
 }


### PR DESCRIPTION
This reverts commit 55145954794a7599c4606ae0bdc8b8c246b6447e.

cc @maxxedev

Sorry folks, I'd like to revert this before making the upcoming release, and I will re-open #14897 to discuss alternate solutions that do not impact existing users.

I believe that `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*` is a popular setting (e.g. this is the default setting in our distro), and #14904 will add redundant (and non-semantically defined) attributes to all log records for all of those users.