### PR TITLE
Gradle config cache: smoke-tests

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -72,13 +72,14 @@ tasks {
       }
     }
 
-    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar").get()
-    inputs.files(layout.files(shadowTask))
+    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar")
+    val agentJarPath = shadowTask.flatMap { it.archiveFile }
+    inputs.files(agentJarPath)
       .withPropertyName("javaagent")
       .withNormalizer(ClasspathNormalizer::class)
 
     doFirst {
-      jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${shadowTask.archiveFile.get()}")
+      jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${agentJarPath.get()}")
     }
   }
 }


### PR DESCRIPTION
Fixes `./gradlew :smoke-tests:test --configuration-cache -PsmokeTestSuite=none`

```
* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:smoke-tests:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize object of type 'com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar', a subtype of 'org.gradle.api.Task', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.1/userguide/configuration_cache_requirements.html#config_cache:requirements:task_access
```