### PR TITLE
Fix generating release bundle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,7 +155,7 @@ tasks {
   }
 
   val generateReleaseBundle by registering(Zip::class) {
-    dependsOn(getTasksByName("publishAllPublicationToReleaseRepoRepository", true))
+    dependsOn(project.tasks.withType<PublishToMavenRepository>())
     from("releaseRepo")
 
     exclude("**/maven-metadata.*")


### PR DESCRIPTION
`2.21.0` was published to central with most artifacts missing, apparently the release bundle didn't include them.