### PR TITLE
Remove unnecessary otel.javaagent.enabled check

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -111,7 +111,7 @@ public class AgentInstaller {
       List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
       installBytebuddyAgent(inst, extensionClassLoader, agentListeners, earlyConfig);
     } else {
-      logger.fine("Tracing is disabled, not installing instrumentations.");
+      logger.fine("Agent is disabled, not installing instrumentations.");
     }
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling;
 
-import static io.opentelemetry.javaagent.tooling.AgentInstaller.JAVAAGENT_ENABLED_CONFIG;
 import static java.util.Collections.emptyList;
 
 import com.google.auto.service.AutoService;
@@ -32,9 +31,6 @@ public class AgentTracerProviderConfigurer implements AutoConfigurationCustomize
   @CanIgnoreReturnValue
   private static SdkTracerProviderBuilder configure(
       SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
-    if (!config.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
-      return sdkTracerProviderBuilder;
-    }
 
     // Register additional thread details logging span processor
     if (config.getBoolean(ADD_THREAD_DETAILS, true)) {


### PR DESCRIPTION
Already checked prior to this at

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/a9b1bfd47a068f577bb99f3972d6b2e79a1dfad0/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java#L110-L112