### PR TITLE
Fix intellij not seeing shaded deps of testing-common

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.library-instrumentation.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.library-instrumentation.gradle.kts
@@ -10,3 +10,11 @@ dependencies {
 
   testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }
+
+testing {
+  suites.withType(JvmTestSuite::class).configureEach {
+    dependencies {
+      implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
+    }
+  }
+}

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -467,7 +467,7 @@ configurations.configureEach {
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")).using(project(":javaagent-extension-api"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")).using(project(":javaagent-tooling"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-agent-for-testing")).using(project(":testing:agent-for-testing"))
-      substitute(module("io.opentelemetry.javaagent:opentelemetry-testing-common")).using(project(":testing-common"))
+      substitute(module("io.opentelemetry.javaagent:opentelemetry-testing-common")).using(project(":testing-common:with-shaded-dependencies"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-muzzle")).using(project(":muzzle"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent")).using(project(":javaagent"))
     }

--- a/instrumentation-annotations-support-testing/build.gradle.kts
+++ b/instrumentation-annotations-support-testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation-annotations-support/build.gradle.kts
+++ b/instrumentation-annotations-support/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }

--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.opentelemetry:opentelemetry-exporter-common")
   testImplementation("org.junit-pioneer:junit-pioneer")

--- a/instrumentation/alibaba-druid-1.0/testing/build.gradle.kts
+++ b/instrumentation/alibaba-druid-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.mockito:mockito-core")
   api("org.mockito:mockito-junit-jupiter")
 

--- a/instrumentation/apache-dbcp-2.0/testing/build.gradle.kts
+++ b/instrumentation/apache-dbcp-2.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.mockito:mockito-core")
   api("org.mockito:mockito-junit-jupiter")
 

