### PR TITLE
Fix servlet image publishing

### DIFF
--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -80,11 +80,11 @@ jobs:
 
       - name: Build Linux docker images
         if: matrix.os != 'windows-latest'
-        run: ./gradlew :smoke-tests:images:servlet:buildLinuxTestImages pushMatrix -PextraTag=${{ needs.prepare.outputs.tag }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        run: ./gradlew :smoke-tests:images:servlet:pushLinuxImages -PextraTag=${{ needs.prepare.outputs.tag }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
 
       - name: Build Windows docker images
         if: matrix.os == 'windows-latest'
-        run: ./gradlew :smoke-tests:images:servlet:buildWindowsTestImages pushMatrix -PextraTag=${{ needs.prepare.outputs.tag }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        run: ./gradlew :smoke-tests:images:servlet:pushWindowsImages -PextraTag=${{ needs.prepare.outputs.tag }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
 
   workflow-notification:
     permissions:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,8 +19,8 @@ plugins {
   // this can't live in pluginManagement currently due to
   // https://github.com/bmuschko/gradle-docker-plugin/issues/1123
   // in particular, these commands are failing (reproducible locally):
-  // ./gradlew :smoke-tests:images:servlet:buildLinuxTestImages pushMatrix -PsmokeTestServer=jetty
-  // ./gradlew :smoke-tests:images:servlet:buildWindowsTestImages pushMatrix -PsmokeTestServer=jetty
+  // ./gradlew :smoke-tests:images:servlet:pushLinuxImages -PsmokeTestServer=jetty
+  // ./gradlew :smoke-tests:images:servlet:pushWindowsImages -PsmokeTestServer=jetty
   id("com.bmuschko.docker-remote-api") version "10.0.0" apply false
   id("com.gradle.develocity") version "4.3"
 }

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -191,12 +191,18 @@ tasks {
   val linuxImages = createDockerTasks(buildLinuxTestImages, false)
   val windowsImages = createDockerTasks(buildWindowsTestImages, true)
 
-  val pushMatrix by registering(DockerPushImage::class) {
+  val pushLinuxImages by registering(DockerPushImage::class) {
     dependsOn(buildLinuxTestImages)
+    group = "publishing"
+    description = "Push Linux Docker images for the test matrix"
+    images.set(linuxImages)
+  }
+
+  val pushWindowsImages by registering(DockerPushImage::class) {
     dependsOn(buildWindowsTestImages)
     group = "publishing"
-    description = "Push all Docker images for the test matrix"
-    images.set(linuxImages + windowsImages)
+    description = "Push Windows Docker images for the test matrix"
+    images.set(windowsImages)
   }
 
   val printSmokeTestsConfigurations by registering {


### PR DESCRIPTION
I broke this in #15585 by making `pushMatrix` run both `buildLinuxTestImages` and `buildWindowsTestImages`, instead of before it was only an ordering constraint when both `pushMatrix` and one of those others was present.
