### PR TITLE
Move lettuce command-encoding-events jvmArgs from 5.0 to 5.1

### DIFF
--- a/instrumentation/lettuce/README.md
+++ b/instrumentation/lettuce/README.md
@@ -1,7 +1,7 @@
 # Settings for the Lettuce instrumentation
 
-| System property                                                             | Type    | Default | Description                                                                    |
-|-----------------------------------------------------------------------------|---------|---------|--------------------------------------------------------------------------------|
-| `otel.instrumentation.lettuce.experimental-span-attributes`                 | Boolean | `false` | Enable the capture of experimental span attributes.                            |
-| `otel.instrumentation.lettuce.connection-telemetry.enabled`                 | Boolean | `false` | Enable the creation of Connect spans.                                          |
-| `otel.instrumentation.lettuce.experimental.command-encoding-events.enabled` | Boolean | `false` | Enable the capture of `redis.encode.start` and `redis.encode.end` span events. |
+| System property                                                             | Type    | Default | Description                                                                                             |
+|-----------------------------------------------------------------------------|---------|---------|---------------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.lettuce.experimental-span-attributes`                 | Boolean | `false` | Enable the capture of experimental span attributes.                                                     |
+| `otel.instrumentation.lettuce.connection-telemetry.enabled`                 | Boolean | `false` | Enable the creation of Connect spans.                                                                   |
+| `otel.instrumentation.lettuce.experimental.command-encoding-events.enabled` | Boolean | `false` | Enable the capture of `redis.encode.start` and `redis.encode.end` span events on Lettuce 5.1 and later. |

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     jvmArgs("-Dotel.instrumentation.lettuce.connection-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.lettuce.experimental.command-encoding-events.enabled=true")
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
 
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
 tasks {
   withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.lettuce.experimental.command-encoding-events.enabled=true")
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
 tasks {
   withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.lettuce.experimental.command-encoding-events.enabled=true")
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.java
@@ -24,7 +24,11 @@ class LettuceAsyncClientTest extends AbstractLettuceAsyncClientTest {
   protected RedisClient createClient(String uri) {
     return RedisClient.create(
         ClientResources.builder()
-            .tracing(LettuceTelemetry.create(testing().getOpenTelemetry()).newTracing())
+            .tracing(
+                LettuceTelemetry.builder(testing().getOpenTelemetry())
+                    .setEncodingSpanEventsEnabled(true)
+                    .build()
+                    .newTracing())
             .build(),
         uri);
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.java
@@ -29,7 +29,11 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest {
   protected RedisClient createClient(String uri) {
     return RedisClient.create(
         ClientResources.builder()
-            .tracing(LettuceTelemetry.create(testing().getOpenTelemetry()).newTracing())
+            .tracing(
+                LettuceTelemetry.builder(testing().getOpenTelemetry())
+                    .setEncodingSpanEventsEnabled(true)
+                    .build()
+                    .newTracing())
             .build(),
         uri);
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.java
@@ -24,7 +24,11 @@ class LettuceSyncClientAuthTest extends AbstractLettuceSyncClientAuthTest {
   protected RedisClient createClient(String uri) {
     return RedisClient.create(
         ClientResources.builder()
-            .tracing(LettuceTelemetry.create(testing().getOpenTelemetry()).newTracing())
+            .tracing(
+                LettuceTelemetry.builder(testing().getOpenTelemetry())
+                    .setEncodingSpanEventsEnabled(true)
+                    .build()
+                    .newTracing())
             .build(),
         uri);
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceSyncClientTest.java
@@ -24,7 +24,11 @@ class LettuceSyncClientTest extends AbstractLettuceSyncClientTest {
   protected RedisClient createClient(String uri) {
     return RedisClient.create(
         ClientResources.builder()
-            .tracing(LettuceTelemetry.create(testing().getOpenTelemetry()).newTracing())
+            .tracing(
+                LettuceTelemetry.builder(testing().getOpenTelemetry())
+                    .setEncodingSpanEventsEnabled(true)
+                    .build()
+                    .newTracing())
             .build(),
         uri);
   }

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
@@ -27,10 +27,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public abstract class AbstractLettuceClientTest {
   protected static final Logger logger = LoggerFactory.getLogger(AbstractLettuceClientTest.class);
 
-  private static final boolean COMMAND_ENCODING_EVENTS_ENABLED =
-      Boolean.getBoolean(
-          "otel.instrumentation.lettuce.experimental.command-encoding-events.enabled");
-
   @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected static final int DB_INDEX = 0;
@@ -88,16 +84,9 @@ public abstract class AbstractLettuceClientTest {
   }
 
   protected static void assertCommandEncodeEvents(SpanData span) {
-    if (COMMAND_ENCODING_EVENTS_ENABLED) {
-      assertThat(span)
-          .hasEventsSatisfyingExactly(
-              event -> event.hasName("redis.encode.start"),
-              event -> event.hasName("redis.encode.end"));
-    } else {
-      assertThat(span.getEvents())
-          .noneSatisfy(event -> assertThat(event).hasName("redis.encode.start"));
-      assertThat(span.getEvents())
-          .noneSatisfy(event -> assertThat(event).hasName("redis.encode.end"));
-    }
+    assertThat(span)
+        .hasEventsSatisfyingExactly(
+            event -> event.hasName("redis.encode.start"),
+            event -> event.hasName("redis.encode.end"));
   }
 }


### PR DESCRIPTION
Extracted from #15652 

The command-encoding-events feature is only supported in Lettuce 5.1+, so move the jvmArgs configuration from the 5.0 module to the 5.1 module and fix the tests.