### PR TITLE
Add link to changelog in breaking change automation

### DIFF
--- a/.github/workflows/pr-automation-comments.yml
+++ b/.github/workflows/pr-automation-comments.yml
@@ -42,7 +42,7 @@ jobs:
                 "",
                 "### Checklist",
                 "- [ ] Migration notes added to the PR description",
-                "- [ ] Breaking change is documented in the changelog entry for the next release",
+                "- [ ] Breaking change is documented in the "Unreleased" section of the [Changelog](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md), preferably as part of this PR.",
                 "- [ ] Consider if this change requires a major version bump",
                 "",
                 "Your migration notes will be included in the release notes to help users upgrade smoothly. The more detailed and helpful they are, the better the user experience will be.",


### PR DESCRIPTION
Clarifying where the changelog should be updated, as discussed [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15423#issuecomment-3599113801)