### PR TITLE
Start adding support for `peer.service.name` (under opt-in flag)

### DIFF
--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -91,14 +91,14 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,code")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database,code,service.peer")
     inputs.dir(jflexOutputDir)
   }
 
   val testBothSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,code/dup")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,code/dup,service.peer/dup")
     inputs.dir(jflexOutputDir)
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.internal.HostAddressAndPortExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
@@ -29,6 +30,9 @@ public final class HttpClientPeerServiceAttributesExtractor<REQUEST, RESPONSE>
 
   // copied from PeerIncubatingAttributes
   private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
+  // copied from ServiceIncubatingAttributes
+  private static final AttributeKey<String> SERVICE_PEER_NAME =
+      AttributeKey.stringKey("service.peer.name");
 
   private final AddressAndPortExtractor<REQUEST> addressAndPortExtractor;
   private final HttpClientAttributesGetter<REQUEST, RESPONSE> attributesGetter;
@@ -82,7 +86,12 @@ public final class HttpClientPeerServiceAttributesExtractor<REQUEST, RESPONSE>
     String peerService =
         mapToPeerService(addressAndPort.getAddress(), addressAndPort.getPort(), pathSupplier);
     if (peerService != null) {
-      attributes.put(PEER_SERVICE, peerService);
+      if (SemconvStability.emitOldServicePeerSemconv()) {
+        attributes.put(PEER_SERVICE, peerService);
+      }
+      if (SemconvStability.emitStableServicePeerSemconv()) {
+        attributes.put(SERVICE_PEER_NAME, peerService);
+      }
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
@@ -22,6 +23,9 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
 
   // copied from PeerIncubatingAttributes
   private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
+  // copied from ServiceIncubatingAttributes
+  private static final AttributeKey<String> SERVICE_PEER_NAME =
+      AttributeKey.stringKey("service.peer.name");
 
   private final ServerAttributesGetter<REQUEST> attributesGetter;
   private final PeerServiceResolver peerServiceResolver;
@@ -63,7 +67,12 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
     Integer serverPort = attributesGetter.getServerPort(request);
     String peerService = mapToPeerService(serverAddress, serverPort);
     if (peerService != null) {
-      attributes.put(PEER_SERVICE, peerService);
+      if (SemconvStability.emitOldServicePeerSemconv()) {
+        attributes.put(PEER_SERVICE, peerService);
+      }
+      if (SemconvStability.emitStableServicePeerSemconv()) {
+        attributes.put(SERVICE_PEER_NAME, peerService);
+      }
     }
   }
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientPeerServiceAttributesExtractorTest.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.PeerIncubatingAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SERVICE_PEER_NAME;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.entry;
@@ -18,8 +21,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -103,8 +106,14 @@ class HttpClientPeerServiceAttributesExtractorTest {
 
     // then
     assertThat(startAttributes.build()).isEmpty();
-    assertThat(endAttributes.build())
-        .containsOnly(entry(PeerIncubatingAttributes.PEER_SERVICE, "myService"));
+    Attributes attrs = endAttributes.build();
+    if (SemconvStability.emitOldServicePeerSemconv()
+        && SemconvStability.emitStableServicePeerSemconv()) {
+      assertThat(attrs)
+          .containsOnly(entry(PEER_SERVICE, "myService"), entry(SERVICE_PEER_NAME, "myService"));
+    } else {
+      assertThat(attrs).containsOnly(entry(maybeStablePeerService(), "myService"));
+    }
   }
 
   @Test
