### PR TITLE
Remove missing elasticsearch dependency exclusion

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
@@ -27,7 +27,6 @@ muzzle {
     group.set("co.elastic.clients")
     module.set("elasticsearch-java")
     versions.set("[8.10,)")
-    skip("9.2.1") // depends on elasticsearch-rest5-client-9.2.1 that is missing from central
   }
 }
 


### PR DESCRIPTION
This reverts commit 15567e413619dec3d42a1461764260989977e243.

The missing artifact is now published on maven central: https://repo.maven.apache.org/maven2/co/elastic/clients/elasticsearch-rest5-client/9.2.1/
