### PR TITLE
Skip query sanitization for prepared statements under stable semconv flag

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
@@ -99,6 +100,11 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     }
 
     if (SemconvStability.emitStableDatabaseSemconv()) {
+      if (isBatch) {
+        internalSet(attributes, DB_OPERATION_BATCH_SIZE, batchSize);
+      }
+      boolean parameterizedQuery = getter.isParameterizedQuery(request);
+      boolean shouldSanitize = statementSanitizationEnabled && !parameterizedQuery;
       if (rawQueryTexts.size() == 1) {
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
@@ -106,7 +112,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         internalSet(
             attributes,
             DB_QUERY_TEXT,
-            statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
+            shouldSanitize ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(
             attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operationName : operationName);
         internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getCollectionName());
@@ -114,7 +120,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
             attributes, DB_STORED_PROCEDURE_NAME, sanitizedStatement.getStoredProcedureName());
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =
-            MultiQuery.analyze(getter.getRawQueryTexts(request), statementSanitizationEnabled);
+            MultiQuery.analyze(getter.getRawQueryTexts(request), shouldSanitize);
         internalSet(attributes, DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         internalSet(attributes, DB_OPERATION_NAME, multiQuery.getOperationName());
         internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getCollectionName());

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
@@ -92,4 +92,17 @@ public interface SqlClientAttributesGetter<REQUEST, RESPONSE>
   default Map<String, String> getDbQueryParameters(REQUEST request) {
     return getQueryParameters(request);
   }
+
+  /**
+   * Returns whether the query is parameterized. Prepared statements are always considered
+   * parameterized even if no parameters are bound. By using a parameterized query the user is
+   * giving a strong signal that any sensitive data will be passed as parameter values, and so the
+   * query does not need to be sanitized. See <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sanitization-of-dbquerytext">sanitization
+   * of db.query.text</a>.
+   */
+  // TODO: make this required to implement
+  default boolean isParameterizedQuery(REQUEST request) {
+    return false;
+  }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -11,11 +11,14 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class CassandraRequest {
 
-  public static CassandraRequest create(Session session, String queryText) {
-    return new AutoValue_CassandraRequest(session, queryText);
+  public static CassandraRequest create(
+      Session session, String queryText, boolean parameterizedQuery) {
+    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
   }
 
   public abstract Session getSession();
 
   public abstract String getQueryText();
+
+  public abstract boolean isParameterizedQuery();
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
@@ -40,4 +40,9 @@ final class CassandraSqlAttributesGetter
       CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     return executionInfo == null ? null : executionInfo.getQueriedHost().getSocketAddress();
   }
+
+  @Override
+  public boolean isParameterizedQuery(CassandraRequest request) {
+    return request.isParameterizedQuery();
+  }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
@@ -48,7 +48,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSet execute(String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -63,7 +63,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSet execute(String query, Object... values) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, values.length > 0);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -78,7 +78,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSet execute(String query, Map<String, Object> values) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, !values.isEmpty());
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -94,7 +94,8 @@ public class TracingSession implements Session {
   @Override
   public ResultSet execute(Statement statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -109,7 +110,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSetFuture executeAsync(String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(query);
@@ -120,7 +121,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSetFuture executeAsync(String query, Object... values) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, values.length > 0);
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(query, values);
@@ -131,7 +132,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSetFuture executeAsync(String query, Map<String, Object> values) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, !values.isEmpty());
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(query, values);
@@ -143,7 +144,8 @@ public class TracingSession implements Session {
   @Override
   public ResultSetFuture executeAsync(Statement statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(statement);

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
@@ -11,11 +11,14 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class CassandraRequest {
 
-  public static CassandraRequest create(Session session, String queryText) {
-    return new AutoValue_CassandraRequest(session, queryText);
+  public static CassandraRequest create(
+      Session session, String queryText, boolean parameterizedQuery) {
+    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
   }
 
   public abstract Session getSession();
 
   public abstract String getQueryText();
+
+  public abstract boolean isParameterizedQuery();
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
@@ -53,4 +53,9 @@ final class CassandraSqlAttributesGetter
     SocketAddress address = coordinator.getEndPoint().resolve();
     return address instanceof InetSocketAddress ? (InetSocketAddress) address : null;
   }
+
+  @Override
+  public boolean isParameterizedQuery(CassandraRequest request) {
+    return request.isParameterizedQuery();
+  }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
@@ -71,7 +71,7 @@ final class TracingCqlSession {
   }
 
   private static ResultSet execute(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -86,7 +86,8 @@ final class TracingCqlSession {
 
   private static ResultSet execute(CqlSession session, Statement<?> statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -102,12 +103,13 @@ final class TracingCqlSession {
   private static CompletionStage<AsyncResultSet> executeAsync(
       CqlSession session, Statement<?> statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     return executeAsync(request, () -> session.executeAsync(statement));
   }
 
   private static CompletionStage<AsyncResultSet> executeAsync(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     return executeAsync(request, () -> session.executeAsync(query));
   }
 

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -11,11 +11,14 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class CassandraRequest {
 
-  public static CassandraRequest create(Session session, String queryText) {
-    return new AutoValue_CassandraRequest(session, queryText);
+  public static CassandraRequest create(
+      Session session, String queryText, boolean parameterizedQuery) {
+    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
   }
 
   public abstract Session getSession();
 
   public abstract String getQueryText();
+
+  public abstract boolean isParameterizedQuery();
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
@@ -56,4 +56,9 @@ final class CassandraSqlAttributesGetter
     }
     return null;
   }
+
+  @Override
+  public boolean isParameterizedQuery(CassandraRequest request) {
+    return request.isParameterizedQuery();
+  }
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/TracingCqlSession.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/TracingCqlSession.java
@@ -86,7 +86,7 @@ final class TracingCqlSession {
   }
 
   private ResultSet execute(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     Context context = instrumenter.start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -101,7 +101,8 @@ final class TracingCqlSession {
 
   private ResultSet execute(CqlSession session, Statement<?> statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     Context context = instrumenter.start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -116,12 +117,13 @@ final class TracingCqlSession {
 
   private CompletionStage<AsyncResultSet> executeAsync(CqlSession session, Statement<?> statement) {
     String query = getQuery(statement);
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request =
+        CassandraRequest.create(session, query, statement instanceof BoundStatement);
     return executeAsync(request, () -> session.executeAsync(statement));
   }
 
   private CompletionStage<AsyncResultSet> executeAsync(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query);
+    CassandraRequest request = CassandraRequest.create(session, query, false);
     return executeAsync(request, () -> session.executeAsync(query));
   }
 

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
@@ -78,13 +78,14 @@ public class JdbcAdviceScope {
       }
       Long batchSize = JdbcData.getPreparedStatementBatchSize((PreparedStatement) statement);
       Map<String, String> parameters = JdbcData.getParameters((PreparedStatement) statement);
-      return DbRequest.create(statement, sql, batchSize, parameters);
+      return DbRequest.create(statement, sql, batchSize, parameters, true);
     } else {
       JdbcData.StatementBatchInfo batchInfo = JdbcData.getStatementBatchInfo(statement);
       if (batchInfo == null) {
         return DbRequest.create(statement, null);
       } else {
-        return DbRequest.create(statement, batchInfo.getStatements(), batchInfo.getBatchSize());
+        return DbRequest.create(
+            statement, batchInfo.getStatements(), batchInfo.getBatchSize(), false);
       }
     }
   }

--- a/instrumentation/jdbc/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/SlickTest.scala
+++ b/instrumentation/jdbc/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/SlickTest.scala
@@ -97,7 +97,11 @@ class SlickTest {
                       DB_CONNECTION_STRING,
                       if (emitStableDatabaseSemconv()) null else "h2:mem:"
                     ),
-                    equalTo(maybeStable(DB_STATEMENT), "SELECT ?"),
+                    equalTo(
+                      maybeStable(DB_STATEMENT),
+                      if (emitStableDatabaseSemconv()) "SELECT 3"
+                      else "SELECT ?"
+                    ),
                     equalTo(maybeStable(DB_OPERATION), "SELECT")
                   )
             }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DbRequest.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DbRequest.java
@@ -30,20 +30,16 @@ public abstract class DbRequest {
   public static DbRequest create(
       PreparedStatement statement, Map<String, String> preparedStatementParameters) {
     return create(
-        statement, JdbcData.preparedStatement.get(statement), preparedStatementParameters);
+        statement,
+        JdbcData.preparedStatement.get(statement),
+        null,
+        preparedStatementParameters,
+        true);
   }
 
   @Nullable
   public static DbRequest create(Statement statement, String dbStatementString) {
-    return create(statement, dbStatementString, null, emptyMap());
-  }
-
-  @Nullable
-  private static DbRequest create(
-      Statement statement,
-      String dbStatementString,
-      Map<String, String> preparedStatementParameters) {
-    return create(statement, dbStatementString, null, preparedStatementParameters);
+    return create(statement, dbStatementString, null, emptyMap(), false);
   }
 
   @Nullable
@@ -51,45 +47,60 @@ public abstract class DbRequest {
       Statement statement,
       String dbStatementString,
       Long batchSize,
-      Map<String, String> preparedStatementParameters) {
+      Map<String, String> preparedStatementParameters,
+      boolean parameterizedQuery) {
     Connection connection = connectionFromStatement(statement);
     if (connection == null) {
       return null;
     }
 
     return create(
-        extractDbInfo(connection), dbStatementString, batchSize, preparedStatementParameters);
+        extractDbInfo(connection),
+        dbStatementString,
+        batchSize,
+        preparedStatementParameters,
+        parameterizedQuery);
   }
 
   public static DbRequest create(
-      Statement statement, Collection<String> queryTexts, Long batchSize) {
+      Statement statement,
+      Collection<String> queryTexts,
+      Long batchSize,
+      boolean parameterizedQuery) {
     Connection connection = connectionFromStatement(statement);
     if (connection == null) {
       return null;
     }
 
-    return create(extractDbInfo(connection), queryTexts, batchSize, emptyMap());
+    return create(extractDbInfo(connection), queryTexts, batchSize, emptyMap(), parameterizedQuery);
   }
 
-  public static DbRequest create(DbInfo dbInfo, String queryText) {
-    return create(dbInfo, queryText, null, emptyMap());
+  public static DbRequest create(DbInfo dbInfo, String queryText, boolean parameterizedQuery) {
+    return create(dbInfo, queryText, null, emptyMap(), parameterizedQuery);
   }
 
   public static DbRequest create(
       DbInfo dbInfo,
       String queryText,
       Long batchSize,
-      Map<String, String> preparedStatementParameters) {
+      Map<String, String> preparedStatementParameters,
+      boolean parameterizedQuery) {
     return create(
-        dbInfo, Collections.singletonList(queryText), batchSize, preparedStatementParameters);
+        dbInfo,
+        Collections.singletonList(queryText),
+        batchSize,
+        preparedStatementParameters,
+        parameterizedQuery);
   }
 
   public static DbRequest create(
       DbInfo dbInfo,
       Collection<String> queryTexts,
       Long batchSize,
-      Map<String, String> preparedStatementParameters) {
-    return create(dbInfo, queryTexts, batchSize, null, preparedStatementParameters);
+      Map<String, String> preparedStatementParameters,
+      boolean parameterizedQuery) {
+    return create(
+        dbInfo, queryTexts, batchSize, null, preparedStatementParameters, parameterizedQuery);
   }
 
   private static DbRequest create(
@@ -97,9 +108,10 @@ public abstract class DbRequest {
       Collection<String> queryTexts,
       Long batchSize,
       String operation,
-      Map<String, String> preparedStatementParameters) {
+      Map<String, String> preparedStatementParameters,
+      boolean parameterizedQuery) {
     return new AutoValue_DbRequest(
-        dbInfo, queryTexts, batchSize, operation, preparedStatementParameters);
+        dbInfo, queryTexts, batchSize, operation, preparedStatementParameters, parameterizedQuery);
   }
 
   @Nullable
@@ -113,7 +125,7 @@ public abstract class DbRequest {
   }
 
   public static DbRequest createTransaction(DbInfo dbInfo, String operation) {
-    return create(dbInfo, Collections.emptyList(), null, operation, emptyMap());
+    return create(dbInfo, Collections.emptyList(), null, operation, emptyMap(), false);
   }
 
   public abstract DbInfo getDbInfo();
@@ -128,4 +140,6 @@ public abstract class DbRequest {
   public abstract String getOperation();
 
   public abstract Map<String, String> getPreparedStatementParameters();
+
+  public abstract boolean isParameterizedQuery();
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -71,6 +71,11 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
     return request.getPreparedStatementParameters();
   }
 
+  @Override
+  public boolean isParameterizedQuery(DbRequest request) {
+    return request.isParameterizedQuery();
+  }
+
   @Nullable
   @Override
   public String getServerAddress(DbRequest request) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -429,12 +429,12 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
   @Override
   protected <T, E extends Exception> T wrapCall(String sql, ThrowingSupplier<T, E> callable)
       throws E {
-    DbRequest request = DbRequest.create(dbInfo, sql, null, parameters);
+    DbRequest request = DbRequest.create(dbInfo, sql, null, parameters, true);
     return wrapCall(request, callable);
   }
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
-    DbRequest request = DbRequest.create(dbInfo, query, batchSize, parameters);
+    DbRequest request = DbRequest.create(dbInfo, query, batchSize, parameters, true);
     return wrapCall(request, callable);
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
@@ -384,7 +384,7 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
 
   protected <T, E extends Exception> T wrapCall(String sql, ThrowingSupplier<T, E> callable)
       throws E {
-    DbRequest request = DbRequest.create(dbInfo, sql);
+    DbRequest request = DbRequest.create(dbInfo, sql, false);
     return wrapCall(request, callable);
   }
 
@@ -409,7 +409,8 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
   }
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
-    DbRequest request = DbRequest.create(dbInfo, batchCommands, batchSize, Collections.emptyMap());
+    DbRequest request =
+        DbRequest.create(dbInfo, batchCommands, batchSize, Collections.emptyMap(), false);
     return wrapCall(request, callable);
   }
 }

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -437,7 +437,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             new org.h2.Driver().connect(jdbcUrls.get("h2"), null),
             null,
             "SELECT 3",
-            "SELECT ?",
+            emitStableDatabaseSemconv() ? "SELECT 3" : "SELECT ?",
             "SELECT " + dbNameLower,
             "h2:mem:",
             null),
@@ -446,7 +446,9 @@ public abstract class AbstractJdbcInstrumentationTest {
             new EmbeddedDriver().connect(jdbcUrls.get("derby"), null),
             "APP",
             "SELECT 3 FROM SYSIBM.SYSDUMMY1",
-            "SELECT ? FROM SYSIBM.SYSDUMMY1",
+            emitStableDatabaseSemconv()
+                ? "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+                : "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
             "SYSIBM.SYSDUMMY1"),
@@ -455,7 +457,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("tomcat").get("h2").getConnection(),
             null,
             "SELECT 3",
-            "SELECT ?",
+            emitStableDatabaseSemconv() ? "SELECT 3" : "SELECT ?",
             "SELECT " + dbNameLower,
             "h2:mem:",
             null),
@@ -464,7 +466,9 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("tomcat").get("derby").getConnection(),
             "APP",
             "SELECT 3 FROM SYSIBM.SYSDUMMY1",
-            "SELECT ? FROM SYSIBM.SYSDUMMY1",
+            emitStableDatabaseSemconv()
+                ? "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+                : "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
             "SYSIBM.SYSDUMMY1"),
@@ -473,7 +477,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("hikari").get("h2").getConnection(),
             null,
             "SELECT 3",
-            "SELECT ?",
+            emitStableDatabaseSemconv() ? "SELECT 3" : "SELECT ?",
             "SELECT " + dbNameLower,
             "h2:mem:",
             null),
