### PR TITLE
Gradle cache config: agent-for-testing

### DIFF
--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -32,13 +32,13 @@ tasks {
       into("extensions")
     }
 
-    doFirst {
-      manifest.from(
+    manifest.from(
+      providers.provider {
         zipTree(agent.singleFile).matching {
           include("META-INF/MANIFEST.MF")
-        }.singleFile,
-      )
-    }
+        }.singleFile
+      }
+    )
   }
 
   afterEvaluate {
@@ -56,6 +56,6 @@ class JavaagentProvider(
   val agentJar: Provider<RegularFile>,
 ) : CommandLineArgumentProvider {
   override fun asArguments(): Iterable<String> = listOf(
-    "-javaagent:${file(agentJar).absolutePath}",
+    "-javaagent:${agentJar.get().asFile.absolutePath}",
   )
 }


### PR DESCRIPTION
Fixes `./gradlew :testing:agent-for-testing:jar --configuration-cache`

```
* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:testing:agent-for-testing:jar` of type `org.gradle.api.tasks.bundling.Jar`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.0/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
```