### PR TITLE
Fix latest dep tests

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
@@ -151,9 +150,6 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                 SERVER_PORT,
                 NETWORK_PEER_ADDRESS,
                 NETWORK_PEER_PORT));
-    if (Boolean.getBoolean("testLatestDeps")) {
-      expected.add(DB_NAMESPACE);
-    }
     assertDurationMetric(testing(), "io.opentelemetry.lettuce-5.1", toArray(expected));
   }
 

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
 
   // dependency management pins logback-classic to 1.3 which is the last release that supports java 8
   latestDepTestLibrary("ch.qos.logback:logback-classic:latest.release")
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-actuator-autoconfigure:3.+") // documented limitation
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -109,6 +109,16 @@ dependencies {
   add("javaSpring3CompileOnly", "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   add("javaSpring3CompileOnly", project(":instrumentation:spring:spring-web:spring-web-3.1:library"))
   add("javaSpring3CompileOnly", project(":instrumentation:spring:spring-webmvc:spring-webmvc-6.0:library"))
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-actuator:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-aop:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-webflux:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-data-mongodb:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-data-r2dbc:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-data-jdbc:3.+") // documented limitation
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter-web:3.0.0")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:3.+") // documented limitation
 }
 
 otelJava {

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.2/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.2/testing/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
 
   testLibrary("org.springframework.cloud:spring-cloud-starter-gateway:2.2.0.RELEASE")
   testLibrary("org.springframework.boot:spring-boot-starter-test:2.2.0.RELEASE")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -27,6 +27,10 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter:3.0.0")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
 }
 
 // spring 6 requires java 17

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -29,6 +29,10 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
   testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean
@@ -42,7 +46,7 @@ testing {
 
         // the "library" configuration is not recognized by the test suite plugin
         val springKafkaVersion = if (latestDepTest) "latest.release" else "2.7.0"
-        val springBootVersion = if (latestDepTest) "latest.release" else "2.5.3"
+        val springBootVersion = if (latestDepTest) "3.+" else "2.5.3"
         implementation("org.springframework.kafka:spring-kafka:$springKafkaVersion")
         implementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
         implementation("org.springframework.boot:spring-boot-starter:$springBootVersion")

--- a/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
   testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.2.4")
   testLibrary("org.springframework.boot:spring-boot-starter:3.2.4")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean
@@ -35,8 +39,8 @@ testing {
 
         if (latestDepTest) {
           implementation("org.springframework.pulsar:spring-pulsar:latest.release")
-          implementation("org.springframework.boot:spring-boot-starter-test:latest.release")
-          implementation("org.springframework.boot:spring-boot-starter:latest.release")
+          implementation("org.springframework.boot:spring-boot-starter-test:3.+")
+          implementation("org.springframework.boot:spring-boot-starter:3.+")
         } else {
           implementation("org.springframework.pulsar:spring-pulsar:1.0.0")
           implementation("org.springframework.boot:spring-boot-starter-test:3.2.4")

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter:1.5.22.RELEASE")
   // spring-retry is required by org.springframework.amqp:spring-rabbit:4.0.0
   testLibrary("org.springframework.retry:spring-retry")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
 }
 
 tasks {

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
@@ -59,6 +59,11 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter-webflux:2.0.0.RELEASE")
   testLibrary("org.springframework.boot:spring-boot-starter-test:2.0.0.RELEASE")
   testLibrary("org.springframework.boot:spring-boot-starter-reactor-netty:2.0.0.RELEASE")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-webflux:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-reactor-netty:3.+") // documented limitation
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/build.gradle.kts
@@ -8,10 +8,13 @@ dependencies {
   compileOnly("org.springframework:spring-webmvc:5.3.0")
   compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 
-  testImplementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
-  testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
+  testLibrary("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+  testLibrary("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
     exclude("org.junit.vintage", "junit-vintage-engine")
   }
+
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:2.+") // see spring-webmvc-6.0 module
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:2.+") // see spring-webmvc-6.0 module
 }
 
 configurations.testRuntimeClasspath {

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/build.gradle.kts
@@ -37,6 +37,11 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter-web:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter-security:3.0.0")
+
+  // tests don't work with spring boot 4 yet
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:3.+") // documented limitation
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-security:3.+") // documented limitation
 }
 
 // spring 6 requires java 17

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/build.gradle.kts
@@ -6,8 +6,8 @@ dependencies {
   compileOnly("org.springframework:spring-webmvc:6.0.0")
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
-  testImplementation("org.springframework.boot:spring-boot-starter-web:3.0.0")
-  testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0")
+  testLibrary("org.springframework.boot:spring-boot-starter-web:3.0.0")
+  testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
 }
 
 // spring 6 requires java 17
@@ -25,5 +25,9 @@ tasks {
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
     options.release.set(null as Int?)
+  }
+
+  withType<Test>().configureEach {
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/WebMvcHttpServerTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/WebMvcHttpServerTest.java
@@ -54,7 +54,8 @@ class WebMvcHttpServerTest extends AbstractHttpServerTest<ConfigurableApplicatio
           return expectedHttpRoute(endpoint, method);
         });
 
-    options.setResponseCodeOnNonStandardHttpMethod(501);
+    options.setResponseCodeOnNonStandardHttpMethod(
+        Boolean.getBoolean("testLatestDeps") ? 200 : 501);
   }
 
   @Test


### PR DESCRIPTION
Limit spring boot version to fix latest dep tests. It might be easier to work on actually fixing these when the build passes. Then it is easier to spot other new failures from unrelated library updates.

Related to #14906