### PR TITLE
Apply javadoc updates to other modules

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetry.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetry.java
@@ -15,18 +15,12 @@ import org.apache.http.impl.client.HttpClientBuilder;
 /** Entrypoint for instrumenting Apache HTTP Client. */
 public final class ApacheHttpClientTelemetry {
 
-  /**
-   * Returns a new {@link ApacheHttpClientTelemetry} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static ApacheHttpClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link ApacheHttpClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static ApacheHttpClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new ApacheHttpClientTelemetryBuilder(openTelemetry);
   }
@@ -41,13 +35,13 @@ public final class ApacheHttpClientTelemetry {
     this.propagators = propagators;
   }
 
-  /** Returns a new {@link CloseableHttpClient} with tracing configured. */
+  /** Returns an instrumented HTTP client. */
   public CloseableHttpClient createHttpClient() {
     return createHttpClientBuilder().build();
   }
 
   /**
-   * Returns a new {@link CloseableHttpClient} with tracing configured.
+   * Returns an instrumented HTTP client.
    *
    * @deprecated Use {@link #createHttpClient()} instead.
    */
@@ -56,13 +50,13 @@ public final class ApacheHttpClientTelemetry {
     return createHttpClient();
   }
 
-  /** Returns a new {@link HttpClientBuilder} to create a client with tracing configured. */
+  /** Returns a builder for creating an instrumented HTTP client. */
   public HttpClientBuilder createHttpClientBuilder() {
     return new TracingHttpClientBuilder(instrumenter, propagators);
   }
 
   /**
-   * Returns a new {@link HttpClientBuilder} to create a client with tracing configured.
+   * Returns a builder for creating an instrumented HTTP client.
    *
    * @deprecated Use {@link #createHttpClientBuilder()} instead.
    */

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import java.util.function.UnaryOperator;
 import org.apache.http.HttpResponse;
 
-/** A builder for {@link ApacheHttpClientTelemetry}. */
+/** Builder for {@link ApacheHttpClientTelemetry}. */
 public final class ApacheHttpClientTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.apache-httpclient-4.3";
@@ -36,8 +36,8 @@ public final class ApacheHttpClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items. The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public ApacheHttpClientTelemetryBuilder addAttributesExtractor(
@@ -47,9 +47,9 @@ public final class ApacheHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ApacheHttpClientTelemetryBuilder setCapturedRequestHeaders(
@@ -59,9 +59,9 @@ public final class ApacheHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ApacheHttpClientTelemetryBuilder setCapturedResponseHeaders(
@@ -71,16 +71,15 @@ public final class ApacheHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -89,10 +88,7 @@ public final class ApacheHttpClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ApacheHttpClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<ApacheHttpClientRequest>> spanNameExtractorCustomizer) {
@@ -100,10 +96,7 @@ public final class ApacheHttpClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link ApacheHttpClientTelemetry} configured with this {@link
-   * ApacheHttpClientTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public ApacheHttpClientTelemetry build() {
     return new ApacheHttpClientTelemetry(builder.build(), openTelemetry.getPropagators());
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetry.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetry.java
@@ -15,13 +15,12 @@ import java.util.function.Function;
 /** Entrypoint for instrumenting Armeria clients. */
 public final class ArmeriaClientTelemetry {
 
-  /**
-   * Returns a new {@link ArmeriaClientTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static ArmeriaClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static ArmeriaClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new ArmeriaClientTelemetryBuilder(openTelemetry);
   }
@@ -32,10 +31,7 @@ public final class ArmeriaClientTelemetry {
     this.instrumenter = instrumenter;
   }
 
-  /**
-   * Returns a new {@link HttpClient} decorator for use with methods like {@link
-   * com.linecorp.armeria.client.ClientBuilder#decorator(Function)}.
-   */
+  /** Returns a decorator for instrumenting Armeria clients. */
   public Function<? super HttpClient, ? extends HttpClient> newDecorator() {
     return client -> new OpenTelemetryClient(client, instrumenter);
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
@@ -36,10 +36,7 @@ public final class ArmeriaClientTelemetryBuilder {
     builder = ArmeriaInstrumenterBuilderFactory.getClientBuilder(openTelemetry);
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanStatusExtractor} and returns a
-   * customized one.
-   */
+  /** Customizes the {@link SpanStatusExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setSpanStatusExtractorCustomizer(
       UnaryOperator<SpanStatusExtractor<ClientRequestContext, RequestLog>>
@@ -49,8 +46,8 @@ public final class ArmeriaClientTelemetryBuilder {
   }
 
   /**
-   * Adds an extra {@link AttributesExtractor} to invoke to set attributes to instrumented items.
-   * The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder addAttributesExtractor(
@@ -60,9 +57,9 @@ public final class ArmeriaClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP client request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedRequestHeaders(
@@ -72,9 +69,9 @@ public final class ArmeriaClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP client response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedResponseHeaders(
@@ -84,16 +81,15 @@ public final class ArmeriaClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -102,10 +98,7 @@ public final class ArmeriaClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<ClientRequestContext>> spanNameExtractorCustomizer) {
@@ -113,6 +106,7 @@ public final class ArmeriaClientTelemetryBuilder {
     return this;
   }
 
+  /** Returns a new instance with the configured settings. */
   public ArmeriaClientTelemetry build() {
     return new ArmeriaClientTelemetry(builder.build());
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetry.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetry.java
@@ -15,13 +15,12 @@ import java.util.function.Function;
 /** Entrypoint for instrumenting Armeria services. */
 public final class ArmeriaServerTelemetry {
 
-  /**
-   * Returns a new {@link ArmeriaServerTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static ArmeriaServerTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static ArmeriaServerTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new ArmeriaServerTelemetryBuilder(openTelemetry);
   }
@@ -32,10 +31,7 @@ public final class ArmeriaServerTelemetry {
     this.instrumenter = instrumenter;
   }
 
-  /**
-   * Returns a new {@link HttpService} decorator for use with methods like {@link
-   * HttpService#decorate(Function)}.
-   */
+  /** Returns a decorator for instrumenting Armeria services. */
   public Function<? super HttpService, ? extends HttpService> newDecorator() {
     return service -> new OpenTelemetryService(service, instrumenter);
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
@@ -34,10 +34,7 @@ public final class ArmeriaServerTelemetryBuilder {
     builder = ArmeriaInstrumenterBuilderFactory.getServerBuilder(openTelemetry);
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanStatusExtractor} and returns a
-   * customized one.
-   */
+  /** Customizes the {@link SpanStatusExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setSpanStatusExtractorCustomizer(
       UnaryOperator<SpanStatusExtractor<ServiceRequestContext, RequestLog>>
@@ -47,8 +44,8 @@ public final class ArmeriaServerTelemetryBuilder {
   }
 
   /**
-   * Adds an extra {@link AttributesExtractor} to invoke to set attributes to instrumented items.
-   * The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder addAttributesExtractor(
@@ -58,9 +55,9 @@ public final class ArmeriaServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedRequestHeaders(
@@ -70,9 +67,9 @@ public final class ArmeriaServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedResponseHeaders(
@@ -82,16 +79,15 @@ public final class ArmeriaServerTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -100,10 +96,7 @@ public final class ArmeriaServerTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<ServiceRequestContext>> spanNameExtractorCustomizer) {
@@ -111,6 +104,7 @@ public final class ArmeriaServerTelemetryBuilder {
     return this;
   }
 
+  /** Returns a new instance with the configured settings. */
   public ArmeriaServerTelemetry build() {
     return new ArmeriaServerTelemetry(builder.build());
   }

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetry.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetry.java
@@ -16,13 +16,12 @@ import java.net.http.HttpResponse;
 /** Entrypoint for instrumenting Java HTTP Client. */
 public final class JavaHttpClientTelemetry {
 
-  /**
-   * Returns a new {@link JavaHttpClientTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static JavaHttpClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static JavaHttpClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new JavaHttpClientTelemetryBuilder(openTelemetry);
   }
@@ -37,22 +36,20 @@ public final class JavaHttpClientTelemetry {
   }
 
   /**
-   * Construct a new OpenTelemetry tracing-enabled {@link HttpClient} using the provided {@link
-   * HttpClient} instance.
+   * Returns an instrumented {@link HttpClient} wrapping the provided client.
    *
-   * @param client An instance of HttpClient configured as desired.
-   * @return a tracing-enabled {@link HttpClient}.
+   * @param client the HttpClient to wrap
+   * @return an instrumented HttpClient
    */
   public HttpClient createHttpClient(HttpClient client) {
     return new OpenTelemetryHttpClient(client, instrumenter, headersSetter);
   }
 
   /**
-   * Construct a new OpenTelemetry tracing-enabled {@link HttpClient} using the provided {@link
-   * HttpClient} instance.
+   * Returns an instrumented {@link HttpClient} wrapping the provided client.
    *
-   * @param client An instance of HttpClient configured as desired.
-   * @return a tracing-enabled {@link HttpClient}.
+   * @param client the HttpClient to wrap
+   * @return an instrumented HttpClient
    * @deprecated Use {@link #createHttpClient(HttpClient)} instead.
    */
   @Deprecated

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetryBuilder.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTelemetryBuilder.java
@@ -35,8 +35,8 @@ public final class JavaHttpClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items. The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public JavaHttpClientTelemetryBuilder addAttributesExtractor(
@@ -46,9 +46,9 @@ public final class JavaHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JavaHttpClientTelemetryBuilder setCapturedRequestHeaders(
@@ -58,9 +58,9 @@ public final class JavaHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JavaHttpClientTelemetryBuilder setCapturedResponseHeaders(
@@ -70,16 +70,15 @@ public final class JavaHttpClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -88,10 +87,7 @@ public final class JavaHttpClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public JavaHttpClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<HttpRequest>> spanNameExtractorCustomizer) {
@@ -99,6 +95,7 @@ public final class JavaHttpClientTelemetryBuilder {
     return this;
   }
 
+  /** Returns a new instance with the configured settings. */
   public JavaHttpClientTelemetry build() {
     return new JavaHttpClientTelemetry(
         builder.build(), new HttpHeadersSetter(openTelemetry.getPropagators()));

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetry.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetry.java
@@ -15,16 +15,13 @@ import org.eclipse.jetty.client.Response;
 /** Entrypoint for instrumenting Jetty client. */
 public final class JettyClientTelemetry {
 
-  /** Returns a new {@link JettyClientTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static JettyClientTelemetry create(OpenTelemetry openTelemetry) {
     JettyClientTelemetryBuilder builder = builder(openTelemetry);
     return builder.build();
   }
 
-  /**
-   * Returns a new {@link JettyClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static JettyClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new JettyClientTelemetryBuilder(openTelemetry);
   }
@@ -46,7 +43,7 @@ public final class JettyClientTelemetry {
     return httpClient;
   }
 
-  /** Returns a new {@link HttpClient} with tracing configured. */
+  /** Returns an instrumented HTTP client. */
   public HttpClient newHttpClient() {
     return new TracingHttpClient(instrumenter);
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -61,8 +61,8 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder addAttributesExtractor(
@@ -72,9 +72,9 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -83,9 +83,9 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
@@ -95,16 +95,15 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -113,10 +112,7 @@ public final class JettyClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Request>> spanNameExtractorCustomizer) {
@@ -124,10 +120,7 @@ public final class JettyClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link JettyClientTelemetry} with the settings of this {@link
-   * JettyClientTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public JettyClientTelemetry build() {
     var instrumenter = builder.build();
     TracingHttpClient tracingHttpClient =

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetry.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetry.java
@@ -16,16 +16,13 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 /** Entrypoint for instrumenting Jetty client. */
 public final class JettyClientTelemetry {
 
-  /** Returns a new {@link JettyClientTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static JettyClientTelemetry create(OpenTelemetry openTelemetry) {
     JettyClientTelemetryBuilder builder = builder(openTelemetry);
     return builder.build();
   }
 
-  /**
-   * Returns a new {@link JettyClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static JettyClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new JettyClientTelemetryBuilder(openTelemetry);
   }
@@ -47,7 +44,7 @@ public final class JettyClientTelemetry {
     return httpClient;
   }
 
-  /** Returns a new {@link HttpClient} with tracing configured. */
+  /** Returns an instrumented HTTP client. */
   public HttpClient newHttpClient() {
     return new TracingHttpClient(instrumenter);
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -21,7 +21,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-/** A builder of {@link JettyClientTelemetry}. */
+/** Builder for {@link JettyClientTelemetry}. */
 public final class JettyClientTelemetryBuilder {
 
   private final DefaultHttpClientInstrumenterBuilder<Request, Response> builder;
@@ -60,8 +60,8 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder addAttributesExtractor(
@@ -71,9 +71,9 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -82,9 +82,9 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
@@ -94,16 +94,15 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -112,10 +111,7 @@ public final class JettyClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Request>> spanNameExtractorCustomizer) {
@@ -123,10 +119,7 @@ public final class JettyClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link JettyClientTelemetry} with the settings of this {@link
-   * JettyClientTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public JettyClientTelemetry build() {
     Instrumenter<Request, Response> instrumenter = builder.build();
     TracingHttpClient tracingHttpClient =

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetry.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetry.java
@@ -29,38 +29,35 @@ public final class NettyClientTelemetry {
         new NettyClientHandlerFactory(instrumenter, emitExperimentalHttpClientEvents);
   }
 
-  /** Returns a new {@link NettyClientTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static NettyClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link NettyClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static NettyClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new NettyClientTelemetryBuilder(openTelemetry);
   }
 
   /**
-   * Returns a new {@link ChannelOutboundHandlerAdapter} that generates telemetry for outgoing HTTP
-   * requests. Must be paired with {@link #createResponseHandler()}.
+   * Returns a handler that instruments outgoing HTTP requests. Must be paired with {@link
+   * #createResponseHandler()}.
    */
   public ChannelOutboundHandlerAdapter createRequestHandler() {
     return handlerFactory.createRequestHandler();
   }
 
   /**
-   * Returns a new {@link ChannelInboundHandlerAdapter} that generates telemetry for incoming HTTP
-   * responses. Must be paired with {@link #createRequestHandler()}.
+   * Returns a handler that instruments incoming HTTP responses. Must be paired with {@link
+   * #createRequestHandler()}.
    */
   public ChannelInboundHandlerAdapter createResponseHandler() {
     return handlerFactory.createResponseHandler();
   }
 
   /**
-   * Returns a new {@link CombinedChannelDuplexHandler} that generates telemetry for outgoing HTTP
-   * requests and incoming responses in a single handler.
+   * Returns a handler that instruments outgoing HTTP requests and incoming responses in a single
+   * handler.
    */
   public CombinedChannelDuplexHandler<
           ? extends ChannelInboundHandlerAdapter, ? extends ChannelOutboundHandlerAdapter>
@@ -69,8 +66,8 @@ public final class NettyClientTelemetry {
   }
 
   /**
-   * Propagate the {@link Context} to the {@link Channel}. This MUST be called before each HTTP
-   * request executed on a {@link Channel}.
+   * Propagates the {@link Context} to the {@link Channel}. Must be called before each HTTP request
+   * on the channel.
    */
   // TODO (trask) rename to setParentContext()?
   public static void setChannelContext(Channel channel, Context context) {

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetryBuilder.java
@@ -20,7 +20,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.internal.Experimental;
 import java.util.Collection;
 import java.util.function.UnaryOperator;
 
-/** A builder of {@link NettyClientTelemetry}. */
+/** Builder for {@link NettyClientTelemetry}. */
 public final class NettyClientTelemetryBuilder {
 
   private final DefaultHttpClientInstrumenterBuilder<NettyRequest, HttpResponse> builder;
@@ -40,9 +40,9 @@ public final class NettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param capturedRequestHeaders A list of HTTP header names.
+   * @param capturedRequestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setCapturedRequestHeaders(
@@ -52,9 +52,9 @@ public final class NettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param capturedResponseHeaders A list of HTTP header names.
+   * @param capturedResponseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setCapturedResponseHeaders(
@@ -64,8 +64,8 @@ public final class NettyClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder addAttributesExtractor(
@@ -75,16 +75,15 @@ public final class NettyClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -93,10 +92,7 @@ public final class NettyClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public NettyClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<NettyRequest>> spanNameExtractorCustomizer) {
@@ -104,7 +100,7 @@ public final class NettyClientTelemetryBuilder {
     return this;
   }
 
-  /** Returns a new {@link NettyClientTelemetry} with the given configuration. */
+  /** Returns a new instance with the configured settings. */
   public NettyClientTelemetry build() {
     return new NettyClientTelemetry(
         new NettyClientInstrumenterFactory(

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetry.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetry.java
@@ -19,14 +19,12 @@ import okhttp3.Response;
 /** Entrypoint for instrumenting OkHttp clients. */
 public final class OkHttpTelemetry {
 
-  /** Returns a new {@link OkHttpTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static OkHttpTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link OkHttpTelemetryBuilder} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static OkHttpTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new OkHttpTelemetryBuilder(openTelemetry);
   }
@@ -41,14 +39,13 @@ public final class OkHttpTelemetry {
   }
 
   /**
-   * Construct a new OpenTelemetry tracing-enabled {@link okhttp3.Call.Factory} using the provided
-   * {@link OkHttpClient} instance.
+   * Returns an instrumented {@link okhttp3.Call.Factory} wrapping the provided client.
    *
-   * <p>Using this method will result in proper propagation and span parenting, for both {@linkplain
-   * Call#execute() synchronous} and {@linkplain Call#enqueue(Callback) asynchronous} usages.
+   * <p>Supports both {@linkplain Call#execute() synchronous} and {@linkplain Call#enqueue(Callback)
+   * asynchronous} calls with proper context propagation.
    *
-   * @param baseClient An instance of OkHttpClient configured as desired.
-   * @return a {@link Call.Factory} for creating new {@link Call} instances.
+   * @param baseClient the OkHttpClient to wrap
+   * @return an instrumented Call.Factory
    */
   public Call.Factory createCallFactory(OkHttpClient baseClient) {
     OkHttpClient.Builder builder = baseClient.newBuilder();
@@ -61,14 +58,13 @@ public final class OkHttpTelemetry {
   }
 
   /**
-   * Construct a new OpenTelemetry tracing-enabled {@link okhttp3.Call.Factory} using the provided
-   * {@link OkHttpClient} instance.
+   * Returns an instrumented {@link okhttp3.Call.Factory} wrapping the provided client.
    *
-   * <p>Using this method will result in proper propagation and span parenting, for both {@linkplain
-   * Call#execute() synchronous} and {@linkplain Call#enqueue(Callback) asynchronous} usages.
+   * <p>Supports both {@linkplain Call#execute() synchronous} and {@linkplain Call#enqueue(Callback)
+   * asynchronous} calls with proper context propagation.
    *
-   * @param baseClient An instance of OkHttpClient configured as desired.
-   * @return a {@link Call.Factory} for creating new {@link Call} instances.
+   * @param baseClient the OkHttpClient to wrap
+   * @return an instrumented Call.Factory
    * @deprecated Use {@link #createCallFactory(OkHttpClient)} instead.
    */
   @Deprecated

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
-/** A builder of {@link OkHttpTelemetry}. */
+/** Builder for {@link OkHttpTelemetry}. */
 public final class OkHttpTelemetryBuilder {
 
   private final DefaultHttpClientInstrumenterBuilder<Interceptor.Chain, Response> builder;
@@ -35,8 +35,8 @@ public final class OkHttpTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public OkHttpTelemetryBuilder addAttributesExtractor(
@@ -46,9 +46,9 @@ public final class OkHttpTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public OkHttpTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -57,9 +57,9 @@ public final class OkHttpTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public OkHttpTelemetryBuilder setCapturedResponseHeaders(Collection<String> responseHeaders) {
@@ -68,16 +68,15 @@ public final class OkHttpTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -86,10 +85,7 @@ public final class OkHttpTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public OkHttpTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Interceptor.Chain>> spanNameExtractorCustomizer) {
@@ -97,9 +93,7 @@ public final class OkHttpTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link OkHttpTelemetry} with the settings of this {@link OkHttpTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public OkHttpTelemetry build() {
     return new OkHttpTelemetry(builder.build(), openTelemetry.getPropagators());
   }


### PR DESCRIPTION
Applies javadoc updates from #15853 to other HTTP libraries. This covers all of the "common" style methods. Will send one more PR for the remaining adhoc methods in #15852.