### PR TITLE
Fix flaky nats test

### DIFF
--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsExperimentalTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsExperimentalTest.java
@@ -15,11 +15,15 @@ import io.nats.client.impl.Headers;
 import io.nats.client.impl.NatsMessage;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractNatsExperimentalTest extends AbstractNatsTest {
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   private int clientId;
 
@@ -44,7 +48,7 @@ public abstract class AbstractNatsExperimentalTest extends AbstractNatsTest {
                   NatsMessage.builder().subject("sub").headers(headers).data("x").build();
               connection.publish(message);
             });
-    connection.closeDispatcher(dispatcher);
+    cleanup.deferCleanup(() -> connection.closeDispatcher(dispatcher));
 
     // then
     testing()


### PR DESCRIPTION
Hopefully resolves https://develocity.opentelemetry.io/s/3exlholke32h2/tests/task/:instrumentation:nats:nats-2.17:library:test/details/io.opentelemetry.instrumentation.nats.v2_17.NatsExperimentalTest/testCapturedHeaders()?expanded-stacktrace=WyIwIl0&top-execution=1
I think the issue is that dispatcher might get closed before the message is processed.