### PR TITLE
Add unit to new failsafe histogram

### DIFF
--- a/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
+++ b/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
@@ -100,7 +100,7 @@ public final class FailsafeTelemetry {
         meter
             .histogramBuilder("failsafe.retry_policy.attempts")
             .setDescription("Number of attempts for each execution.")
-            .setUnit("{retry_attempt}")
+            .setUnit("{attempt}")
             .ofLongs()
             .setExplicitBucketBoundariesAdvice(Arrays.asList(1L, 2L, 3L, 5L))
             .build();


### PR DESCRIPTION
Noticed this came [up blank in the recent metadata update](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15534/files#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1R3952).