### PR TITLE
Only rebuild PRs on specific labels

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -3,10 +3,11 @@ name: Build pull request
 on:
   pull_request:
     types:
-      - labeled
       - opened
       - synchronize
       - reopened
+  # called from rebuild-pull-request-on-label.yml
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/rebuild-pull-request-on-label.yml
+++ b/.github/workflows/rebuild-pull-request-on-label.yml
@@ -1,0 +1,19 @@
+name: Build on test labels
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-build:
+    # Only run if one of the test labels was added
+    if: |
+      github.event.label.name == 'test openj9' ||
+      github.event.label.name == 'test windows' ||
+      github.event.label.name == 'test native'
+    uses: ./.github/workflows/build-pull-request.yml


### PR DESCRIPTION
I noticed build was retriggered on https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15094 after I added the "breaking changes" label.