@@ -133,7 +142,13 @@ class HttpClientPeerServiceAttributesExtractorTest {
 
     // then
     assertThat(startAttributes.build()).isEmpty();
-    assertThat(endAttributes.build())
-        .containsOnly(entry(PeerIncubatingAttributes.PEER_SERVICE, "myService"));
+    Attributes attrs = endAttributes.build();
+    if (SemconvStability.emitOldServicePeerSemconv()
+        && SemconvStability.emitStableServicePeerSemconv()) {
+      assertThat(attrs)
+          .containsOnly(entry(PEER_SERVICE, "myService"), entry(SERVICE_PEER_NAME, "myService"));
+    } else {
+      assertThat(attrs).containsOnly(entry(maybeStablePeerService(), "myService"));
+    }
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceAttributesExtractorTest.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.net;
 
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.PeerIncubatingAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SERVICE_PEER_NAME;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,8 +18,8 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -97,7 +100,13 @@ class PeerServiceAttributesExtractorTest {
 
     // then
     assertThat(startAttributes.build()).isEmpty();
-    assertThat(endAttributes.build())
-        .containsOnly(entry(PeerIncubatingAttributes.PEER_SERVICE, "myService"));
+    Attributes attrs = endAttributes.build();
+    if (SemconvStability.emitOldServicePeerSemconv()
+        && SemconvStability.emitStableServicePeerSemconv()) {
+      assertThat(attrs)
+          .containsOnly(entry(PEER_SERVICE, "myService"), entry(SERVICE_PEER_NAME, "myService"));
+    } else {
+      assertThat(attrs).containsOnly(entry(maybeStablePeerService(), "myService"));
+    }
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -24,12 +24,18 @@ public final class SemconvStability {
   private static final boolean emitOldCodeSemconv;
   private static final boolean emitStableCodeSemconv;
 
+  private static final boolean emitOldServicePeerSemconv;
+  private static final boolean emitStableServicePeerSemconv;
+
   static {
     boolean oldDatabase = true;
     boolean stableDatabase = false;
 
     boolean oldCode = true;
     boolean stableCode = false;
+
+    boolean oldServicePeer = true;
+    boolean stableServicePeer = false;
 
     String value = System.getProperty("otel.semconv-stability.opt-in");
     if (value == null) {
@@ -58,6 +64,15 @@ public final class SemconvStability {
         oldCode = true;
         stableCode = true;
       }
+
+      if (values.contains("service.peer")) {
+        oldServicePeer = false;
+        stableServicePeer = true;
+      }
+      if (values.contains("service.peer/dup")) {
+        oldServicePeer = true;
+        stableServicePeer = true;
+      }
     }
 
     emitOldDatabaseSemconv = oldDatabase;
@@ -65,6 +80,9 @@ public final class SemconvStability {
 
     emitOldCodeSemconv = oldCode;
     emitStableCodeSemconv = stableCode;
+
+    emitOldServicePeerSemconv = oldServicePeer;
+    emitStableServicePeerSemconv = stableServicePeer;
   }
 
   public static boolean emitOldDatabaseSemconv() {
@@ -73,6 +91,14 @@ public final class SemconvStability {
 
   public static boolean emitStableDatabaseSemconv() {
     return emitStableDatabaseSemconv;
+  }
+
+  public static boolean emitOldServicePeerSemconv() {
+    return emitOldServicePeerSemconv;
+  }
+
+  public static boolean emitStableServicePeerSemconv() {
+    return emitStableServicePeerSemconv;
   }
 
   private static final Map<String, String> dbSystemNameMap = new HashMap<>();

--- a/instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -35,4 +35,14 @@ tasks {
   check {
     dependsOn(testing.suites)
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.testing.junit.http;
 
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.comparingRootSpanAttribute;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -31,7 +32,6 @@ import io.opentelemetry.semconv.SchemaUrls;
 import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 import io.opentelemetry.semconv.UserAgentAttributes;
-import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.UrlIncubatingAttributes;
 import java.net.URI;
@@ -1074,7 +1074,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
         .hasKind(SpanKind.CLIENT)
         .hasAttributesSatisfying(
             attrs -> {
-              // Check for peer.service when running with javaagent instrumentation
+              // Check for service.peer.name when running with javaagent instrumentation
               String distroName =
                   span.actual()
                       .getResource()
@@ -1082,8 +1082,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
               if ("opentelemetry-java-instrumentation".equals(distroName)) {
                 String expectedPeerService = options.getExpectedPeerServiceName().apply(uri);
                 if (expectedPeerService != null) {
-                  assertThat(attrs)
-                      .containsEntry(PeerIncubatingAttributes.PEER_SERVICE, expectedPeerService);
+                  assertThat(attrs).containsEntry(maybeStablePeerService(), expectedPeerService);
                 }
               }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/service/SemconvServiceStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/service/SemconvServiceStabilityUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.testing.junit.service;
+
+import static io.opentelemetry.semconv.incubating.PeerIncubatingAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SERVICE_PEER_NAME;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+
+// until old peer.service attribute is dropped in 3.0
+@SuppressWarnings("deprecation") // using deprecated semconv
+public final class SemconvServiceStabilityUtil {
+
+  /** Returns PEER_SERVICE or SERVICE_PEER_NAME depending on service.peer semconv stability mode. */
+  public static AttributeKey<String> maybeStablePeerService() {
+    if (SemconvStability.emitStableServicePeerSemconv()) {
+      return SERVICE_PEER_NAME;
+    }
+    return PEER_SERVICE;
+  }
+
+  private SemconvServiceStabilityUtil() {}
+}


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/pull/3097