### PR TITLE
Gradle config cache: resources

### DIFF
--- a/instrumentation/resources/library/build.gradle.kts
+++ b/instrumentation/resources/library/build.gradle.kts
@@ -88,10 +88,8 @@ testing {
 tasks {
   test {
     dependsOn(jar)
-    doFirst {
-      // use the final jar instead of directories with built classes to test the mrjar functionality
-      classpath = jar.get().outputs.files + classpath
-    }
+    // use the final jar instead of directories with built classes to test the mrjar functionality
+    classpath = project.files(jar) + classpath
     systemProperty("testSecret", "test")
     systemProperty("testPassword", "test")
     systemProperty("testNotRedacted", "test")


### PR DESCRIPTION
Fixes `./gradlew :instrumentation:resources:library:test --configuration-cache`:

```
* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:instrumentation:resources:library:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize object of type 'org.gradle.kotlin.dsl.TaskContainerScope', a subtype of 'org.gradle.api.tasks.TaskContainer', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.0/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
```