### PR TITLE
Remove unneeded option

### DIFF
--- a/instrumentation/spring/spring-web/spring-web-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/web/v6_0/SpringRestTemplateTest.java
+++ b/instrumentation/spring/spring-web/spring-web-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/web/v6_0/SpringRestTemplateTest.java
@@ -106,7 +106,6 @@ class SpringRestTemplateTest extends AbstractHttpClientTest<HttpEntity<String>> 
     optionsBuilder.setExpectedClientSpanNameMapper(
         (uri, method) -> method + " " + getTemplate(uri));
     optionsBuilder.setExpectedUrlTemplateMapper(SpringRestTemplateTest::getTemplate);
-    optionsBuilder.setHasUrlTemplate(true);
   }
 
   private static String getTemplate(URI uri) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -1134,11 +1134,10 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
               if (httpClientAttributes.contains(UrlAttributes.URL_FULL)) {
                 assertThat(attrs).containsEntry(UrlAttributes.URL_FULL, uri.toString());
               }
-              if (options.getHasUrlTemplate()) {
+              String expectedUrlTemplate = options.getExpectedUrlTemplateMapper().apply(uri);
+              if (expectedUrlTemplate != null) {
                 assertThat(attrs)
-                    .containsEntry(
-                        UrlIncubatingAttributes.URL_TEMPLATE,
-                        options.getExpectedUrlTemplateMapper().apply(uri));
+                    .containsEntry(UrlIncubatingAttributes.URL_TEMPLATE, expectedUrlTemplate);
               }
               if (httpClientAttributes.contains(HttpAttributes.HTTP_REQUEST_METHOD)) {
                 assertThat(attrs).containsEntry(HttpAttributes.HTTP_REQUEST_METHOD, method);

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
@@ -39,7 +39,7 @@ public abstract class HttpClientTestOptions {
   public static final BiFunction<URI, String, String> DEFAULT_EXPECTED_CLIENT_SPAN_NAME_MAPPER =
       (uri, method) -> HttpConstants._OTHER.equals(method) ? "HTTP" : method;
 
-  public static final Function<URI, String> DEFAULT_EXPECTED_URL_TEMPLATE_MAPPER = URI::getPath;
+  public static final Function<URI, String> DEFAULT_EXPECTED_URL_TEMPLATE_MAPPER = uri -> null;
 
   public static final int FOUND_STATUS_CODE = HttpStatus.FOUND.code();
 
@@ -99,8 +99,6 @@ public abstract class HttpClientTestOptions {
 
   public abstract Function<URI, String> getHttpProtocolVersion();
 
-  public abstract boolean getHasUrlTemplate();
-
   public abstract boolean getTestPeerService();
 
   public abstract Function<URI, String> getExpectedPeerServiceName();
@@ -148,7 +146,6 @@ public abstract class HttpClientTestOptions {
           .setTestNonStandardHttpMethod(true)
           .setTestCaptureHttpHeaders(true)
           .setHasSendRequest(true)
-          .setHasUrlTemplate(false)
           .setTestPeerService(true)
           .setExpectedPeerServiceName(uri -> "test-peer-service")
           .setHttpProtocolVersion(uri -> "1.1");
@@ -199,8 +196,6 @@ public abstract class HttpClientTestOptions {
     Builder setTestNonStandardHttpMethod(boolean value);
 
     Builder setHasSendRequest(boolean value);
-
-    Builder setHasUrlTemplate(boolean value);
 
     Builder setTestPeerService(boolean value);
 
@@ -281,11 +276,6 @@ public abstract class HttpClientTestOptions {
     @CanIgnoreReturnValue
     default Builder spanEndsAfterBody() {
       return setSpanEndsAfterType(SpanEndsAfterType.BODY);
-    }
-
-    @CanIgnoreReturnValue
-    default Builder enableUrlTemplate() {
-      return setHasUrlTemplate(true);
     }
 
     HttpClientTestOptions build();


### PR DESCRIPTION
we don't need a separate url template enabled option and can just check whether the expected value is not null