### PR TITLE
ClickHouse extract queryId attribute

### DIFF
--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseAttributesExtractor.java
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseAttributesExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.common;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import org.jspecify.annotations.Nullable;
+
+class ClickHouseAttributesExtractor implements AttributesExtractor<ClickHouseDbRequest, Void> {
+
+  private static final AttributeKey<String> QUERY_ID =
+      AttributeKey.stringKey("clickhouse.query_id");
+
+  @Override
+  public void onStart(
+      AttributesBuilder attributes,
+      Context parentContext,
+      ClickHouseDbRequest clickHouseDbRequest) {
+    String queryId = clickHouseDbRequest.getQueryId();
+    if (queryId != null) {
+      attributes.put(QUERY_ID, clickHouseDbRequest.getQueryId());
+    }
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      ClickHouseDbRequest clickHouseDbRequest,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseDbRequest.java
@@ -18,8 +18,12 @@ public abstract class ClickHouseDbRequest {
       SqlStatementSanitizer.create(AgentCommonConfig.get().isStatementSanitizationEnabled());
 
   public static ClickHouseDbRequest create(
-      @Nullable String host, @Nullable Integer port, @Nullable String dbName, String sql) {
-    return new AutoValue_ClickHouseDbRequest(host, port, dbName, sanitizer.sanitize(sql));
+      @Nullable String host,
+      @Nullable Integer port,
+      @Nullable String dbName,
+      @Nullable String queryId,
+      String sql) {
+    return new AutoValue_ClickHouseDbRequest(host, port, dbName, queryId, sanitizer.sanitize(sql));
   }
 
   @Nullable
@@ -30,6 +34,9 @@ public abstract class ClickHouseDbRequest {
 
   @Nullable
   public abstract String getDbName();
+
+  @Nullable
+  public abstract String getQueryId();
 
   public abstract SqlStatementInfo getSqlStatementInfo();
 }

--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseInstrumenterFactory.java
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseInstrumenterFactory.java
@@ -28,6 +28,7 @@ public final class ClickHouseInstrumenterFactory {
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
         .addAttributesExtractor(
             ServerAttributesExtractor.create(new ClickHouseNetworkAttributesGetter()))
+        .addAttributesExtractor(new ClickHouseAttributesExtractor())
         .addOperationMetrics(DbClientMetrics.get())
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -60,6 +60,7 @@ public class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
                   .getServer()
                   .getDatabase()
                   .orElse(ClickHouseDefaults.DATABASE.getDefaultValue().toString()),
+              clickHouseRequest.getQueryId().orElse(null),
               ClickHouseRequestAccess.getQuery(clickHouseRequest));
 
       return ClickHouseScope.start(instrumenter(), currentContext(), request);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -32,6 +33,7 @@ import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.ClickHouseResponseSummary;
 import com.clickhouse.data.ClickHouseFormat;
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
@@ -44,6 +46,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,9 @@ class ClickHouseClientV1Test {
   private static String host;
   private static ClickHouseNode server;
   private static ClickHouseClient client;
+
+  private static final AttributeKey<String> queryIdKey =
+      AttributeKey.stringKey("clickhouse.query_id");
 
   @BeforeAll
   static void setup() throws ClickHouseException {
@@ -182,6 +188,11 @@ class ClickHouseClientV1Test {
           response.close();
         });
 
+    List<AttributeAssertion> attributeAssertions =
+        Stream.concat(
+                attributeAssertions("select * from " + tableName, "SELECT").stream(),
+                Stream.of(equalTo(queryIdKey, "test_query_id")))
+            .collect(toList());
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -190,8 +201,7 @@ class ClickHouseClientV1Test {
                     span.hasName("SELECT " + dbName)
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            attributeAssertions("select * from " + tableName, "SELECT"))));
+                        .hasAttributesSatisfyingExactly(attributeAssertions)));
   }
 
   @Test

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -68,10 +68,15 @@ public class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
       }
 
       String database = client.getConfiguration().get("database");
+      String queryId = null;
+      if (querySettings != null) {
+        queryId = querySettings.getQueryId();
+      }
+
       Context parentContext = currentContext();
       ClickHouseDbRequest request =
           ClickHouseDbRequest.create(
-              addressAndPort.getAddress(), addressAndPort.getPort(), database, sqlQuery);
+              addressAndPort.getAddress(), addressAndPort.getPort(), database, queryId, sqlQuery);
 
       return ClickHouseScope.start(instrumenter(), parentContext, request);
     }


### PR DESCRIPTION
If the client already specified a queryId attribute, it should be extracted and added as an attribute.