### PR TITLE
Fix spring-jms for 4.0 update

### DIFF
--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -27,10 +27,6 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter:3.0.0")
-
-  // tests don't work with spring boot 4 yet
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
 }
 
 // spring 6 requires java 17

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/AbstractSpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/AbstractSpringJmsListenerTest.java
@@ -45,12 +45,12 @@ abstract class AbstractSpringJmsListenerTest {
   @BeforeAll
   static void setUp() {
     broker =
-        new GenericContainer<>("quay.io/artemiscloud/activemq-artemis-broker:artemis.2.27.0")
-            .withEnv("AMQ_USER", "test")
-            .withEnv("AMQ_PASSWORD", "test")
+        new GenericContainer<>("apache/activemq-artemis:2.44.0")
+            .withEnv("ARTEMIS_USER", "test")
+            .withEnv("ARTEMIS_PASSWORD", "test")
             .withEnv("JAVA_TOOL_OPTIONS", "-Dbrokerconfig.maxDiskUsage=-1")
             .withExposedPorts(61616, 8161)
-            .waitingFor(Wait.forLogMessage(".*Server is now live.*", 1))
+            .waitingFor(Wait.forLogMessage(".*Server is now active.*", 1))
             .withStartupTimeout(Duration.ofMinutes(2))
             .withLogConsumer(new Slf4jLogConsumer(logger));
     broker.start();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -113,6 +113,8 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
             "org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter$$Lambda")
         .allowClass("org.springframework.boot.autoconfigure.BackgroundPreinitializer$")
         .allowClass(
+            "org.springframework.boot.autoconfigure.preinitialize.BackgroundPreinitializingApplicationListener$")
+        .allowClass(
             "org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration$$Lambda")
         .allowClass("org.springframework.boot.autoconfigure.condition.OnClassCondition$")
         .allowClass(


### PR DESCRIPTION
Related to #15429

The `BackgroundPreinitializingApplicationListener` ignore is a common change amongst many of these modules, so that change is also present in #15433

Related to #14906