### PR TITLE
Another try to fix gradle remote cache

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -88,15 +88,9 @@ develocity {
 }
 
 buildCache {
-  remote<HttpBuildCache> {
-    url = uri("$develocityServer/cache/")
+  remote(develocity.buildCache) {
+    server = develocityServer
     isPush = isCI && develocityAccessKey.isNotEmpty()
-    if (develocityAccessKey.isNotEmpty()) {
-      credentials {
-        username = ""
-        password = develocityAccessKey
-      }
-    }
   }
 }
 


### PR DESCRIPTION
I tested it locally with `DEVELOCITY_ACCESS_KEY` this time 😄 