### PR TITLE
Disable errorprone RequestExplicitNullMarking

### DIFF
--- a/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -124,6 +124,7 @@ tasks {
 
         // Requires adding compile dependency to JSpecify
         disable("AddNullMarkedToPackageInfo")
+        disable("RequireExplicitNullMarking")
 
         if (testLatestDeps) {
           // Some latest dep tests are compiled for java 17 although the base version uses an older


### PR DESCRIPTION
Copied from https://github.com/open-telemetry/opentelemetry-java/pull/7890