### PR TITLE
Try to work around openj9 jit crash

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -342,7 +342,10 @@ tasks.withType<Test>().configureEach {
   val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
     ?: false
   if (useJ9 && testJavaVersion != null && testJavaVersion.isJava8) {
-    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*},exclude={io/opentelemetry/testing/internal/io/netty/buffer/AbstractByteBuf.*}")
+    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*}," +
+        "exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*}," +
+        "exclude={io/opentelemetry/testing/internal/io/netty/buffer/AbstractByteBuf.*}," +
+        "exclude={io/opentelemetry/testing/internal/io/netty/handler/codec/base64/Base64.*}")
   }
 
   // There's no real harm in setting this for all tests even if any happen to not be using context


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15179
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15180
Initially I thought that this was somehow caused by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15091 but since the crash looks unrelated and the test runs on freshly released openj9-0.56.0 (released October 28, 2025) I think it could be a regression in openj9.