### PR TITLE
Remove native-image component configuration

### DIFF
--- a/.github/workflows/reusable-native-tests.yml
+++ b/.github/workflows/reusable-native-tests.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           version: "latest"
           java-version: ${{ matrix.test-java-version }}
-          components: "native-image"
       - name: Running test
         env:
           DOCKER_COMPOSE_TEST: "true"


### PR DESCRIPTION
This is no longer needed:

From https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/20451183518 :

<img width="1391" height="245" alt="image" src="https://github.com/user-attachments/assets/db80b4c9-9143-46a8-be9d-34fa973128db" />

Ref: https://github.com/oracle/graal/pull/5995