### PR TITLE
Fix metadata update action

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Commit and push changes
         if: steps.diffcheck.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           git commit -m "chore: update instrumentation list [automated]" || echo "No changes to commit."


### PR DESCRIPTION
Hopefully resolves #16020 

This variable was removed in #15555 , and it actually continued to work as of the 16th of december (#15676).

I think it broke when the action was updated in https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/e58f88124a

There are some issues around the git authentication changing in that github action that i think are related:

- https://github.com/actions/checkout/issues/2359
- https://github.com/actions/checkout/issues/2321

