### PR TITLE
Add --no-build-cache to generateLicenseReport in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-otel-sdk.yml
+++ b/.github/workflows/auto-update-otel-sdk.yml
@@ -75,7 +75,8 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 
       - name: Update license report
-        run: ./gradlew generateLicenseReport
+        # with the build cache enabled occasionally produces outdated results
+        run: ./gradlew generateLicenseReport --no-build-cache
 
       - name: Undo license report clean
         if: failure()


### PR DESCRIPTION
hopefully fixes weird issue in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15550