@@ -482,7 +486,9 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("hikari").get("derby").getConnection(),
             "APP",
             "SELECT 3 FROM SYSIBM.SYSDUMMY1",
-            "SELECT ? FROM SYSIBM.SYSDUMMY1",
+            emitStableDatabaseSemconv()
+                ? "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+                : "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
             "SYSIBM.SYSDUMMY1"),
@@ -491,7 +497,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("c3p0").get("h2").getConnection(),
             null,
             "SELECT 3",
-            "SELECT ?",
+            emitStableDatabaseSemconv() ? "SELECT 3" : "SELECT ?",
             "SELECT " + dbNameLower,
             "h2:mem:",
             null),
@@ -500,7 +506,9 @@ public abstract class AbstractJdbcInstrumentationTest {
             cpDatasources.get("c3p0").get("derby").getConnection(),
             "APP",
             "SELECT 3 FROM SYSIBM.SYSDUMMY1",
-            "SELECT ? FROM SYSIBM.SYSDUMMY1",
+            emitStableDatabaseSemconv()
+                ? "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+                : "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
             "SYSIBM.SYSDUMMY1"),
@@ -510,7 +518,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             new org.h2.Driver().connect(jdbcUrls.get("h2"), null),
             null,
             "CALL ABS(-3)",
-            "CALL ABS(?)",
+            emitStableDatabaseSemconv() ? "CALL ABS(-3)" : "CALL ABS(?)",
             emitStableDatabaseSemconv() ? "CALL ABS" : "CALL " + dbNameLower + ".ABS",
             "h2:mem:",
             null));
