### PR TITLE
tests should also use ConfigPropertiesBackedConfigProvider

### DIFF
--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
@@ -63,8 +63,7 @@ class ConfigurationPropertiesSupplierTest {
   void userPropertiesSupplier() {
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
-        OpenTelemetryInstaller.installOpenTelemetrySdk(
-            this.getClass().getClassLoader(), EarlyInitAgentConfig.create());
+        OpenTelemetryInstaller.installOpenTelemetrySdk(this.getClass().getClassLoader());
 
     // then
     assertThat(


### PR DESCRIPTION
to avoid testing an internal API (ConfigProperties)

split off from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15791