--- a/instrumentation/apache-dubbo-2.7/testing/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 val apacheDubboVersion = "2.7.5"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.apache.dubbo:dubbo:$apacheDubboVersion")
   api("org.apache.dubbo:dubbo-config-api:$apacheDubboVersion")

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/testing/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/testing/build.gradle.kts
@@ -13,7 +13,7 @@ tasks {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.apache.httpcomponents:httpclient:4.3")
 

--- a/instrumentation/armeria/armeria-1.3/testing/build.gradle.kts
+++ b/instrumentation/armeria/armeria-1.3/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.linecorp.armeria:armeria:1.3.0")
   api("com.linecorp.armeria:armeria-junit4:1.3.0")

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.amazonaws:aws-lambda-java-core:1.0.0")
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.amazonaws:aws-lambda-java-core:1.0.0")
   api("com.amazonaws:aws-lambda-java-events:2.2.1")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.amazonaws:aws-java-sdk-core:1.11.0")
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("software.amazon.awssdk:apache-client:2.2.0")
   // older versions don't play nice with armeria http server

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -20,13 +20,6 @@ subprojects {
     instrumentationProjectTest.configure {
       dependsOn(subProj.tasks.named("test"))
     }
-
-    // this only exists to make Intellij happy since it doesn't (currently at least) understand our
-    // inclusion of this artifact inside :testing-common
-    dependencies {
-      compileOnly(project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-      testCompileOnly(project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-    }
   }
 
   plugins.withId("io.opentelemetry.instrumentation.muzzle-check") {

--- a/instrumentation/c3p0-0.9/testing/build.gradle.kts
+++ b/instrumentation/c3p0-0.9/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.mockito:mockito-core")
   api("org.mockito:mockito-junit-jupiter")
 

--- a/instrumentation/cassandra/cassandra-4-common/testing/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("com.datastax.oss:java-driver-core:4.0.0")
   implementation("org.testcontainers:testcontainers")

--- a/instrumentation/cassandra/cassandra-4.4/testing/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.4/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("com.datastax.oss:java-driver-core:4.4.0")
   implementation("io.projectreactor:reactor-core:3.5.3")

--- a/instrumentation/couchbase/couchbase-common/testing/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.couchbase.mock:CouchbaseMock:1.5.19")
   // Earliest version that seems to allow queries with CouchbaseMock:

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("org.elasticsearch.client:transport:6.0.0")
   implementation(project(":instrumentation:elasticsearch:elasticsearch-transport-common:testing"))

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/testing/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/testing/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
   compileOnly("org.elasticsearch.client:transport:5.3.0")
   compileOnly("org.elasticsearch:elasticsearch:5.3.0")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/executors/testing/build.gradle.kts
+++ b/instrumentation/executors/testing/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 dependencies {
   api("org.junit.jupiter:junit-jupiter-api")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/graphql-java/graphql-java-common/testing/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-common/testing/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("com.graphql-java:graphql-java:12.0")
 }

--- a/instrumentation/grpc-1.6/testing/build.gradle.kts
+++ b/instrumentation/grpc-1.6/testing/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 val grpcVersion = "1.6.0"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("io.grpc:grpc-core:$grpcVersion")
   api("io.grpc:grpc-protobuf:$grpcVersion")

--- a/instrumentation/helidon-4.3/testing/build.gradle.kts
+++ b/instrumentation/helidon-4.3/testing/build.gradle.kts
@@ -7,6 +7,6 @@ otelJava {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("io.helidon.webserver:helidon-webserver:4.3.0")
 }

--- a/instrumentation/hibernate/hibernate-reactive-1.0/hibernate-reactive-2.0-testing/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/hibernate-reactive-2.0-testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers")
 
   compileOnly("org.hibernate.reactive:hibernate-reactive-core:2.0.0.Final")

--- a/instrumentation/hibernate/testing/build.gradle.kts
+++ b/instrumentation/hibernate/testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/hikaricp-3.0/testing/build.gradle.kts
+++ b/instrumentation/hikaricp-3.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.mockito:mockito-core")
   api("org.mockito:mockito-junit-jupiter")
 

--- a/instrumentation/java-http-client/testing/build.gradle.kts
+++ b/instrumentation/java-http-client/testing/build.gradle.kts
@@ -7,5 +7,5 @@ otelJava {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/java-http-server/testing/build.gradle.kts
+++ b/instrumentation/java-http-server/testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   compileOnly("javax:javaee-api:7.0")
 
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("io.opentelemetry:opentelemetry-api")
 
   val arquillianVersion = "1.7.0.Alpha10"

--- a/instrumentation/jaxrs/jaxrs-common/testing/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.opentelemetry:opentelemetry-api")
   implementation("org.slf4j:slf4j-api")

--- a/instrumentation/jaxws/jaxws-2.0-arquillian-testing/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-arquillian-testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   compileOnly("javax:javaee-api:7.0")
 
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("io.opentelemetry:opentelemetry-api")
   implementation("org.jsoup:jsoup:1.13.1")
 

--- a/instrumentation/jaxws/jaxws-2.0-common-testing/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-common-testing/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
   api("org.eclipse.jetty:jetty-webapp:9.4.35.v20201120")
   api("org.springframework.ws:spring-ws-core:3.0.0.RELEASE")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/jaxws/jaxws-3.0-common-testing/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-3.0-common-testing/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
   api("org.eclipse.jetty:jetty-webapp:11.0.17")
   api("org.springframework.ws:spring-ws-core:4.0.0")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/jdbc/testing/build.gradle.kts
+++ b/instrumentation/jdbc/testing/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("com.google.guava:guava")
 
   compileOnly("com.h2database:h2:1.3.169")

--- a/instrumentation/jedis/jedis-1.4/testing/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/testing/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
   compileOnly("redis.clients:jedis:1.4.0")
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers")
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/testing/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.eclipse.jetty:jetty-client:12.0.0")
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 val jettyVers_base9 = "9.2.0.v20140526"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.eclipse.jetty:jetty-client:$jettyVers_base9")
 

--- a/instrumentation/jmx-metrics/library/build.gradle.kts
+++ b/instrumentation/jmx-metrics/library/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   implementation("org.snakeyaml:snakeyaml-engine")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("org.testcontainers:testcontainers")
 
   testImplementation("org.testcontainers:testcontainers-junit-jupiter")

--- a/instrumentation/jsf/jsf-jakarta-common/testing/build.gradle.kts
+++ b/instrumentation/jsf/jsf-jakarta-common/testing/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   api("org.eclipse.jetty:apache-jstl:11.0.0")
   api("org.eclipse.jetty:apache-jsp:11.0.0")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.jsoup:jsoup:1.13.1")
 
   implementation("org.glassfish:jakarta.el:4.0.2")

--- a/instrumentation/jsf/jsf-javax-common/testing/build.gradle.kts
+++ b/instrumentation/jsf/jsf-javax-common/testing/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   compileOnly("jakarta.faces:jakarta.faces-api:2.3.2")
   compileOnly("jakarta.el:jakarta.el-api:3.0.3")
 
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.jsoup:jsoup:1.13.1")
 
   val jettyVersion = "9.4.35.v20201120"

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("org.apache.kafka:kafka-clients:0.11.0.0")
 

--- a/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
@@ -12,7 +12,7 @@ val agentShadowJar = project(":javaagent").tasks.named<ShadowJar>("shadowJar")
 
 dependencies {
   testImplementation(project(":smoke-tests"))
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("org.apache.kafka:kafka-clients:3.6.1")
   testImplementation("io.opentelemetry:opentelemetry-exporter-logging")

--- a/instrumentation/ktor/ktor-2.0/testing/build.gradle.kts
+++ b/instrumentation/ktor/ktor-2.0/testing/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 val ktorVersion = "2.0.0"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.ktor:ktor-client-core:$ktorVersion")
   implementation("io.ktor:ktor-server-core:$ktorVersion")

--- a/instrumentation/ktor/ktor-3.0/testing/build.gradle.kts
+++ b/instrumentation/ktor/ktor-3.0/testing/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 val ktorVersion = "3.0.0"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.ktor:ktor-client-core:$ktorVersion")
   implementation("io.ktor:ktor-server-core:$ktorVersion")

--- a/instrumentation/lettuce/lettuce-5.1/testing/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   // 6.0+ added protocolVersion access which allows forcing RESP2 for consistency in tests
   compileOnly("io.lettuce:lettuce-core:6.0.0.RELEASE")

--- a/instrumentation/log4j/log4j-appender-2.17/testing/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("io.opentelemetry:opentelemetry-sdk-testing")
 
   api("org.apache.logging.log4j:log4j-api:2.17.0")

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/build.gradle.kts
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.apache.logging.log4j:log4j-core:2.7")
 

--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -71,7 +71,6 @@ testing {
       dependencies {
         implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
         implementation("io.opentelemetry:opentelemetry-sdk-testing")
-        implementation(project(":testing-common"))
 
         if (latestDepTest) {
           implementation("ch.qos.logback:logback-classic:latest.release")
@@ -95,7 +94,6 @@ testing {
       dependencies {
         implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
         implementation("io.opentelemetry:opentelemetry-sdk-testing")
-        implementation(project(":testing-common"))
 
         if (latestDepTest) {
           implementation("ch.qos.logback:logback-classic:latest.release")
@@ -125,7 +123,6 @@ testing {
       dependencies {
         implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
         implementation("io.opentelemetry:opentelemetry-sdk-testing")
-        implementation(project(":testing-common"))
 
         if (latestDepTest) {
           implementation("ch.qos.logback:logback-classic:latest.release")
@@ -155,7 +152,6 @@ testing {
       dependencies {
         implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
         implementation("io.opentelemetry:opentelemetry-sdk-testing")
-        implementation(project(":testing-common"))
 
         if (latestDepTest) {
           implementation("ch.qos.logback:logback-classic:latest.release")

--- a/instrumentation/logback/logback-appender-1.0/testing/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("io.opentelemetry:opentelemetry-sdk-testing")
 
   api("ch.qos.logback:logback-classic:1.0.0")

--- a/instrumentation/logback/logback-mdc-1.0/testing/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   compileOnly(project(":instrumentation:logback:logback-mdc-1.0:library"))
 
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("ch.qos.logback:logback-classic:1.0.0")
 

--- a/instrumentation/micrometer/micrometer-1.5/testing/build.gradle.kts
+++ b/instrumentation/micrometer/micrometer-1.5/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("io.micrometer:micrometer-core:1.5.0")
 }

--- a/instrumentation/mongo/mongo-common/testing/build.gradle.kts
+++ b/instrumentation/mongo/mongo-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.testcontainers:testcontainers-mongodb")
 
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/nats/nats-2.17/testing/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("io.nats:jnats:2.17.2")
 

--- a/instrumentation/netty/netty-4.1/testing/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("io.netty:netty-codec-http:4.1.0.Final")
 }

--- a/instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("com.squareup.okhttp3:okhttp:3.0.0")
 

--- a/instrumentation/openai/openai-java-1.1/openai3-testing/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/openai3-testing/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   compileOnly("com.openai:openai-java:3.0.0")
 }

--- a/instrumentation/openai/openai-java-1.1/testing/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("com.openai:openai-java:1.1.0")
   api(project(":instrumentation:openai:openai-java-1.1:openai3-testing"))
 }

--- a/instrumentation/opensearch/opensearch-rest-common/testing/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-rest-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.testcontainers:testcontainers")
   api("org.opensearch:opensearch-testcontainers:2.0.0")
 

--- a/instrumentation/oracle-ucp-11.2/testing/build.gradle.kts
+++ b/instrumentation/oracle-ucp-11.2/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers-oracle-free")
 
   compileOnly("com.oracle.database.jdbc:ucp:11.2.0.4")

--- a/instrumentation/oshi/testing/build.gradle.kts
+++ b/instrumentation/oshi/testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -67,10 +67,6 @@ testing {
   suites {
     val tapirTest by registering(JvmTestSuite::class) {
       dependencies {
-        // this only exists to make Intellij happy since it doesn't (currently at least) understand our
-        // inclusion of this artifact inside :testing-common
-        compileOnly(project.dependencies.project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-
         if (findProperty("testLatestDeps") as Boolean) {
           implementation("com.typesafe.akka:akka-http_2.13:latest.release")
           implementation("com.typesafe.akka:akka-stream_2.13:latest.release")

--- a/instrumentation/play/play-ws/play-ws-common/testing/build.gradle.kts
+++ b/instrumentation/play/play-ws/play-ws-common/testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 val scalaVersion = "2.12"
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("com.typesafe.play:play-ahc-ws-standalone_$scalaVersion:1.0.2")
 
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/quarkus-resteasy-reactive/common-testing/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/common-testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/quartz-2.0/testing/build.gradle.kts
+++ b/instrumentation/quartz-2.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.quartz-scheduler:quartz:2.0.0")
 }

--- a/instrumentation/r2dbc-1.0/testing/build.gradle.kts
+++ b/instrumentation/r2dbc-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.r2dbc:r2dbc-spi:1.0.0.RELEASE")
 

--- a/instrumentation/ratpack/ratpack-1.4/testing/build.gradle.kts
+++ b/instrumentation/ratpack/ratpack-1.4/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   // it's important for these to not be api dependencies, because api dependencies pull in their
   // transitive dependencies as well, which causes issues for testLatestDep

--- a/instrumentation/reactor/reactor-3.1/testing/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("io.projectreactor:reactor-core:3.1.0.RELEASE")
 

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("io.projectreactor.kafka:reactor-kafka:1.0.0.RELEASE")
   implementation("org.testcontainers:testcontainers-kafka")

--- a/instrumentation/redisson/redisson-common/testing/build.gradle.kts
+++ b/instrumentation/redisson/redisson-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.opentelemetry:opentelemetry-api")
   implementation("org.testcontainers:testcontainers")

--- a/instrumentation/restlet/restlet-1.1/testing/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.1/testing/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("org.restlet:org.restlet:1.1.5")
   implementation("com.noelios.restlet:com.noelios.restlet:1.1.5")

--- a/instrumentation/restlet/restlet-2.0/testing/build.gradle.kts
+++ b/instrumentation/restlet/restlet-2.0/testing/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("org.restlet.jse:org.restlet:2.0.2")
   implementation("org.restlet.jse:org.restlet.ext.spring:2.0.2")

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.apache.rocketmq:rocketmq-test:4.8.0")
 
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   // earlier versions have bugs that may make tests flaky.
   implementation("org.apache.rocketmq:rocketmq-client-java:5.0.2")

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/build.gradle.kts
@@ -4,6 +4,4 @@ plugins {
 
 dependencies {
   implementation(project(":instrumentation-api"))
-
-  testImplementation(project(":testing-common"))
 }

--- a/instrumentation/rxjava/rxjava-2.0/testing/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-2.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("io.reactivex.rxjava2:rxjava:2.1.3")
 
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/rxjava/rxjava-3-common/testing/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-3-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("io.reactivex.rxjava3:rxjava:3.0.12")
 

--- a/instrumentation/servlet/servlet-5.0/testing/build.gradle.kts
+++ b/instrumentation/servlet/servlet-5.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api(project(":instrumentation:servlet:servlet-common:bootstrap"))
 
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")

--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
   testRuntimeOnly("com.h2database:h2:1.4.197")
   testRuntimeOnly("io.r2dbc:r2dbc-h2:1.0.0.RELEASE")
 
-  testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation(project(":instrumentation:resources:library"))
@@ -125,7 +124,6 @@ testing {
     val testLogbackAppender by registering(JvmTestSuite::class) {
       dependencies {
         implementation(project())
-        implementation(project(":testing-common"))
         implementation("io.opentelemetry:opentelemetry-sdk")
         implementation("io.opentelemetry:opentelemetry-sdk-testing")
         implementation("org.mockito:mockito-inline")

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-common/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("org.springframework.boot:spring-boot-starter-test:2.0.0.RELEASE")
 }

--- a/instrumentation/spring/spring-data/spring-data-common/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-data/spring-data-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("org.hibernate:hibernate-core:4.3.0.Final")
   compileOnly("org.springframework.data:spring-data-commons:1.8.0.RELEASE")

--- a/instrumentation/spring/spring-integration-4.1/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   api("org.testcontainers:testcontainers")
 

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/spring/spring-kafka-2.7/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers-kafka")
 
   compileOnly("org.springframework.kafka:spring-kafka:2.7.0")

--- a/instrumentation/spring/spring-pulsar-1.0/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers-pulsar")
 
   compileOnly("org.springframework.pulsar:spring-pulsar:1.0.0")

--- a/instrumentation/spring/spring-security-config-6.0/library/build.gradle.kts
+++ b/instrumentation/spring/spring-security-config-6.0/library/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
 
   implementation(project(":instrumentation:reactor:reactor-3.1:library"))
 
-  testImplementation(project(":testing-common"))
   testLibrary("org.springframework:spring-test:6.0.0")
 }
 

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
 
   testLibrary("org.springframework:spring-web:3.1.0.RELEASE")
 
-  testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("org.springframework:spring-webflux:5.0.0.RELEASE")
   compileOnly("org.springframework.boot:spring-boot-starter-reactor-netty:2.0.0.RELEASE")

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("org.springframework:spring-webflux:5.0.0.RELEASE")
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
   compileOnly("org.springframework:spring-webmvc:5.3.0")
   compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 
-  testImplementation(project(":testing-common"))
   testImplementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
   testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
     exclude("org.junit.vintage", "junit-vintage-engine")

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
   compileOnly("org.springframework:spring-webmvc:6.0.0")
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
-  testImplementation(project(":testing-common"))
   testImplementation("org.springframework.boot:spring-boot-starter-web:3.0.0")
   testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0")
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE")
   compileOnly("org.springframework.boot:spring-boot-starter-web:1.5.17.RELEASE")

--- a/instrumentation/struts/struts-2.3/javaagent/build.gradle.kts
+++ b/instrumentation/struts/struts-2.3/javaagent/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
 
   library("org.apache.struts:struts2-core:2.3.1")
 
-  testImplementation(project(":testing-common"))
   testImplementation("org.eclipse.jetty:jetty-server:8.0.0.v20110901")
   testImplementation("org.eclipse.jetty:jetty-servlet:8.0.0.v20110901")
   testRuntimeOnly("javax.servlet:javax.servlet-api:3.0.1")

--- a/instrumentation/struts/struts-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/struts/struts-7.0/javaagent/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
 
   library("org.apache.struts:struts2-core:7.0.0")
 
-  testImplementation(project(":testing-common"))
   testImplementation("org.eclipse.jetty:jetty-server:11.0.0")
   testImplementation("org.eclipse.jetty:jetty-servlet:11.0.0")
   testImplementation("jakarta.servlet:jakarta.servlet-api:5.0.0")

--- a/instrumentation/vaadin-14.2/testing/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/testing/build.gradle.kts
@@ -6,6 +6,6 @@ dependencies {
   compileOnly("com.vaadin:vaadin-spring-boot-starter:14.2.0")
 
   api("org.testcontainers:testcontainers-selenium")
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.seleniumhq.selenium:selenium-java:4.8.3")
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.testcontainers:testcontainers-kafka")
 
   compileOnly("io.vertx:vertx-kafka-client:3.6.0")

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/build.gradle.kts
@@ -33,10 +33,6 @@ testing {
   suites {
     val version35Test by registering(JvmTestSuite::class) {
       dependencies {
-        // this only exists to make Intellij happy since it doesn't (currently at least) understand our
-        // inclusion of this artifact inside :testing-common
-        compileOnly(project.dependencies.project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-
         val version = if (testLatestDeps) "3.+" else "3.5.0"
         implementation("org.hsqldb:hsqldb:2.3.4")
         compileOnly("io.vertx:vertx-codegen:$version")
@@ -50,10 +46,6 @@ testing {
 
     val version41Test by registering(JvmTestSuite::class) {
       dependencies {
-        // this only exists to make Intellij happy since it doesn't (currently at least) understand our
-        // inclusion of this artifact inside :testing-common
-        compileOnly(project.dependencies.project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-
         val version = if (testLatestDeps) "4.+" else "4.1.0"
         implementation("org.hsqldb:hsqldb:2.3.4")
         compileOnly("io.vertx:vertx-codegen:$version")
@@ -67,10 +59,6 @@ testing {
 
     val version5Test by registering(JvmTestSuite::class) {
       dependencies {
-        // this only exists to make Intellij happy since it doesn't (currently at least) understand our
-        // inclusion of this artifact inside :testing-common
-        compileOnly(project.dependencies.project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-
         val version = if (testLatestDeps) "latest.release" else "5.0.0"
         implementation("org.hsqldb:hsqldb:2.3.4")
         compileOnly("io.vertx:vertx-codegen:$version")

--- a/instrumentation/vertx/vertx-web-3.0/testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-web-3.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation("io.vertx:vertx-web:3.0.0")
 

--- a/instrumentation/vibur-dbcp-11.0/testing/build.gradle.kts
+++ b/instrumentation/vibur-dbcp-11.0/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("org.mockito:mockito-core")
   api("org.mockito:mockito-junit-jupiter")
 

--- a/instrumentation/wicket-8.0/common-testing/build.gradle.kts
+++ b/instrumentation/wicket-8.0/common-testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   implementation("org.apache.wicket:wicket:8.0.0")
   implementation("org.jsoup:jsoup:1.13.1")
 }

--- a/instrumentation/xxl-job/xxl-job-common/testing/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-common/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":testing-common"))
+  implementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   compileOnly("com.xuxueli:xxl-job-core:2.1.2") {
     exclude("org.codehaus.groovy", "groovy")

--- a/javaagent-bootstrap/build.gradle.kts
+++ b/javaagent-bootstrap/build.gradle.kts
@@ -8,7 +8,7 @@ group = "io.opentelemetry.javaagent"
 dependencies {
   implementation(project(":instrumentation-api"))
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation(project(":instrumentation:resources:library"))
 }
 

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   compileOnly("com.google.code.findbugs:annotations")
   testCompileOnly("com.google.code.findbugs:annotations")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("com.google.guava:guava")
   testImplementation("org.junit-pioneer:junit-pioneer")
   testImplementation("com.fasterxml.jackson.core:jackson-databind")

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
   testCompileOnly(project(":javaagent-bootstrap"))
   testCompileOnly(project(":javaagent-extension-api"))
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentracing.contrib.dropwizard:dropwizard-opentracing:0.2.2")
 }
 

--- a/muzzle/build.gradle.kts
+++ b/muzzle/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("com.google.guava:guava")
 }

--- a/sdk-autoconfigure-support/build.gradle.kts
+++ b/sdk-autoconfigure-support/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
 
   compileOnly("com.google.code.findbugs:annotations")
   testCompileOnly("com.google.code.findbugs:annotations")
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -139,6 +139,7 @@ include(":testing:agent-exporter")
 include(":testing:agent-for-testing")
 include(":testing:dependencies-shaded-for-testing")
 include(":testing-common")
+include(":testing-common:with-shaded-dependencies")
 include(":testing-common:integration-tests")
 include(":testing-common:library-for-integration-tests")
 

--- a/smoke-tests-otel-starter/spring-smoke-testing/build.gradle.kts
+++ b/smoke-tests-otel-starter/spring-smoke-testing/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   compileOnly(platform("org.springframework.boot:spring-boot-dependencies:2.6.15"))
   compileOnly("org.springframework.boot:spring-boot-starter")
   compileOnly("org.springframework.boot:spring-boot-starter-test")
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
   api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   implementation("com.google.guava:guava")
 }

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  api(project(":testing-common"))
+  api("io.opentelemetry.javaagent:opentelemetry-testing-common")
 
   implementation(platform("io.grpc:grpc-bom:1.76.0"))
   implementation("org.slf4j:slf4j-api")
@@ -31,10 +31,6 @@ dependencies {
 
   implementation("com.github.docker-java:docker-java-core:$dockerJavaVersion")
   implementation("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")
-
-  // make IntelliJ see shaded Armeria and protobuf
-  compileOnly(project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
-  testCompileOnly(project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
 }
 
 tasks {

--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -66,9 +66,4 @@ tasks {
   javadoc {
     enabled = false
   }
-
-  jar {
-    // When there are duplicates between multiple shaded dependencies, just ignore them.
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  }
 }

--- a/testing-common/with-shaded-dependencies/build.gradle.kts
+++ b/testing-common/with-shaded-dependencies/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+  id("otel.java-conventions")
+}
+
+// this module exists to make Intellij happy since it doesn't (currently at least) understand our
+// inclusion of shaded dependencies into testing-common
+// we use dependency substitution to replace io.opentelemetry.javaagent:opentelemetry-testing-common
+// with this module
+dependencies {
+  api(project(":testing-common"))
+  api(project(":testing:dependencies-shaded-for-testing", configuration = "shadow"))
+}

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   extensionLibs(project(":testing:agent-exporter", configuration = "shadow"))
   agent(project(":javaagent", configuration = "baseJar"))
 
-  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-api")
 }
 


### PR DESCRIPTION
Intellij doesn't understand our inclusion of shaded dependencies into `testing-common`. We have tried to work around this by also adding a dependency to `testing:dependencies-shaded-for-testing` but this isn't done everywhere. This PR attempts to solve it by introducing a separate module that depends on both `testing-common` and `testing:dependencies-shaded-for-testing`. Dependency substitution is used to replace usages of `testing-common` with that module.