### PR TITLE
Move experimental servlet method out of public API

### DIFF
--- a/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetryBuilder.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetryBuilder.java
@@ -48,6 +48,8 @@ public final class ServletTelemetryBuilder {
         (builder, emit) -> builder.builder.setEmitExperimentalHttpServerTelemetry(emit));
     Experimental.internalSetAddTraceIdRequestAttribute(
         (builder, value) -> builder.addTraceIdRequestAttribute = value);
+    Experimental.internalSetCapturedRequestParameters(
+        (builder, params) -> builder.servletBuilder.setCaptureRequestParameters(params));
   }
 
   ServletTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -114,11 +116,14 @@ public final class ServletTelemetryBuilder {
    * Configures the HTTP request parameters that will be captured as span attributes.
    *
    * @param captureRequestParameters A list of request parameter names.
+   * @deprecated Use {@link Experimental#setCapturedRequestParameters(ServletTelemetryBuilder,
+   *     Collection)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder setCapturedRequestParameters(
       List<String> captureRequestParameters) {
-    servletBuilder.captureRequestParameters(captureRequestParameters);
+    servletBuilder.setCaptureRequestParameters(captureRequestParameters);
     return this;
   }
 

--- a/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/internal/Experimental.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/internal/Experimental.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.servlet.v3_0.internal;
 
 import io.opentelemetry.instrumentation.servlet.v3_0.ServletTelemetryBuilder;
+import java.util.Collection;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
@@ -25,6 +26,10 @@ public final class Experimental {
 
   @Nullable
   private static volatile BiConsumer<ServletTelemetryBuilder, Boolean> setCaptureEnduserId;
+
+  @Nullable
+  private static volatile BiConsumer<ServletTelemetryBuilder, Collection<String>>
+      setCapturedRequestParameters;
 
   public static void setEmitExperimentalTelemetry(
       ServletTelemetryBuilder builder, boolean emitExperimentalTelemetry) {
@@ -47,6 +52,13 @@ public final class Experimental {
     }
   }
 
+  public static void setCapturedRequestParameters(
+      ServletTelemetryBuilder builder, Collection<String> capturedRequestParameters) {
+    if (setCapturedRequestParameters != null) {
+      setCapturedRequestParameters.accept(builder, capturedRequestParameters);
+    }
+  }
+
   public static void internalSetEmitExperimentalTelemetry(
       BiConsumer<ServletTelemetryBuilder, Boolean> setEmitExperimentalTelemetry) {
     Experimental.setEmitExperimentalTelemetry = setEmitExperimentalTelemetry;
@@ -60,6 +72,11 @@ public final class Experimental {
   public static void internalSetCaptureEnduserId(
       BiConsumer<ServletTelemetryBuilder, Boolean> setCaptureEnduserId) {
     Experimental.setCaptureEnduserId = setCaptureEnduserId;
+  }
+
+  public static void internalSetCapturedRequestParameters(
+      BiConsumer<ServletTelemetryBuilder, Collection<String>> setCapturedRequestParameters) {
+    Experimental.setCapturedRequestParameters = setCapturedRequestParameters;
   }
 
   private Experimental() {}

--- a/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTestUtil.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTestUtil.java
@@ -21,8 +21,8 @@ public class ServletTestUtil {
     ServletTelemetryBuilder builder =
         ServletTelemetry.builder(openTelemetry)
             .setCapturedRequestHeaders(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-            .setCapturedResponseHeaders(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
-            .setCapturedRequestParameters(singletonList("test-parameter"));
+            .setCapturedResponseHeaders(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER));
+    Experimental.setCapturedRequestParameters(builder, singletonList("test-parameter"));
     Experimental.addTraceIdRequestAttribute(builder, true);
     return builder.build().newFilter();
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AgentServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AgentServletInstrumenterBuilder.java
@@ -66,7 +66,7 @@ public final class AgentServletInstrumenterBuilder<REQUEST, RESPONSE> {
     ServletInstrumenterBuilder<REQUEST, RESPONSE> builder =
         ServletInstrumenterBuilder.create(
                 instrumentationName, GlobalOpenTelemetry.get(), httpAttributesGetter, accessor)
-            .captureRequestParameters(CAPTURE_REQUEST_PARAMETERS)
+            .setCaptureRequestParameters(CAPTURE_REQUEST_PARAMETERS)
             .setCaptureExperimentalAttributes(CAPTURE_EXPERIMENTAL_ATTRIBUTES)
             .setCaptureEnduserId(AgentCommonConfig.get().getEnduserConfig().isIdEnabled());
     for (ContextCustomizer<? super ServletRequestContext<REQUEST>> contextCustomizer :

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletInstrumenterBuilder.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
   private boolean propagateOperationListenersToOnEnd;
   private boolean captureExperimentalAttributes;
   private boolean captureEnduserId;
-  private final List<String> captureRequestParameters = new ArrayList<>();
+  private List<String> captureRequestParameters = new ArrayList<>();
 
   private final DefaultHttpServerInstrumenterBuilder<
           ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
@@ -95,9 +96,9 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
   }
 
   @CanIgnoreReturnValue
-  public ServletInstrumenterBuilder<REQUEST, RESPONSE> captureRequestParameters(
-      List<String> captureRequestParameters) {
-    this.captureRequestParameters.addAll(captureRequestParameters);
+  public ServletInstrumenterBuilder<REQUEST, RESPONSE> setCaptureRequestParameters(
+      Collection<String> captureRequestParameters) {
+    this.captureRequestParameters = new ArrayList<>(captureRequestParameters);
     return this;
   }
 

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletRequestParametersExtractor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletRequestParametersExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,10 +29,10 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
       new ConcurrentHashMap<>();
 
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
-  private final List<String> captureRequestParameters;
+  private final Collection<String> captureRequestParameters;
 
   public ServletRequestParametersExtractor(
-      ServletAccessor<REQUEST, RESPONSE> accessor, List<String> captureRequestParameters) {
+      ServletAccessor<REQUEST, RESPONSE> accessor, Collection<String> captureRequestParameters) {
     this.accessor = accessor;
     this.captureRequestParameters = captureRequestParameters;
   }


### PR DESCRIPTION
Moving to experimental since there's no corresponding semantic convention for this (unlike unknown methods for example).

Related to
- #12846