### PR TITLE
Gradle configuration caching: jflex

### DIFF
--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -44,7 +44,8 @@ val generateJflex by tasks.registering(JavaExec::class) {
     outputDir.mkdirs()
     val specFile = sourceDir.asFile.resolve("SqlSanitizer.jflex")
     args(
-      "-d", outputDir.absolutePath,
+      "-d",
+      outputDir.absolutePath,
       "--nobak",
       specFile.absolutePath,
     )


### PR DESCRIPTION
There's too much to do at once, so just gonna chip away slowly...

Fixes `./gradlew :instrumentation-api-incubator:generateJflex --configuration-cache`:

```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':instrumentation-api-incubator:generateJflex'.
> Invocation of 'Task.project' by task ':instrumentation-api-incubator:generateJflex' at execution time is unsupported with the configuration cache.
```