### PR TITLE
Ratpack library instrumentation: rename three methods

### DIFF
--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetry.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackServerTelemetry.java
@@ -78,7 +78,7 @@ public final class RatpackServerTelemetry {
   }
 
   /** Creates an {@link ExecInterceptor} instance to support Ratpack Registry binding. */
-  public static ExecInterceptor createExecInterceptor() {
+  public ExecInterceptor createExecInterceptor() {
     return OpenTelemetryExecInterceptor.INSTANCE;
   }
 
@@ -93,7 +93,7 @@ public final class RatpackServerTelemetry {
   }
 
   /** Creates an {@link ExecInitializer} instance to support Ratpack Registry binding. */
-  public static ExecInitializer createExecInitializer() {
+  public ExecInitializer createExecInitializer() {
     return OpenTelemetryExecInitializer.INSTANCE;
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/OpenTelemetryModule.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/OpenTelemetryModule.java
@@ -49,8 +49,8 @@ public class OpenTelemetryModule extends AbstractModule {
 
   @Singleton
   @Provides
-  static ExecInterceptor ratpackExecInterceptor() {
-    return RatpackServerTelemetry.createExecInterceptor();
+  static ExecInterceptor ratpackExecInterceptor(RatpackServerTelemetry telemetry) {
+    return telemetry.createExecInterceptor();
   }
 
   @Singleton
@@ -61,7 +61,7 @@ public class OpenTelemetryModule extends AbstractModule {
 
   @Singleton
   @Provides
-  static ExecInitializer ratpackExecInitializer() {
-    return RatpackServerTelemetry.createExecInitializer();
+  static ExecInitializer ratpackExecInitializer(RatpackServerTelemetry telemetry) {
+    return telemetry.createExecInitializer();
   }
 }


### PR DESCRIPTION
Rename
- getHandler() -> createHandler()
- getExecInterceptor() -> createExecInterceptor()
- getExecInitializer() -> createExecInitializer()
