### PR TITLE
Deprecate JavaHttpServerTelemetry.configure()

### DIFF
--- a/instrumentation/java-http-server/library/README.md
+++ b/instrumentation/java-http-server/library/README.md
@@ -57,7 +57,8 @@ public class Application {
 
     OpenTelemetry openTelemetry = //...
 
-    JavaHttpServerTelemetry.create(openTelemetry).configure(context);
+    Filter filter = JavaHttpServerTelemetry.create(openTelemetry).createFilter();
+    context.getFilters().add(0, filter);
   }
 }
 ```

--- a/instrumentation/java-http-server/library/src/main/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerTelemetry.java
+++ b/instrumentation/java-http-server/library/src/main/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerTelemetry.java
@@ -35,7 +35,12 @@ public final class JavaHttpServerTelemetry {
     return new OpenTelemetryFilter(instrumenter);
   }
 
-  /** Configures the {@link HttpContext} to produce telemetry. */
+  /**
+   * Configures the {@link HttpContext} to produce telemetry.
+   *
+   * @deprecated Use {@link #createFilter()} and add it to the {@link HttpContext} directly.
+   */
+  @Deprecated
   public void configure(HttpContext httpContext) {
     httpContext.getFilters().add(0, createFilter());
   }


### PR DESCRIPTION
Seems like an unnecessary convenience wrapper for createFilter()