### PR TITLE
Use `db.query.summary` for span name when available

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -136,11 +136,16 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     @Override
     public String extract(REQUEST request) {
-      String namespace = getter.getDbNamespace(request);
-      String operationName = getter.getDbOperationName(request);
       if (SemconvStability.emitStableDatabaseSemconv()) {
+        String querySummary = getter.getDbQuerySummary(request);
+        if (querySummary != null) {
+          return querySummary;
+        }
+        String operationName = getter.getDbOperationName(request);
         return computeSpanNameStable(getter, request, operationName, null, null);
       }
+      String namespace = getter.getDbNamespace(request);
+      String operationName = getter.getDbOperationName(request);
       return computeSpanName(namespace, operationName, null, null);
     }
   }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -137,6 +138,26 @@ class DbClientSpanNameExtractorTest {
 
     // then
     assertEquals("DB Query", spanName);
+  }
+
+  @Test
+  void shouldUseQuerySummaryWhenAvailable() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    // Needs to be lenient because not called during this test under old semconv mode
+    lenient().when(dbAttributesGetter.getDbQuerySummary(dbRequest)).thenReturn("SELECT users");
+    // Needs to be lenient because not called during this test under new semconv mode
+    lenient().when(dbAttributesGetter.getDbOperationName(dbRequest)).thenReturn("SELECT");
+    lenient().when(dbAttributesGetter.getDbNamespace(dbRequest)).thenReturn("database");
+
+    SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(dbAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertEquals(emitStableDatabaseSemconv() ? "SELECT users" : "SELECT database", spanName);
   }
 
   @Test


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#name

none of the instrumentations implement `db.query.summary` yet, but this PR will allow me to add that support 1-by-1 afterwards in the instrumentations that don't implement SqlClientAttributesExtractor (clickhouse, couchbase, and influx)