### PR TITLE
Fix spring-kafka latestDeps failures

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/AbstractMessageListenerContainerInstrumentation.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/AbstractMessageListenerContainerInstrumentation.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7;
 
 import static io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7.SpringKafkaSingletons.telemetry;
-import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -35,7 +34,6 @@ public class AbstractMessageListenerContainerInstrumentation implements TypeInst
     // and failure methods on a batch interceptor
     transformer.applyAdviceToMethod(
         named("getRecordInterceptor")
-            .and(isProtected())
             .and(takesArguments(0))
             .and(returns(named("org.springframework.kafka.listener.RecordInterceptor"))),
         this.getClass().getName() + "$GetRecordInterceptorAdvice");


### PR DESCRIPTION
This method is now [public](https://github.com/spring-projects/spring-kafka/blob/main/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java#L469) in 4.0

The tests were failing because this instrumentation was no longer applying, which meant we were no longer suppressing the `INTERNAL` `consumer` spans


<img width="1661" height="223" alt="image" src="https://github.com/user-attachments/assets/15f3f12e-6cac-4240-a7d1-4ef9a47921de" />
