### PR TITLE
Apply javadoc updates to remaining common HTTP library methods

### DIFF
--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackClientTelemetry.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackClientTelemetry.java
@@ -27,17 +27,12 @@ import ratpack.http.client.RequestSpec;
  */
 public final class RatpackClientTelemetry {
 
-  /**
-   * Returns a new {@link RatpackClientTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static RatpackClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link RatpackClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static RatpackClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new RatpackClientTelemetryBuilder(openTelemetry);
   }
@@ -48,7 +43,7 @@ public final class RatpackClientTelemetry {
     httpClientInstrumenter = new OpenTelemetryHttpClient(clientInstrumenter);
   }
 
-  /** Returns instrumented instance of {@link HttpClient} with OpenTelemetry. */
+  /** Returns an instrumented wrapper for the given {@link HttpClient}. */
   public HttpClient instrument(HttpClient httpClient) throws Exception {
     return httpClientInstrumenter.instrument(httpClient);
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackClientTelemetryBuilder.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackClientTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import ratpack.http.client.HttpResponse;
 import ratpack.http.client.RequestSpec;
 
-/** A builder for {@link RatpackClientTelemetry}. */
+/** Builder for {@link RatpackClientTelemetry}. */
 public final class RatpackClientTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.ratpack-1.7";
@@ -42,9 +42,9 @@ public final class RatpackClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP client request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RatpackClientTelemetryBuilder setCapturedRequestHeaders(
@@ -54,9 +54,9 @@ public final class RatpackClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP client response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RatpackClientTelemetryBuilder setCapturedResponseHeaders(
@@ -66,16 +66,15 @@ public final class RatpackClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -84,10 +83,7 @@ public final class RatpackClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public RatpackClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<RequestSpec>> spanNameExtractorCustomizer) {
@@ -95,7 +91,7 @@ public final class RatpackClientTelemetryBuilder {
     return this;
   }
 
-  /** Returns a new {@link RatpackClientTelemetry} with the configuration of this builder. */
+  /** Returns a new instance with the configured settings. */
   public RatpackClientTelemetry build() {
     return new RatpackClientTelemetry(builder.build());
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetry.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetry.java
@@ -36,17 +36,12 @@ import ratpack.registry.RegistrySpec;
  */
 public final class RatpackServerTelemetry {
 
-  /**
-   * Returns a new {@link RatpackServerTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static RatpackServerTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link RatpackServerTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static RatpackServerTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new RatpackServerTelemetryBuilder(openTelemetry);
   }
@@ -72,7 +67,7 @@ public final class RatpackServerTelemetry {
     return OpenTelemetryExecInitializer.INSTANCE;
   }
 
-  /** Configures the {@link RegistrySpec} with OpenTelemetry. */
+  /** Configures the {@link RegistrySpec} to produce telemetry. */
   public void configureRegistry(RegistrySpec registry) {
     registry.add(HandlerDecorator.prepend(serverHandler));
     registry.add(OpenTelemetryExecInterceptor.INSTANCE);

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetryBuilder.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import ratpack.http.Request;
 import ratpack.http.Response;
 
-/** A builder for {@link RatpackServerTelemetry}. */
+/** Builder for {@link RatpackServerTelemetry}. */
 public final class RatpackServerTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.ratpack-1.7";
@@ -35,8 +35,8 @@ public final class RatpackServerTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items. The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public RatpackServerTelemetryBuilder addAttributesExtractor(
@@ -46,9 +46,9 @@ public final class RatpackServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RatpackServerTelemetryBuilder setCapturedRequestHeaders(
@@ -58,9 +58,9 @@ public final class RatpackServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RatpackServerTelemetryBuilder setCapturedResponseHeaders(
@@ -70,16 +70,15 @@ public final class RatpackServerTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -88,10 +87,7 @@ public final class RatpackServerTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public RatpackServerTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Request>> spanNameExtractorCustomizer) {
@@ -99,7 +95,7 @@ public final class RatpackServerTelemetryBuilder {
     return this;
   }
 
-  /** Returns a new {@link RatpackServerTelemetry} with the configuration of this builder. */
+  /** Returns a new instance with the configured settings. */
   public RatpackServerTelemetry build() {
     return new RatpackServerTelemetry(builder.build());
   }

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetry.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetry.java
@@ -14,14 +14,12 @@ import org.restlet.data.Response;
 /** Entrypoint for instrumenting Restlet servers. */
 public final class RestletTelemetry {
 
-  /** Returns a new {@link RestletTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static RestletTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link RestletTelemetryBuilder} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static RestletTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new RestletTelemetryBuilder(openTelemetry);
   }
@@ -32,17 +30,13 @@ public final class RestletTelemetry {
     this.serverInstrumenter = serverInstrumenter;
   }
 
-  /**
-   * Returns a new {@link Filter} which can be used to wrap {@link org.restlet.Restlet}
-   * implementations.
-   */
+  /** Returns a {@link Filter} that instruments HTTP requests. */
   public Filter createFilter(String path) {
     return new TracingFilter(serverInstrumenter, path);
   }
 
   /**
-   * Returns a new {@link Filter} which can be used to wrap {@link org.restlet.Restlet}
-   * implementations.
+   * Returns a {@link Filter} that instruments HTTP requests.
    *
    * @deprecated Use {@link #createFilter(String)} instead.
    */

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
 
-/** A builder of {@link RestletTelemetry}. */
+/** Builder for {@link RestletTelemetry}. */
 public final class RestletTelemetryBuilder {
 
   private final DefaultHttpServerInstrumenterBuilder<Request, Response> builder;
@@ -33,8 +33,8 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder addAttributesExtractor(
@@ -44,9 +44,9 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -55,9 +55,9 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setCapturedResponseHeaders(Collection<String> responseHeaders) {
@@ -66,16 +66,15 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -84,10 +83,7 @@ public final class RestletTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Request>> spanNameExtractorCustomizer) {
@@ -95,10 +91,7 @@ public final class RestletTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link RestletTelemetry} with the settings of this {@link
-   * RestletTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public RestletTelemetry build() {
     return new RestletTelemetry(builder.build());
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetry.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetry.java
@@ -14,14 +14,12 @@ import org.restlet.routing.Filter;
 /** Entrypoint for instrumenting Restlet servers. */
 public final class RestletTelemetry {
 
-  /** Returns a new {@link RestletTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static RestletTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link RestletTelemetryBuilder} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static RestletTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new RestletTelemetryBuilder(openTelemetry);
   }
@@ -32,17 +30,13 @@ public final class RestletTelemetry {
     this.serverInstrumenter = serverInstrumenter;
   }
 
-  /**
-   * Returns a new {@link Filter} which can be used to wrap {@link org.restlet.Restlet}
-   * implementations.
-   */
+  /** Returns a {@link Filter} that instruments HTTP requests. */
   public Filter createFilter(String path) {
     return new TracingFilter(serverInstrumenter, path);
   }
 
   /**
-   * Returns a new {@link Filter} which can be used to wrap {@link org.restlet.Restlet}
-   * implementations.
+   * Returns a {@link Filter} that instruments HTTP requests.
    *
    * @deprecated Use {@link #createFilter(String)} instead.
    */

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import org.restlet.Request;
 import org.restlet.Response;
 
-/** A builder of {@link RestletTelemetry}. */
+/** Builder for {@link RestletTelemetry}. */
 public final class RestletTelemetryBuilder {
 
   private final DefaultHttpServerInstrumenterBuilder<Request, Response> builder;
@@ -33,8 +33,8 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder addAttributesExtractor(
@@ -44,9 +44,9 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -55,9 +55,9 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setCapturedResponseHeaders(Collection<String> responseHeaders) {
@@ -66,16 +66,15 @@ public final class RestletTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -84,10 +83,7 @@ public final class RestletTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public RestletTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<Request>> spanNameExtractorCustomizer) {
@@ -95,10 +91,7 @@ public final class RestletTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link RestletTelemetry} with the settings of this {@link
-   * RestletTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public RestletTelemetry build() {
     return new RestletTelemetry(builder.build());
   }

--- a/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetry.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetry.java
@@ -17,14 +17,12 @@ import javax.servlet.http.HttpServletResponse;
 /** Entrypoint for instrumenting Servlets. */
 public final class ServletTelemetry {
 
-  /** Returns a new {@link ServletTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static ServletTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link ServletTelemetryBuilder} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static ServletTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new ServletTelemetryBuilder(openTelemetry);
   }
@@ -44,13 +42,13 @@ public final class ServletTelemetry {
     this.addTraceIdRequestAttribute = addTraceIdRequestAttribute;
   }
 
-  /** Returns a new {@link Filter} for producing telemetry. */
+  /** Returns a {@link Filter} that instruments HTTP requests. */
   public Filter createFilter() {
     return new Servlet3TelemetryFilter(instrumenter, addTraceIdRequestAttribute);
   }
 
   /**
-   * Returns a new {@link Filter} for producing telemetry.
+   * Returns a {@link Filter} that instruments HTTP requests.
    *
    * @deprecated Use {@link #createFilter()} instead.
    */

--- a/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetryBuilder.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTelemetryBuilder.java
@@ -30,7 +30,7 @@ import java.util.function.UnaryOperator;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** A builder of {@link ServletTelemetry}. */
+/** Builder for {@link ServletTelemetry}. */
 public final class ServletTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.servlet-3.0";
 
@@ -61,10 +61,7 @@ public final class ServletTelemetryBuilder {
     builder = servletBuilder.getBuilder();
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanStatusExtractor} and returns a
-   * customized one.
-   */
+  /** Customizes the {@link SpanStatusExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder setSpanStatusExtractorCustomizer(
       UnaryOperator<SpanStatusExtractor<HttpServletRequest, HttpServletResponse>>
@@ -80,8 +77,8 @@ public final class ServletTelemetryBuilder {
   }
 
   /**
-   * Adds an extra {@link AttributesExtractor} to invoke to set attributes to instrumented items.
-   * The {@link AttributesExtractor} will be executed after all default extractors.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder addAttributesExtractor(
@@ -93,9 +90,9 @@ public final class ServletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -104,9 +101,9 @@ public final class ServletTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP server response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder setCapturedResponseHeaders(Collection<String> responseHeaders) {
@@ -130,16 +127,15 @@ public final class ServletTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -148,10 +144,7 @@ public final class ServletTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public ServletTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<HttpServletRequest>> spanNameExtractorCustomizer) {
@@ -163,6 +156,7 @@ public final class ServletTelemetryBuilder {
     return this;
   }
 
+  /** Returns a new instance with the configured settings. */
   public ServletTelemetry build() {
     return new ServletTelemetry(
         servletBuilder.build(HttpSpanNameExtractor.create(httpAttributesGetter)),

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetry.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetry.java
@@ -15,15 +15,12 @@ import org.springframework.web.client.RestTemplate;
 /** Entrypoint for instrumenting Spring {@link org.springframework.web.client.RestTemplate}. */
 public final class SpringWebTelemetry {
 
-  /** Returns a new {@link SpringWebTelemetry} configured with the given {@link OpenTelemetry}. */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link SpringWebTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SpringWebTelemetryBuilder(openTelemetry);
   }
@@ -35,8 +32,7 @@ public final class SpringWebTelemetry {
   }
 
   /**
-   * Returns a new {@link ClientHttpRequestInterceptor} that can be used with {@link
-   * RestTemplate#getInterceptors()}. For example:
+   * Returns an interceptor for instrumenting {@link RestTemplate} requests.
    *
    * <pre>{@code
    * restTemplate.getInterceptors().add(SpringWebTelemetry.create(openTelemetry).createInterceptor());
@@ -47,8 +43,7 @@ public final class SpringWebTelemetry {
   }
 
   /**
-   * Returns a new {@link ClientHttpRequestInterceptor} that can be used with {@link
-   * RestTemplate#getInterceptors()}. For example:
+   * Returns an interceptor for instrumenting {@link RestTemplate} requests.
    *
    * <pre>{@code
    * restTemplate.getInterceptors().add(SpringWebTelemetry.create(openTelemetry).createInterceptor());

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
-/** A builder of {@link SpringWebTelemetry}. */
+/** Builder for {@link SpringWebTelemetry}. */
 public final class SpringWebTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-web-3.1";
   private final DefaultHttpClientInstrumenterBuilder<HttpRequest, ClientHttpResponse> builder;
@@ -43,8 +43,8 @@ public final class SpringWebTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder addAttributesExtractor(
@@ -54,9 +54,9 @@ public final class SpringWebTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -65,9 +65,9 @@ public final class SpringWebTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder setCapturedResponseHeaders(Collection<String> responseHeaders) {
@@ -75,10 +75,7 @@ public final class SpringWebTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<HttpRequest>> spanNameExtractorCustomizer) {
@@ -87,16 +84,15 @@ public final class SpringWebTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -105,10 +101,7 @@ public final class SpringWebTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link SpringWebTelemetry} with the settings of this {@link
-   * SpringWebTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public SpringWebTelemetry build() {
     return new SpringWebTelemetry(builder.build());
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetry.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetry.java
@@ -18,18 +18,12 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 /** Entrypoint for instrumenting Spring Webflux HTTP clients. */
 public final class SpringWebfluxClientTelemetry {
 
-  /**
-   * Returns a new {@link SpringWebfluxClientTelemetry} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebfluxClientTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link SpringWebfluxClientTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebfluxClientTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SpringWebfluxClientTelemetryBuilder(openTelemetry);
   }
@@ -45,8 +39,7 @@ public final class SpringWebfluxClientTelemetry {
   }
 
   /**
-   * Adds the OpenTelemetry telemetry producing {@link ExchangeFilterFunction} to the provided list
-   * of filter functions.
+   * Adds an instrumented {@link ExchangeFilterFunction} to the provided list.
    *
    * @param exchangeFilterFunctions existing filter functions
    */
@@ -60,9 +53,8 @@ public final class SpringWebfluxClientTelemetry {
   }
 
   /**
-   * Adds the OpenTelemetry telemetry producing {@link ExchangeFilterFunction} to the provided list
-   * of filter functions. Also registers the Reactor context propagation hook {@link
-   * ContextPropagationOperator} for propagating OpenTelemetry context into reactive pipelines.
+   * Adds an instrumented {@link ExchangeFilterFunction} to the provided list. Also registers the
+   * Reactor context propagation hook for reactive pipelines.
    *
    * @param exchangeFilterFunctions existing filter functions
    */

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetryBuilder.java
@@ -19,7 +19,7 @@ import java.util.function.UnaryOperator;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
-/** A builder of {@link SpringWebfluxClientTelemetry}. */
+/** Builder for {@link SpringWebfluxClientTelemetry}. */
 public final class SpringWebfluxClientTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-webflux-5.3";
 
@@ -40,8 +40,8 @@ public final class SpringWebfluxClientTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items for WebClient.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxClientTelemetryBuilder addAttributesExtractor(
@@ -51,9 +51,9 @@ public final class SpringWebfluxClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP WebClient request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxClientTelemetryBuilder setCapturedRequestHeaders(
@@ -63,9 +63,9 @@ public final class SpringWebfluxClientTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP WebClient response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxClientTelemetryBuilder setCapturedResponseHeaders(
@@ -75,16 +75,15 @@ public final class SpringWebfluxClientTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpClientAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -93,10 +92,7 @@ public final class SpringWebfluxClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public SpringWebfluxClientTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<ClientRequest>> spanNameExtractorCustomizer) {
@@ -104,10 +100,7 @@ public final class SpringWebfluxClientTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link SpringWebfluxClientTelemetry} with the settings of this {@link
-   * SpringWebfluxClientTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public SpringWebfluxClientTelemetry build() {
     return new SpringWebfluxClientTelemetry(builder.build(), openTelemetry.getPropagators());
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetry.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetry.java
@@ -14,18 +14,12 @@ import org.springframework.web.server.WebFilter;
 /** Entrypoint for instrumenting Spring Webflux HTTP services. */
 public final class SpringWebfluxServerTelemetry {
 
-  /**
-   * Returns a new {@link SpringWebfluxServerTelemetry} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebfluxServerTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link SpringWebfluxServerTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebfluxServerTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SpringWebfluxServerTelemetryBuilder(openTelemetry);
   }
@@ -39,23 +33,14 @@ public final class SpringWebfluxServerTelemetry {
     this.serverInstrumenter = serverInstrumenter;
   }
 
-  /**
-   * Returns an OpenTelemetry telemetry producing {@link WebFilter} that can be registered with
-   * Spring Webflux to instrument HTTP server requests.
-   *
-   * @return OpenTelemetry telemetry producing {@link WebFilter}
-   */
+  /** Returns a {@link WebFilter} that instruments HTTP server requests. */
   public WebFilter createWebFilter() {
     return new TelemetryProducingWebFilter(serverInstrumenter);
   }
 
   /**
-   * Returns an OpenTelemetry telemetry producing {@link WebFilter} that can be registered with
-   * Spring Webflux to instrument HTTP server requests. Also registers the Reactor context
-   * propagation hook {@link ContextPropagationOperator} for propagating OpenTelemetry context into
-   * reactive pipelines.
-   *
-   * @return OpenTelemetry telemetry producing {@link WebFilter}
+   * Returns a {@link WebFilter} that instruments HTTP server requests. Also registers the Reactor
+   * context propagation hook for reactive pipelines.
    */
   public WebFilter createWebFilterAndRegisterReactorHook() {
     registerReactorHook();

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetryBuilder.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.function.UnaryOperator;
 import org.springframework.web.server.ServerWebExchange;
 
-/** A builder of {@link SpringWebfluxServerTelemetry}. */
+/** Builder for {@link SpringWebfluxServerTelemetry}. */
 public final class SpringWebfluxServerTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-webflux-5.3";
 
@@ -39,8 +39,8 @@ public final class SpringWebfluxServerTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxServerTelemetryBuilder addAttributesExtractor(
@@ -50,10 +50,9 @@ public final class SpringWebfluxServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes from server
-   * instrumentation.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxServerTelemetryBuilder setCapturedRequestHeaders(
@@ -63,10 +62,9 @@ public final class SpringWebfluxServerTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes from server
-   * instrumentation.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebfluxServerTelemetryBuilder setCapturedResponseHeaders(
@@ -76,16 +74,15 @@ public final class SpringWebfluxServerTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -94,10 +91,7 @@ public final class SpringWebfluxServerTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public SpringWebfluxServerTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<ServerWebExchange>> spanNameExtractorCustomizer) {
@@ -105,10 +99,7 @@ public final class SpringWebfluxServerTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link SpringWebfluxServerTelemetry} with the settings of this {@link
-   * SpringWebfluxServerTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public SpringWebfluxServerTelemetry build() {
     return new SpringWebfluxServerTelemetry(builder.build());
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetry.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetry.java
@@ -14,17 +14,12 @@ import javax.servlet.http.HttpServletResponse;
 /** Entrypoint for instrumenting Spring Web MVC apps. */
 public final class SpringWebMvcTelemetry {
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebMvcTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebMvcTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SpringWebMvcTelemetryBuilder(openTelemetry);
   }
@@ -35,7 +30,7 @@ public final class SpringWebMvcTelemetry {
     this.instrumenter = instrumenter;
   }
 
-  /** Returns a new {@link Filter} that generates telemetry for received HTTP requests. */
+  /** Returns a {@link Filter} that instruments HTTP requests. */
   public Filter createServletFilter() {
     return new WebMvcTelemetryProducingFilter(instrumenter);
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** A builder of {@link SpringWebMvcTelemetry}. */
+/** Builder for {@link SpringWebMvcTelemetry}. */
 public final class SpringWebMvcTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-webmvc-5.3";
@@ -42,8 +42,8 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder addAttributesExtractor(
@@ -53,9 +53,9 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -64,9 +64,9 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setCapturedResponseHeaders(
@@ -75,10 +75,7 @@ public final class SpringWebMvcTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<HttpServletRequest>> spanNameExtractorCustomizer) {
@@ -87,16 +84,15 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -105,10 +101,7 @@ public final class SpringWebMvcTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetry} with the settings of this {@link
-   * SpringWebMvcTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public SpringWebMvcTelemetry build() {
     return new SpringWebMvcTelemetry(builder.build());
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetry.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetry.java
@@ -14,17 +14,12 @@ import jakarta.servlet.http.HttpServletResponse;
 /** Entrypoint for instrumenting Spring Web MVC apps. */
 public final class SpringWebMvcTelemetry {
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetry} configured with the given {@link OpenTelemetry}.
-   */
+  /** Returns a new instance configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebMvcTelemetry create(OpenTelemetry openTelemetry) {
     return builder(openTelemetry).build();
   }
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetryBuilder} configured with the given {@link
-   * OpenTelemetry}.
-   */
+  /** Returns a builder configured with the given {@link OpenTelemetry} instance. */
   public static SpringWebMvcTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SpringWebMvcTelemetryBuilder(openTelemetry);
   }
@@ -35,7 +30,7 @@ public final class SpringWebMvcTelemetry {
     this.instrumenter = instrumenter;
   }
 
-  /** Returns a new {@link Filter} that generates telemetry for received HTTP requests. */
+  /** Returns a {@link Filter} that instruments HTTP requests. */
   public Filter createServletFilter() {
     return new WebMvcTelemetryProducingFilter(instrumenter);
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcTelemetryBuilder.java
@@ -18,7 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.function.UnaryOperator;
 
-/** A builder of {@link SpringWebMvcTelemetry}. */
+/** Builder for {@link SpringWebMvcTelemetry}. */
 public final class SpringWebMvcTelemetryBuilder {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-webmvc-6.0";
@@ -41,8 +41,8 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Adds an additional {@link AttributesExtractor} to invoke to set attributes to instrumented
-   * items.
+   * Adds an {@link AttributesExtractor} to extract attributes from requests and responses. Executed
+   * after all default extractors.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder addAttributesExtractor(
@@ -52,9 +52,9 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP request headers that will be captured as span attributes.
+   * Configures HTTP request headers to capture as span attributes.
    *
-   * @param requestHeaders A list of HTTP header names.
+   * @param requestHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
@@ -63,9 +63,9 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the HTTP response headers that will be captured as span attributes.
+   * Configures HTTP response headers to capture as span attributes.
    *
-   * @param responseHeaders A list of HTTP header names.
+   * @param responseHeaders HTTP header names to capture.
    */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setCapturedResponseHeaders(
@@ -74,10 +74,7 @@ public final class SpringWebMvcTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Sets a customizer that receives the default {@link SpanNameExtractor} and returns a customized
-   * one.
-   */
+  /** Customizes the {@link SpanNameExtractor} by transforming the default instance. */
   @CanIgnoreReturnValue
   public SpringWebMvcTelemetryBuilder setSpanNameExtractorCustomizer(
       UnaryOperator<SpanNameExtractor<HttpServletRequest>> spanNameExtractorCustomizer) {
@@ -86,16 +83,15 @@ public final class SpringWebMvcTelemetryBuilder {
   }
 
   /**
-   * Configures the instrumentation to recognize an alternative set of HTTP request methods.
+   * Configures recognized HTTP request methods.
    *
-   * <p>By default, this instrumentation defines "known" methods as the ones listed in <a
-   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
-   * method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   * <p>By default, recognizes methods from <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and PATCH from <a
+   * href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
    *
-   * <p>Note: calling this method <b>overrides</b> the default known method sets completely; it does
-   * not supplement it.
+   * <p><b>Note:</b> This <b>overrides</b> defaults completely; it does not supplement them.
    *
-   * @param knownMethods A set of recognized HTTP request methods.
+   * @param knownMethods HTTP request methods to recognize.
    * @see HttpServerAttributesExtractorBuilder#setKnownMethods(Collection)
    */
   @CanIgnoreReturnValue
@@ -104,10 +100,7 @@ public final class SpringWebMvcTelemetryBuilder {
     return this;
   }
 
-  /**
-   * Returns a new {@link SpringWebMvcTelemetry} with the settings of this {@link
-   * SpringWebMvcTelemetryBuilder}.
-   */
+  /** Returns a new instance with the configured settings. */
   public SpringWebMvcTelemetry build() {
     return new SpringWebMvcTelemetry(builder.build());
   }


### PR DESCRIPTION
Missed a few in #15857.

This covers just the "common" style methods. Will send one more PR for the remaining adhoc methods in #15852.