### PR TITLE
Fix import

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/CustomJodaModule.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/CustomJodaModule.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.opentelemetry.testing.internal.jackson.core.JsonTokenId;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;


### PR DESCRIPTION
since the field referenced through this import points to a constant having the wrong import doesn't break at run time