### PR TITLE
Force branch overwrite in metadata nightly job

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -70,13 +70,7 @@ jobs:
         run: |
           BRANCH_NAME="otelbot/metadata-update-main"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          if git ls-remote --exit-code --heads origin "$BRANCH_NAME"; then
-            git fetch origin "$BRANCH_NAME"
-            git checkout "$BRANCH_NAME"
-            git merge origin/main --no-edit
-          else
-            git checkout -b "$BRANCH_NAME" origin/main
-          fi
+          git checkout -B "$BRANCH_NAME"
 
       - name: Commit and push changes
         if: steps.diffcheck.outputs.has_diff == 'true'
@@ -85,7 +79,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           git commit -m "chore: update instrumentation list [automated]" || echo "No changes to commit."
-          git push origin "$BRANCH_NAME"
+          git push --force origin "$BRANCH_NAME"
 
       - name: Create PR if needed
         if: steps.diffcheck.outputs.has_diff == 'true'
@@ -119,3 +113,14 @@ jobs:
           else
             echo "No open PR found for branch $BRANCH_NAME."
           fi
+
+  workflow-notification:
+    permissions:
+      contents: read
+      issues: write
+    needs:
+      - update
+    if: always()
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.update.result == 'success' }}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/18702650904/job/53334377239

```
Run BRANCH_NAME="otelbot/metadata-update-main"
8258f601d86096c2b57e15a33fe766b5542852a5	refs/heads/otelbot/metadata-update-main
From https://github.com/open-telemetry/opentelemetry-java-instrumentation
 * branch                  otelbot/metadata-update-main -> FETCH_HEAD
 * [new branch]            otelbot/metadata-update-main -> origin/otelbot/metadata-update-main
error: Your local changes to the following files would be overwritten by checkout:
	docs/instrumentation-list.yaml
Please commit your changes or stash them before you switch branches.
Aborting
```

Also adding a notification for when this fails in the future