### PR TITLE
Fix apache http client 5 latest dep test

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
@@ -13,7 +13,7 @@ muzzle {
 dependencies {
   library("org.apache.httpcomponents.client5:httpclient5:5.0")
   // https://issues.apache.org/jira/browse/HTTPCORE-653
-  implementation("org.apache.httpcomponents.core5:httpcore5:5.0.3")
+  testImplementation("org.apache.httpcomponents.core5:httpcore5:5.0.3")
 
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent"))
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15632
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15643

Currently the latest version of `httpcore5` is not compatible with latest `httpclient5`. Since we add this dependency only to use a slightly newer version of `httpcore5` we don't need to use `library`. By using `testImplementation` we get the version of `httpcore5` that `httpclient5` depends on in the latest dep tests.