### PR TITLE
Gradle config cache: jmx-metrics

### DIFF
--- a/instrumentation/jmx-metrics/library/build.gradle.kts
+++ b/instrumentation/jmx-metrics/library/build.gradle.kts
@@ -19,21 +19,26 @@ dependencies {
 
 tasks {
   test {
-    // get packaged agent jar for testing
-    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar").get()
-    dependsOn(shadowTask)
-
+    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar")
     val testAppTask = project(":instrumentation:jmx-metrics:testing-webapp").tasks.named<War>("war")
+
+    dependsOn(shadowTask)
     dependsOn(testAppTask)
 
-    inputs.files(layout.files(shadowTask))
+    val agentJar = shadowTask.flatMap { it.archiveFile }
+    val testAppWar = testAppTask.flatMap { it.archiveFile }
+
+    inputs.file(agentJar)
       .withPropertyName("javaagent")
       .withNormalizer(ClasspathNormalizer::class)
+    inputs.file(testAppWar)
+      .withPropertyName("testWebApp")
+      .withNormalizer(ClasspathNormalizer::class)
 
-    doFirst {
-      jvmArgs(
-        "-Dio.opentelemetry.javaagent.path=${shadowTask.archiveFile.get()}",
-        "-Dio.opentelemetry.testapp.path=${testAppTask.get().archiveFile.get().asFile.absolutePath}"
+    jvmArgumentProviders += CommandLineArgumentProvider {
+      listOf(
+        "-Dio.opentelemetry.javaagent.path=${agentJar.get().asFile.absolutePath}",
+        "-Dio.opentelemetry.testapp.path=${testAppWar.get().asFile.absolutePath}",
       )
     }
   }


### PR DESCRIPTION
Fixes `./gradlew :instrumentation:jmx-metrics:library:test --configuration-cache`:

```
* What went wrong:
Configuration cache problems found in this build.

2 problems were found storing the configuration cache.
- Task `:instrumentation:jmx-metrics:library:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize object of type 'com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar', a subtype of 'org.gradle.api.Task', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.0/userguide/configuration_cache_requirements.html#config_cache:requirements:task_access
- Task `:instrumentation:jmx-metrics:library:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize object of type 'org.gradle.api.tasks.bundling.War', a subtype of 'org.gradle.api.Task', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.0/userguide/configuration_cache_requirements.html#config_cache:requirements:task_access
```