@@ -1052,7 +1060,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             "jdbc:h2:mem:" + dbName,
             null,
             "SELECT 3;",
-            "SELECT ?;",
+            emitStableDatabaseSemconv() ? "SELECT 3;" : "SELECT ?;",
             "SELECT " + dbNameLower,
             "h2:mem:",
             null),
@@ -1063,7 +1071,9 @@ public abstract class AbstractJdbcInstrumentationTest {
             "jdbc:derby:memory:" + dbName + ";create=true",
             "APP",
             "SELECT 3 FROM SYSIBM.SYSDUMMY1",
-            "SELECT ? FROM SYSIBM.SYSDUMMY1",
+            emitStableDatabaseSemconv()
+                ? "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+                : "SELECT ? FROM SYSIBM.SYSDUMMY1",
             "SELECT SYSIBM.SYSDUMMY1",
             "derby:memory:",
             "SYSIBM.SYSDUMMY1"),
@@ -1398,7 +1408,9 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 emitStableDatabaseSemconv() ? null : "hsqldb:mem:"),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"),
+                                emitStableDatabaseSemconv()
+                                    ? "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
+                                    : "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"),
                             equalTo(maybeStable(DB_OPERATION), "SELECT"),
                             equalTo(maybeStable(DB_SQL_TABLE), "INFORMATION_SCHEMA.SYSTEM_USERS")));
     for (int i = 0; i < numQueries; i++) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -35,6 +35,7 @@ public final class DbExecution {
   private final Integer port;
   private final String connectionString;
   private final String rawQueryText;
+  private final boolean parameterizedQuery;
 
   private Context context;
 
@@ -73,6 +74,9 @@ public final class DbExecution {
                 query ->
                     R2dbcSqlCommenterUtil.getOriginalQuery(queryInfo.getConnectionInfo(), query))
             .collect(Collectors.joining(";\n"));
+    this.parameterizedQuery =
+        queryInfo.getQueries().stream()
+            .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());
     R2dbcSqlCommenterUtil.clearQueries(queryInfo.getConnectionInfo());
   }
 
