### PR TITLE
Fix flaky openai test

### DIFF
--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -63,6 +63,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.openai.TestHelper;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,14 +74,18 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class AbstractChatTest extends AbstractOpenAiTest {
+
   protected static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
 
   protected static final String TEST_CHAT_MODEL = "gpt-4o-mini";
   protected static final String TEST_CHAT_RESPONSE_MODEL = "gpt-4o-mini-2024-07-18";
   protected static final String TEST_CHAT_INPUT =
       "Answer in up to 3 words: Which ocean contains Bouvet Island?";
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected final ChatCompletion doCompletions(ChatCompletionCreateParams params) {
     return doCompletions(params, getClient(), getClientAsync());
@@ -878,6 +883,8 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                 .apiKey("testing")
                 .maxRetries(0)
                 .build());
+    cleanup.deferCleanup(client::close);
+    cleanup.deferCleanup(clientAsync::close);
 
     ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()
@@ -1583,6 +1590,8 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                 .apiKey("testing")
                 .maxRetries(0)
                 .build());
+    cleanup.deferCleanup(client::close);
+    cleanup.deferCleanup(clientAsync::close);
 
     ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/s3khsy5f64yei/tests/task/:instrumentation:openai:openai-java-1.1:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.openai.v1_1.ChatTest/streamConnectionError()?expanded-stacktrace=WyIyIl0&top-execution=1

It seems that this test fails only on openj9. I have a suspicion that openj9 gc is smart and figures out that some objects like the openai client have become unreachable before the test ends. Openai wraps okhttp in `PhantomReachableClosingHttpClient` when this object becomes unreachable it will trigger the shutdown of the okhttp client. My guess is that okhttp client gets shut down before the test completes. Hopefully shutting down the openai client at the end of the test ensures that the openai client and the objects it uses won't get shut down too early.