### PR TITLE
Don't run license automation on draft PRs

### DIFF
--- a/.github/workflows/auto-license-report.yml
+++ b/.github/workflows/auto-license-report.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   check:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
follow up from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15089#issuecomment-3430440426