### PR TITLE
Fix publishing smoke test images

### DIFF
--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -192,8 +192,8 @@ tasks {
   val windowsImages = createDockerTasks(buildWindowsTestImages, true)
 
   val pushMatrix by registering(DockerPushImage::class) {
-    mustRunAfter(buildLinuxTestImages)
-    mustRunAfter(buildWindowsTestImages)
+    dependsOn(buildLinuxTestImages)
+    dependsOn(buildWindowsTestImages)
     group = "publishing"
     description = "Push all Docker images for the test matrix"
     images.set(linuxImages + windowsImages)


### PR DESCRIPTION
Broke while fixing config cache issue in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15569