### PR TITLE
Implement `db.stored_procedure.name` stable semconv attribute

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -12,26 +12,34 @@ import javax.annotation.Nullable;
 
 class MultiQuery {
 
-  @Nullable private final String mainIdentifier;
+  @Nullable private final String collectionName;
+  @Nullable private final String storedProcedureName;
   @Nullable private final String operationName;
   private final Set<String> queryTexts;
 
   private MultiQuery(
-      @Nullable String mainIdentifier, @Nullable String operationName, Set<String> queryTexts) {
-    this.mainIdentifier = mainIdentifier;
+      @Nullable String collectionName,
+      @Nullable String storedProcedureName,
+      @Nullable String operationName,
+      Set<String> queryTexts) {
+    this.collectionName = collectionName;
+    this.storedProcedureName = storedProcedureName;
     this.operationName = operationName;
     this.queryTexts = queryTexts;
   }
 
   static MultiQuery analyze(
       Collection<String> rawQueryTexts, boolean statementSanitizationEnabled) {
-    UniqueValue uniqueMainIdentifier = new UniqueValue();
+    UniqueValue uniqueCollectionName = new UniqueValue();
+    UniqueValue uniqueStoredProcedureName = new UniqueValue();
     UniqueValue uniqueOperationName = new UniqueValue();
     Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     for (String rawQueryText : rawQueryTexts) {
       SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-      String mainIdentifier = sanitizedStatement.getMainIdentifier();
-      uniqueMainIdentifier.set(mainIdentifier);
+      String collectionName = sanitizedStatement.getCollectionName();
+      uniqueCollectionName.set(collectionName);
+      String storedProcedureName = sanitizedStatement.getStoredProcedureName();
+      uniqueStoredProcedureName.set(storedProcedureName);
       String operationName = sanitizedStatement.getOperationName();
       uniqueOperationName.set(operationName);
       uniqueQueryTexts.add(
@@ -39,12 +47,29 @@ class MultiQuery {
     }
 
     return new MultiQuery(
-        uniqueMainIdentifier.getValue(), uniqueOperationName.getValue(), uniqueQueryTexts);
+        uniqueCollectionName.getValue(),
+        uniqueStoredProcedureName.getValue(),
+        uniqueOperationName.getValue(),
+        uniqueQueryTexts);
   }
 
   @Nullable
+  public String getCollectionName() {
+    return collectionName;
+  }
+
+  @Nullable
+  public String getStoredProcedureName() {
+    return storedProcedureName;
+  }
+
+  /**
+   * @deprecated Use {@link #getCollectionName()} or {@link #getStoredProcedureName()} instead.
+   */
+  @Deprecated
+  @Nullable
   public String getMainIdentifier() {
-    return mainIdentifier;
+    return collectionName != null ? collectionName : storedProcedureName;
   }
 
   @Nullable

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -59,8 +60,6 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     return new SqlClientAttributesExtractorBuilder<>(getter);
   }
 
-  private static final String SQL_CALL = "CALL";
-
   private final SqlClientAttributesGetter<REQUEST, RESPONSE> getter;
   private final InternalNetworkAttributesExtractor<REQUEST, RESPONSE> internalNetworkExtractor;
   private final ServerAttributesExtractor<REQUEST, RESPONSE> serverAttributesExtractor;
@@ -100,9 +99,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
             DB_STATEMENT,
             statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(attributes, DB_OPERATION, operationName);
-        if (!SQL_CALL.equals(operationName)) {
-          internalSet(attributes, oldSemconvTableAttribute, sanitizedStatement.getMainIdentifier());
-        }
+        internalSet(attributes, oldSemconvTableAttribute, sanitizedStatement.getCollectionName());
       }
     }
 
@@ -120,9 +117,9 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
             statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(
             attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operationName : operationName);
-        if (!SQL_CALL.equals(operationName)) {
-          internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getMainIdentifier());
-        }
+        internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getCollectionName());
+        internalSet(
+            attributes, DB_STORED_PROCEDURE_NAME, sanitizedStatement.getStoredProcedureName());
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =
             MultiQuery.analyze(getter.getRawQueryTexts(request), statementSanitizationEnabled);
@@ -133,12 +130,8 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
                 ? "BATCH " + multiQuery.getOperationName()
                 : "BATCH";
         internalSet(attributes, DB_OPERATION_NAME, operationName);
-
-        if (multiQuery.getMainIdentifier() != null
-            && (multiQuery.getOperationName() == null
-                || !SQL_CALL.equals(multiQuery.getOperationName()))) {
-          internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getMainIdentifier());
-        }
+        internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getCollectionName());
+        internalSet(attributes, DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
       }
     }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
