### PR TITLE
Fix double quoting of 'when' condition in metadata

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.docs.parsers;
 
+import static io.opentelemetry.instrumentation.docs.parsers.TelemetryParser.normalizeWhenCondition;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
@@ -62,8 +64,7 @@ public class EmittedMetricsParser {
                 path -> {
                   String content = FileManager.readFileToString(path.toString());
                   if (content != null) {
-                    String when = content.substring(0, content.indexOf('\n'));
-                    String whenKey = when.replace("when: ", "");
+                    String whenKey = normalizeWhenCondition(content);
 
                     int metricsIndex = content.indexOf("metrics_by_scope:");
                     if (metricsIndex != -1) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.docs.parsers;
 
+import static io.opentelemetry.instrumentation.docs.parsers.TelemetryParser.normalizeWhenCondition;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
@@ -49,8 +51,7 @@ public class EmittedSpanParser {
                 path -> {
                   String content = FileManager.readFileToString(path.toString());
                   if (content != null) {
-                    String when = content.substring(0, content.indexOf('\n'));
-                    String whenKey = when.replace("when: ", "");
+                    String whenKey = normalizeWhenCondition(content);
 
                     spansByScope.putIfAbsent(whenKey, new StringBuilder("spans_by_scope:\n"));
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
@@ -73,5 +73,25 @@ class TelemetryParser {
         || scopeAllowList.getOrDefault(moduleScope, emptySet()).contains(telemetryScope);
   }
 
+  /**
+   * Normalizes the 'when' condition from the given content by stripping quotes and whitespace.
+   *
+   * @param content the content containing the 'when' condition
+   * @return normalized when condition
+   */
+  static String normalizeWhenCondition(String content) {
+    if (content == null) {
+      return "";
+    }
+
+    String when = content.substring(0, content.indexOf('\n'));
+    String whenCondition = when.replace("when: ", "").strip();
+    // Remove surrounding quotes if present (to avoid double-quoting in output)
+    if (whenCondition.startsWith("\"") && whenCondition.endsWith("\"")) {
+      whenCondition = whenCondition.substring(1, whenCondition.length() - 1);
+    }
+    return whenCondition;
+  }
+
   private TelemetryParser() {}
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
-@SuppressWarnings("NullAway")
 class EmittedMetricsParserTest {
 
   @Test

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TelemetryParserTest {
+
+  @Test
+  void normalizeWhenConditionStripsQuotes() {
+    String content =
+        """
+        when: "otel.instrumentation.common.experimental.view-telemetry.enabled=true,otel.instrumentation.jsp.experimental-span-attributes=true"
+        metrics_by_scope:
+          - scope: io.opentelemetry.jsp-2.3
+        """;
+
+    String result = TelemetryParser.normalizeWhenCondition(content);
+
+    assertThat(result)
+        .isEqualTo(
+            "otel.instrumentation.common.experimental.view-telemetry.enabled=true,otel.instrumentation.jsp.experimental-span-attributes=true");
+  }
+
+  @Test
+  void normalizeWhenConditionHandlesUnquotedValue() {
+    String content =
+        """
+        when: default
+        metrics_by_scope:
+          - scope: io.opentelemetry.test
+        """;
+
+    String result = TelemetryParser.normalizeWhenCondition(content);
+
+    assertThat(result).isEqualTo("default");
+  }
+
+  @Test
+  void normalizeWhenConditionReturnsEmptyForNull() {
+    String result = TelemetryParser.normalizeWhenCondition(null);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void normalizeWhenConditionHandlesComplexConditions() {
+    String content =
+        """
+        when: "config1=value1,config2=value2,config3=value3"
+        spans_by_scope:
+          - scope: io.opentelemetry.test
+        """;
+
+    String result = TelemetryParser.normalizeWhenCondition(content);
+
+    assertThat(result).isEqualTo("config1=value1,config2=value2,config3=value3");
+  }
+}


### PR DESCRIPTION
With the new jackson serialization, we now have some [double quoting](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15354/files#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1R6893) for `when` conditions with commas. This fixes that.