### PR TITLE
Deprecate Netty experimental method that is still in public API

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyServerSingletons.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyServerSingletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.netty.v4_1.NettyServerTelemetry;
 import io.opentelemetry.instrumentation.netty.v4_1.NettyServerTelemetryBuilder;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.Experimental;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.server.NettyServerInstrumenterBuilderUtil;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 
@@ -19,8 +20,7 @@ public final class NettyServerSingletons {
         .apply(builder)
         .configure(AgentCommonConfig.get());
     if (AgentCommonConfig.get().shouldEmitExperimentalHttpServerTelemetry()) {
-      // this logic is only used in agent
-      builder.setEmitExperimentalHttpServerEvents(true);
+      Experimental.setEmitExperimentalTelemetry(builder, true);
     }
     SERVER_TELEMETRY = builder.build();
   }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetryBuilder.java
@@ -48,7 +48,10 @@ public final class NettyServerTelemetryBuilder {
    * Configures emission of experimental events.
    *
    * @param emitExperimentalHttpServerEvents set to true to emit events
+   * @deprecated Use {@link Experimental#setEmitExperimentalTelemetry(NettyServerTelemetryBuilder,
+   *     boolean)} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public NettyServerTelemetryBuilder setEmitExperimentalHttpServerEvents(
       boolean emitExperimentalHttpServerEvents) {


### PR DESCRIPTION
Related to
- #12846