### PR TITLE
feat(vertx): inject context to downstream

### DIFF
--- a/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
@@ -13,6 +13,8 @@ muzzle {
 
 dependencies {
   compileOnly("io.vertx:vertx-web:3.0.0")
+  compileOnly("io.vertx:vertx-codegen:3.0.0")
+  compileOnly("io.vertx:vertx-docgen:3.0.0")
 
   // We need both version as different versions of Vert.x use different versions of Netty
   testInstrumentation(project(":instrumentation:netty:netty-4.0:javaagent"))


### PR DESCRIPTION
With this PR we are propagating the `traceparent` to downstream applications according to the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/). I am not sure if there is any best way to achieve that, in case, just guide me through and I'll change the code accordingly.

Closes #15284