### PR TITLE
Rename a method to 'wrap'

### DIFF
--- a/instrumentation/java-http-client/library/README.md
+++ b/instrumentation/java-http-client/library/README.md
@@ -43,7 +43,7 @@ public class JavaHttpClientConfiguration {
 
   //Use this HttpClient implementation for making standard http client calls.
   public HttpClient createTracedClient(OpenTelemetry openTelemetry) {
-    return JavaHttpClientTelemetry.builder(openTelemetry).build().createHttpClient(createClient());
+    return JavaHttpClientTelemetry.builder(openTelemetry).build().wrap(createClient());
   }
 
   //your configuration of the Java HTTP Client goes here:

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetry.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetry.java
@@ -38,22 +38,17 @@ public final class JavaHttpClientTelemetry {
   /**
    * Returns an instrumented {@link HttpClient} wrapping the provided client.
    *
-   * @param client the HttpClient to wrap
-   * @return an instrumented HttpClient
-   */
-  public HttpClient createHttpClient(HttpClient client) {
-    return new OpenTelemetryHttpClient(client, instrumenter, headersSetter);
-  }
-
-  /**
-   * Returns an instrumented {@link HttpClient} wrapping the provided client.
-   *
-   * @param client the HttpClient to wrap
-   * @return an instrumented HttpClient
-   * @deprecated Use {@link #createHttpClient(HttpClient)} instead.
+   * @param client An instance of HttpClient configured as desired.
+   * @return a tracing-enabled {@link HttpClient}.
+   * @deprecated Use {@link #wrap(HttpClient)} instead.
    */
   @Deprecated
   public HttpClient newHttpClient(HttpClient client) {
-    return createHttpClient(client);
+    return wrap(client);
+  }
+
+  /** Returns a new instrumented {@link HttpClient} that wraps the provided client. */
+  public HttpClient wrap(HttpClient client) {
+    return new OpenTelemetryHttpClient(client, instrumenter, headersSetter);
   }
 }

--- a/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -28,7 +28,7 @@ class JavaHttpClientTest {
           .setCapturedResponseHeaders(
               Collections.singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
           .build()
-          .createHttpClient(httpClient);
+          .wrap(httpClient);
     }
   }
 


### PR DESCRIPTION
I think `wrap` has evolved as our method name for wrapping an instance (e.g. in JdbcTelemetry)

Related to
- #12846