### PR TITLE
Update spring-rabbit latestDep tests for 4.0

### DIFF
--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -12,6 +12,8 @@ muzzle {
   }
 }
 
+val latestDepTest = findProperty("testLatestDeps") as Boolean
+
 dependencies {
   library("org.springframework.amqp:spring-rabbit:1.0.0.RELEASE")
 
@@ -24,9 +26,9 @@ dependencies {
   // spring-retry is required by org.springframework.amqp:spring-rabbit:4.0.0
   testLibrary("org.springframework.retry:spring-retry")
 
-  // tests don't work with spring boot 4 yet
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:3.+") // documented limitation
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
+  if (latestDepTest) {
+    testLibrary("org.springframework.boot:spring-boot-starter-amqp:latest.release")
+  }
 }
 
 tasks {
@@ -35,8 +37,6 @@ tasks {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
 }
-
-val latestDepTest = findProperty("testLatestDeps") as Boolean
 
 // spring 6 requires java 17
 if (latestDepTest) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -113,6 +113,8 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
             "org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter$$Lambda")
         .allowClass("org.springframework.boot.autoconfigure.BackgroundPreinitializer$")
         .allowClass(
+            "org.springframework.boot.autoconfigure.preinitialize.BackgroundPreinitializingApplicationListener$")
+        .allowClass(
             "org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration$$Lambda")
         .allowClass("org.springframework.boot.autoconfigure.condition.OnClassCondition$")
         .allowClass(


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15429

The `BackgroundPreinitializingApplicationListener` ignore is a common change amongst many of these modules, so that change is also present in some of the other PRs

Related to #14906