### PR TITLE
Fix logback log replay test

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
@@ -42,8 +42,12 @@ abstract class AbstractOpenTelemetryAppenderTest {
     LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
     loggerContext.putProperty("test-property", "test-value");
 
-    logger.info("log message 1");
-    executeAfterLogsExecution();
+    try {
+      logger.info("log message 1");
+      executeAfterLogsExecution();
+    } finally {
+      Helper.resetLoggerContext();
+    }
 
     getTesting()
         .waitAndAssertLogRecords(


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15164
Restores finally block removed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15150 Currently `LogReplayOpenTelemetryAppenderTest.twoLogs` always fails on first run in latest dep mode, because a previous test doesn't properly clean up. Due to retry it is just flaky in regular test runs. Graalvm tests don't retry.