### PR TITLE
Fix link checks on main

### DIFF
--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -16,13 +16,16 @@ jobs:
 
       - uses: jdx/mise-action@9dc7d5dd454262207dea3ab5a06a3df6afc8ff26 # v3.4.1
 
-      - name: Link check - relative links (all files)
+      - name: Link check for pull requests
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: mise run lint:local-links
+        run: |
+          mise run lint:local-links
+          mise run lint:links-in-modified-files --base origin/${{ github.base_ref }} --head ${{ github.event.pull_request.head.sha }} --event pull_request
 
-      - name: Link check (modified files only)
+      - name: Link check for pushes and scheduled workflows
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: mise run lint:links-in-modified-files --base origin/${{ github.base_ref }} --head ${{ github.event.pull_request.head.sha }} --event ${{ github.event_name }}
+        run: mise run lint:links


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/19641848122/job/56247114893

```
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```