### PR TITLE
Gradle config cache: wildfly testing

### DIFF
--- a/instrumentation/jaxws/jaxws-2.0-wildfly-testing/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-wildfly-testing/build.gradle.kts
@@ -41,37 +41,28 @@ tasks {
     destinationDirectory.set(layout.buildDirectory.dir("tmp"))
     archiveFileName.set("logback-classic-modified.jar")
     exclude("/META-INF/services/javax.servlet.ServletContainerInitializer")
-    doFirst {
-      configurations.configureEach {
-        if (name.lowercase().endsWith("testruntimeclasspath")) {
-          val logbackJar = find { it.name.contains("logback-classic") }
-          logbackJar?.let {
-            from(zipTree(logbackJar))
-          }
-        }
-      }
-    }
+
+    val testRuntimeClasspath = configurations.named("testRuntimeClasspath")
+    from({
+      testRuntimeClasspath.get().filter { it.name.contains("logback-classic") }.map { zipTree(it) }
+    })
   }
 
   test {
     dependsOn(modifyLogbackJar)
     dependsOn(setupServer)
 
-    doFirst {
-      // --add-modules is unrecognized on jdk8, ignore it instead of failing
-      jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
-      // needed for java 11 to avoid org.jboss.modules.ModuleNotFoundException: java.se
-      jvmArgs("--add-modules=java.se")
-      // add offset to default port values
-      jvmArgs("-Djboss.socket.binding.port-offset=200")
+    // --add-modules is unrecognized on jdk8, ignore it instead of failing
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+    // needed for java 11 to avoid org.jboss.modules.ModuleNotFoundException: java.se
+    jvmArgs("--add-modules=java.se")
+    // add offset to default port values
+    jvmArgs("-Djboss.socket.binding.port-offset=200")
 
-      // remove logback-classic from classpath
-      classpath = classpath.filter {
-        !it.absolutePath.contains("logback-classic")
-      }
-      // add modified copy of logback-classic to classpath
-      classpath = classpath.plus(files(layout.buildDirectory.file("tmp/logback-classic-modified.jar")))
-    }
+    // remove logback-classic from classpath and add modified copy
+    classpath = classpath.filter {
+      !it.absolutePath.contains("logback-classic")
+    }.plus(files(layout.buildDirectory.file("tmp/logback-classic-modified.jar")))
   }
 }
 


### PR DESCRIPTION
Fixes `./gradlew :instrumentation:spring:spring-webmvc:spring-webmvc-3.1:wildfly-testing:test --configuration-cache` (and related):

```
- Task `:instrumentation:spring:spring-webmvc:spring-webmvc-3.1:wildfly-testing:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.2.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
```