### PR TITLE
Add explicit context propagation for servlet async runnables

### DIFF
--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AsyncRunnableWrapper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AsyncRunnableWrapper.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 
 public class AsyncRunnableWrapper<REQUEST> implements Runnable {
   private final ServletHelper<REQUEST, ?> helper;
@@ -27,7 +28,7 @@ public class AsyncRunnableWrapper<REQUEST> implements Runnable {
 
   @Override
   public void run() {
-    try {
+    try (Scope ignored = context.makeCurrent()) {
       runnable.run();
     } catch (Throwable throwable) {
       helper.recordAsyncException(context, throwable);


### PR DESCRIPTION
Found in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15188
Although the context seems to be propagated by other instrumentations e.g executor doing it explicitly feels more reliable.