### PR TITLE
move internal virtual field for indy migration

### DIFF
--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
@@ -35,9 +35,19 @@ public class TestInstrumentationModule extends InstrumentationModule
   }
 
   @Override
+  public boolean isHelperClass(String className) {
+    return "instrumentation.TestSingletons".equals(className);
+  }
+
+  @Override
   public void injectClasses(ClassInjector injector) {
     injector
         .proxyBuilder("instrumentation.TestHelperClass")
         .inject(InjectionMode.CLASS_AND_RESOURCE);
+  }
+
+  @Override
+  public boolean isIndyReady() {
+    return true;
   }
 }

--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestSingletons.java
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestSingletons.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package instrumentation;
+
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+
+public class TestSingletons {
+
+  public static final VirtualField<Runnable, String> STRING =
+      VirtualField.find(Runnable.class, String.class);
+
+  private TestSingletons() {}
+}

--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestTypeInstrumentation.java
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/main/java/instrumentation/TestTypeInstrumentation.java
@@ -5,9 +5,9 @@
 
 package instrumentation;
 
+import static instrumentation.TestSingletons.STRING;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
-import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
@@ -36,7 +36,7 @@ public class TestTypeInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToReturned
     @Advice.OnMethodExit
     public static String methodExit(@Advice.This Runnable test) {
-      VirtualField.find(Runnable.class, String.class).set(test, "instrumented");
+      STRING.set(test, "instrumented");
       return "instrumented";
     }
   }
@@ -47,7 +47,7 @@ public class TestTypeInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToReturned
     @Advice.OnMethodExit
     public static String methodExit(@Advice.This Runnable test) {
-      return VirtualField.find(Runnable.class, String.class).get(test);
+      return STRING.get(test);
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to deal with leftover from #14646 

Part of #13031

I think/hope this should be the last `VirtualField` that needs to be moved to an helper class.