### PR TITLE
Update VERSIONING.md

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -9,9 +9,6 @@ Artifacts in this repository follow the same compatibility requirements describe
 EXCEPT for the following incompatible changes which are allowed in stable artifacts in this
 repository:
 
-- Changes to the telemetry produced by instrumentation
-  (there will be some guarantees about telemetry stability in the future, see discussions
-  in <https://github.com/open-telemetry/opentelemetry-specification/issues/1301>)
 - Changes to configuration properties that contain the word `experimental`
 - Changes to configuration properties under the namespace `otel.javaagent.testing`
 


### PR DESCRIPTION
Realized that though this has been our practice since 2.0, we never updated the official policy.

Also, there were a couple of breaking changes to telemetry in 2.x that we accepted due to them being low impact changes to lesser used instrumentations. We'll need to follow this (now) official policy going forwards even in these cases.

There are a couple of interesting follow-up discussions we can have:
- New instrumentations should probably start out behind an experimental flag until there is some feedback (or lack of feedback over some time) that they don't need to take in any breaking changes to telemetry until the next major version bump.
- In 3.0, we could choose to make some lesser used instrumentations opt-in and mark them explicitly as experimental.

cc @brunobat for raising this ❤️