### PR TITLE
chore(ci): move from container to VM on cncf hosted runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - language: actions
           - language: java
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
We noticed that the workflow might have performance issues running on a container on the CNCF-hosted runner. This PR moves it to a Virtual Machine.

Below is the list of available VM based hosted runners: (you may need to enable them in your organization's settings)

```
# amd64
oracle-vm-2cpu-8gb-x86-64
oracle-vm-4cpu-16gb-x86-64
oracle-vm-8cpu-32gb-x86-64
oracle-vm-16cpu-64gb-x86-64
oracle-vm-24cpu-96gb-x86-64
oracle-vm-32cpu-128gb-x86-64

# arm64
oracle-vm-2cpu-8gb-arm64
oracle-vm-4cpu-16gb-arm64
oracle-vm-8cpu-32gb-arm64
oracle-vm-16cpu-64gb-arm64
oracle-vm-24cpu-96gb-arm64
oracle-vm-32cpu-128gb-arm64
```
