### PR TITLE
Add server span name feature to metadata

### DIFF
--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -201,7 +201,8 @@ the relevant functionality descriptions.
 
 List of possible options:
 
-* `HTTP_ROUTE`: Instrumentation that enriches HTTP spans with route information
+* `HTTP_ROUTE`: Instrumentation that enriches HTTP spans with route information (e.g., `/users/{id}`). Sets both the span name and the `http.route` attribute.
+* `SERVER_SPAN_NAME`: Instrumentation that enriches the HTTP server span name with controller, view, or operation information. This feature applies to instrumentations that update the server span name based on framework-specific information (like JSF view IDs or JAX-WS operation names) without setting the `http.route` attribute. The key distinction from `HTTP_ROUTE` is that `SERVER_SPAN_NAME` only updates the span name, while `HTTP_ROUTE` updates both the span name and the `http.route` attribute.
 * `CONTEXT_PROPAGATION`: Instrumentation that propagates OpenTelemetry context across application or thread boundaries. This applies to:
   * Inter-process/application context propagation: Passing context through headers between applications (HTTP, gRPC, messaging, etc.)
   * Inter-thread context propagation: Passing context from one thread to another (executors, actors, reactive streams, etc.)

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -5681,10 +5681,10 @@ libraries:
   - name: jaxws-2.0-axis2-1.6
     display_name: Apache Axis2 1.6 JAX-WS 2.x
     description: |
-      This instrumentation enriches HTTP server spans with route information, and enables controller spans for Apache Axis2 JAX-WS web services (controller spans are disabled by default).
+      This instrumentation enriches server span names with web service operation information, and enables controller spans for Apache Axis2 JAX-WS web services (controller spans are disabled by default).
     library_link: https://axis.apache.org/axis2/java/core/
     features:
-    - HTTP_ROUTE
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jaxws/jaxws-2.0-axis2-1.6
     scope:
@@ -5705,10 +5705,10 @@ libraries:
   - name: jaxws-cxf-3.0
     display_name: Apache CXF 3.x JAX-WS
     description: |
-      This instrumentation enriches HTTP server spans with route information, and enables controller spans for Apache CXF JAX-WS web services (controller spans are disabled by default).
+      This instrumentation enriches server span names with web service operation information, and enables controller spans for Apache CXF JAX-WS web services (controller spans are disabled by default).
     library_link: https://cxf.apache.org/
     features:
-    - HTTP_ROUTE
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jaxws/jaxws-cxf-3.0
     scope:
@@ -5757,10 +5757,10 @@ libraries:
   - name: jaxws-metro-2.2
     display_name: Metro JAX-WS
     description: |
-      This instrumentation enriches HTTP server spans with route information, and enables controller spans for Metro JAX-WS web services (controller spans are disabled by default).
+      This instrumentation enriches server span names with web service operation information, and enables controller spans for Metro JAX-WS web services (controller spans are disabled by default).
     library_link: https://javaee.github.io/metro/
     features:
-    - HTTP_ROUTE
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jaxws/jaxws-metro-2.2
     scope:
@@ -6659,9 +6659,10 @@ libraries:
   - name: jsf-mojarra-1.2
     display_name: JSF
     description: |
-      This instrumentation enables controller spans for Mojarra JSF action listeners (controller spans are disabled by default).
+      This instrumentation enriches server span names with JSF view information, and enables controller spans for Mojarra JSF action listeners (controller spans are disabled by default).
     library_link: https://github.com/eclipse-ee4j/mojarra
     features:
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jsf/jsf-mojarra-1.2
     scope:
@@ -6686,9 +6687,10 @@ libraries:
   - name: jsf-mojarra-3.0
     display_name: JSF
     description: |
-      This instrumentation enables controller spans for Mojarra JSF action listeners (controller spans are disabled by default).
+      This instrumentation enriches server span names with JSF view information, and enables controller spans for Mojarra JSF action listeners (controller spans are disabled by default).
     library_link: https://github.com/eclipse-ee4j/mojarra
     features:
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jsf/jsf-mojarra-3.0
     minimum_java_version: 11
@@ -6710,9 +6712,10 @@ libraries:
   - name: jsf-myfaces-1.2
     display_name: JSF
     description: |
-      This instrumentation enables controller spans for Apache MyFaces action listeners (controller spans are disabled by default).
+      This instrumentation enriches server span names with JSF view information, and enables controller spans for Apache MyFaces action listeners (controller spans are disabled by default).
     library_link: https://myfaces.apache.org/
     features:
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jsf/jsf-myfaces-1.2
     scope:
@@ -6733,9 +6736,10 @@ libraries:
   - name: jsf-myfaces-3.0
     display_name: JSF
     description: |
-      This instrumentation enables controller spans for Apache MyFaces action listeners (controller spans are disabled by default).
+      This instrumentation enriches server span names with JSF view information, and enables controller spans for Apache MyFaces action listeners (controller spans are disabled by default).
     library_link: https://myfaces.apache.org/
     features:
+    - SERVER_SPAN_NAME
     - CONTROLLER_SPANS
     source_path: instrumentation/jsf/jsf-myfaces-3.0
     minimum_java_version: 11

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -138,6 +138,7 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
   * The specific functionality that the instrumentation provides
   * Options are:
     * HTTP_ROUTE
