### PR TITLE
Prevent renovate from updating node

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -162,7 +162,7 @@
     {
       // vaadin 14 tests require node 16
       matchPackageNames: [
-        'node',
+        'actions/node-versions',
       ],
       matchUpdateTypes: [
         'major',


### PR DESCRIPTION
based on the renovate log I think `actions/node-versions` is the correct package name