### PR TITLE
Allow defining jul helper classes without using temp directory

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JulLookupSupplier.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JulLookupSupplier.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jul;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.Supplier;
+
+/**
+ * Helper class that provides a MethodHandles.Lookup that allows defining classes in this package.
+ */
+public final class JulLookupSupplier implements Supplier<MethodHandles.Lookup> {
+
+  @Override
+  public MethodHandles.Lookup get() {
+    return MethodHandles.lookup();
+  }
+}

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -19,6 +19,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.internal.injection.I
 import io.opentelemetry.javaagent.instrumentation.executors.ExecutorLookupSupplier;
 import io.opentelemetry.javaagent.instrumentation.internal.lambda.LambdaLookupSupplier;
 import io.opentelemetry.javaagent.instrumentation.internal.reflection.ReflectionLookupSupplier;
+import io.opentelemetry.javaagent.instrumentation.jul.JulLookupSupplier;
 import io.opentelemetry.javaagent.tooling.muzzle.HelperResource;
 import java.io.File;
 import java.io.IOException;
@@ -339,6 +340,7 @@ public class HelperInjector implements Transformer {
   static {
     // add lookups for instrumentations that define classes in boot loader
     addPackageLookup(new ExecutorLookupSupplier());
+    addPackageLookup(new JulLookupSupplier());
     addPackageLookup(new LambdaLookupSupplier());
     addPackageLookup(new ReflectionLookupSupplier());
     // because all generated virtual field classes are in the same package we can use lookup to


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15666
On jdk 23+ we don't use unsafe to define classes in boot loader. We can either provide a `MethodHandles.Lookup` for the desired package or fall back to using `Instrumentation.appendToBootstrapClassLoaderSearch`. The latter needs to create a temporary jar which won't work when the temp directory isn't writable. 