### PR TITLE
Rename setMessagingReceiveInstrumentationEnabled to setMessagingReceiveTelemetryEnabled

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -38,7 +38,7 @@ public class TracingRequestHandler extends RequestHandler2 {
           .setCaptureExperimentalSpanAttributes(
               AgentInstrumentationConfig.get()
                   .getBoolean("otel.instrumentation.aws-sdk.experimental-span-attributes", false))
-          .setMessagingReceiveInstrumentationEnabled(
+          .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
           .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .build()

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
@@ -25,7 +25,7 @@ public class TracingRequestHandler extends RequestHandler2 {
           .setCaptureExperimentalSpanAttributes(
               ConfigPropertiesUtil.getBoolean(
                   "otel.instrumentation.aws-sdk.experimental-span-attributes", false))
-          .setMessagingReceiveInstrumentationEnabled(
+          .setMessagingReceiveTelemetryEnabled(
               ConfigPropertiesUtil.getBoolean(
                   "otel.instrumentation.messaging.experimental.receive-telemetry.enabled", false))
           .setCapturedHeaders(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
@@ -20,7 +20,7 @@ public class AwsSdkTelemetryBuilder {
 
   private List<String> capturedHeaders = emptyList();
   private boolean captureExperimentalSpanAttributes;
-  private boolean messagingReceiveInstrumentationEnabled;
+  private boolean messagingReceiveTelemetryEnabled;
 
   AwsSdkTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -54,11 +54,26 @@ public class AwsSdkTelemetryBuilder {
    *
    * <p>Note that this will cause the consumer side to start a new trace, with only a span link
    * connecting it to the producer trace.
+   *
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
-    this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
+  }
+
+  /**
+   * Set whether to capture the consumer message receive telemetry in messaging instrumentation.
+   *
+   * <p>Note that this will cause the consumer side to start a new trace, with only a span link
+   * connecting it to the producer trace.
+   */
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder setMessagingReceiveTelemetryEnabled(
+      boolean messagingReceiveTelemetryEnabled) {
+    this.messagingReceiveTelemetryEnabled = messagingReceiveTelemetryEnabled;
     return this;
   }
 
@@ -70,6 +85,6 @@ public class AwsSdkTelemetryBuilder {
         openTelemetry,
         capturedHeaders,
         captureExperimentalSpanAttributes,
-        messagingReceiveInstrumentationEnabled);
+        messagingReceiveTelemetryEnabled);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
@@ -27,7 +27,7 @@ class SqsTracingTest extends AbstractSqsTracingTest {
     return client.withRequestHandlers(
         AwsSdkTelemetry.builder(testing().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
-            .setMessagingReceiveInstrumentationEnabled(true)
+            .setMessagingReceiveTelemetryEnabled(true)
             .setCapturedHeaders(singletonList("Test-Message-Header"))
             .build()
             .newRequestHandler());

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkSingletons.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkSingletons.java
@@ -27,7 +27,7 @@ public final class AwsSdkSingletons {
     }
 
     @Override
-    protected boolean messagingReceiveInstrumentationEnabled() {
+    protected boolean messagingReceiveTelemetryEnabled() {
       return ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
     }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AwsSdkSingletons.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AwsSdkSingletons.java
@@ -29,7 +29,7 @@ public final class AwsSdkSingletons {
     }
 
     @Override
-    protected boolean messagingReceiveInstrumentationEnabled() {
+    protected boolean messagingReceiveTelemetryEnabled() {
       return ConfigPropertiesUtil.getBoolean(
           "otel.instrumentation.messaging.experimental.receive-telemetry.enabled", false);
     }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
@@ -23,7 +23,7 @@ public final class AwsSdkTelemetryBuilder {
   private boolean useMessagingPropagator;
   private boolean recordIndividualHttpError;
   private boolean useXrayPropagator = true;
-  private boolean messagingReceiveInstrumentationEnabled;
+  private boolean messagingReceiveTelemetryEnabled;
   private boolean genaiCaptureMessageContent;
 
   AwsSdkTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -108,11 +108,26 @@ public final class AwsSdkTelemetryBuilder {
    *
    * <p>Note that this will cause the consumer side to start a new trace, with only a span link
    * connecting it to the producer trace.
+   *
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
-    this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
+  }
+
+  /**
+   * Set whether to capture the consumer message receive telemetry in messaging instrumentation.
+   *
+   * <p>Note that this will cause the consumer side to start a new trace, with only a span link
+   * connecting it to the producer trace.
+   */
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder setMessagingReceiveTelemetryEnabled(
+      boolean messagingReceiveTelemetryEnabled) {
+    this.messagingReceiveTelemetryEnabled = messagingReceiveTelemetryEnabled;
     return this;
   }
 
@@ -139,7 +154,7 @@ public final class AwsSdkTelemetryBuilder {
         useMessagingPropagator,
         useXrayPropagator,
         recordIndividualHttpError,
-        messagingReceiveInstrumentationEnabled,
+        messagingReceiveTelemetryEnabled,
         genaiCaptureMessageContent);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AbstractAwsSdkTelemetryFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AbstractAwsSdkTelemetryFactory.java
@@ -20,7 +20,7 @@ public abstract class AbstractAwsSdkTelemetryFactory {
     return getBoolean("otel.instrumentation.aws-sdk.experimental-span-attributes", false);
   }
 
-  protected abstract boolean messagingReceiveInstrumentationEnabled();
+  protected abstract boolean messagingReceiveTelemetryEnabled();
 
   private boolean useMessagingPropagator() {
     return getBoolean(
@@ -42,7 +42,7 @@ public abstract class AbstractAwsSdkTelemetryFactory {
     return AwsSdkTelemetry.builder(GlobalOpenTelemetry.get())
         .setCapturedHeaders(getCapturedHeaders())
         .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes())
-        .setMessagingReceiveInstrumentationEnabled(messagingReceiveInstrumentationEnabled())
+        .setMessagingReceiveTelemetryEnabled(messagingReceiveTelemetryEnabled())
         .setUseConfiguredPropagatorForMessaging(useMessagingPropagator())
         .setRecordIndividualHttpError(recordIndividualHttpError())
         .setGenaiCaptureMessageContent(genaiCaptureMessageContent())

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
@@ -32,7 +32,7 @@ abstract class Aws2SqsTracingTest extends AbstractAws2SqsTracingTest {
     AwsSdkTelemetryBuilder telemetryBuilder =
         AwsSdkTelemetry.builder(getTesting().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
-            .setMessagingReceiveInstrumentationEnabled(true)
+            .setMessagingReceiveTelemetryEnabled(true)
             .setCapturedHeaders(singletonList("Test-Message-Header"));
 
     configure(telemetryBuilder);

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
@@ -22,7 +22,7 @@ public final class JmsSingletons {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-            .setMessagingReceiveInstrumentationEnabled(
+            .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
 
     PRODUCER_INSTRUMENTER = factory.createProducerInstrumenter();

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
@@ -22,7 +22,7 @@ public final class JmsSingletons {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-            .setMessagingReceiveInstrumentationEnabled(
+            .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
 
     PRODUCER_INSTRUMENTER = factory.createProducerInstrumenter();

--- a/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsInstrumenterFactory.java
@@ -40,10 +40,20 @@ public final class JmsInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public JmsInstrumenterFactory setMessagingReceiveInstrumentationEnabled(
+  public JmsInstrumenterFactory setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
+   */
+  @CanIgnoreReturnValue
+  @Deprecated
+  public JmsInstrumenterFactory setMessagingReceiveInstrumentationEnabled(
+      boolean messagingReceiveInstrumentationEnabled) {
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
   }
 
   public Instrumenter<MessageWithDestination, Void> createProducerInstrumenter() {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -33,7 +33,7 @@ public final class KafkaSingletons {
             .setCaptureExperimentalSpanAttributes(
                 AgentInstrumentationConfig.get()
                     .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-            .setMessagingReceiveInstrumentationEnabled(
+            .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
     PRODUCER_INSTRUMENTER = instrumenterFactory.createProducerInstrumenter();
     CONSUMER_RECEIVE_INSTRUMENTER = instrumenterFactory.createConsumerReceiveInstrumenter();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -114,7 +114,7 @@ public final class KafkaTelemetryBuilder {
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
             .setCapturedHeaders(capturedHeaders)
             .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
-            .setMessagingReceiveInstrumentationEnabled(messagingReceiveInstrumentationEnabled);
+            .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
 
     return new KafkaTelemetry(
         openTelemetry,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -63,10 +63,20 @@ public final class KafkaInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public KafkaInstrumenterFactory setMessagingReceiveInstrumentationEnabled(
+  public KafkaInstrumenterFactory setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
+   */
+  @CanIgnoreReturnValue
+  @Deprecated
+  public KafkaInstrumenterFactory setMessagingReceiveInstrumentationEnabled(
+      boolean messagingReceiveInstrumentationEnabled) {
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
   }
 
   public Instrumenter<KafkaProducerRequest, RecordMetadata> createProducerInstrumenter() {

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSingletons.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSingletons.java
@@ -22,7 +22,7 @@ public final class KafkaStreamsSingletons {
           .setCaptureExperimentalSpanAttributes(
               AgentInstrumentationConfig.get()
                   .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-          .setMessagingReceiveInstrumentationEnabled(
+          .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
           .createConsumerProcessInstrumenter();
 

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaSingletons.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaSingletons.java
@@ -22,7 +22,7 @@ final class ReactorKafkaSingletons {
           .setCaptureExperimentalSpanAttributes(
               AgentInstrumentationConfig.get()
                   .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-          .setMessagingReceiveInstrumentationEnabled(
+          .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
           .createConsumerProcessInstrumenter();
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
@@ -41,7 +41,7 @@ public class KafkaInstrumentationAutoConfiguration {
     return SpringKafkaTelemetry.builder(openTelemetryProvider.getObject())
         .setCaptureExperimentalSpanAttributes(
             config.getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-        .setMessagingReceiveInstrumentationEnabled(
+        .setMessagingReceiveTelemetryEnabled(
             config.getBoolean(
                 "otel.instrumentation.messaging.experimental.receive-telemetry.enabled", false))
         .setCapturedHeaders(

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
@@ -23,7 +23,7 @@ public final class SpringJmsSingletons {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-            .setMessagingReceiveInstrumentationEnabled(RECEIVE_TELEMETRY_ENABLED);
+            .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
     LISTENER_INSTRUMENTER = factory.createConsumerProcessInstrumenter(true);
     RECEIVE_INSTRUMENTER = factory.createConsumerReceiveInstrumenter();

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
@@ -23,7 +23,7 @@ public final class SpringJmsSingletons {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-            .setMessagingReceiveInstrumentationEnabled(RECEIVE_TELEMETRY_ENABLED);
+            .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
     LISTENER_INSTRUMENTER = factory.createConsumerProcessInstrumenter(true);
     RECEIVE_INSTRUMENTER = factory.createConsumerReceiveInstrumenter();

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
@@ -23,7 +23,7 @@ public final class SpringKafkaSingletons {
           .setCaptureExperimentalSpanAttributes(
               AgentInstrumentationConfig.get()
                   .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-          .setMessagingReceiveInstrumentationEnabled(
+          .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
           .build();
   private static final Instrumenter<KafkaReceiveRequest, Void> BATCH_PROCESS_INSTRUMENTER;
@@ -35,7 +35,7 @@ public final class SpringKafkaSingletons {
             .setCaptureExperimentalSpanAttributes(
                 AgentInstrumentationConfig.get()
                     .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-            .setMessagingReceiveInstrumentationEnabled(
+            .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
             .setErrorCauseExtractor(SpringKafkaErrorCauseExtractor.INSTANCE);
     BATCH_PROCESS_INSTRUMENTER = factory.createBatchProcessInstrumenter();

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
@@ -49,10 +49,20 @@ public final class SpringKafkaTelemetryBuilder {
    * connecting it to the producer trace.
    */
   @CanIgnoreReturnValue
-  public SpringKafkaTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
+  public SpringKafkaTelemetryBuilder setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
+   */
+  @CanIgnoreReturnValue
+  @Deprecated
+  public SpringKafkaTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
+      boolean messagingReceiveInstrumentationEnabled) {
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
   }
 
   /**
@@ -64,7 +74,7 @@ public final class SpringKafkaTelemetryBuilder {
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
             .setCapturedHeaders(capturedHeaders)
             .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
-            .setMessagingReceiveInstrumentationEnabled(messagingReceiveInstrumentationEnabled)
+            .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled)
             .setErrorCauseExtractor(SpringKafkaErrorCauseExtractor.INSTANCE);
 
     return new SpringKafkaTelemetry(

--- a/instrumentation/vertx/vertx-kafka-client-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/v3_6/VertxKafkaSingletons.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/v3_6/VertxKafkaSingletons.java
@@ -27,7 +27,7 @@ public final class VertxKafkaSingletons {
             .setCaptureExperimentalSpanAttributes(
                 AgentInstrumentationConfig.get()
                     .getBoolean("otel.instrumentation.kafka.experimental-span-attributes", false))
-            .setMessagingReceiveInstrumentationEnabled(
+            .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
     BATCH_PROCESS_INSTRUMENTER = factory.createBatchProcessInstrumenter();
     PROCESS_INSTRUMENTER = factory.createConsumerProcessInstrumenter();


### PR DESCRIPTION
Extracted from #15651

Renaming it to match the configuration property `otel.instrumentation.messaging.experimental.receive-telemetry.enabled`.
