### PR TITLE
[wip] capture servlet request body

### DIFF
--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/body/Servlet5BodyCaptureInputStreamWrapper.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/body/Servlet5BodyCaptureInputStreamWrapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.body;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Servlet5BodyCaptureInputStreamWrapper extends ServletInputStream {
+
+  private final ServletInputStream inputStream;
+  private final ByteBuffer buffer;
+
+  public Servlet5BodyCaptureInputStreamWrapper(ServletInputStream inputStream, ByteBuffer buffer) {
+    this.inputStream = inputStream;
+    this.buffer = buffer;
+  }
+
+  @Override
+  public int read() throws IOException {
+    int read = inputStream.read();
+    if (read > 0 && buffer.hasRemaining()) {
+      buffer.put((byte) read);
+    }
+    return read;
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    // TODO: handle exceptions by marking content as read
+    int read = inputStream.read(b, off, len);
+    if (read > 0) {
+      int length = Math.min(read, buffer.remaining());
+      buffer.put(b, off, length);
+    }
+    return read;
+  }
+
+  @Override
+  public int readLine(byte[] b, int off, int len) throws IOException {
+    int read = inputStream.readLine(b, off, len);
+    if (read > 0) {
+      int length = Math.min(read, buffer.remaining());
+      buffer.put(b, off, length);
+    }
+    return read;
+  }
+
+  @Override
+  public boolean isFinished() {
+    return inputStream.isFinished();
+  }
+
+  @Override
+  public boolean isReady() {
+    return inputStream.isReady();
+  }
+
+  @Override
+  public void setReadListener(ReadListener readListener) {
+    inputStream.setReadListener(readListener);
+  }
+}

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/body/Servlet5BodyCaptureRequestWrapper.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/body/Servlet5BodyCaptureRequestWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.body;
+
+import static io.opentelemetry.instrumentation.servlet.internal.ServletRequestBodyExtractor.REQUEST_BODY_ATTRIBUTE;
+
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class Servlet5BodyCaptureRequestWrapper extends HttpServletRequestWrapper {
+
+  // TODO: make request size configurable
+  private static final int MAX_CAPACITY = 100;
+
+  /**
+   * Constructs a request object wrapping the given request.
+   *
+   * @param request the {@link HttpServletRequest} to be wrapped.
+   * @throws IllegalArgumentException if the request is null
+   */
+  public Servlet5BodyCaptureRequestWrapper(HttpServletRequest request) {
+    super(request);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    ServletInputStream inputStream = super.getInputStream();
+    if (inputStream == null || inputStream.isFinished()) {
+      return inputStream;
+    }
+    ByteBuffer buffer = ByteBuffer.allocate(MAX_CAPACITY);
+    super.setAttribute(REQUEST_BODY_ATTRIBUTE, buffer);
+    return new Servlet5BodyCaptureInputStreamWrapper(inputStream, buffer);
+  }
+}

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/AbstractServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/AbstractServlet5Test.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.AUTH_REQUIRED;
+import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_BODY;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_PARAMETERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
@@ -92,6 +93,7 @@ public abstract class AbstractServlet5Test<SERVER, CONTEXT> extends AbstractHttp
     addServlet(context, INDEXED_CHILD.getPath(), servlet);
     addServlet(context, CAPTURE_HEADERS.getPath(), servlet);
     addServlet(context, CAPTURE_PARAMETERS.getPath(), servlet);
+    addServlet(context, CAPTURE_BODY.getPath(), servlet);
     addServlet(context, HTML_PRINT_WRITER.getPath(), servlet);
     addServlet(context, HTML_SERVLET_OUTPUT_STREAM.getPath(), servlet);
   }

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.controller;
+import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_BODY;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_PARAMETERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
@@ -21,6 +22,7 @@ import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -72,6 +74,14 @@ public class TestServlet5 {
                     "request parameter does not have expected value " + value);
               }
 
