### PR TITLE
Add more disk space cleanup

### DIFF
--- a/.github/scripts/gha-free-disk-space.sh
+++ b/.github/scripts/gha-free-disk-space.sh
@@ -8,4 +8,5 @@ sudo rm -rf /usr/local/lib/android
 sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/local/julia*
 sudo rm -rf /usr/share/swift
+sudo rm -rf /usr/local/.ghcup
 df -h


### PR DESCRIPTION
Removes a [haskell utility](https://www.haskell.org/ghcup/) and frees up another ~7GB of disk space

[Current cleanup runs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/20930730369/job/60140671191?pr=15836):

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   35G   37G  49% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

[Cleanup with this change](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/20934511317/job/60153587543?pr=15851):

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   28G   44G  39% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```