### PR TITLE
Turn down logging in metadata job

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -2,6 +2,15 @@ name: Metadata Update
 
 on:
   workflow_dispatch:  # allow this to be manually triggered
+    inputs:
+      debug_logging:
+        description: 'Enable debug logging'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
   schedule:
     - cron: "00 1 * * *" # daily at 1:00 UTC
 
@@ -44,6 +53,8 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 
       - name: Collect telemetry
+        env:
+          DEBUG_LOGGING: ${{ inputs.debug_logging || 'false' }}
         run: ./instrumentation-docs/ci-collect.sh
 
       - name: Run documentation analyzer


### PR DESCRIPTION
Hopefully resolves #15577 

The jobs are running out of disk space, so hoping that turning down the logging will help. I also added the ability to re-trigger the job with the logs re-enabled in case we need to debug something.

I will put some thought into how to partition this job, or other ways to help it scale as we enable more instrumentations to gather telemetry from (we're at like ~60-70 percent of the potential modules I think).

<img width="1413" height="263" alt="image" src="https://github.com/user-attachments/assets/63082e4c-d351-44ca-b901-a2c076c074ae" />
