### PR TITLE
Fix race condition in PekkoRouteHolder using synchronized

### DIFF
--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoRouteHolder.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoRouteHolder.java
@@ -33,7 +33,7 @@ public class PekkoRouteHolder implements ImplicitContextKeyed {
     return context.get(KEY);
   }
 
-  public void push(Uri.Path beforeMatch, Uri.Path afterMatch, String pathToPush) {
+  public synchronized void push(Uri.Path beforeMatch, Uri.Path afterMatch, String pathToPush) {
     // Only accept the suggested 'pathToPush' if:
     // - either this is the first match, or
     // - the unmatched part of the path from the previous match is what the current match
@@ -50,26 +50,26 @@ public class PekkoRouteHolder implements ImplicitContextKeyed {
     lastWasMatched = true;
   }
 
-  public void didNotMatch() {
+  public synchronized void didNotMatch() {
     lastWasMatched = false;
   }
 
-  public void pushIfNotCompletelyMatched(String pathToPush) {
+  public synchronized void pushIfNotCompletelyMatched(String pathToPush) {
     if (lastUnmatchedPath != null && !lastUnmatchedPath.isEmpty()) {
       route.append(pathToPush);
     }
   }
 
-  public String route() {
+  public synchronized String route() {
     return lastWasMatched ? route.toString() : null;
   }
 
-  public void save() {
+  public synchronized void save() {
     savedStates.add(new State(lastUnmatchedPath, route));
     route = new StringBuilder(route);
   }
 
-  public void restore() {
+  public synchronized void restore() {
     State popped = savedStates.pollLast();
     if (popped != null) {
       lastUnmatchedPath = popped.lastUnmatchedPath;

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoRouteHolder.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoRouteHolder.java
@@ -82,7 +82,7 @@ public class PekkoRouteHolder implements ImplicitContextKeyed {
     return context.with(KEY, this);
   }
 
-  private PekkoRouteHolder() {}
+  PekkoRouteHolder() {}
 
   private static class State {
     private final Uri.Path lastUnmatchedPath;

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoHttpConcurrencyTest.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoHttpConcurrencyTest.java
@@ -1,0 +1,44 @@
+package io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server.route;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+class PekkoHttpConcurrencyTest {
+
+  @Test
+  void testConcurrency() throws InterruptedException {
+   /* PekkoRouteHolder holder = new PekkoRouteHolder();
+    int threadCount = 50;
+    int iterations = 100000;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+    for (int i = 0; i < iterations; i++) {
+      executor.submit(() -> {
+        try {
+          holder.save();
+          holder.didNotMatch();
+          holder.pushIfNotCompletelyMatched("/test");
+          holder.route();
+          holder.restore();
+        } catch (RuntimeException e) {
+          errors.add(e);
+        }
+      });
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+    if (!errors.isEmpty()) {
+      for (Throwable t : errors) {
+        t.printStackTrace();
+      }
+    }
+    assertTrue(errors.isEmpty(), "Concurrency issue detected! Check logs.");
+  }*/
+}

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoHttpConcurrencyTest.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/route/PekkoHttpConcurrencyTest.java
@@ -1,44 +1,112 @@
 package io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server.route;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
-import org.junit.jupiter.api.Test;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import org.apache.pekko.http.scaladsl.model.Uri;
+import org.junit.jupiter.api.Test;
 
 class PekkoHttpConcurrencyTest {
 
   @Test
-  void testConcurrency() throws InterruptedException {
-   /* PekkoRouteHolder holder = new PekkoRouteHolder();
+  void sharedHolder_shouldCorruptState_underConcurrency() throws InterruptedException {
+
+    PekkoRouteHolder sharedHolder = new PekkoRouteHolder();
+
     int threadCount = 50;
-    int iterations = 100000;
+    int iterations = 10_000;
+
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(iterations);
 
     for (int i = 0; i < iterations; i++) {
       executor.submit(() -> {
         try {
-          holder.save();
-          holder.didNotMatch();
-          holder.pushIfNotCompletelyMatched("/test");
-          holder.route();
-          holder.restore();
-        } catch (RuntimeException e) {
+          start.await();
+
+          String myPath = "/test-" + Thread.currentThread().getId() + "-" + System.nanoTime();
+          Uri.Path before = null;
+          Uri.Path after = mock(Uri.Path.class);
+          sharedHolder.save();
+          sharedHolder.push(before, after, myPath);
+
+          String result = sharedHolder.route();
+          if (result == null || !result.contains(myPath)) {
+            errors.add(new IllegalStateException(
+                "Data interleaved. Expected [" + myPath + "] to be in [" + result + "]"));
+          }
+
+          sharedHolder.restore();
+
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           errors.add(e);
+        } catch (Throwable t) {
+          errors.add(t);
+        } finally {
+          done.countDown();
         }
       });
     }
 
-    executor.shutdown();
-    executor.awaitTermination(30, TimeUnit.SECONDS);
-    if (!errors.isEmpty()) {
-      for (Throwable t : errors) {
-        t.printStackTrace();
-      }
+    start.countDown();
+    done.await();
+    executor.shutdownNow();
+    assertTrue(errors.isEmpty(), "Shared holder corrupted! Errors: " + errors);
+  }
+
+  @Test
+  void perRequestHolder_shouldNotCorruptState_underConcurrency() throws InterruptedException {
+    int threadCount = 50;
+    int iterations = 10_000;
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(iterations);
+
+    for (int i = 0; i < iterations; i++) {
+      executor.submit(() -> {
+        try {
+          start.await();
+          PekkoRouteHolder holder = new PekkoRouteHolder();
+          String myPath = "/test-" + Thread.currentThread().getId() + "-" + System.nanoTime();
+
+          Uri.Path before = null;
+          Uri.Path after = mock(Uri.Path.class);
+
+          holder.save();
+          holder.push(before, after, myPath);
+
+          String result = holder.route();
+          if (result == null || !result.contains(myPath)) {
+            errors.add(new IllegalStateException("Unexpected corruption in per-request holder."));
+          }
+
+          holder.restore();
+
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          errors.add(e);
+        } catch (Throwable t) {
+          errors.add(t);
+        } finally {
+          done.countDown();
+        }
+      });
     }
-    assertTrue(errors.isEmpty(), "Concurrency issue detected! Check logs.");
-  }*/
+
+    start.countDown();
+    done.await();
+    executor.shutdownNow();
+    assertTrue(errors.isEmpty(), "Per-request holder should never be corrupted.");
+  }
 }


### PR DESCRIPTION
In Pekko HTTP’s asynchronous execution model, multiple threads may access the same PekkoRouteHolder instance concurrently.
The class previously relied on a non-thread-safe StringBuilder and mutable fields without synchronization, which allowed concurrent route-matching operations to corrupt internal state.

Changes

Added synchronized to all methods that mutate internal state in PekkoRouteHolder.

Ensured that route path updates and unmatched path state updates occur atomically.

Technical Rationale (Alternatives Considered)

- StringBuffer
StringBuffer synchronizes individual method calls, but it does not guarantee atomicity across multiple dependent state updates. Since the route path and unmatched path must be updated together to maintain consistency, this approach was insufficient to fully resolve the race condition.

- Immutable String
Using immutable String objects was also considered. However, frequent string concatenation during Pekko route matching would result in excessive object creation and increased GC pressure, negatively impacting performance.

- synchronized methods (chosen approach)
Synchronizing state-modifying methods ensures consistency across related fields with minimal structural changes. Given that route matching is not a hot path with heavy contention, the performance impact is negligible while fully addressing the race condition.

issue : https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15681