### PR TITLE
Improve sanitization for Redis ACL command

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
@@ -192,9 +192,10 @@ public final class RedisCommandSanitizer {
     // Server
     // CONFIG SET can set any property, including the master password
     sanitizers.put("CONFIG", keepTwoArgs);
+    // ACL SETUSER can contain passwords (prefixed with '>') or password hashes (prefixed with '#')
+    sanitizers.put("ACL", keepOneArg);
     for (String command :
         asList(
-            "ACL",
             "BGREWRITEAOF",
             "BGSAVE",
             "COMMAND",


### PR DESCRIPTION
Redis ACL commands can contain sensitive information such as plain-text passwords and access control rules.

For example
```redis
ACL SETUSER alice on >MySecretPass ~user:alice:* +@read +@write
```

This command creates an admin user with a plain-text password.
However, in RedisCommandSanitizer, the ACL command is currently configured with KeepAllArgs.INSTANCE, which means all arguments of the ACL command can be exposed without any masking.

ACL has more than 10 subcommands, and the number and structure of arguments vary depending on the subcommand. Because of this, it is very tricky to sanitize ACL commands accurately.
Instead, it is better to keep only the subcommand and mask all arguments after it. For this reason, using `CommandAndNumArgs(1)` to preserve the subcommand and mask the rest of the arguments would be a better approach.

By `CommandAndNumArgs(1)`, ACL commands can sanitize as shown below:
```
// ACL SETUSER alice on >MySecretPass ~user:alice:* +@read +@write
ACL SETUSER ? ? ? ? ? ?

// ACL DRYRUN auditor AUTH MySecretPass
ACL DRYRUN ? ? ?
```