### PR TITLE
Don't run spotless automation on draft PRs

### DIFF
--- a/.github/workflows/auto-spotless.yml
+++ b/.github/workflows/auto-spotless.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   check:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
I've noticed it clutters up some draft PRs, and I don't think we lose much by excluding them.