### PR TITLE
Disable errorprone RequestExplicitNullMarking

### DIFF
--- a/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -124,7 +124,6 @@ tasks {
 
         // Requires adding compile dependency to JSpecify
         disable("AddNullMarkedToPackageInfo")
-        disable("RequireExplicitNullMarking")
 
         if (testLatestDeps) {
           // Some latest dep tests are compiled for java 17 although the base version uses an older

--- a/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
@@ -18,6 +18,10 @@ nullaway {
 
 tasks {
   withType<JavaCompile>().configureEach {
+    options.errorprone {
+      // workaround for https://github.com/google/error-prone/issues/5387
+      check("RequireExplicitNullMarking", CheckSeverity.OFF)
+    }
     options.errorprone.nullaway {
       if (name.contains("test", ignoreCase = true)) {
         disable()
@@ -30,4 +34,3 @@ tasks {
     }
   }
 }
-


### PR DESCRIPTION
Currently not causing failures, but spamming warnings.

Ported from https://github.com/open-telemetry/opentelemetry-java/pull/7890