### PR TITLE
Fix typo in ratpack test path

### DIFF
--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -208,7 +208,7 @@ readonly INSTRUMENTATIONS=(
   "rabbitmq-2.7:javaagent:testExperimental"
   "ratpack:ratpack-1.4:javaagent:test"
   "ratpack:ratpack-1.7:javaagent:test"
-  "ratpack:ratpack-1.7:javaagent:library"
+  "ratpack:ratpack-1.7:library:test"
   "reactor:reactor-netty:reactor-netty-0.9:javaagent:test"
   "reactor:reactor-netty:reactor-netty-1.0:javaagent:test"
   "rediscala-1.8:javaagent:test"


### PR DESCRIPTION
Fixes #15803


https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/20838187327/job/59867075168

> * What went wrong:
Cannot locate tasks that match ':instrumentation:ratpack:ratpack-1.7:javaagent:library' as task 'library' not found in project ':instrumentation:ratpack:ratpack-1.7:javaagent'.
