### PR TITLE
Remove markdown files from spotless

### DIFF
--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -85,14 +85,9 @@ if (project == rootProject) {
         ".gitattributes",
         ".gitconfig",
         ".editorconfig",
-        "*.md",
         "gradle.properties",
-        ".github/**/*.md",
         ".github/**/*.sh",
-        "docs/**/*.md",
-        "examples/**/*.md",
-        "examples/**/gradle.properties",
-        "licenses/**/*.md"
+        "examples/**/gradle.properties"
       )
       leadingTabsToSpaces()
       trimTrailingWhitespace()

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -303,6 +303,22 @@ tasks {
     delete(rootProject.file("licenses"))
   }
 
+  val trimLicenseTrailingWhitespace by registering {
+    val licenseFile = rootDir.toPath().resolve("licenses/licenses.md")
+    val newline = System.lineSeparator()
+    doLast {
+      if (Files.exists(licenseFile)) {
+        val content = String(Files.readAllBytes(licenseFile), Charsets.UTF_8)
+        val normalized = content.lineSequence()
+          .map { it.trimEnd() }
+          .toList()
+          .dropLastWhile { it.isEmpty() }
+          .joinToString(newline) + newline
+        Files.write(licenseFile, normalized.toByteArray(Charsets.UTF_8))
+      }
+    }
+  }
+
   val removeLicenseDate by registering {
     // removing the license report date makes it idempotent
     val rootDirPath = rootDir.toPath()
@@ -328,7 +344,7 @@ tasks {
   val generateLicenseReportTask = named("generateLicenseReport")
   generateLicenseReportTask.configure {
     dependsOn(cleanLicenses)
-    finalizedBy(":spotlessApply")
+    finalizedBy(trimLicenseTrailingWhitespace)
     finalizedBy(removeLicenseDate)
     // disable licence report generation unless this task is explicitly run
     // the files produced by this task are used by other tasks without declaring them as dependency


### PR DESCRIPTION
Markdown files are already checked by markdown lint, so no need to check them with spotless as well.

Related to @laurit's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15553#discussion_r2596229762