@@ -102,6 +106,10 @@ public final class DbExecution {
 
   public String getRawQueryText() {
     return rawQueryText;
+  }
+
+  public boolean isParameterizedQuery() {
+    return parameterizedQuery;
   }
 
   public Context getContext() {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -69,4 +69,9 @@ public enum R2dbcSqlAttributesGetter implements SqlClientAttributesGetter<DbExec
   public Integer getServerPort(DbExecution request) {
     return request.getPort();
   }
+
+  @Override
+  public boolean isParameterizedQuery(DbExecution request) {
+    return request.isParameterizedQuery();
+  }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryExecutorInstrumentation.java
@@ -84,6 +84,7 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
         // PreparedStatement, use the first argument that is either of these. PromiseInternal is
         // always at the end of the argument list.
         String sql = null;
+        boolean preparedStatement = false;
         PromiseInternal<?> promiseInternal = null;
         for (Object argument : arguments) {
           if (sql == null) {
@@ -91,6 +92,7 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
               sql = (String) argument;
             } else if (argument instanceof PreparedStatement) {
               sql = ((PreparedStatement) argument).sql();
+              preparedStatement = true;
             }
           } else if (argument instanceof PromiseInternal) {
             promiseInternal = (PromiseInternal<?>) argument;
@@ -101,7 +103,8 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
         }
 
         VertxSqlClientRequest otelRequest =
-            new VertxSqlClientRequest(sql, QueryExecutorUtil.getConnectOptions(queryExecutor));
+            new VertxSqlClientRequest(
+                sql, QueryExecutorUtil.getConnectOptions(queryExecutor), preparedStatement);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, otelRequest)) {
           return new AdviceScope(callDepth, null, null, null);

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v5_0/sql/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v5_0/sql/QueryExecutorInstrumentation.java
@@ -83,6 +83,7 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
         // PreparedStatement, use the first argument that is either of these. PromiseInternal is
         // always at the end of the argument list.
         String sql = null;
+        boolean preparedStatement = false;
         PromiseInternal<?> promiseInternal = null;
         for (Object argument : arguments) {
           if (sql == null) {
@@ -90,6 +91,7 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
               sql = (String) argument;
             } else if (argument instanceof PreparedStatement) {
               sql = ((PreparedStatement) argument).sql();
+              preparedStatement = true;
             }
           } else if (argument instanceof PromiseInternal) {
             promiseInternal = (PromiseInternal<?>) argument;
@@ -100,7 +102,8 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
         }
 
         VertxSqlClientRequest otelRequest =
-            new VertxSqlClientRequest(sql, QueryExecutorUtil.getConnectOptions(queryExecutor));
+            new VertxSqlClientRequest(
+                sql, QueryExecutorUtil.getConnectOptions(queryExecutor), preparedStatement);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, otelRequest)) {
           return new AdviceScope(callDepth);

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlClientAttributesGetter.java
@@ -70,6 +70,11 @@ enum VertxSqlClientAttributesGetter
     return null;
   }
 
