### PR TITLE
Fix native test CI condition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@ test native:
 - all:
   - changed-files:
       - any-glob-to-any-file:
-          - instrumentation/logback/logback-appender-10/library/**
+          - instrumentation/logback/logback-appender-1.0/library/**
           - instrumentation/jdbc/library/**
           - instrumentation/spring/**
           - smoke-tests-otel-starter/**


### PR DESCRIPTION
I think this is why native tests weren't run on https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14649, which led to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14915