### PR TITLE
Switch codeql back to normal runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - language: actions
           - language: java
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
@laurit just queueing this up for you in case https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15189#issuecomment-3470894123 doesn't clear up shortly