+              resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(endpoint.getBody());
+            } else if (CAPTURE_BODY.equals(endpoint)) {
+              // read body to trigger body capture
+              ServletInputStream requestBody = req.getInputStream();
+              while (!requestBody.isFinished()) {
+                requestBody.read();
+              }
               resp.setStatus(endpoint.getStatus());
               resp.getWriter().print(endpoint.getBody());
             } else if (ERROR.equals(endpoint)) {

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/build.gradle.kts
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/build.gradle.kts
@@ -22,5 +22,6 @@ if (testLatestDeps) {
 tasks {
   withType<Test>().configureEach {
     jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+    jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-body=true")
   }
 }

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
@@ -72,6 +72,7 @@ public abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Co
     super.configure(options);
     options.setContextPath("/tomcat-context");
     options.setTestError(testError());
+    options.setTestRequestBodyCapture(true);
   }
 
   public boolean testError() {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AgentServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/AgentServletInstrumenterBuilder.java
@@ -32,6 +32,9 @@ public final class AgentServletInstrumenterBuilder<REQUEST, RESPONSE> {
   private static final boolean CAPTURE_EXPERIMENTAL_ATTRIBUTES =
       DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "servlet")
           .getBoolean("experimental_span_attributes/development", false);
+  private static final boolean CAPTURE_REQUEST_BODY =
+      DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "servlet")
+          .getBoolean("capture_request_body/development", false);
 
   private AgentServletInstrumenterBuilder() {}
 
@@ -68,7 +71,8 @@ public final class AgentServletInstrumenterBuilder<REQUEST, RESPONSE> {
                 instrumentationName, GlobalOpenTelemetry.get(), httpAttributesGetter, accessor)
             .setCaptureRequestParameters(CAPTURE_REQUEST_PARAMETERS)
             .setCaptureExperimentalAttributes(CAPTURE_EXPERIMENTAL_ATTRIBUTES)
-            .setCaptureEnduserId(AgentCommonConfig.get().getEnduserConfig().isIdEnabled());
+            .setCaptureEnduserId(AgentCommonConfig.get().getEnduserConfig().isIdEnabled())
+            .setCaptureRequestBody(CAPTURE_REQUEST_BODY);
     for (ContextCustomizer<? super ServletRequestContext<REQUEST>> contextCustomizer :
         contextCustomizers) {
       builder.addContextCustomizer(contextCustomizer);

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletInstrumenterBuilder.java
@@ -36,6 +36,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
           ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
       builder;
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
+  private boolean captureRequestBody;
 
   private ServletInstrumenterBuilder(
       String instrumentationName,
@@ -102,6 +103,13 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
     return this;
   }
 
+  @CanIgnoreReturnValue
+  public ServletInstrumenterBuilder<REQUEST, RESPONSE> setCaptureRequestBody(
+      boolean captureRequestBody) {
+    this.captureRequestBody = captureRequestBody;
+    return this;
+  }
+
   public Instrumenter<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> build(
       SpanNameExtractor<ServletRequestContext<REQUEST>> spanNameExtractor) {
 
@@ -115,6 +123,10 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
                     new ServletRequestParametersExtractor<>(accessor, captureRequestParameters);
             builder.addAttributesExtractor(requestParametersExtractor);
           }
+          if (captureRequestBody) {
+            builder.addAttributesExtractor(new ServletRequestBodyExtractor<>(accessor));
+          }
+
           for (ContextCustomizer<? super ServletRequestContext<REQUEST>> contextCustomizer :
               contextCustomizers) {
             builder.addContextCustomizer(contextCustomizer);

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletRequestBodyExtractor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/internal/ServletRequestBodyExtractor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.servlet.internal;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class ServletRequestBodyExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<
+        ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
+
+  private static final AttributeKey<String> SPAN_BODY_ATTRIBUTE =
+      AttributeKey.stringKey("http.request.body.text");
+  public static final String REQUEST_BODY_ATTRIBUTE = "otel.request.body";
+
+  private final ServletAccessor<REQUEST, RESPONSE> accessor;
+
+  public ServletRequestBodyExtractor(ServletAccessor<REQUEST, RESPONSE> accessor) {
+    this.accessor = accessor;
+  }
+
+  @Override
+  public void onStart(
+      AttributesBuilder attributes,
+      Context parentContext,
+      ServletRequestContext<REQUEST> requestServletRequestContext) {}
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      ServletRequestContext<REQUEST> requestServletRequestContext,
+      @Nullable ServletResponseContext<RESPONSE> responseServletResponseContext,
+      @Nullable Throwable error) {
+
+    Object requestBody =
+        accessor.getRequestAttribute(
+            requestServletRequestContext.request(), REQUEST_BODY_ATTRIBUTE);
+
+    if (requestBody instanceof ByteBuffer) {
+      ByteBuffer buffer = (ByteBuffer) requestBody;
+      // TODO: decide how to get the charset/encoding
+      buffer.arrayOffset();
+      attributes.put(
+          SPAN_BODY_ATTRIBUTE,
+          new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+    jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-body=true")
     jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
@@ -65,6 +65,7 @@ public final class HttpServerTestOptions {
   boolean testNonStandardHttpMethod = true;
   boolean verifyServerSpanEndTime = true;
   boolean useHttp2 = false;
+  boolean testRequestBodyCapture;
 
   HttpServerTestOptions() {}
 
@@ -229,6 +230,12 @@ public final class HttpServerTestOptions {
   @CanIgnoreReturnValue
   public HttpServerTestOptions useHttp2() {
     return setUseHttp2(true);
+  }
+
+  @CanIgnoreReturnValue
+  public HttpServerTestOptions setTestRequestBodyCapture(boolean testRequestBodyCapture) {
+    this.testRequestBodyCapture = testRequestBodyCapture;
+    return this;
   }
 
   @FunctionalInterface

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
@@ -32,6 +32,8 @@ public class ServerEndpoint {
   public static final ServerEndpoint CAPTURE_PARAMETERS =
       new ServerEndpoint("CAPTURE_PARAMETERS", "captureParameters", 200, "parameters captured");
 
+  public static final ServerEndpoint CAPTURE_BODY =
+      new ServerEndpoint("CAPTURE_BODY", "captureBody", 200, "response body");
   // TODO: add tests for the following cases:
   public static final ServerEndpoint QUERY_PARAM =
       new ServerEndpoint("QUERY_PARAM", "query?some=query", 200, "some=query");


### PR DESCRIPTION
This is an early prototype implementation of servlet request body capture.
The goal of this PR is to gather feedback on the suggested approach and having this feature provided (but opt-in) by default.

- adds `otel.instrumentation.servlet.experimental.capture-request-body=true|false` config option
- maximum body size is not configurable (yet)
- body capture implemented by copying in-memory (duplicates in-memory)
- limited to request body
- limited to Servlet 5.x for now
- limited to `Servlet.getInputStream()`, `Servlet.getReader()` not supported

Relates to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8778