+  @Override
+  public boolean isParameterizedQuery(VertxSqlClientRequest request) {
+    return request.isParameterizedQuery();
+  }
+
   private static List<Function<Exception, String>> createResponseStatusExtractors() {
     return Arrays.asList(
         responseStatusExtractor("io.vertx.sqlclient.DatabaseException", "getSqlState"),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlClientRequest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlClientRequest.java
@@ -10,10 +10,13 @@ import io.vertx.sqlclient.SqlConnectOptions;
 public final class VertxSqlClientRequest {
   private final String queryText;
   private final SqlConnectOptions sqlConnectOptions;
+  private final boolean parameterizedQuery;
 
-  public VertxSqlClientRequest(String queryText, SqlConnectOptions sqlConnectOptions) {
+  public VertxSqlClientRequest(
+      String queryText, SqlConnectOptions sqlConnectOptions, boolean parameterizedQuery) {
     this.queryText = queryText;
     this.sqlConnectOptions = sqlConnectOptions;
+    this.parameterizedQuery = parameterizedQuery;
   }
 
   public String getQueryText() {
@@ -34,5 +37,9 @@ public final class VertxSqlClientRequest {
 
   public Integer getPort() {
     return sqlConnectOptions != null ? sqlConnectOptions.getPort() : null;
+  }
+
+  public boolean isParameterizedQuery() {
+    return parameterizedQuery;
   }
 }


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sanitization-of-dbquerytext

TODO add opt-in to sanitize anyways?