### PR TITLE
Fix RestClient unnecessary bean creation in Spring Boot autoconfigura…

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/testSpring3/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/web/RestClientInstrumentationAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testSpring3/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/web/RestClientInstrumentationAutoConfigurationTest.java
@@ -87,4 +87,29 @@ class RestClientInstrumentationAutoConfigurationTest {
                         "otelRestClientBeanPostProcessor", RestClientBeanPostProcessor.class))
                 .isNotNull());
   }
+
+  /**
+   * Tests that the bean post-processor returns the original bean instance when the interceptor is
+   * already present, avoiding unnecessary bean creation.
+   */
+  @Test
+  void doesNotCreateNewBeanWhenInterceptorAlreadyPresent() {
+    contextRunner
+        .withPropertyValues("otel.instrumentation.spring-web.enabled=true")
+        .run(
+            context -> {
+              RestClient originalBean = context.getBean(RestClient.class);
+              RestClientBeanPostProcessor postProcessor =
+                  context.getBean(
+                      "otelRestClientBeanPostProcessor", RestClientBeanPostProcessor.class);
+
+              // Process the bean again - should return the same instance since interceptor is
+              // already present
+              Object processedBean =
+                  postProcessor.postProcessAfterInitialization(originalBean, "restClient");
+
+              // Verify that the same instance is returned
+              assertThat(processedBean).isSameAs(originalBean);
+            });
+  }
 }


### PR DESCRIPTION
…tion

The RestClientBeanPostProcessor was creating a new RestClient bean every time it processed a bean, even when the OpenTelemetry interceptor was already present. This resulted in unnecessary bean creation and caused issues with proxy/delegate RestClient beans.

Changes:
- Modified RestClientBeanPostProcessor to track whether the interceptor was actually added during the mutation operation
- Return the original bean instance if the interceptor is already present
- Only create a new bean instance when the interceptor is actually added
- Added test case to verify bean identity is preserved when interceptor exists

This fix ensures that:
1. No unnecessary bean creation occurs when the interceptor is already present
2. Proxy/delegate RestClient beans work correctly
3. RestClient beans created with an injected RestClient.Builder that already has the interceptor configured are not unnecessarily mutated

Fixes the issue where RestClient beans with the OTel interceptor already configured would still trigger mutation and new bean creation.