### PR TITLE
Gradle cache config: javaagent module

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -291,7 +291,7 @@ tasks {
     jvmArgs("-Dotel.metrics.exporter=none")
     jvmArgs("-Dotel.logs.exporter=none")
 
-    jvmArgumentProviders.add(JavaagentProvider(shadowJar.flatMap { it.archiveFile }))
+    jvmArgumentProviders.add(JavaagentProvider(shadowJar.flatMap { it.archiveFile }.map { it.asFile.absolutePath }))
 
     testLogging {
       events("started")
@@ -459,12 +459,11 @@ fun ShadowJar.excludeBootstrapClasses() {
 }
 
 class JavaagentProvider(
-  @InputFile
-  @PathSensitive(PathSensitivity.RELATIVE)
-  val agentJar: Provider<RegularFile>,
+  @Input
+  val agentJarPath: Provider<String>,
 ) : CommandLineArgumentProvider {
   override fun asArguments(): Iterable<String> = listOf(
-    "-javaagent:${file(agentJar).absolutePath}",
+    "-javaagent:${agentJarPath.get()}",
     "-Dotel.javaagent.testing.transform-safe-logging.enabled=true"
   )
 }


### PR DESCRIPTION
Fixes `./gradlew :javaagent:test --configuration-cache`:

```
* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:javaagent:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
```