### PR TITLE
[Spring starter] Add cache to reduce environment variable lookups

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -100,7 +100,6 @@ public class OpenTelemetryAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk(
         Environment env,
         OtlpExporterProperties otlpExporterProperties,

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
@@ -25,7 +25,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * any time.
  */
 public class SpringConfigProperties implements ConfigProperties {
-  private final CachedPropertyResolver cachedEnvironment;
+  private final CachedPropertyResolver environment;
 
   private final ExpressionParser parser;
   private final OtlpExporterProperties otlpExporterProperties;
@@ -44,7 +44,7 @@ public class SpringConfigProperties implements ConfigProperties {
       OtelResourceProperties resourceProperties,
       OtelSpringProperties otelSpringProperties,
       ConfigProperties otelSdkProperties) {
-    this.cachedEnvironment = new CachedPropertyResolver(environment);
+    this.environment = new CachedPropertyResolver(environment);
     this.parser = parser;
     this.otlpExporterProperties = otlpExporterProperties;
     this.resourceProperties = resourceProperties;
@@ -152,7 +152,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public String getString(String name) {
     String normalizedName = ConfigUtil.normalizeEnvironmentVariableKey(name);
-    String value = cachedEnvironment.getProperty(normalizedName, String.class);
+    String value = environment.getProperty(normalizedName, String.class);
     if (value == null && normalizedName.equals("otel.exporter.otlp.protocol")) {
       // SDK autoconfigure module defaults to `grpc`, but this module aligns with
       // recommendation in specification to default to `http/protobuf`
@@ -165,8 +165,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Boolean getBoolean(String name) {
     return or(
-        cachedEnvironment.getProperty(
-            ConfigUtil.normalizeEnvironmentVariableKey(name), Boolean.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Boolean.class),
         otelSdkProperties.getBoolean(name));
   }
 
@@ -174,8 +173,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Integer getInt(String name) {
     return or(
-        cachedEnvironment.getProperty(
-            ConfigUtil.normalizeEnvironmentVariableKey(name), Integer.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Integer.class),
         otelSdkProperties.getInt(name));
   }
 
@@ -183,7 +181,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Long getLong(String name) {
     return or(
-        cachedEnvironment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Long.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Long.class),
         otelSdkProperties.getLong(name));
   }
 
@@ -191,8 +189,7 @@ public class SpringConfigProperties implements ConfigProperties {
   @Override
   public Double getDouble(String name) {
     return or(
-        cachedEnvironment.getProperty(
-            ConfigUtil.normalizeEnvironmentVariableKey(name), Double.class),
+        environment.getProperty(ConfigUtil.normalizeEnvironmentVariableKey(name), Double.class),
         otelSdkProperties.getDouble(name));
   }
 
@@ -212,8 +209,7 @@ public class SpringConfigProperties implements ConfigProperties {
       }
     }
 
-    List<String> envValue =
-        (List<String>) cachedEnvironment.getProperty(normalizedName, List.class);
+    List<String> envValue = (List<String>) environment.getProperty(normalizedName, List.class);
     return or(envValue, otelSdkProperties.getList(name));
   }
 
@@ -240,7 +236,7 @@ public class SpringConfigProperties implements ConfigProperties {
       return specialMap;
     }
 
-    String value = cachedEnvironment.getProperty(normalizedName);
+    String value = environment.getProperty(normalizedName);
     if (value == null) {
       return otelSdkMap;
     }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.withSettings;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporter.otlp.internal.OtlpSpanExporterProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -57,27 +56,6 @@ class OpenTelemetryAutoConfigurationTest {
                     .hasBean("customOpenTelemetry")
                     .doesNotHaveBean("openTelemetry")
                     .hasBean("otelProperties"));
-  }
-
-  private static class CustomAutoConfiguredSdkConfiguration {
-    @Bean
-    public AutoConfiguredOpenTelemetrySdk customAutoConfiguredSdk() {
-      return AutoConfiguredOpenTelemetrySdk.builder().build();
-    }
-  }
-
-  @Test
-  @DisplayName(
-      "when Application Context contains AutoConfiguredOpenTelemetrySdk bean should NOT use default")
-  void customAutoConfiguredOpenTelemetrySdk() {
-    this.contextRunner
-        .withUserConfiguration(CustomAutoConfiguredSdkConfiguration.class)
-        .withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
-        .run(
-            context ->
-                assertThat(context)
-                    .hasBean("customAutoConfiguredSdk")
-                    .doesNotHaveBean("autoConfiguredOpenTelemetrySdk"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #15009

Add ability for users to customize AutoConfiguredOpenTelemetrySdk, and add cache for environment config lookups.