@@ -11,9 +11,11 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class SqlStatementInfo {
 
+  private static final String SQL_CALL = "CALL";
+
   public static SqlStatementInfo create(
-      @Nullable String queryText, @Nullable String operationName, @Nullable String mainIdentifier) {
-    return new AutoValue_SqlStatementInfo(queryText, operationName, mainIdentifier);
+      @Nullable String queryText, @Nullable String operationName, @Nullable String target) {
+    return new AutoValue_SqlStatementInfo(queryText, operationName, target);
   }
 
   @Nullable
@@ -40,6 +42,31 @@ public abstract class SqlStatementInfo {
     return getOperationName();
   }
 
+  /**
+   * Returns the table/collection name, or null for CALL operations.
+   *
+   * @see #getStoredProcedureName()
+   */
   @Nullable
-  public abstract String getMainIdentifier();
+  public String getCollectionName() {
+    return SQL_CALL.equals(getOperationName()) ? null : getTarget();
+  }
+
+  /** Returns the stored procedure name for CALL operations, or null for other operations. */
+  @Nullable
+  public String getStoredProcedureName() {
+    return SQL_CALL.equals(getOperationName()) ? getTarget() : null;
+  }
+
+  /**
+   * @deprecated Use {@link #getCollectionName()} or {@link #getStoredProcedureName()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getMainIdentifier() {
+    return getCollectionName() != null ? getCollectionName() : getStoredProcedureName();
+  }
+
+  @Nullable
+  abstract String getTarget();
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -39,7 +39,9 @@ class SqlStatementSanitizerTest {
     SqlStatementInfo expected = expectedFunction.apply(original);
     assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
     assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
-    assertThat(result.getMainIdentifier()).isEqualToIgnoringCase(expected.getMainIdentifier());
+    assertThat(result.getCollectionName()).isEqualToIgnoringCase(expected.getCollectionName());
+    assertThat(result.getStoredProcedureName())
+        .isEqualToIgnoringCase(expected.getStoredProcedureName());
   }
 
   @ParameterizedTest
@@ -88,7 +90,8 @@ class SqlStatementSanitizerTest {
     SqlStatementInfo expected = expectFunc.apply(actual);
     assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
     assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
-    assertThat(result.getMainIdentifier()).isEqualTo(expected.getMainIdentifier());
+    assertThat(result.getCollectionName()).isEqualTo(expected.getCollectionName());
+    assertThat(result.getStoredProcedureName()).isEqualTo(expected.getStoredProcedureName());
   }
 
   @Test

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/OperationNameUtil.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/OperationNameUtil.java
@@ -22,8 +22,10 @@ public final class OperationNameUtil {
     SqlStatementInfo info = sanitizer.sanitize(query);
     if (info.getOperationName() != null) {
       operation = info.getOperationName();
-      if (info.getMainIdentifier() != null) {
-        operation += " " + info.getMainIdentifier();
+      if (info.getCollectionName() != null) {
+        operation += " " + info.getCollectionName();
+      } else if (info.getStoredProcedureName() != null) {
+        operation += " " + info.getStoredProcedureName();
       }
     }
     return operation;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.javaagent.instrumentation.hibernate.ExperimentalT
 import static io.opentelemetry.javaagent.instrumentation.hibernate.ExperimentalTestHelper.experimental;
 import static io.opentelemetry.javaagent.instrumentation.hibernate.ExperimentalTestHelper.experimentalSatisfies;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -129,7 +130,10 @@ class ProcedureCallTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "hsqldb:mem:"),
-                            equalTo(maybeStable(DB_OPERATION), "CALL")),
+                            equalTo(maybeStable(DB_OPERATION), "CALL"),
+                            equalTo(
+                                DB_STORED_PROCEDURE_NAME,
+                                emitStableDatabaseSemconv() ? "TEST_PROC" : null)),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
@@ -356,7 +357,17 @@ public abstract class AbstractJdbcInstrumentationTest {
             "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS",
             "SELECT INFORMATION_SCHEMA.SYSTEM_USERS",
             "hsqldb:mem:",
-            "INFORMATION_SCHEMA.SYSTEM_USERS"));
+            "INFORMATION_SCHEMA.SYSTEM_USERS"),
+        // stored procedure test
+        Arguments.of(
+            "h2",
+            new org.h2.Driver().connect(jdbcUrls.get("h2"), null),
+            null,
+            "CALL ABS(-3)",
+            "CALL ABS(?)",
+            "CALL " + dbNameLower + ".ABS",
+            "h2:mem:",
+            null));
   }
 
   @ParameterizedTest
@@ -379,6 +390,7 @@ public abstract class AbstractJdbcInstrumentationTest {
     resultSet.next();
     assertThat(resultSet.getInt(1)).isEqualTo(3);
 
+    boolean isCallStatement = query.toUpperCase(Locale.ROOT).startsWith("CALL");
     testing()
         .waitAndAssertTraces(
             trace ->
@@ -395,8 +407,14 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 equalTo(
                                     DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
                                 equalTo(maybeStable(DB_STATEMENT), sanitizedQuery),
-                                equalTo(maybeStable(DB_OPERATION), "SELECT"),
-                                equalTo(maybeStable(DB_SQL_TABLE), table))));
+                                equalTo(
+                                    maybeStable(DB_OPERATION), isCallStatement ? "CALL" : "SELECT"),
+                                equalTo(maybeStable(DB_SQL_TABLE), table),
+                                equalTo(
+                                    DB_STORED_PROCEDURE_NAME,
+                                    isCallStatement && emitStableDatabaseSemconv()
+                                        ? "ABS"
+                                        : null))));
 
     if (table != null) {
       assertDurationMetric(
@@ -485,7 +503,17 @@ public abstract class AbstractJdbcInstrumentationTest {
             "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
-            "SYSIBM.SYSDUMMY1"));
+            "SYSIBM.SYSDUMMY1"),
+        // stored procedure test
+        Arguments.of(
+            "h2",
+            new org.h2.Driver().connect(jdbcUrls.get("h2"), null),
+            null,
+            "CALL ABS(-3)",
+            "CALL ABS(?)",
+            "CALL " + dbNameLower + ".ABS",
+            "h2:mem:",
+            null));
   }
 
   @ParameterizedTest
@@ -515,6 +543,7 @@ public abstract class AbstractJdbcInstrumentationTest {
     resultSet.next();
     assertThat(resultSet.getInt(1)).isEqualTo(3);
 
+    boolean isCallStatement = query.toUpperCase(Locale.ROOT).startsWith("CALL");
     testing()
         .waitAndAssertTraces(
             trace ->
@@ -531,8 +560,14 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 equalTo(
                                     DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
                                 equalTo(maybeStable(DB_STATEMENT), sanitizedQuery),
-                                equalTo(maybeStable(DB_OPERATION), "SELECT"),
-                                equalTo(maybeStable(DB_SQL_TABLE), table))));
+                                equalTo(
+                                    maybeStable(DB_OPERATION), isCallStatement ? "CALL" : "SELECT"),
+                                equalTo(maybeStable(DB_SQL_TABLE), table),
+                                equalTo(
+                                    DB_STORED_PROCEDURE_NAME,
+                                    isCallStatement && emitStableDatabaseSemconv()
+                                        ? "ABS"
+                                        : null))));
   }
 
   @ParameterizedTest
@@ -555,6 +590,7 @@ public abstract class AbstractJdbcInstrumentationTest {
     resultSet.next();
     assertThat(resultSet.getInt(1)).isEqualTo(3);
 
+    boolean isCallStatement = query.toUpperCase(Locale.ROOT).startsWith("CALL");
     testing()
         .waitAndAssertTraces(
             trace ->
@@ -571,8 +607,14 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 equalTo(
                                     DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
                                 equalTo(maybeStable(DB_STATEMENT), sanitizedQuery),
-                                equalTo(maybeStable(DB_OPERATION), "SELECT"),
-                                equalTo(maybeStable(DB_SQL_TABLE), table))));
+                                equalTo(
+                                    maybeStable(DB_OPERATION), isCallStatement ? "CALL" : "SELECT"),
+                                equalTo(maybeStable(DB_SQL_TABLE), table),
+                                equalTo(
+                                    DB_STORED_PROCEDURE_NAME,
+                                    isCallStatement && emitStableDatabaseSemconv()
+                                        ? "ABS"
+                                        : null))));
   }
 
   @ParameterizedTest
@@ -595,6 +637,7 @@ public abstract class AbstractJdbcInstrumentationTest {
     resultSet.next();
     assertThat(resultSet.getInt(1)).isEqualTo(3);
 
+    boolean isCallStatement = query.toUpperCase(Locale.ROOT).startsWith("CALL");
     testing()
         .waitAndAssertTraces(
             trace ->
@@ -611,8 +654,14 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 equalTo(
                                     DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
                                 equalTo(maybeStable(DB_STATEMENT), sanitizedQuery),
-                                equalTo(maybeStable(DB_OPERATION), "SELECT"),
-                                equalTo(maybeStable(DB_SQL_TABLE), table))));
+                                equalTo(
+                                    maybeStable(DB_OPERATION), isCallStatement ? "CALL" : "SELECT"),
+                                equalTo(maybeStable(DB_SQL_TABLE), table),
+                                equalTo(
+                                    DB_STORED_PROCEDURE_NAME,
+                                    isCallStatement && emitStableDatabaseSemconv()
+                                        ? "ABS"
+                                        : null))));
   }
 
   static Stream<Arguments> statementUpdateStream() throws SQLException {


### PR DESCRIPTION
Part of #12608
Resolves #15718

~Currently built on top of #15833~