### PR TITLE
Gradle cache config: bytebuddy

### DIFF
--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
@@ -1,7 +1,7 @@
 import io.opentelemetry.javaagent.muzzle.generation.ClasspathByteBuddyPlugin
 import io.opentelemetry.javaagent.muzzle.generation.ClasspathTransformation
+import io.opentelemetry.javaagent.muzzle.generation.ConfigurationCacheFriendlyByteBuddyTask
 import net.bytebuddy.ClassFileVersion
-import net.bytebuddy.build.gradle.ByteBuddySimpleTask
 import net.bytebuddy.build.gradle.Transformation
 
 plugins {
@@ -61,7 +61,7 @@ tasks {
 
 fun createLanguageTask(
   compileTaskProvider: TaskProvider<*>, name: String): TaskProvider<*> {
-  return tasks.register<ByteBuddySimpleTask>(name) {
+  return tasks.register(name, ConfigurationCacheFriendlyByteBuddyTask::class.java) {
     setGroup("Byte Buddy")
     outputs.cacheIf { true }
     classFileVersion = ClassFileVersion.JAVA_V8

--- a/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/generation/ConfigurationCacheFriendlyByteBuddyTask.kt
+++ b/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/generation/ConfigurationCacheFriendlyByteBuddyTask.kt
@@ -1,0 +1,30 @@
+package io.opentelemetry.javaagent.muzzle.generation
+
+import net.bytebuddy.build.Plugin
+import net.bytebuddy.build.gradle.ByteBuddySimpleTask
+import org.gradle.api.tasks.TaskAction
+import java.io.IOException
+
+/**
+ * Byte Buddy task variant that avoids calling getProject() during task execution,
+ * making it compatible with Gradle configuration cache. Can be removed once
+ * https://github.com/raphw/byte-buddy/pull/1874 is released.
+ */
+open class ConfigurationCacheFriendlyByteBuddyTask : ByteBuddySimpleTask() {
+
+  @TaskAction
+  @Throws(IOException::class)
+  override fun apply() {
+    val sourceDir = source
+    val targetDir = target
+
+    if (sourceDir != targetDir && deleteRecursively(targetDir)) {
+      logger.debug("Deleted all target files in {}", targetDir)
+    }
+
+    doApply(
+      Plugin.Engine.Source.ForFolder(sourceDir),
+      Plugin.Engine.Target.ForFolder(targetDir)
+    )
+  }
+}


### PR DESCRIPTION
Can be reverted hopefully after upstream fix / release (https://github.com/raphw/byte-buddy/pull/1874)


Fixes `./gradlew :instrumentation:internal:internal-lambda:javaagent:byteBuddyJava --configuration-cache`:

```
* What went wrong:
Execution failed for task ':instrumentation:internal:internal-lambda:javaagent:byteBuddyJava'.
> Invocation of 'Task.project' by task ':instrumentation:internal:internal-lambda:javaagent:byteBuddyJava' at execution time is unsupported with the configuration cache.
```