### PR TITLE
Exclude compile-stub from metadata analysis

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
@@ -69,7 +69,7 @@ public record FileManager(String rootDir) {
     }
 
     if (filePath.matches(
-        ".*(/test/|/testing|/build/|-common/|-common-|common-|-testing|bootstrap/src).*")) {
+        ".*(/test/|/testing|/build/|-common/|-common-|common-|/compile-stub/|-testing|bootstrap/src).*")) {
       return false;
     }
 


### PR DESCRIPTION
Fixes [this](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15097/files#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1R6869-R6873)