+    * SERVER_SPAN_NAME
     * CONTEXT_PROPAGATION
     * AUTO_INSTRUMENTATION_SHIM
     * CONTROLLER_SPANS

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationFeature.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationFeature.java
@@ -11,6 +11,7 @@ package io.opentelemetry.instrumentation.docs.internal;
  */
 public enum InstrumentationFeature {
   HTTP_ROUTE,
+  SERVER_SPAN_NAME,
   CONTEXT_PROPAGATION,
   AUTO_INSTRUMENTATION_SHIM,
   CONTROLLER_SPANS,

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/metadata.yaml
@@ -1,10 +1,11 @@
 display_name: Apache Axis2 1.6 JAX-WS 2.x
 description: >
-  This instrumentation enriches HTTP server spans with route information, and enables controller
-  spans for Apache Axis2 JAX-WS web services (controller spans are disabled by default).
+  This instrumentation enriches server span names with web service operation information, and
+  enables controller spans for Apache Axis2 JAX-WS web services (controller spans are disabled by
+  default).
 library_link: https://axis.apache.org/axis2/java/core/
 features:
-  - HTTP_ROUTE
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-cxf-3.0/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-cxf-3.0/metadata.yaml
@@ -1,10 +1,11 @@
 display_name: Apache CXF 3.x JAX-WS
 description: >
-  This instrumentation enriches HTTP server spans with route information, and enables controller
-  spans for Apache CXF JAX-WS web services (controller spans are disabled by default).
+  This instrumentation enriches server span names with web service operation information, and
+  enables controller spans for Apache CXF JAX-WS web services (controller spans are disabled by
+  default).
 library_link: https://cxf.apache.org/
 features:
-  - HTTP_ROUTE
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-metro-2.2/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-metro-2.2/metadata.yaml
@@ -1,10 +1,10 @@
 display_name: Metro JAX-WS
 description: >
-  This instrumentation enriches HTTP server spans with route information, and enables controller
-  spans for Metro JAX-WS web services (controller spans are disabled by default).
+  This instrumentation enriches server span names with web service operation information, and
+  enables controller spans for Metro JAX-WS web services (controller spans are disabled by default).
 library_link: https://javaee.github.io/metro/
 features:
-  - HTTP_ROUTE
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 configurations:
   - name: otel.instrumentation.common.experimental.controller-telemetry.enabled

--- a/instrumentation/jsf/jsf-mojarra-1.2/metadata.yaml
+++ b/instrumentation/jsf/jsf-mojarra-1.2/metadata.yaml
@@ -1,8 +1,9 @@
 display_name: JSF
 description: >
-  This instrumentation enables controller spans for Mojarra JSF action listeners (controller spans
-  are disabled by default).
+  This instrumentation enriches server span names with JSF view information, and enables controller
+  spans for Mojarra JSF action listeners (controller spans are disabled by default).
 features:
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 library_link: https://github.com/eclipse-ee4j/mojarra
 configurations:

--- a/instrumentation/jsf/jsf-mojarra-3.0/metadata.yaml
+++ b/instrumentation/jsf/jsf-mojarra-3.0/metadata.yaml
@@ -1,8 +1,9 @@
 display_name: JSF
 description: >
-  This instrumentation enables controller spans for Mojarra JSF action listeners (controller spans
-  are disabled by default).
+  This instrumentation enriches server span names with JSF view information, and enables controller
+  spans for Mojarra JSF action listeners (controller spans are disabled by default).
 features:
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 library_link: https://github.com/eclipse-ee4j/mojarra
 configurations:

--- a/instrumentation/jsf/jsf-myfaces-1.2/metadata.yaml
+++ b/instrumentation/jsf/jsf-myfaces-1.2/metadata.yaml
@@ -1,8 +1,9 @@
 display_name: JSF
 description: >
-  This instrumentation enables controller spans for Apache MyFaces action listeners (controller
-  spans are disabled by default).
+  This instrumentation enriches server span names with JSF view information, and enables controller
+  spans for Apache MyFaces action listeners (controller spans are disabled by default).
 features:
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 library_link: https://myfaces.apache.org/
 configurations:

--- a/instrumentation/jsf/jsf-myfaces-3.0/metadata.yaml
+++ b/instrumentation/jsf/jsf-myfaces-3.0/metadata.yaml
@@ -1,8 +1,9 @@
 display_name: JSF
 description: >
-  This instrumentation enables controller spans for Apache MyFaces action listeners (controller
-  spans are disabled by default).
+  This instrumentation enriches server span names with JSF view information, and enables controller
+  spans for Apache MyFaces action listeners (controller spans are disabled by default).
 features:
+  - SERVER_SPAN_NAME
   - CONTROLLER_SPANS
 library_link: https://myfaces.apache.org/
 configurations:


### PR DESCRIPTION
Related to #14096 

Discussed [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15212#discussion_r2488777145)

Adds a new feature descriptor `SERVER_SPAN_NAME` to distinguish instrumentations that populate the span name, but don't also update the `http.route` attribute.