### PR TITLE
Rename database method/fields/etc to match stable semconv terminology (1 of several)

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -13,33 +13,33 @@ import javax.annotation.Nullable;
 class MultiQuery {
 
   @Nullable private final String mainIdentifier;
-  @Nullable private final String operation;
-  private final Set<String> statements;
+  @Nullable private final String operationName;
+  private final Set<String> queryTexts;
 
   private MultiQuery(
-      @Nullable String mainIdentifier, @Nullable String operation, Set<String> statements) {
+      @Nullable String mainIdentifier, @Nullable String operationName, Set<String> queryTexts) {
     this.mainIdentifier = mainIdentifier;
-    this.operation = operation;
-    this.statements = statements;
+    this.operationName = operationName;
+    this.queryTexts = queryTexts;
   }
 
   static MultiQuery analyze(
       Collection<String> rawQueryTexts, boolean statementSanitizationEnabled) {
     UniqueValue uniqueMainIdentifier = new UniqueValue();
-    UniqueValue uniqueOperation = new UniqueValue();
-    Set<String> uniqueStatements = new LinkedHashSet<>();
+    UniqueValue uniqueOperationName = new UniqueValue();
+    Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     for (String rawQueryText : rawQueryTexts) {
       SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
       String mainIdentifier = sanitizedStatement.getMainIdentifier();
       uniqueMainIdentifier.set(mainIdentifier);
-      String operation = sanitizedStatement.getOperation();
-      uniqueOperation.set(operation);
-      uniqueStatements.add(
-          statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
+      String operationName = sanitizedStatement.getOperationName();
+      uniqueOperationName.set(operationName);
+      uniqueQueryTexts.add(
+          statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
     }
 
     return new MultiQuery(
-        uniqueMainIdentifier.getValue(), uniqueOperation.getValue(), uniqueStatements);
+        uniqueMainIdentifier.getValue(), uniqueOperationName.getValue(), uniqueQueryTexts);
   }
 
   @Nullable
@@ -48,12 +48,29 @@ class MultiQuery {
   }
 
   @Nullable
-  public String getOperation() {
-    return operation;
+  public String getOperationName() {
+    return operationName;
   }
 
+  /**
+   * @deprecated Use {@link #getOperationName()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getOperation() {
+    return getOperationName();
+  }
+
+  public Set<String> getQueryTexts() {
+    return queryTexts;
+  }
+
+  /**
+   * @deprecated Use {@link #getQueryTexts()} instead.
+   */
+  @Deprecated
   public Set<String> getStatements() {
-    return statements;
+    return getQueryTexts();
   }
 
   private static class UniqueValue {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -94,13 +94,13 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
       if (rawQueryTexts.size() == 1) { // for backcompat(?)
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-        String operation = sanitizedStatement.getOperation();
+        String operationName = sanitizedStatement.getOperationName();
         internalSet(
             attributes,
             DB_STATEMENT,
-            statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
-        internalSet(attributes, DB_OPERATION, operation);
-        if (!SQL_CALL.equals(operation)) {
+            statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
+        internalSet(attributes, DB_OPERATION, operationName);
+        if (!SQL_CALL.equals(operationName)) {
           internalSet(attributes, oldSemconvTableAttribute, sanitizedStatement.getMainIdentifier());
         }
       }
@@ -113,26 +113,30 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
       if (rawQueryTexts.size() == 1) {
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-        String operation = sanitizedStatement.getOperation();
+        String operationName = sanitizedStatement.getOperationName();
         internalSet(
             attributes,
             DB_QUERY_TEXT,
-            statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
-        internalSet(attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operation : operation);
-        if (!SQL_CALL.equals(operation)) {
+            statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
+        internalSet(
+            attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operationName : operationName);
+        if (!SQL_CALL.equals(operationName)) {
           internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getMainIdentifier());
         }
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =
             MultiQuery.analyze(getter.getRawQueryTexts(request), statementSanitizationEnabled);
-        internalSet(attributes, DB_QUERY_TEXT, join("; ", multiQuery.getStatements()));
+        internalSet(attributes, DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
 
-        String operation =
-            multiQuery.getOperation() != null ? "BATCH " + multiQuery.getOperation() : "BATCH";
-        internalSet(attributes, DB_OPERATION_NAME, operation);
+        String operationName =
+            multiQuery.getOperationName() != null
+                ? "BATCH " + multiQuery.getOperationName()
+                : "BATCH";
+        internalSet(attributes, DB_OPERATION_NAME, operationName);
 
         if (multiQuery.getMainIdentifier() != null
-            && (multiQuery.getOperation() == null || !SQL_CALL.equals(multiQuery.getOperation()))) {
+            && (multiQuery.getOperationName() == null
+                || !SQL_CALL.equals(multiQuery.getOperationName()))) {
           internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getMainIdentifier());
         }
       }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
@@ -12,15 +12,33 @@ import javax.annotation.Nullable;
 public abstract class SqlStatementInfo {
 
   public static SqlStatementInfo create(
-      @Nullable String fullStatement, @Nullable String operation, @Nullable String identifier) {
-    return new AutoValue_SqlStatementInfo(fullStatement, operation, identifier);
+      @Nullable String queryText, @Nullable String operationName, @Nullable String mainIdentifier) {
+    return new AutoValue_SqlStatementInfo(queryText, operationName, mainIdentifier);
   }
 
   @Nullable
-  public abstract String getFullStatement();
+  public abstract String getQueryText();
+
+  /**
+   * @deprecated Use {@link #getQueryText()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getFullStatement() {
+    return getQueryText();
+  }
 
   @Nullable
-  public abstract String getOperation();
+  public abstract String getOperationName();
+
+  /**
+   * @deprecated Use {@link #getOperationName()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getOperation() {
+    return getOperationName();
+  }
 
   @Nullable
   public abstract String getMainIdentifier();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -21,7 +21,7 @@ class SqlStatementSanitizerTest {
   @MethodSource("sqlArgs")
   void sanitizeSql(String original, String expected) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(original);
-    assertThat(result.getFullStatement()).isEqualTo(expected);
+    assertThat(result.getQueryText()).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -29,7 +29,7 @@ class SqlStatementSanitizerTest {
   void normalizeCouchbase(String original, String expected) {
     SqlStatementInfo result =
         SqlStatementSanitizer.create(true).sanitize(original, SqlDialect.COUCHBASE);
-    assertThat(result.getFullStatement()).isEqualTo(expected);
+    assertThat(result.getQueryText()).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -37,8 +37,8 @@ class SqlStatementSanitizerTest {
   void simplifySql(String original, Function<String, SqlStatementInfo> expectedFunction) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(original);
     SqlStatementInfo expected = expectedFunction.apply(original);
-    assertThat(result.getFullStatement()).isEqualTo(expected.getFullStatement());
-    assertThat(result.getOperation()).isEqualTo(expected.getOperation());
+    assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
+    assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
     assertThat(result.getMainIdentifier()).isEqualToIgnoringCase(expected.getMainIdentifier());
   }
 
@@ -46,7 +46,7 @@ class SqlStatementSanitizerTest {
   @MethodSource("sensitiveArgs")
   void sanitizeSensitive(String original, String expected) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(original);
-    assertThat(result.getFullStatement()).isEqualTo(expected);
+    assertThat(result.getQueryText()).isEqualTo(expected);
   }
 
   private static Stream<Arguments> sensitiveArgs() {
@@ -86,8 +86,8 @@ class SqlStatementSanitizerTest {
       String actual, Function<String, SqlStatementInfo> expectFunc) {
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(actual);
     SqlStatementInfo expected = expectFunc.apply(actual);
-    assertThat(result.getFullStatement()).isEqualTo(expected.getFullStatement());
-    assertThat(result.getOperation()).isEqualTo(expected.getOperation());
+    assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
+    assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
     assertThat(result.getMainIdentifier()).isEqualTo(expected.getMainIdentifier());
   }
 
@@ -108,7 +108,7 @@ class SqlStatementSanitizerTest {
       s += String.valueOf(i);
     }
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(s);
-    assertThat(result.getFullStatement()).isEqualTo("?");
+    assertThat(result.getQueryText()).isEqualTo("?");
   }
 
   @Test
@@ -118,7 +118,7 @@ class SqlStatementSanitizerTest {
       s += String.valueOf(i);
     }
     SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(s);
-    assertThat(result.getFullStatement()).isEqualTo(s.substring(0, AutoSqlSanitizer.LIMIT));
+    assertThat(result.getQueryText()).isEqualTo(s.substring(0, AutoSqlSanitizer.LIMIT));
   }
 
   @Test
@@ -127,7 +127,7 @@ class SqlStatementSanitizerTest {
     for (int i = 0; i < 10000; i++) {
       s.append("SELECT * FROM TABLE WHERE FIELD = 1234 AND ");
     }
-    String sanitized = SqlStatementSanitizer.create(true).sanitize(s.toString()).getFullStatement();
+    String sanitized = SqlStatementSanitizer.create(true).sanitize(s.toString()).getQueryText();
     assertThat(sanitized.length()).isLessThanOrEqualTo(AutoSqlSanitizer.LIMIT);
     assertThat(sanitized).doesNotContain("1234");
   }
@@ -152,7 +152,7 @@ class SqlStatementSanitizerTest {
     }
     s.append("?)");
 
-    String sanitized = SqlStatementSanitizer.create(true).sanitize(s.toString()).getFullStatement();
+    String sanitized = SqlStatementSanitizer.create(true).sanitize(s.toString()).getQueryText();
 
     assertThat(sanitized).isEqualTo("select col from table where col in (?)");
   }
@@ -162,7 +162,7 @@ class SqlStatementSanitizerTest {
     // test that short statement is cached
     String shortStatement = "SELECT * FROM TABLE WHERE FIELD = 1234";
     String sanitizedShort =
-        SqlStatementSanitizer.create(true).sanitize(shortStatement).getFullStatement();
+        SqlStatementSanitizer.create(true).sanitize(shortStatement).getQueryText();
     assertThat(sanitizedShort).doesNotContain("1234");
     assertThat(SqlStatementSanitizer.isCached(shortStatement)).isTrue();
 
@@ -173,7 +173,7 @@ class SqlStatementSanitizerTest {
     }
     String largeStatement = s.toString();
     String sanitizedLarge =
-        SqlStatementSanitizer.create(true).sanitize(largeStatement).getFullStatement();
+        SqlStatementSanitizer.create(true).sanitize(largeStatement).getQueryText();
     assertThat(sanitizedLarge).doesNotContain("1234");
     assertThat(SqlStatementSanitizer.isCached(largeStatement)).isFalse();
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
@@ -72,19 +72,19 @@ class DbSpanDecorator extends BaseSpanDecorator {
       case "cql":
         Object cqlObj = exchange.getIn().getHeader("CamelCqlQuery");
         if (cqlObj != null) {
-          return sanitizer.sanitize(cqlObj.toString()).getFullStatement();
+          return sanitizer.sanitize(cqlObj.toString()).getQueryText();
         }
         return null;
       case "jdbc":
         Object body = exchange.getIn().getBody();
         if (body instanceof String) {
-          return sanitizer.sanitize((String) body).getFullStatement();
+          return sanitizer.sanitize((String) body).getQueryText();
         }
         return null;
       case "sql":
         Object sqlquery = exchange.getIn().getHeader("CamelSqlQuery");
         if (sqlquery instanceof String) {
-          return sanitizer.sanitize((String) sqlquery).getFullStatement();
+          return sanitizer.sanitize((String) sqlquery).getQueryText();
         }
         return null;
       default:

--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseAttributesGetter.java
@@ -25,7 +25,7 @@ final class ClickHouseAttributesGetter
     if (request.getSqlStatementInfo() == null) {
       return null;
     }
-    return request.getSqlStatementInfo().getFullStatement();
+    return request.getSqlStatementInfo().getQueryText();
   }
 
   @Nullable
@@ -34,7 +34,7 @@ final class ClickHouseAttributesGetter
     if (request.getSqlStatementInfo() == null) {
       return null;
     }
-    return request.getSqlStatementInfo().getOperation();
+    return request.getSqlStatementInfo().getOperationName();
   }
 
   @SuppressWarnings("deprecation") // using deprecated DbSystemIncubatingValues

--- a/instrumentation/couchbase/couchbase-2-common/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQuerySanitizerTest.java
+++ b/instrumentation/couchbase/couchbase-2-common/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQuerySanitizerTest.java
@@ -24,7 +24,7 @@ class CouchbaseQuerySanitizerTest {
   @ParameterizedTest
   @MethodSource("providesArguments")
   void testShouldNormalizeStringQuery(Parameter parameter) {
-    String normalized = CouchbaseQuerySanitizer.sanitize(parameter.query).getFullStatement();
+    String normalized = CouchbaseQuerySanitizer.sanitize(parameter.query).getQueryText();
     assertThat(normalized).isNotNull();
     // the analytics query ends up with trailing ';' in earlier couchbase version, but no trailing
     // ';' in later couchbase version

--- a/instrumentation/couchbase/couchbase-2-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-2-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseRequestInfo.java
@@ -47,7 +47,7 @@ public abstract class CouchbaseRequestInfo {
     SqlStatementInfo statement = CouchbaseQuerySanitizer.sanitize(query);
 
     return new AutoValue_CouchbaseRequestInfo(
-        bucket, statement.getFullStatement(), statement.getOperation(), false);
+        bucket, statement.getQueryText(), statement.getOperationName(), false);
   }
 
   private static String computeOperation(Class<?> declaringClass, String methodName) {

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
@@ -32,7 +32,7 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   @Nullable
   public String getDbQueryText(GeodeRequest request) {
     // sanitized statement is cached
-    return sanitizer.sanitize(request.getQuery()).getFullStatement();
+    return sanitizer.sanitize(request.getQuery()).getQueryText();
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/OperationNameUtil.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/OperationNameUtil.java
@@ -20,8 +20,8 @@ public final class OperationNameUtil {
     // operation name
     String operation = "Hibernate Query";
     SqlStatementInfo info = sanitizer.sanitize(query);
-    if (info.getOperation() != null) {
-      operation = info.getOperation();
+    if (info.getOperationName() != null) {
+      operation = info.getOperationName();
       if (info.getMainIdentifier() != null) {
         operation += " " + info.getMainIdentifier();
       }

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
@@ -13,7 +13,7 @@ final class InfluxDbAttributesGetter implements DbClientAttributesGetter<InfluxD
   @Nullable
   @Override
   public String getDbQueryText(InfluxDbRequest request) {
-    return request.getSqlStatementInfo().getFullStatement();
+    return request.getSqlStatementInfo().getQueryText();
   }
 
   @Nullable
@@ -22,7 +22,7 @@ final class InfluxDbAttributesGetter implements DbClientAttributesGetter<InfluxD
     if (request.getOperation() != null) {
       return request.getOperation();
     }
-    return request.getSqlStatementInfo().getOperation();
+    return request.getSqlStatementInfo().getOperationName();
   }
 
   @Override


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12608

Update terminology to match stable semconv:
- SqlStatementInfo: fullStatement → queryText, operation → operationName
- MultiQuery: operation → operationName
