### PR TITLE
indy an early init setting that can't wait for declarative config bridge

### DIFF
--- a/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigPropertiesTest.java
+++ b/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigPropertiesTest.java
@@ -77,9 +77,9 @@ class ConfigPropertiesBackedDeclarativeConfigPropertiesTest {
 
   @Test
   void testAgentPrefix() {
-    DeclarativeConfigProperties config = createConfig("otel.javaagent.experimental.indy", "true");
+    DeclarativeConfigProperties config = createConfig("otel.javaagent.experimental.foo", "true");
 
-    assertThat(config.getStructured("java").getStructured("agent").getBoolean("indy/development"))
+    assertThat(config.getStructured("java").getStructured("agent").getBoolean("foo/development"))
         .isNotNull()
         .isTrue();
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
@@ -179,9 +180,7 @@ public abstract class InstrumentationModule implements Ordered {
     private static final boolean indyEnabled;
 
     static {
-      indyEnabled =
-          DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "agent")
-              .getBoolean("indy/development", false);
+      indyEnabled = ConfigPropertiesUtil.getBoolean("otel.javaagent.experimental.indy", false);
       if (indyEnabled) {
         logger.info("Enabled indy for instrumentation modules");
       }


### PR DESCRIPTION
I noticed that it's called from spring actuator

``` 
> opentelemetry-java-instrumentation/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0

gradle check                                           
```

```
> Task :instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagent:byteBuddyJava FAILED
```

with this change to check for early config state

```diff
Index: javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java	(revision 61be207a4a06b68895da9e570ada2d89ed07bd19)
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java	(date 1768288999068)
@@ -10,6 +10,8 @@
 import static net.bytebuddy.matcher.ElementMatchers.any;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -180,6 +182,12 @@
     private static final boolean indyEnabled;
 
     static {
+      OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+      if (!(openTelemetry instanceof ExtendedOpenTelemetry)) {
+        String msg =
+            "OpenTelemetry instance is not an ExtendedOpenTelemetry, indy instrumentation disabled";
+        throw new ConfigurationException(msg);
+      }
       indyEnabled = ConfigPropertiesUtil.getBoolean("otel.javaagent.experimental.indy", false);
       if (indyEnabled) {
         logger.info("Enabled indy for instrumentation modules");
```