### PR TITLE
Simplified Declarative Configuration API, Option A

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DeclarativeConfigUtil.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DeclarativeConfigUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.config.internal;
+
+import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class DeclarativeConfigUtil {
+
+  private DeclarativeConfigUtil() {}
+
+  public static ExtendedDeclarativeConfigProperties get(OpenTelemetry openTelemetry) {
+    DeclarativeConfigProperties javaConfig = empty();
+    if (openTelemetry instanceof ExtendedOpenTelemetry) {
+      ExtendedOpenTelemetry extendedOpenTelemetry = (ExtendedOpenTelemetry) openTelemetry;
+      DeclarativeConfigProperties instrumentationConfig =
+          extendedOpenTelemetry.getConfigProvider().getInstrumentationConfig();
+      if (instrumentationConfig != null) {
+        javaConfig = instrumentationConfig.getStructured("java", empty());
+      }
+    }
+    return new ExtendedDeclarativeConfigProperties(javaConfig);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/ExtendedDeclarativeConfigProperties.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/ExtendedDeclarativeConfigProperties.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.config.internal;
+
+import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.common.ComponentLoader;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class ExtendedDeclarativeConfigProperties implements DeclarativeConfigProperties {
+
+  private final DeclarativeConfigProperties delegate;
+
+  ExtendedDeclarativeConfigProperties(DeclarativeConfigProperties delegate) {
+    this.delegate = delegate;
+  }
+
+  public ExtendedDeclarativeConfigProperties get(String name) {
+    return new ExtendedDeclarativeConfigProperties(delegate.getStructured(name, empty()));
+  }
+
+  @Nullable
+  @Override
+  public String getString(String name) {
+    return delegate.getString(name);
+  }
+
+  @Nullable
+  @Override
+  public Boolean getBoolean(String name) {
+    return delegate.getBoolean(name);
+  }
+
+  @Nullable
+  @Override
+  public Integer getInt(String name) {
+    return delegate.getInt(name);
+  }
+
+  @Nullable
+  @Override
+  public Long getLong(String name) {
+    return delegate.getLong(name);
+  }
+
+  @Nullable
+  @Override
+  public Double getDouble(String name) {
+    return delegate.getDouble(name);
+  }
+
+  @Nullable
+  @Override
+  public <T> List<T> getScalarList(String name, Class<T> scalarType) {
+    return delegate.getScalarList(name, scalarType);
+  }
+
+  @Nullable
+  @Override
+  public DeclarativeConfigProperties getStructured(String name) {
+    return delegate.getStructured(name);
+  }
+
+  @Nullable
+  @Override
+  public List<DeclarativeConfigProperties> getStructuredList(String name) {
+    return delegate.getStructuredList(name);
+  }
+
+  @Override
+  public Set<String> getPropertyKeys() {
+    return delegate.getPropertyKeys();
+  }
+
+  @Override
+  public ComponentLoader getComponentLoader() {
+    return delegate.getComponentLoader();
+  }
+}

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
@@ -5,13 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.graphql.v12_0;
 
-import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
-
 import graphql.execution.instrumentation.Instrumentation;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
-import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.ExtendedDeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.graphql.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v12_0.GraphQLTelemetry;
 
@@ -51,24 +49,13 @@ public final class GraphqlSingletons {
     private final boolean addOperationNameToSpanName;
 
     Configuration(OpenTelemetry openTelemetry) {
-      DeclarativeConfigProperties javaConfig = empty();
-      if (openTelemetry instanceof ExtendedOpenTelemetry) {
-        ExtendedOpenTelemetry extendedOpenTelemetry = (ExtendedOpenTelemetry) openTelemetry;
-        DeclarativeConfigProperties instrumentationConfig =
-            extendedOpenTelemetry.getConfigProvider().getInstrumentationConfig();
-        if (instrumentationConfig != null) {
-          javaConfig = instrumentationConfig.getStructured("java", empty());
-        }
-      }
-      DeclarativeConfigProperties graphqlConfig = javaConfig.getStructured("graphql", empty());
+      ExtendedDeclarativeConfigProperties config = DeclarativeConfigUtil.get(openTelemetry);
 
-      this.captureQuery = graphqlConfig.getBoolean("capture_query", true);
+      this.captureQuery = config.get("graphql").getBoolean("capture_query", true);
       this.querySanitizerEnabled =
-          graphqlConfig.getStructured("query_sanitizer", empty()).getBoolean("enabled", true);
+          config.get("graphql").get("query_sanitizer").getBoolean("enabled", true);
       this.addOperationNameToSpanName =
-          graphqlConfig
-              .getStructured("add_operation_name_to_span_name", empty())
-              .getBoolean("enabled", false);
+          config.get("graphql").get("add_operation_name_to_span_name").getBoolean("enabled", false);
     }
   }
 

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
@@ -5,13 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.graphql.v20_0;
 
-import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
-
 import graphql.execution.instrumentation.Instrumentation;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
-import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.ExtendedDeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.graphql.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v20_0.GraphQLTelemetry;
 
@@ -20,10 +18,11 @@ public final class GraphqlSingletons {
   private static final GraphQLTelemetry TELEMETRY;
 
   static {
-    Configuration config = new Configuration(GlobalOpenTelemetry.get());
+    OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+    Configuration config = new Configuration(openTelemetry);
 
     TELEMETRY =
-        GraphQLTelemetry.builder(GlobalOpenTelemetry.get())
+        GraphQLTelemetry.builder(openTelemetry)
             .setCaptureQuery(config.captureQuery)
             .setSanitizeQuery(config.sanitizeQuery)
             .setDataFetcherInstrumentationEnabled(config.dataFetcherEnabled)
@@ -58,28 +57,16 @@ public final class GraphqlSingletons {
     private final boolean addOperationNameToSpanName;
 
     Configuration(OpenTelemetry openTelemetry) {
-      DeclarativeConfigProperties javaConfig = empty();
-      if (openTelemetry instanceof ExtendedOpenTelemetry) {
-        ExtendedOpenTelemetry extendedOpenTelemetry = (ExtendedOpenTelemetry) openTelemetry;
-        DeclarativeConfigProperties instrumentationConfig =
-            extendedOpenTelemetry.getConfigProvider().getInstrumentationConfig();
-        if (instrumentationConfig != null) {
-          javaConfig = instrumentationConfig.getStructured("java", empty());
-        }
-      }
-      DeclarativeConfigProperties graphqlConfig = javaConfig.getStructured("graphql", empty());
+      ExtendedDeclarativeConfigProperties config = DeclarativeConfigUtil.get(openTelemetry);
 
-      this.captureQuery = graphqlConfig.getBoolean("capture_query", true);
-      this.sanitizeQuery =
-          graphqlConfig.getStructured("query_sanitizer", empty()).getBoolean("enabled", true);
+      this.captureQuery = config.get("graphql").getBoolean("capture_query", true);
+      this.sanitizeQuery = config.get("graphql").get("query_sanitizer").getBoolean("enabled", true);
       this.dataFetcherEnabled =
-          graphqlConfig.getStructured("data_fetcher", empty()).getBoolean("enabled", false);
+          config.get("graphql").get("data_fetcher").getBoolean("enabled", false);
       this.trivialDataFetcherEnabled =
-          graphqlConfig.getStructured("trivial_data_fetcher", empty()).getBoolean("enabled", false);
+          config.get("graphql").get("trivial_data_fetcher").getBoolean("enabled", false);
       this.addOperationNameToSpanName =
-          graphqlConfig
-              .getStructured("add_operation_name_to_span_name", empty())
-              .getBoolean("enabled", false);
+          config.get("graphql").get("add_operation_name_to_span_name").getBoolean("enabled", false);
     }
   }
 


### PR DESCRIPTION
Exploring options for us to start using in this repository immediately, and to recommend upstream to the Declarative Configuration API.

```
  // instrumentation/development:
  //   java:
  //     graphql:
  //       capture_query: true
  //       query_sanitizer:
  //         enabled: true
  //       data_fetcher:
  //         enabled: false
  //       trivial_data_fetcher:
  //         enabled: false
  //       add_operation_name_to_span_name:
  //         enabled: false
  private static final class Configuration {

    private final boolean captureQuery;
    private final boolean sanitizeQuery;
    private final boolean dataFetcherEnabled;
    private final boolean trivialDataFetcherEnabled;
    private final boolean addOperationNameToSpanName;

    Configuration(OpenTelemetry openTelemetry) {
      ExtendedDeclarativeConfigProperties config = DeclarativeConfigUtil.get(openTelemetry);

      this.captureQuery = config.get("graphql").getBoolean("capture_query", true);
      this.sanitizeQuery = config.get("graphql").get("query_sanitizer").getBoolean("enabled", true);
      this.dataFetcherEnabled =
          config.get("graphql").get("data_fetcher").getBoolean("enabled", false);
      this.trivialDataFetcherEnabled =
          config.get("graphql").get("trivial_data_fetcher").getBoolean("enabled", false);
      this.addOperationNameToSpanName =
          config.get("graphql").get("add_operation_name_to_span_name").getBoolean("enabled", false);
    }
  }
```