### PR TITLE
Update spring-kafka latestDep tests for 4.0

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -11,8 +11,6 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") as Boolean
-
 dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
@@ -34,6 +32,7 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-kafka:latest.release")
 }
 
+val latestDepTest = findProperty("testLatestDeps") as Boolean
 val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
 
 testing {
@@ -43,11 +42,15 @@ testing {
         implementation(project(":instrumentation:spring:spring-kafka-2.7:testing"))
 
         // the "library" configuration is not recognized by the test suite plugin
-        val springKafkaVersion = if (latestDepTest) "org.springframework.boot:spring-boot-starter-kafka:latest.release" else "org.springframework.kafka:spring-kafka:2.7.0"
+        val springKafkaVersion = if (latestDepTest) "latest.release" else "2.7.0"
         val springBootVersion = if (latestDepTest) "latest.release" else "2.5.3"
-        implementation(springKafkaVersion)
+        implementation("org.springframework.kafka:spring-kafka:$springKafkaVersion")
         implementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
         implementation("org.springframework.boot:spring-boot-starter:$springBootVersion")
+
+        if (latestDepTest) {
+          implementation("org.springframework.boot:spring-boot-starter-kafka:latest.release")
+        }
       }
 
       targets {


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15429

The `BackgroundPreinitializingApplicationListener` ignore is a common change amongst many of these modules, so that change is also present in some of the other PRs

Related to #14906