### PR TITLE
Ensure consistent EarlyInitAgentConfig access

### DIFF
--- a/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
+++ b/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
@@ -10,6 +10,7 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class ApplicationLoggingInstrumentationModule extends InstrumentationModu
   public boolean defaultEnabled(ConfigProperties config) {
     // only enable this instrumentation if the application logger is enabled
     return super.defaultEnabled(config)
-        && "application".equals(config.getString("otel.javaagent.logging"));
+        && "application".equals(EarlyInitAgentConfig.get().getOtelJavaagentLogging());
   }
 
   @Override

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/instrumentationannotations/WithSpanInstrumentation.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/instrumentationannotations/WithSpanInstrumentation.java
@@ -18,12 +18,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
-import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AsmApi;
 import io.opentelemetry.javaagent.instrumentation.instrumentationannotations.AnnotationExcludedMethods;
 import io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.instrumentationannotations.SpanAttributeUtil.Parameter;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import java.util.Arrays;
 import java.util.List;
 import kotlin.coroutines.Continuation;
@@ -58,8 +58,7 @@ class WithSpanInstrumentation implements TypeInstrumentation {
   private static final boolean CHECK_CLASS =
       DeclarativeConfigUtil.getInstrumentationConfig(
               GlobalOpenTelemetry.get(), "kotlinx_coroutines")
-          .getBoolean(
-              "check_class", ConfigPropertiesUtil.getBoolean("otel.javaagent.debug", false));
+          .getBoolean("check_class", EarlyInitAgentConfig.get().isOtelJavaagentDebug());
 
   private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
   // this matcher matches all methods that should be excluded from transformation

--- a/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggingCustomizer.java
+++ b/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggingCustomizer.java
@@ -21,8 +21,7 @@ public final class ApplicationLoggingCustomizer implements LoggingCustomizer {
 
   @Override
   public void init(EarlyInitAgentConfig earlyConfig) {
-    int limit =
-        earlyConfig.getInt("otel.javaagent.logging.application.logs-buffer-max-records", 2048);
+    int limit = earlyConfig.getOtelJavaagentLoggingApplicationLogsBufferMaxRecords();
     InMemoryLogStore inMemoryLogStore = new InMemoryLogStore(limit);
     ApplicationLoggerFactory loggerFactory = new ApplicationLoggerFactory(inMemoryLogStore);
     // register a shutdown hook that'll dump the logs to stderr in case something goes wrong

--- a/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
+++ b/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
@@ -36,7 +36,7 @@ public final class Slf4jSimpleLoggingCustomizer implements LoggingCustomizer {
     setSystemPropertyDefault(
         SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
 
-    if (earlyConfig.getBoolean("otel.javaagent.debug", false)) {
+    if (earlyConfig.isOtelJavaagentDebug()) {
       setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
       setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "okhttp3.internal.http2", "INFO");
       setSystemPropertyDefault(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -80,8 +80,6 @@ public class AgentInstaller {
 
   private static final Logger logger = Logger.getLogger(AgentInstaller.class.getName());
 
-  static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
-
   // This property may be set to force synchronous AgentListener#afterAgent() execution: the
   // condition for delaying the AgentListener initialization is pretty broad and in case it covers
   // too much javaagent users can file a bug, force sync execution by setting this property to true
@@ -107,7 +105,7 @@ public class AgentInstaller {
     }
 
     logVersionInfo();
-    if (earlyConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
+    if (earlyConfig.isOtelJavaagentEnabled()) {
       List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
       installBytebuddyAgent(inst, extensionClassLoader, agentListeners, earlyConfig);
     } else {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -71,12 +71,12 @@ public class AgentStarterImpl implements AgentStarter {
   public void start() {
     installTransformers();
 
-    EarlyInitAgentConfig earlyConfig = EarlyInitAgentConfig.create();
+    EarlyInitAgentConfig earlyConfig = EarlyInitAgentConfig.get();
     extensionClassLoader = createExtensionClassLoader(getClass().getClassLoader(), earlyConfig);
     // allows loading instrumenter customizers from agent and extensions
     ServiceLoaderUtil.setLoadFunction(clazz -> ServiceLoader.load(clazz, extensionClassLoader));
 
-    String loggerImplementationName = earlyConfig.getString("otel.javaagent.logging");
+    String loggerImplementationName = earlyConfig.getOtelJavaagentLogging();
     // default to the built-in stderr slf4j-simple logger
     if (loggerImplementationName == null) {
       loggerImplementationName = "simple";

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.javaagent.tooling;
 
-import static io.opentelemetry.javaagent.tooling.AgentInstaller.JAVAAGENT_ENABLED_CONFIG;
 import static java.util.Collections.emptyList;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.instrumentation.thread.internal.AddThreadDetailsSpanProcessor;
-import io.opentelemetry.javaagent.tooling.config.AgentConfig;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -32,9 +31,6 @@ public class AgentTracerProviderConfigurer implements AutoConfigurationCustomize
   @CanIgnoreReturnValue
   private static SdkTracerProviderBuilder configure(
       SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
-    if (!config.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
-      return sdkTracerProviderBuilder;
-    }
 
     // Register additional thread details logging span processor
     if (config.getBoolean(ADD_THREAD_DETAILS, true)) {
@@ -48,7 +44,7 @@ public class AgentTracerProviderConfigurer implements AutoConfigurationCustomize
 
   private static void maybeEnableLoggingExporter(
       SdkTracerProviderBuilder builder, ConfigProperties config) {
-    if (AgentConfig.isDebugModeEnabled(config)) {
+    if (EarlyInitAgentConfig.get().isOtelJavaagentDebug()) {
       // don't install another instance if the user has already explicitly requested it.
       if (loggingExporterIsNotAlreadyConfigured(config)) {
         builder.addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()));

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -42,7 +42,6 @@ import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
 // TODO find a way to initialize logging before using this class
 @SuppressWarnings("SystemOut")
 public class ExtensionClassLoader extends URLClassLoader {
-  public static final String EXTENSIONS_CONFIG = "otel.javaagent.extensions";
 
   private final boolean isSecurityManagerSupportEnabled;
 
@@ -62,7 +61,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 
     includeEmbeddedExtensionsIfFound(extensions, javaagentFile);
 
-    extensions.addAll(parseLocation(earlyConfig.getString(EXTENSIONS_CONFIG), javaagentFile));
+    extensions.addAll(parseLocation(earlyConfig.getOtelJavaagentExtensions(), javaagentFile));
 
     // TODO when logging is configured add warning about deprecated property
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -74,8 +74,8 @@ public final class OpenTelemetryInstaller {
         // these properties are used to initialize the SDK before the configuration file
         // is loaded for consistency, we pass them to the bridge, so that they can be read
         // later with the same value from the {@link DeclarativeConfigPropertiesBridge}
-        .addOverride("otel.javaagent.debug", earlyConfig.getBoolean("otel.javaagent.debug", false))
-        .addOverride("otel.javaagent.logging", earlyConfig.getString("otel.javaagent.logging"))
+        .addOverride("otel.javaagent.debug", earlyConfig.isOtelJavaagentDebug())
+        .addOverride("otel.javaagent.logging", earlyConfig.getOtelJavaagentLogging())
         .buildFromInstrumentationConfig(configProvider.getInstrumentationConfig());
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SpanLoggingCustomizerProvider.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SpanLoggingCustomizerProvider.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.tooling;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.logging.internal.AbstractSpanLoggingCustomizerProvider;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 
@@ -17,8 +17,6 @@ public class SpanLoggingCustomizerProvider extends AbstractSpanLoggingCustomizer
 
   @Override
   protected boolean isEnabled(OpenTelemetryConfigurationModel model) {
-    // read from system properties as it's an early init property and the config bridge is not
-    // available here
-    return ConfigPropertiesUtil.getBoolean("otel.javaagent.debug", false);
+    return EarlyInitAgentConfig.get().isOtelJavaagentDebug();
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -7,14 +7,9 @@ package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 
 public final class AgentConfig {
-
-  public static boolean isDebugModeEnabled(ConfigProperties config) {
-    return config.getBoolean("otel.javaagent.debug", false);
-  }
 
   public static String instrumentationMode() {
     String mode =

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
@@ -15,6 +15,16 @@ import javax.annotation.Nullable;
  */
 public final class EarlyInitAgentConfig {
 
+  private static final EarlyInitAgentConfig INSTANCE = create();
+
+  public static EarlyInitAgentConfig get() {
+    return INSTANCE;
+  }
+
+  /**
+   * @deprecated Use {@link #get()} instead.
+   */
+  @Deprecated
   public static EarlyInitAgentConfig create() {
     return new EarlyInitAgentConfig(ConfigurationFile.getProperties());
   }
@@ -26,6 +36,36 @@ public final class EarlyInitAgentConfig {
   }
 
   @Nullable
+  public String getOtelJavaagentLogging() {
+    return getString("otel.javaagent.logging");
+  }
+
+  @Nullable
+  public String getOtelJavaagentExtensions() {
+    return getString("otel.javaagent.extensions");
+  }
+
+  public boolean isOtelJavaagentDebug() {
+    return getBoolean("otel.javaagent.debug", false);
+  }
+
+  public boolean isOtelJavaagentEnabled() {
+    return getBoolean("otel.javaagent.enabled", true);
+  }
+
+  public boolean isOtelJavaagentExperimentalFieldInjectionEnabled() {
+    return getBoolean("otel.javaagent.experimental.field-injection.enabled", true);
+  }
+
+  public int getOtelJavaagentLoggingApplicationLogsBufferMaxRecords() {
+    return getInt("otel.javaagent.logging.application.logs-buffer-max-records", 2048);
+  }
+
+  /**
+   * @deprecated Use specific property accessors instead.
+   */
+  @Nullable
+  @Deprecated
   public String getString(String propertyName) {
     String value = ConfigPropertiesUtil.getString(propertyName);
     if (value != null) {
@@ -34,6 +74,10 @@ public final class EarlyInitAgentConfig {
     return configFileContents.get(propertyName);
   }
 
+  /**
+   * @deprecated Use specific property accessors instead.
+   */
+  @Deprecated
   public boolean getBoolean(String propertyName, boolean defaultValue) {
     String configFileValueStr = configFileContents.get(propertyName);
     boolean configFileValue =
@@ -41,6 +85,10 @@ public final class EarlyInitAgentConfig {
     return ConfigPropertiesUtil.getBoolean(propertyName, configFileValue);
   }
 
+  /**
+   * @deprecated Use specific property accessors instead.
+   */
+  @Deprecated
   public int getInt(String propertyName, int defaultValue) {
     try {
       String configFileValueStr = configFileContents.get(propertyName);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationConfiguration.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationConfiguration.java
@@ -11,8 +11,7 @@ public final class FieldBackedImplementationConfiguration {
   static boolean fieldInjectionEnabled = true;
 
   public static void configure(EarlyInitAgentConfig config) {
-    fieldInjectionEnabled =
-        config.getBoolean("otel.javaagent.experimental.field-injection.enabled", true);
+    fieldInjectionEnabled = config.isOtelJavaagentExperimentalFieldInjectionEnabled();
   }
 
   private FieldBackedImplementationConfiguration() {}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -77,16 +77,14 @@ public final class InstrumentationModuleInstaller {
     }
 
     if (instrumentationModule.isIndyModule()) {
-      return installIndyModule(instrumentationModule, parentAgentBuilder, config);
+      return installIndyModule(instrumentationModule, parentAgentBuilder);
     } else {
-      return installInjectingModule(instrumentationModule, parentAgentBuilder, config);
+      return installInjectingModule(instrumentationModule, parentAgentBuilder);
     }
   }
 
   private AgentBuilder installIndyModule(
-      InstrumentationModule instrumentationModule,
-      AgentBuilder parentAgentBuilder,
-      ConfigProperties config) {
+      InstrumentationModule instrumentationModule, AgentBuilder parentAgentBuilder) {
     List<String> helperClassNames =
         InstrumentationModuleMuzzle.getHelperClassNames(instrumentationModule);
     HelperResourceBuilderImpl helperResourceBuilder = new HelperResourceBuilderImpl();
@@ -118,7 +116,7 @@ public final class InstrumentationModuleInstaller {
           .injectClasses(injectedClassesCollector);
     }
 
-    MuzzleMatcher muzzleMatcher = new MuzzleMatcher(logger, instrumentationModule, config);
+    MuzzleMatcher muzzleMatcher = new MuzzleMatcher(logger, instrumentationModule);
 
     Function<ClassLoader, List<HelperClassDefinition>> helperGenerator =
         cl -> {
@@ -170,9 +168,7 @@ public final class InstrumentationModuleInstaller {
   }
 
   private AgentBuilder installInjectingModule(
-      InstrumentationModule instrumentationModule,
-      AgentBuilder parentAgentBuilder,
-      ConfigProperties config) {
+      InstrumentationModule instrumentationModule, AgentBuilder parentAgentBuilder) {
     List<String> helperClassNames =
         InstrumentationModuleMuzzle.getHelperClassNames(instrumentationModule);
     HelperResourceBuilderImpl helperResourceBuilder = new HelperResourceBuilderImpl();
@@ -189,7 +185,7 @@ public final class InstrumentationModuleInstaller {
       return parentAgentBuilder;
     }
 
-    MuzzleMatcher muzzleMatcher = new MuzzleMatcher(logger, instrumentationModule, config);
+    MuzzleMatcher muzzleMatcher = new MuzzleMatcher(logger, instrumentationModule);
     AgentBuilder.Transformer helperInjector =
         new HelperInjector(
             instrumentationModule.instrumentationName(),

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
@@ -13,12 +13,11 @@ import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TransformSafeLogger;
 import io.opentelemetry.javaagent.tooling.Utils;
-import io.opentelemetry.javaagent.tooling.config.AgentConfig;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyModuleRegistry;
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader;
 import io.opentelemetry.javaagent.tooling.muzzle.Mismatch;
 import io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.security.ProtectionDomain;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,12 +44,10 @@ class MuzzleMatcher implements AgentBuilder.RawMatcher {
   private volatile ReferenceMatcher referenceMatcher;
 
   MuzzleMatcher(
-      TransformSafeLogger instrumentationLogger,
-      InstrumentationModule instrumentationModule,
-      ConfigProperties config) {
+      TransformSafeLogger instrumentationLogger, InstrumentationModule instrumentationModule) {
     this.instrumentationLogger = instrumentationLogger;
     this.instrumentationModule = instrumentationModule;
-    this.muzzleLogLevel = AgentConfig.isDebugModeEnabled(config) ? WARNING : FINE;
+    this.muzzleLogLevel = EarlyInitAgentConfig.get().isOtelJavaagentDebug() ? WARNING : FINE;
   }
 
   @Override

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/test/HelperInjectionTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/test/HelperInjectionTest.java
@@ -106,7 +106,7 @@ class HelperInjectionTest {
     AgentInstaller.installBytebuddyAgent(
         ByteBuddyAgent.getInstrumentation(),
         this.getClass().getClassLoader(),
-        EarlyInitAgentConfig.create());
+        EarlyInitAgentConfig.get());
 
     String helperClassName = HelperInjectionTest.class.getPackage().getName() + ".HelperClass";
     HelperInjector injector =

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.java
@@ -37,7 +37,7 @@ class OpenTelemetryInstallerTest {
   void globalOpenTelemetry() {
     AutoConfiguredOpenTelemetrySdk sdk =
         OpenTelemetryInstaller.installOpenTelemetrySdk(
-            EarlyInitAgentConfig.class.getClassLoader(), EarlyInitAgentConfig.create());
+            EarlyInitAgentConfig.class.getClassLoader(), EarlyInitAgentConfig.get());
 
     assertThat(sdk).isNotNull().isNotEqualTo(OpenTelemetry.noop());
   }
@@ -63,7 +63,7 @@ class OpenTelemetryInstallerTest {
     Supplier<ConfigProperties> configPropertiesSupplier =
         () ->
             OpenTelemetryInstaller.getDeclarativeConfigBridgedProperties(
-                EarlyInitAgentConfig.create(),
+                EarlyInitAgentConfig.get(),
                 SdkConfigProvider.create(
                     DeclarativeConfiguration.parse(
                         new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)))));

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
@@ -47,7 +47,7 @@ class ConfigurationPropertiesSupplierTest {
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
         OpenTelemetryInstaller.installOpenTelemetrySdk(
-            this.getClass().getClassLoader(), EarlyInitAgentConfig.create());
+            this.getClass().getClassLoader(), EarlyInitAgentConfig.get());
 
     // then
     assertThat(AutoConfigureUtil.getConfig(autoConfiguredSdk).getString("custom.key"))

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/OtlpProtocolPropertiesSupplierTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/OtlpProtocolPropertiesSupplierTest.java
@@ -32,7 +32,7 @@ class OtlpProtocolPropertiesSupplierTest {
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
         OpenTelemetryInstaller.installOpenTelemetrySdk(
-            this.getClass().getClassLoader(), EarlyInitAgentConfig.create());
+            this.getClass().getClassLoader(), EarlyInitAgentConfig.get());
 
     // then
     assertThat(
@@ -45,7 +45,7 @@ class OtlpProtocolPropertiesSupplierTest {
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
         OpenTelemetryInstaller.installOpenTelemetrySdk(
-            this.getClass().getClassLoader(), EarlyInitAgentConfig.create());
+            this.getClass().getClassLoader(), EarlyInitAgentConfig.get());
 
     // then
     assertThat(


### PR DESCRIPTION
Limit it to specific known properties.

Future PRs:
- See if a couple of the properties can be moved out of "early config" and to normal config
- Stop passing around `EarlyInitAgentConfig` instance now that it's a singleton
