### PR TITLE
strict test on request & body size in http metrics attributes

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
@@ -102,7 +102,13 @@ public final class HttpServerExperimentalMetrics implements OperationListener {
     // request count (otherwise it will split the timeseries)
     activeRequests.add(-1, startAttributes, context);
 
-    Attributes sizeAttributes = startAttributes.toBuilder().putAll(endAttributes).build();
+    Attributes sizeAttributes = startAttributes.toBuilder()
+        .putAll(endAttributes)
+        // Those attributes do not have any meaning on metric because the metric is an aggregation of their
+        // value, so we remove them.
+        .removeIf(attributeKey -> attributeKey.getKey().equals("http.request.body.size"))
+        .removeIf(attributeKey -> attributeKey.getKey().equals("http.response.body.size"))
+        .build();
 
     Long requestBodySize = getHttpRequestBodySize(endAttributes, startAttributes);
     if (requestBodySize != null) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
@@ -102,15 +102,7 @@ public final class HttpServerExperimentalMetrics implements OperationListener {
     // request count (otherwise it will split the timeseries)
     activeRequests.add(-1, startAttributes, context);
 
-    Attributes sizeAttributes =
-        startAttributes.toBuilder()
-            .putAll(endAttributes)
-            // Those attributes do not have any meaning on metric because the metric is an
-            // aggregation of their
-            // value, so we remove them.
-            .removeIf(attributeKey -> attributeKey.getKey().equals("http.request.body.size"))
-            .removeIf(attributeKey -> attributeKey.getKey().equals("http.response.body.size"))
-            .build();
+    Attributes sizeAttributes = startAttributes.toBuilder().putAll(endAttributes).build();
 
     Long requestBodySize = getHttpRequestBodySize(endAttributes, startAttributes);
     if (requestBodySize != null) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetrics.java
@@ -102,13 +102,15 @@ public final class HttpServerExperimentalMetrics implements OperationListener {
     // request count (otherwise it will split the timeseries)
     activeRequests.add(-1, startAttributes, context);
 
-    Attributes sizeAttributes = startAttributes.toBuilder()
-        .putAll(endAttributes)
-        // Those attributes do not have any meaning on metric because the metric is an aggregation of their
-        // value, so we remove them.
-        .removeIf(attributeKey -> attributeKey.getKey().equals("http.request.body.size"))
-        .removeIf(attributeKey -> attributeKey.getKey().equals("http.response.body.size"))
-        .build();
+    Attributes sizeAttributes =
+        startAttributes.toBuilder()
+            .putAll(endAttributes)
+            // Those attributes do not have any meaning on metric because the metric is an
+            // aggregation of their
+            // value, so we remove them.
+            .removeIf(attributeKey -> attributeKey.getKey().equals("http.request.body.size"))
+            .removeIf(attributeKey -> attributeKey.getKey().equals("http.response.body.size"))
+            .build();
 
     Long requestBodySize = getHttpRequestBodySize(endAttributes, startAttributes);
     if (requestBodySize != null) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
@@ -92,6 +92,13 @@ class HttpClientExperimentalMetricsTest {
                                 point ->
                                     point
                                         .hasSum(100 /* bytes */)
+                                        // those span attributes must be discarded by attribute
+                                        // advice
+                                        .hasAttributesSatisfying(
+                                            attributes ->
+                                                assertThat(attributes)
+                                                    .doesNotContainKey("http.request.body.size")
+                                                    .doesNotContainKey("http.response.body.size"))
                                         .hasAttributesSatisfying(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
                                             equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
@@ -92,14 +92,7 @@ class HttpClientExperimentalMetricsTest {
                                 point ->
                                     point
                                         .hasSum(100 /* bytes */)
-                                        // those span attributes must be discarded by attribute
-                                        // advice
-                                        .hasAttributesSatisfying(
-                                            attributes ->
-                                                assertThat(attributes)
-                                                    .doesNotContainKey("http.request.body.size")
-                                                    .doesNotContainKey("http.response.body.size"))
-                                        .hasAttributesSatisfying(
+                                        .hasAttributesSatisfyingExactly(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
                                             equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
                                             equalTo(ErrorAttributes.ERROR_TYPE, "400"),
@@ -125,7 +118,7 @@ class HttpClientExperimentalMetricsTest {
                                 point ->
                                     point
                                         .hasSum(200 /* bytes */)
-                                        .hasAttributesSatisfying(
+                                        .hasAttributesSatisfyingExactly(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
                                             equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
                                             equalTo(ErrorAttributes.ERROR_TYPE, "400"),

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetricsTest.java
@@ -156,7 +156,7 @@ class HttpServerExperimentalMetricsTest {
                                 point ->
                                     point
                                         .hasSum(100 /* bytes */)
-                                        .hasAttributesSatisfying(
+                                        .hasAttributesSatisfyingExactly(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
                                             equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
                                             equalTo(ErrorAttributes.ERROR_TYPE, "500"),
@@ -181,7 +181,7 @@ class HttpServerExperimentalMetricsTest {
                                 point ->
                                     point
                                         .hasSum(200 /* bytes */)
-                                        .hasAttributesSatisfying(
+                                        .hasAttributesSatisfyingExactly(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
                                             equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
                                             equalTo(ErrorAttributes.ERROR_TYPE, "500"),


### PR DESCRIPTION
The experimental HTTP metrics collect provide the following metrics:
- `http.server.request.body.size`
- `http.server.response.body.size`

The metric attributes are directly derived from the span attributes, and this could make the metric attribute to contain `http.request.body.size` and `http.response.body.size` if the metric "advice" attributes are not properly applied.

This PR makes the test assertion strict to ensure no extra attribute leaks from the span to the metrics.

Related to slack conversation here: https://cloud-native.slack.com/archives/C014L2KCTE3/p1768816425410149

EDIT: this was initially opened as a bugfix, but in fact it's working as expected, so I've switched to making the tests more strict to ensure those attributes are not added to the http metrics.