### PR TITLE
Redis instrumentations: consolidate configuration access to in *Singletons

### DIFF
--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
@@ -7,13 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 
 final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, Void> {
 
-  private static final RedisCommandSanitizer sanitizer =
-      RedisCommandSanitizer.create(AgentCommonConfig.get().isStatementSanitizationEnabled());
+  private final RedisCommandSanitizer sanitizer;
+
+  JedisDbAttributesGetter(boolean statementSanitizerEnabled) {
+    this.sanitizer = RedisCommandSanitizer.create(statementSanitizerEnabled);
+  }
 
   @Override
   public String getDbSystem(JedisRequest request) {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
@@ -21,7 +21,8 @@ public final class JedisSingletons {
   private static final Instrumenter<JedisRequest, Void> INSTRUMENTER;
 
   static {
-    JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
+    JedisDbAttributesGetter dbAttributesGetter =
+        new JedisDbAttributesGetter(AgentCommonConfig.get().isStatementSanitizationEnabled());
     JedisNetworkAttributesGetter netAttributesGetter = new JedisNetworkAttributesGetter();
 
     INSTRUMENTER =

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -71,5 +71,10 @@ public final class LettuceSingletons {
     return CONNECT_INSTRUMENTER;
   }
 
+  public static boolean experimentalSpanAttributes() {
+    return AgentInstrumentationConfig.get()
+        .getBoolean("otel.instrumentation.lettuce.experimental-span-attributes", false);
+  }
+
   private LettuceSingletons() {}
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndCommandAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndCommandAsyncBiFunction.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.experimentalSpanAttributes;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.instrumenter;
 
 import io.lettuce.core.protocol.RedisCommand;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 
@@ -25,10 +25,6 @@ import java.util.function.BiFunction;
  */
 public class EndCommandAsyncBiFunction<T, U extends Throwable, R>
     implements BiFunction<T, Throwable, R> {
-
-  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
-      AgentInstrumentationConfig.get()
-          .getBoolean("otel.instrumentation.lettuce.experimental-span-attributes", false);
 
   private final Context context;
   private final RedisCommand<?, ?, ?> command;
@@ -46,7 +42,7 @@ public class EndCommandAsyncBiFunction<T, U extends Throwable, R>
 
   public static void end(Context context, RedisCommand<?, ?, ?> command, Throwable throwable) {
     if (throwable instanceof CancellationException) {
-      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      if (experimentalSpanAttributes()) {
         Span.fromContext(context).setAttribute("lettuce.command.cancelled", true);
       }
       // and don't report this as an error

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndConnectAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndConnectAsyncBiFunction.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.connectInstrumenter;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.experimentalSpanAttributes;
 
 import io.lettuce.core.RedisURI;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 
@@ -26,10 +26,6 @@ import java.util.function.BiFunction;
 public class EndConnectAsyncBiFunction<T, U extends Throwable, R>
     implements BiFunction<T, Throwable, R> {
 
-  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
-      AgentInstrumentationConfig.get()
-          .getBoolean("otel.instrumentation.lettuce.experimental-span-attributes", false);
-
   private final Context context;
   private final RedisURI redisUri;
 
@@ -41,7 +37,7 @@ public class EndConnectAsyncBiFunction<T, U extends Throwable, R>
   @Override
   public R apply(T t, Throwable throwable) {
     if (throwable instanceof CancellationException) {
-      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      if (experimentalSpanAttributes()) {
         Span.fromContext(context).setAttribute("lettuce.command.cancelled", true);
       }
       // and don't report this as an error

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
@@ -9,7 +9,6 @@ import io.lettuce.core.protocol.RedisCommand;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.instrumentation.lettuce.common.LettuceArgSplitter;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import java.util.List;
@@ -18,8 +17,11 @@ import javax.annotation.Nullable;
 final class LettuceDbAttributesGetter
     implements DbClientAttributesGetter<RedisCommand<?, ?, ?>, Void> {
 
-  private static final RedisCommandSanitizer sanitizer =
-      RedisCommandSanitizer.create(AgentCommonConfig.get().isStatementSanitizationEnabled());
+  private final RedisCommandSanitizer sanitizer;
+
+  LettuceDbAttributesGetter(boolean statementSanitizerEnabled) {
+    this.sanitizer = RedisCommandSanitizer.create(statementSanitizerEnabled);
+  }
 
   @SuppressWarnings("deprecation") // using deprecated DbSystemIncubatingValues
   @Override

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -35,7 +35,8 @@ public final class LettuceSingletons {
       VirtualField.find(AsyncCommand.class, Context.class);
 
   static {
-    LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
+    LettuceDbAttributesGetter dbAttributesGetter =
+        new LettuceDbAttributesGetter(AgentCommonConfig.get().isStatementSanitizationEnabled());
 
     INSTRUMENTER =
         Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
@@ -71,6 +72,11 @@ public final class LettuceSingletons {
 
   public static Instrumenter<RedisURI, Void> connectInstrumenter() {
     return CONNECT_INSTRUMENTER;
+  }
+
+  public static boolean experimentalSpanAttributes() {
+    return AgentInstrumentationConfig.get()
+        .getBoolean("otel.instrumentation.lettuce.experimental-span-attributes", false);
   }
 
   private LettuceSingletons() {}

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceFluxTerminationRunnable.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceFluxTerminationRunnable.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.rx;
 
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.experimentalSpanAttributes;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.instrumenter;
 
 import io.lettuce.core.protocol.RedisCommand;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import org.reactivestreams.Subscription;
@@ -19,10 +19,6 @@ import reactor.core.publisher.Signal;
 import reactor.core.publisher.SignalType;
 
 public class LettuceFluxTerminationRunnable implements Consumer<Signal<?>>, Runnable {
-
-  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
-      AgentInstrumentationConfig.get()
-          .getBoolean("otel.instrumentation.lettuce.experimental-span-attributes", false);
 
   private Context context;
   private int numResults;
@@ -38,7 +34,7 @@ public class LettuceFluxTerminationRunnable implements Consumer<Signal<?>>, Runn
 
   private void finishSpan(boolean isCommandCancelled, Throwable throwable) {
     if (context != null) {
-      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      if (experimentalSpanAttributes()) {
         Span span = Span.fromContext(context);
         span.setAttribute("lettuce.command.results.count", numResults);
         if (isCommandCancelled) {


### PR DESCRIPTION
Extracted from #15652

Preferring to inject configuration where it makes sense (e.g. Getters/Extractors).