### PR TITLE
[POC] Add opt-in support for emitting exceptions as logs

### DIFF
--- a/EXCEPTION-EXTRACTOR-REVIEW.md
+++ b/EXCEPTION-EXTRACTOR-REVIEW.md
@@ -1,0 +1,201 @@
+# Exception Event Extractor Review Checklist
+
+Findings from reviewing `7f8e5ec..HEAD`.
+
+---
+
+## 1. Bug: GWT build missing `classpath`
+
+- [ ] `instrumentation/gwt-2.0/javaagent/build.gradle.kts` — add `classpath = sourceSets.test.get().runtimeClasspath` to the `testExceptionSignalLogs` task
+
+---
+
+## 2. Missing Exception Event Extractors
+
+Instrumentations that build `Instrumenter` instances but do not call `Experimental.setExceptionEventExtractor()`.
+
+### Controller/Handler spans (INTERNAL, under HTTP server spans)
+
+- [ ] `instrumentation/finatra-2.9/javaagent` — `FinatraSingletons.java`
+- [ ] `instrumentation/grails-3.0/javaagent` — `GrailsSingletons.java`
+- [ ] `instrumentation/jaxws/jaxws-metro-2.2/javaagent` — `MetroSingletons.java`
+- [ ] `instrumentation/jaxws/jaxws-cxf-3.0/javaagent` — `CxfSingletons.java`
+- [ ] `instrumentation/jaxws/jaxws-common/javaagent` — `JaxWsInstrumenterFactory.java`
+- [ ] `instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent` — `Axis2Singletons.java`
+- [ ] `instrumentation/jaxrs/jaxrs-common/javaagent` — `JaxrsInstrumenterFactory.java`
+- [ ] `instrumentation/jaxrs/jaxrs-1.0/javaagent` — `JaxrsSingletons.java`
+- [ ] `instrumentation/play/play-mvc/play-mvc-2.6/javaagent` — `Play26Singletons.java`
+- [ ] `instrumentation/play/play-mvc/play-mvc-2.4/javaagent` — `Play24Singletons.java`
+- [ ] `instrumentation/jsf/jsf-myfaces-3.0/javaagent` — `MyFacesSingletons.java`
+- [ ] `instrumentation/jsf/jsf-myfaces-1.2/javaagent` — `MyFacesSingletons.java`
+- [ ] `instrumentation/jsf/jsf-mojarra-3.0/javaagent` — `MojarraSingletons.java`
+- [ ] `instrumentation/jsf/jsf-mojarra-1.2/javaagent` — `MojarraSingletons.java`
+- [ ] `instrumentation/jfinal-3.2/javaagent` — `JFinalSingletons.java`
+- [ ] `instrumentation/tapestry-5.4/javaagent` — `TapestrySingletons.java`
+- [ ] `instrumentation/struts/struts-7.0/javaagent` — `StrutsSingletons.java`
+- [ ] `instrumentation/struts/struts-2.3/javaagent` — `StrutsSingletons.java`
+- [ ] `instrumentation/ratpack/ratpack-1.4/javaagent` — `RatpackSingletons.java`
+- [ ] `instrumentation/spring/spring-webmvc/spring-webmvc-common/javaagent` — `SpringWebMvcInstrumenterFactory.java`
+- [ ] `instrumentation/spring/spring-ws-2.0/javaagent` — `SpringWsSingletons.java`
+- [ ] `instrumentation/servlet/servlet-common/javaagent` — `ResponseInstrumenterFactory.java`
+
+### View/Render spans
+
+- [ ] `instrumentation/dropwizard/dropwizard-views-0.7/javaagent` — `DropwizardSingletons.java`
+- [ ] `instrumentation/jsp-2.3/javaagent` — `JspCompilationContextInstrumentationSingletons.java`
+- [ ] `instrumentation/jsp-2.3/javaagent` — `HttpJspPageInstrumentationSingletons.java`
+
+### Code/Method tracing
+
+- [ ] `instrumentation/external-annotations/javaagent` — `ExternalAnnotationSingletons.java`
+- [ ] `instrumentation/methods/javaagent` — `MethodSingletons.java`
+- [ ] `instrumentation/mybatis-3.2/javaagent` — `MyBatisSingletons.java`
+- [ ] `instrumentation/spring/spring-data/spring-data-1.8/javaagent` — `SpringDataSingletons.java`
+
+### GraphQL
+
+- [ ] `instrumentation/graphql-java/graphql-java-common/library` — `OpenTelemetryInstrumentationHelper.java`
+- [ ] `instrumentation/graphql-java/graphql-java-20.0/library` — `GraphqlInstrumenterFactory.java`
+
+### Batch Processing
+
+- [ ] `instrumentation/spring/spring-batch-3.0/javaagent` — `StepSingletons.java`
+- [ ] `instrumentation/spring/spring-batch-3.0/javaagent` — `ItemSingletons.java`
+
+### Vaadin (4 instrumenters)
+
+- [ ] `instrumentation/vaadin-14.2/javaagent` — `VaadinSingletons.java` (CLIENT_CALLABLE, REQUEST_HANDLER, RPC, SERVICE)
+
+### Netty connection/SSL sub-instrumenters
+
+- [ ] `instrumentation/netty/netty-3.8/javaagent` — `NettyClientSingletons.java` (CONNECTION_INSTRUMENTER)
+- [ ] `instrumentation/netty/netty-common-4.0/library` — `NettyClientInstrumenterFactory.java` (connection + SSL)
+
+---
+
+## 3. Missing `testExceptionSignalLogs` Gradle Tasks
+
+Modules that call `setExceptionEventExtractor` but have no `testExceptionSignalLogs` task.
+
+### Direct modules
+
+- [x] `instrumentation/hystrix-1.4/javaagent/build.gradle.kts`
+- [x] `instrumentation/apache-elasticjob-3.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/camel-2.20/javaagent/build.gradle.kts`
+- [x] `instrumentation/powerjob-4.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/quartz-2.0/library/build.gradle.kts`
+- [x] `instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts`
+- [x] `instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/build.gradle.kts`
+- [x] `instrumentation/opentelemetry-extension-annotations-1.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/build.gradle.kts`
+- [x] `instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/spring/spring-scheduling-3.1/javaagent/build.gradle.kts`
+- [x] `instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts`
+- [x] `instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts`
+
+### Common modules (+ their leaf modules)
+
+- [x] `instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/build.gradle.kts`
+- [x] `instrumentation/kafka/kafka-connect-2.6/javaagent/build.gradle.kts`
+- [x] `instrumentation/hibernate/hibernate-common/javaagent/build.gradle.kts` + leaf modules (4.0, 6.0)
+- [x] `instrumentation/jms/jms-common/javaagent/build.gradle.kts` + leaf modules
+- [x] `instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/build.gradle.kts` + leaf modules
+- [x] `instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/build.gradle.kts` + leaf modules
+- [x] `instrumentation/clickhouse/clickhouse-client-common/javaagent/build.gradle.kts` + leaf modules (v1, v2)
+- [x] `instrumentation/redisson/redisson-common/javaagent/build.gradle.kts` + leaf modules
+- [x] `instrumentation/opensearch/opensearch-rest-common/javaagent/build.gradle.kts` + leaf modules
+- [x] `instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/build.gradle.kts` + leaf modules
+- [x] `instrumentation/xxl-job/xxl-job-common/javaagent/build.gradle.kts` + leaf modules
+
+---
+
+## 4. Test Files Missing Conditional Exception Assertions
+
+Tests with `.hasException(` that are not gated by `emitExceptionAsSpanEvents()` and have no `emitExceptionAsLogs()` log assertions. When `-Dotel.semconv.exception.signal.opt-in=logs` is active, these will fail.
+
+### DB tests
+
+- [x] `instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/…/ClickHouseClientV2Test.java`
+- [x] `instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/…/ClickHouseClientV1Test.java`
+- [x] `instrumentation/hibernate/hibernate-4.0/javaagent/src/test/…/SessionTest.java`
+- [x] `instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate6Test/…/SessionTest.java`
+- [x] `instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/…/SessionTest.java`
+- [x] `instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/…/ProcedureCallTest.java`
+- [x] `instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/…/Elasticsearch53SpringTemplateTest.java`
+
+### HTTP tests
+
+- [x] `instrumentation/http-url-connection/javaagent/src/test/…/HttpUrlConnectionTest.java`
+- [x] `instrumentation/kubernetes-client-7.0/javaagent/src/test/…/KubernetesClientTest.java`
+- [x] `instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/…/KubernetesClientVer20Test.java`
+
+### Netty connection/SSL tests
+
+- [x] `instrumentation/netty/netty-4.1/javaagent/src/test/…/Netty41ConnectionSpanTest.java`
+- [x] `instrumentation/netty/netty-4.1/javaagent/src/test/…/Netty41ClientSslTest.java`
+- [x] `instrumentation/netty/netty-4.0/javaagent/src/test/…/Netty40ConnectionSpanTest.java`
+- [x] `instrumentation/netty/netty-4.0/javaagent/src/test/…/Netty40ClientSslTest.java`
+- [x] `instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/…/ReactorNettyConnectionSpanTest.java`
+- [x] `instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/…/ReactorNettyClientSslTest.java`
+- [x] `instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/…/ReactorNettyConnectionSpanTest.java`
+
+### Reactor Netty HTTP tests
+
+- [x] `instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/…/AbstractReactorNettyHttpClientTest.java`
+- [x] `instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/…/AbstractReactorNettyHttpClientTest.java`
+
+### Framework handler tests
+
+- [x] `instrumentation/grails-3.0/javaagent/src/test/…/GrailsTest.java`
+- [x] `instrumentation/jfinal-3.2/javaagent/src/test/…/JFinalTest.java`
+- [x] `instrumentation/tapestry-5.4/javaagent/src/test/…/TapestryTest.java`
+- [x] `instrumentation/struts/struts-7.0/javaagent/src/test/…/Struts2ActionSpanTest.java`
+- [x] `instrumentation/struts/struts-2.3/javaagent/src/test/…/Struts2ActionSpanTest.java`
+- [x] `instrumentation/dropwizard/dropwizard-testing/src/test/…/DropwizardTest.java`
+- [x] `instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/test/…/PlayServerTest.java`
+- [x] `instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/latestDepTest/…/PlayServerTest.java`
+- [x] `instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/…/PlayServerTest.java`
+- [x] `instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/…/PlayServerTest.java`
+- [x] `instrumentation/spring/spring-webmvc/spring-webmvc-3.1/wildfly-testing/src/test/…/AbstractOpenTelemetryHandlerMappingFilterTest.java`
+
+### Scheduled job tests
+
+- [x] `instrumentation/apache-elasticjob-3.0/javaagent/src/test/…/ElasticJobTest.java`
+- [x] `instrumentation/spring/spring-batch-3.0/javaagent/src/test/…/SpringBatchTest.java`
+
+### Annotation/tracing tests
+
+- [x] `instrumentation/external-annotations/javaagent/src/test/…/TraceAnnotationsTest.java`
+- [x] `instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/…/WithSpanInstrumentationTest.java`
+- [x] `instrumentation/methods/javaagent/src/test/…/MethodTest.java`
+- [x] `instrumentation/rxjava/rxjava-2.0/javaagent/src/test/…/BaseRxJava2WithSpanTest.java`
+
+### AWS Lambda tests
+
+- [x] `instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/…/AwsLambdaStreamWrapperTest.java`
+- [x] `instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/…/AwsLambdaStreamWrapperHttpPropagationTest.java`
+- [x] `instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/…/AwsLambdaStreamHandlerTest.java`
+- [x] `instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/…/AwsLambdaStreamHandlerTest.java`
+- [x] `instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/…/AwsLambdaWrapperTest.java`
+
+### AWS SDK tests
+
+- [x] `instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/…/S3ClientTest.java`
+- [x] `instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/…/Aws0ClientTest.java`
+
+### Other
+
+- [x] `instrumentation/graphql-java/graphql-java-20.0/library/src/test/…/GraphqlTest.java`
+- [x] `instrumentation/hystrix-1.4/javaagent/src/test/…/HystrixTest.java`
+- [x] `instrumentation/hystrix-1.4/javaagent/src/test/…/HystrixObservableTest.java`
+- [x] `instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/test/…/TracerTest.java`
+- [x] `instrumentation/spring/spring-kafka-2.7/javaagent/src/test/…/SpringKafkaTest.java`
+- [x] `instrumentation/servlet/servlet-2.2/javaagent/src/test/…/HttpServletResponseTest.java`
+- [x] `instrumentation/servlet/servlet-3.0/javaagent-testing/src/test/…/HttpServletResponseTest.java`
+
+---
+
+## 5. Design Note: Controller exceptions lost in logs mode
+
+`AbstractHttpServerTest.assertControllerSpan()` gates `.hasException()` with `emitExceptionAsSpanEvents()`, but no log assertion is added for controller exceptions. The `assertExceptionLogs()` call at line 797 checks for `http.server.request.exception` (the server span's event name), not the controller span's. Since the controller instrumenters in section 2 don't have extractors, controller exceptions are silently dropped in logs mode. Decide whether this is acceptable or if controller-level extractors are needed.

--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -102,7 +102,21 @@ tasks {
     inputs.dir(jflexOutputDir)
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    inputs.dir(jflexOutputDir)
+  }
+
+  val testExceptionSignalLogsDup by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs/dup")
+    inputs.dir(jflexOutputDir)
+  }
+
   check {
-    dependsOn(testStableSemconv, testBothSemconv)
+    dependsOn(testStableSemconv, testBothSemconv, testExceptionSignalLogs, testExceptionSignalLogsDup)
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
@@ -14,6 +14,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.CommonConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientExperimentalMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientServicePeerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimentalAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.internal.HttpClientUrlTemplateUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -223,6 +224,7 @@ public final class DefaultHttpClientInstrumenterBuilder<REQUEST, RESPONSE> {
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpClientMetrics.get())
             .setSchemaUrl(SchemaUrls.V1_37_0);
+    Experimental.setExceptionEventExtractor(builder, HttpExceptionEventExtractors.client());
     if (emitExperimentalHttpClientTelemetry) {
       builder
           .addAttributesExtractor(HttpExperimentalAttributesExtractor.create(attributesGetter))

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpServerInstrumenterBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpServerInstrumenterBuilder.java
@@ -11,6 +11,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.CommonConfig;
+import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimentalAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpServerExperimentalMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -19,6 +20,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
@@ -215,6 +217,7 @@ public final class DefaultHttpServerInstrumenterBuilder<REQUEST, RESPONSE> {
             .addContextCustomizer(httpServerRouteBuilder.build())
             .addOperationMetrics(HttpServerMetrics.get())
             .setSchemaUrl(SchemaUrls.V1_37_0);
+    Experimental.setExceptionEventExtractor(builder, HttpExceptionEventExtractors.server());
     if (emitExperimentalHttpServerTelemetry) {
       builder
           .addAttributesExtractor(HttpExperimentalAttributesExtractor.create(attributesGetter))

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/instrumenter/DefaultExceptionEventExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/instrumenter/DefaultExceptionEventExtractor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.instrumenter;
+
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+
+/**
+ * {@link ExceptionEventExtractor} that sets the given event name, using {@link Severity#ERROR} when
+ * the span is a local root, and {@link Severity#DEBUG} otherwise.
+ */
+final class DefaultExceptionEventExtractor<REQUEST> implements ExceptionEventExtractor<REQUEST> {
+
+  private final String eventName;
+
+  static <REQUEST> ExceptionEventExtractor<REQUEST> create(String eventName) {
+    return new DefaultExceptionEventExtractor<>(eventName);
+  }
+
+  private DefaultExceptionEventExtractor(String eventName) {
+    this.eventName = eventName;
+  }
+
+  @Override
+  public void extract(LogRecordBuilder logRecordBuilder, Context context, REQUEST request) {
+    logRecordBuilder.setEventName(eventName);
+    Span currentSpan = Span.fromContext(context);
+    Span localRootSpan = LocalRootSpan.fromContextOrNull(context);
+    if (currentSpan.equals(localRootSpan)) {
+      logRecordBuilder.setSeverity(Severity.ERROR);
+    } else {
+      logRecordBuilder.setSeverity(Severity.DEBUG);
+    }
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/instrumenter/ExceptionEventExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/instrumenter/ExceptionEventExtractor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.instrumenter;
+
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.internal.InternalExceptionEventExtractor;
+
+/**
+ * Extractor that populates the exception event {@link LogRecordBuilder} for a request. This allows
+ * instrumentations to set the event name, severity, and any additional attributes on the exception
+ * log event.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+@FunctionalInterface
+public interface ExceptionEventExtractor<REQUEST> extends InternalExceptionEventExtractor<REQUEST> {
+
+  /**
+   * Returns an {@link ExceptionEventExtractor} that always sets the given event name and severity.
+   */
+  static <REQUEST> ExceptionEventExtractor<REQUEST> create(String eventName, Severity severity) {
+    return (logRecordBuilder, context, request) -> {
+      logRecordBuilder.setEventName(eventName);
+      logRecordBuilder.setSeverity(severity);
+    };
+  }
+
+  /**
+   * Returns an {@link ExceptionEventExtractor} that sets the given event name, with {@link
+   * Severity#ERROR} for local root spans and {@link Severity#DEBUG} otherwise.
+   */
+  static <REQUEST> ExceptionEventExtractor<REQUEST> create(String eventName) {
+    return DefaultExceptionEventExtractor.create(eventName);
+  }
+
+  /**
+   * Populates the exception event {@link LogRecordBuilder} with the event name, severity, and any
+   * additional attributes for the given context and request.
+   */
+  @Override
+  void extract(LogRecordBuilder logRecordBuilder, Context context, REQUEST request);
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbExceptionEventExtractors.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.db;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+
+/**
+ * {@link ExceptionEventExtractor} constants for DB client instrumentations.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class DbExceptionEventExtractors {
+
+  /** Exception event extractor for DB client spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> client() {
+    return ExceptionEventExtractor.create("db.client.operation.exception", Severity.WARN);
+  }
+
+  private DbExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiExceptionEventExtractors.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.genai;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+
+/**
+ * {@link ExceptionEventExtractor} constants for GenAI client instrumentations.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class GenAiExceptionEventExtractors {
+
+  /** Exception event extractor for GenAI client spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> client() {
+    return ExceptionEventExtractor.create("gen_ai.client.operation.exception", Severity.WARN);
+  }
+
+  private GenAiExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExceptionEventExtractors.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.http;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+
+/**
+ * {@link ExceptionEventExtractor} constants for HTTP client and server instrumentations.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class HttpExceptionEventExtractors {
+
+  /** Exception event extractor for HTTP client spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> client() {
+    return ExceptionEventExtractor.create("http.client.request.exception", Severity.WARN);
+  }
+
+  /** Exception event extractor for HTTP server spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> server() {
+    return ExceptionEventExtractor.create("http.server.request.exception", Severity.ERROR);
+  }
+
+  private HttpExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingExceptionEventExtractors.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+
+/**
+ * {@link ExceptionEventExtractor} constants for messaging instrumentations.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class MessagingExceptionEventExtractors {
+
+  /** Exception event extractor for messaging client operation spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> client() {
+    return ExceptionEventExtractor.create("messaging.client.operation.exception", Severity.WARN);
+  }
+
+  /** Exception event extractor for messaging process spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> process() {
+    return ExceptionEventExtractor.create("messaging.process.exception", Severity.ERROR);
+  }
+
+  private MessagingExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcExceptionEventExtractors.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+
+/**
+ * {@link ExceptionEventExtractor} constants for RPC client and server instrumentations.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class RpcExceptionEventExtractors {
+
+  /** Exception event extractor for RPC client spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> client() {
+    return ExceptionEventExtractor.create("rpc.client.call.exception", Severity.WARN);
+  }
+
+  /** Exception event extractor for RPC server spans. */
+  public static <REQUEST> ExceptionEventExtractor<REQUEST> server() {
+    return ExceptionEventExtractor.create("rpc.server.call.exception", Severity.ERROR);
+  }
+
+  private RpcExceptionEventExtractors() {}
+}

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -44,4 +44,26 @@ tasks {
     jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+  }
+
+  val testExceptionSignalLogsDup by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs/dup")
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs, testExceptionSignalLogsDup)
+  }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
@@ -32,6 +32,10 @@ public final class Experimental {
   private static volatile BiConsumer<InstrumenterBuilder<?, ?>, AttributesExtractor<?, ?>>
       operationListenerAttributesExtractorAdder;
 
+  @Nullable
+  private static volatile BiConsumer<InstrumenterBuilder<?, ?>, InternalExceptionEventExtractor<?>>
+      exceptionEventExtractorSetter;
+
   private Experimental() {}
 
   public static void setRedactQueryParameters(
@@ -84,5 +88,24 @@ public final class Experimental {
           operationListenerAttributesExtractorAdder) {
     Experimental.operationListenerAttributesExtractorAdder =
         (BiConsumer) operationListenerAttributesExtractorAdder;
+  }
+
+  /**
+   * Sets the {@link InternalExceptionEventExtractor} that will determine the exception event name
+   * and severity. Only used when stable exception semconv is enabled.
+   */
+  public static <REQUEST> void setExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder,
+      InternalExceptionEventExtractor<? super REQUEST> exceptionEventExtractor) {
+    if (exceptionEventExtractorSetter != null) {
+      exceptionEventExtractorSetter.accept(builder, exceptionEventExtractor);
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"}) // we lose the generic type information
+  public static <REQUEST> void internalSetExceptionEventExtractor(
+      BiConsumer<InstrumenterBuilder<REQUEST, ?>, InternalExceptionEventExtractor<? super REQUEST>>
+          exceptionEventExtractorSetter) {
+    Experimental.exceptionEventExtractorSetter = (BiConsumer) exceptionEventExtractorSetter;
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InternalExceptionEventExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InternalExceptionEventExtractor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.context.Context;
+
+/**
+ * Internal functional interface for exception event extraction. Public API is in {@code
+ * ExceptionEventExtractor} in the incubator module.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+@FunctionalInterface
+public interface InternalExceptionEventExtractor<REQUEST> {
+
+  /**
+   * Populates the exception event {@link LogRecordBuilder} with the event name, severity, and any
+   * additional attributes for the given context and request.
+   */
+  void extract(LogRecordBuilder logRecordBuilder, Context context, REQUEST request);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvExceptionSignal.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvExceptionSignal.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class SemconvExceptionSignal {
+
+  private static final boolean emitExceptionAsSpanEvents;
+  private static final boolean emitExceptionAsLogs;
+
+  static {
+    boolean spanEvents = true;
+    boolean logs = false;
+
+    String value = System.getProperty("otel.semconv.exception.signal.opt-in");
+    if (value == null) {
+      value = System.getenv("OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN");
+    }
+    if (value != null) {
+      if (value.equals("logs")) {
+        spanEvents = false;
+        logs = true;
+      } else if (value.equals("logs/dup")) {
+        spanEvents = true;
+        logs = true;
+      }
+    }
+
+    emitExceptionAsSpanEvents = spanEvents;
+    emitExceptionAsLogs = logs;
+  }
+
+  public static boolean emitExceptionAsSpanEvents() {
+    return emitExceptionAsSpanEvents;
+  }
+
+  public static boolean emitExceptionAsLogs() {
+    return emitExceptionAsLogs;
+  }
+
+  private SemconvExceptionSignal() {}
+}

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
@@ -21,3 +21,15 @@ tasks.withType<Test>().configureEach {
   // required on jdk17
   jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboClientNetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
@@ -17,6 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import java.util.ArrayList;
@@ -107,6 +109,10 @@ public final class DubboTelemetryBuilder {
             .addAttributesExtractors(attributesExtractors)
             .addOperationMetrics(RpcClientMetrics.get());
 
+    Experimental.setExceptionEventExtractor(
+        serverInstrumenterBuilder, RpcExceptionEventExtractors.server());
+    Experimental.setExceptionEventExtractor(
+        clientInstrumenterBuilder, RpcExceptionEventExtractors.client());
     return new DubboTelemetry(
         serverInstrumenterBuilder.buildServerInstrumenter(DubboHeadersGetter.INSTANCE),
         clientInstrumenterBuilder.buildClientInstrumenter(DubboHeadersSetter.INSTANCE));

--- a/instrumentation/apache-elasticjob-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/build.gradle.kts
@@ -30,7 +30,13 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.apache-elasticjob.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobSingletons.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobSingletons.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.apacheelasticjob.v3_0;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class ElasticJobSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.apache-elasticjob-3.0";
@@ -38,6 +42,8 @@ public final class ElasticJobSingletons {
       builder.addAttributesExtractor(new ElasticJobExperimentalAttributeExtractor());
     }
 
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
     return builder.buildInstrumenter();
   }
 

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobTest.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.apacheelasticjob.v3_0;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.comparingRootSpanAttribute;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -283,7 +284,10 @@ class ElasticJobTest {
                     span.hasKind(SpanKind.INTERNAL)
                         .hasName("TestFailedJob.execute")
                         .hasStatus(StatusData.error())
-                        .hasException(new RuntimeException("Simulated job failure for testing"))
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new RuntimeException("Simulated job failure for testing")
+                                : null)
                         .hasAttributesSatisfyingExactly(
                             elasticJobAttributes(
                                 "failedElasticJob",

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -86,7 +87,7 @@ class AwsLambdaStreamHandlerTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
@@ -34,3 +34,15 @@ tasks.withType<Test>().configureEach {
   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
@@ -5,9 +5,14 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0.internal;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 
 /**
@@ -17,14 +22,16 @@ import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 public final class AwsLambdaFunctionInstrumenterFactory {
 
   public static AwsLambdaFunctionInstrumenter createInstrumenter(OpenTelemetry openTelemetry) {
-    return new AwsLambdaFunctionInstrumenter(
-        openTelemetry,
+    InstrumenterBuilder<AwsLambdaRequest, Object> builder =
         Instrumenter.builder(
                 openTelemetry,
                 "io.opentelemetry.aws-lambda-core-1.0",
                 AwsLambdaFunctionInstrumenterFactory::spanName)
-            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
-            .buildInstrumenter(SpanKindExtractor.alwaysServer()));
+            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor());
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("faas.invocation.exception", ERROR));
+    return new AwsLambdaFunctionInstrumenter(
+        openTelemetry, builder.buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 
   private static String spanName(AwsLambdaRequest input) {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
@@ -126,7 +127,7 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
                         .hasTraceId("4fd0b6131f19f39af59518d127b0cafe")
                         .hasParentSpanId("0000000000000456")
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 CLOUD_RESOURCE_ID,

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
@@ -107,7 +108,7 @@ class AwsLambdaStreamWrapperTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 CLOUD_RESOURCE_ID,

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
@@ -84,7 +85,7 @@ public abstract class AbstractAwsLambdaTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasStatus(StatusData.error())
-                            .hasException(thrown)
+                            .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -86,7 +87,7 @@ class AwsLambdaStreamHandlerTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaWrapperTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
@@ -94,7 +95,7 @@ class AwsLambdaWrapperTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 CLOUD_RESOURCE_ID,

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/build.gradle.kts
@@ -39,3 +39,15 @@ tasks.withType<Test>().configureEach {
   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3ClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3ClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -124,7 +125,7 @@ class S3ClientTest extends AbstractS3ClientTest {
                         span.hasName("S3.HeadBucket")
                             .hasKind(CLIENT)
                             .hasStatus(StatusData.error())
-                            .hasException(caught)
+                            .hasException(emitExceptionAsSpanEvents() ? caught : null)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
                                 equalTo(URL_FULL, "https://s3.amazonaws.com"),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws0ClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws0ClientTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -257,7 +258,7 @@ class Aws0ClientTest {
                     span.hasName("S3.GetObject")
                         .hasKind(CLIENT)
                         .hasStatus(StatusData.error())
-                        .hasException(caught)
+                        .hasException(emitExceptionAsSpanEvents() ? caught : null)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(URL_FULL, "http://localhost:" + UNUSABLE_PORT),
@@ -295,7 +296,7 @@ class Aws0ClientTest {
                     span.hasName("S3.GetObject")
                         .hasKind(CLIENT)
                         .hasStatus(StatusData.error())
-                        .hasException(caught)
+                        .hasException(emitExceptionAsSpanEvents() ? caught : null)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(URL_FULL, "https://s3.amazonaws.com"),
@@ -333,7 +334,7 @@ class Aws0ClientTest {
                     span.hasName("S3.GetObject")
                         .hasKind(CLIENT)
                         .hasStatus(StatusData.error())
-                        .hasException(caught)
+                        .hasException(emitExceptionAsSpanEvents() ? caught : null)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(URL_FULL, server.httpUri().toString()),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -58,7 +58,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -80,11 +80,16 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -101,8 +101,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRequest.java
@@ -11,7 +11,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
 @AutoValue
-abstract class CamelRequest {
+public abstract class CamelRequest {
 
   public static CamelRequest create(
       SpanDecorator spanDecorator,

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelSingletons.java
@@ -14,6 +14,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.decorators.DecoratorRegistry;
 import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
@@ -73,6 +74,13 @@ public final class CamelSingletons {
         Instrumenter.builder(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor);
     builder.addAttributesExtractor(attributesExtractor);
     builder.setSpanStatusExtractor(spanStatusExtractor);
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) ->
+            request
+                .getSpanDecorator()
+                .getExceptionEventExtractor(request.getSpanKind())
+                .extract(logRecordBuilder, context, request));
 
     INSTRUMENTER = builder.buildInstrumenter(request -> request.getSpanKind());
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/SpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/SpanDecorator.java
@@ -26,11 +26,20 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
 /** This interface represents a decorator specific to the component/endpoint being instrumented. */
 public interface SpanDecorator {
+
+  /**
+   * Returns the {@link ExceptionEventExtractor} for the given span kind.
+   *
+   * @param spanKind The span kind
+   * @return The exception event extractor
+   */
+  ExceptionEventExtractor<CamelRequest> getExceptionEventExtractor(SpanKind spanKind);
 
   /**
    * This method indicates whether the component associated with the SpanDecorator should result in

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/BaseSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/BaseSpanDecorator.java
@@ -30,7 +30,9 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelDirection;
+import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelRequest;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.SpanDecorator;
 import java.util.HashMap;
 import java.util.Map;
@@ -83,6 +85,11 @@ class BaseSpanDecorator implements SpanDecorator {
       return map;
     }
     return emptyMap();
+  }
+
+  @Override
+  public ExceptionEventExtractor<CamelRequest> getExceptionEventExtractor(SpanKind spanKind) {
+    return ExceptionEventExtractor.create("camel.exception");
   }
 
   @Override

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
@@ -34,10 +34,14 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuery;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuerySanitizer;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelDirection;
+import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelRequest;
 import java.net.URI;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -55,6 +59,11 @@ class DbSpanDecorator extends BaseSpanDecorator {
   DbSpanDecorator(String component, String system) {
     this.component = component;
     this.system = system;
+  }
+
+  @Override
+  public ExceptionEventExtractor<CamelRequest> getExceptionEventExtractor(SpanKind spanKind) {
+    return DbExceptionEventExtractors.client();
   }
 
   @Override

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
@@ -30,11 +30,15 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelDirection;
+import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
@@ -48,6 +52,14 @@ class HttpSpanDecorator extends BaseSpanDecorator {
   private static final String GET_METHOD = "GET";
   private static final Set<String> knownMethods =
       AgentCommonConfig.get().getKnownHttpRequestMethods();
+
+  @Override
+  public ExceptionEventExtractor<CamelRequest> getExceptionEventExtractor(SpanKind spanKind) {
+    if (spanKind == SpanKind.SERVER) {
+      return HttpExceptionEventExtractors.server();
+    }
+    return HttpExceptionEventExtractors.client();
+  }
 
   protected String getProtocol() {
     return "http";

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/MessagingSpanDecorator.java
@@ -28,7 +28,10 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingExceptionEventExtractors;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelDirection;
+import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelRequest;
 import java.net.URI;
 import java.util.Map;
 import org.apache.camel.Endpoint;
@@ -40,6 +43,14 @@ class MessagingSpanDecorator extends BaseSpanDecorator {
 
   public MessagingSpanDecorator(String component) {
     this.component = component;
+  }
+
+  @Override
+  public ExceptionEventExtractor<CamelRequest> getExceptionEventExtractor(SpanKind spanKind) {
+    if (spanKind == SpanKind.CONSUMER) {
+      return MessagingExceptionEventExtractors.process();
+    }
+    return MessagingExceptionEventExtractors.client();
   }
 
   @Override

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -49,13 +49,19 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -11,9 +11,12 @@ import com.datastax.driver.core.ExecutionInfo;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -27,7 +30,7 @@ public final class CassandraSingletons {
   static {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    INSTRUMENTER =
+    InstrumenterBuilder<CassandraRequest, ExecutionInfo> builder =
         Instrumenter.<CassandraRequest, ExecutionInfo>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
@@ -39,8 +42,9 @@ public final class CassandraSingletons {
                         AgentCommonConfig.get().isQuerySanitizationEnabled())
                     .build())
             .addAttributesExtractor(new CassandraAttributesExtractor())
-            .addOperationMetrics(DbClientMetrics.get())
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -33,12 +33,18 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.4/library/build.gradle.kts
@@ -27,7 +27,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/build.gradle.kts
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/build.gradle.kts
@@ -6,3 +6,15 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseInstrumenterFactory.java
+++ b/instrumentation/clickhouse/clickhouse-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/common/ClickHouseInstrumenterFactory.java
@@ -8,9 +8,12 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.common;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.util.function.Function;
 
 public final class ClickHouseInstrumenterFactory {
@@ -21,16 +24,18 @@ public final class ClickHouseInstrumenterFactory {
     ClickHouseAttributesGetter dbAttributesGetter =
         new ClickHouseAttributesGetter(errorCodeExtractor);
 
-    return Instrumenter.<ClickHouseDbRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            instrumenterName,
-            DbClientSpanNameExtractor.createForMigration(dbAttributesGetter))
-        .addAttributesExtractor(
-            SqlClientAttributesExtractor.<ClickHouseDbRequest, Void>builder(dbAttributesGetter)
-                .setTableAttribute(null)
-                .build())
-        .addOperationMetrics(DbClientMetrics.get())
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<ClickHouseDbRequest, Void> builder =
+        Instrumenter.<ClickHouseDbRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                instrumenterName,
+                DbClientSpanNameExtractor.createForMigration(dbAttributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.<ClickHouseDbRequest, Void>builder(dbAttributesGetter)
+                    .setTableAttribute(null)
+                    .build())
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private ClickHouseInstrumenterFactory() {}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/build.gradle.kts
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/build.gradle.kts
@@ -37,7 +37,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
@@ -271,7 +272,7 @@ class ClickHouseClientV1Test {
                                 : "SELECT " + databaseName)
                         .hasKind(SpanKind.CLIENT)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), databaseName),

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/build.gradle.kts
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/build.gradle.kts
@@ -31,7 +31,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
@@ -262,7 +263,7 @@ class ClickHouseClientV2Test {
                                 : "SELECT " + databaseName)
                         .hasKind(SpanKind.CLIENT)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), databaseName),

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
@@ -49,13 +49,19 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
@@ -10,10 +10,12 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class CouchbaseSingletons {
 
@@ -40,6 +42,7 @@ public final class CouchbaseSingletons {
       builder.addAttributesExtractor(new ExperimentalAttributesExtractor());
     }
 
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
     INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/dropwizard/dropwizard-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizard/DropwizardTest.java
+++ b/instrumentation/dropwizard/dropwizard-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizard/DropwizardTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.dropwizard;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -108,7 +109,8 @@ class DropwizardTest extends AbstractHttpServerTest<DropwizardTestSupport<Config
         .hasKind(INTERNAL);
     if (EXCEPTION.equals(endpoint)) {
       span.hasStatus(StatusData.error())
-          .hasException(new IllegalStateException(EXCEPTION.getBody()));
+          .hasException(
+              emitExceptionAsSpanEvents() ? new IllegalStateException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
@@ -89,7 +89,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
@@ -51,7 +51,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -49,7 +49,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -54,7 +54,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/build.gradle.kts
@@ -15,4 +15,14 @@ tasks {
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
 
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
@@ -8,10 +8,13 @@ package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -43,12 +46,14 @@ public final class ElasticsearchRestInstrumenterFactory {
         spanNameExtractorTransformer.apply(
             new ElasticsearchSpanNameExtractor(dbClientAttributesGetter));
 
-    return Instrumenter.<ElasticsearchRestRequest, Response>builder(
-            openTelemetry, instrumentationName, spanNameExtractor)
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(esClientAttributesExtractor)
-        .addAttributesExtractors(attributesExtractors)
-        .addOperationMetrics(DbClientMetrics.get())
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<ElasticsearchRestRequest, Response> builder =
+        Instrumenter.<ElasticsearchRestRequest, Response>builder(
+                openTelemetry, instrumentationName, spanNameExtractor)
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(esClientAttributesExtractor)
+            .addAttributesExtractors(attributesExtractors)
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
@@ -73,7 +73,13 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.elasticsearch.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv, testExperimental)
+    dependsOn(testing.suites, testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -93,8 +93,14 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.elasticsearch.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3.
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -183,7 +184,7 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(expectedException)
+                        .hasException(emitExceptionAsSpanEvents() ? expectedException : null)
                         .hasAttributesSatisfyingExactly(assertions)));
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -123,8 +123,14 @@ tasks {
     }
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, stableSemconvSuites, experimentalSuites)
+    dependsOn(testing.suites, stableSemconvSuites, experimentalSuites, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportInstrumenterFactory.java
@@ -10,10 +10,12 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import org.elasticsearch.action.ActionResponse;
 
 public final class ElasticsearchTransportInstrumenterFactory {
@@ -42,6 +44,8 @@ public final class ElasticsearchTransportInstrumenterFactory {
       instrumenterBuilder.addAttributesExtractor(experimentalAttributesExtractor);
     }
 
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, DbExceptionEventExtractors.client());
     return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchNodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/AbstractElasticsearchNodeClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
@@ -127,13 +128,13 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(expectedException),
+                        .hasException(emitExceptionAsSpanEvents() ? expectedException : null),
                 span ->
                     span.hasName("GetAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(expectedException)
+                        .hasException(emitExceptionAsSpanEvents() ? expectedException : null)
                         .hasAttributesSatisfyingExactly(assertions),
                 span ->
                     span.hasName("callback")

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/TraceAnnotationsTest.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/extannotations/TraceAnnotationsTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.extannotations;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -84,7 +85,7 @@ class TraceAnnotationsTest {
                 span ->
                     span.hasName("SayTracedHello.sayError")
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(assertCodeFunction("sayError"))));
   }
 

--- a/instrumentation/geode-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/geode-1.4/javaagent/build.gradle.kts
@@ -20,20 +20,25 @@ dependencies {
 val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
 
 tasks {
+  withType<Test>().configureEach {
+    systemProperty("collectMetadata", collectMetadata)
+  }
+
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
-    systemProperty("collectMetadata", collectMetadata)
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
-  test {
-    systemProperty("collectMetadata", collectMetadata)
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
   }
 
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/grails-3.0/javaagent/src/test/java/test/GrailsTest.java
+++ b/instrumentation/grails-3.0/javaagent/src/test/java/test/GrailsTest.java
@@ -5,6 +5,7 @@
 
 package test;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -167,7 +168,8 @@ class GrailsTest extends AbstractHttpServerTest<ConfigurableApplicationContext> 
 
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalStateException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalStateException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/graphql-java/graphql-java-20.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/v20_0/GraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/v20_0/GraphqlTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.graphql.v20_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
@@ -310,13 +311,19 @@ class GraphqlTest extends AbstractGraphqlTest {
                             equalTo(GRAPHQL_FIELD_NAME, "bookById"),
                             equalTo(GRAPHQL_FIELD_PATH, "/bookById"))
                         .hasStatus(StatusData.error())
-                        .hasException(new IllegalStateException("fetching book failed")),
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new IllegalStateException("fetching book failed")
+                                : null),
                 span ->
                     span.hasName("fetchBookById")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(spanWithName("bookById"))
                         .hasStatus(StatusData.error())
-                        .hasException(new IllegalStateException("fetching book failed"))));
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new IllegalStateException("fetching book failed")
+                                : null)));
   }
 
   // test data fetcher returning an error

--- a/instrumentation/grpc-1.6/library/build.gradle.kts
+++ b/instrumentation/grpc-1.6/library/build.gradle.kts
@@ -17,12 +17,22 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
     // latest dep test occasionally fails because network type is ipv6 instead of the expected ipv4
     // and peer address is 0:0:0:0:0:0:0:1 instead of 127.0.0.1
     jvmArgs("-Djava.net.preferIPv4Stack=true")
+  }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -12,6 +12,7 @@ import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSizeAttributesExtractor;
@@ -196,6 +197,10 @@ public final class GrpcTelemetryBuilder {
     Experimental.addOperationListenerAttributesExtractor(
         serverInstrumenterBuilder, RpcSizeAttributesExtractor.create(rpcAttributesGetter));
 
+    Experimental.setExceptionEventExtractor(
+        serverInstrumenterBuilder, RpcExceptionEventExtractors.server());
+    Experimental.setExceptionEventExtractor(
+        clientInstrumenterBuilder, RpcExceptionEventExtractors.client());
     return new GrpcTelemetry(
         serverInstrumenterBuilder.buildServerInstrumenter(GrpcRequestGetter.INSTANCE),
         // gRPC client interceptors require two phases, one to set up request and one to execute.

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtSingletons.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtSingletons.java
@@ -7,10 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.gwt;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.lang.reflect.Method;
 
 public final class GwtSingletons {
@@ -20,17 +23,21 @@ public final class GwtSingletons {
   public static final ContextKey<Boolean> RPC_CONTEXT_KEY =
       ContextKey.named("opentelemetry-gwt-rpc-context-key");
 
+  public static final ContextKey<Throwable[]> RPC_THROWABLE_KEY =
+      ContextKey.named("opentelemetry-gwt-rpc-throwable");
+
   private static final Instrumenter<Method, Void> INSTRUMENTER;
 
   static {
     GwtRpcAttributesGetter rpcAttributesGetter = GwtRpcAttributesGetter.INSTANCE;
-    INSTRUMENTER =
+    InstrumenterBuilder<Method, Void> builder =
         Instrumenter.<Method, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer());
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    Experimental.setExceptionEventExtractor(builder, RpcExceptionEventExtractors.server());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
@@ -76,7 +76,13 @@ tasks {
       }
     }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental, stableSemconvSuites)
+    dependsOn(testing.suites, testExperimental, stableSemconvSuites, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
@@ -108,7 +108,13 @@ tasks {
       }
     }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental, stableSemconvSuites)
+    dependsOn(testing.suites, testExperimental, stableSemconvSuites, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v4_0;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStableDbSystemName;
@@ -503,7 +504,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(
                                 HIBERNATE_SESSION_ID,
                                 trace.getSpan(1).getAttributes().get(HIBERNATE_SESSION_ID)))
-                        .hasException(mappingException),
+                        .hasException(emitExceptionAsSpanEvents() ? mappingException : null),
                 span ->
                     span.hasName("Transaction.commit")
                         .hasKind(INTERNAL)

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/build.gradle.kts
@@ -119,7 +119,13 @@ tasks {
     }
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental, stableSemconvSuites)
+    dependsOn(testing.suites, testExperimental, stableSemconvSuites, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate6Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate6Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.hibernate.v6_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStableDbSystemName;
@@ -177,8 +178,10 @@ class SessionTest extends AbstractHibernateTest {
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
                         .hasException(
-                            new UnknownEntityTypeException(
-                                "Unable to locate persister: java.lang.Long"))
+                            emitExceptionAsSpanEvents()
+                                ? new UnknownEntityTypeException(
+                                    "Unable to locate persister: java.lang.Long")
+                                : null)
                         .hasAttributesSatisfyingExactly(
                             experimentalSatisfies(
                                 HIBERNATE_SESSION_ID,

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/SessionTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.hibernate.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStableDbSystemName;
@@ -189,7 +190,10 @@ class SessionTest extends AbstractHibernateTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(new UnknownEntityTypeException("java.lang.Long"))
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new UnknownEntityTypeException("java.lang.Long")
+                                : null)
                         .hasAttributesSatisfyingExactly(
                             experimentalSatisfies(
                                 HIBERNATE_SESSION_ID,

--- a/instrumentation/hibernate/hibernate-common/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-common/javaagent/build.gradle.kts
@@ -4,3 +4,15 @@
 plugins {
   id("otel.javaagent-instrumentation")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateInstrumenterFactory.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateInstrumenterFactory.java
@@ -7,8 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.hibernate;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class HibernateInstrumenterFactory {
   static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
@@ -20,6 +22,9 @@ public final class HibernateInstrumenterFactory {
     InstrumenterBuilder<HibernateOperation, Void> instrumenterBuilder =
         Instrumenter.builder(
             GlobalOpenTelemetry.get(), instrumentationName, HibernateOperation::getName);
+
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, ExceptionEventExtractor.create("hibernate.exception"));
 
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       instrumenterBuilder.addAttributesExtractor(new HibernateExperimentalAttributesExtractor());

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/build.gradle.kts
@@ -52,7 +52,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.javaagent.instrumentation.hibernate.ExperimentalTestHelper.HIBERNATE_SESSION_ID;
@@ -189,7 +190,7 @@ class ProcedureCallTest {
                     span.hasName("ProcedureCall.getOutputs TEST_PROC")
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
-                        .hasException(exception)
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfyingExactly(
                             experimentalSatisfies(

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
@@ -130,8 +130,14 @@ tasks {
     }
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, stableSemconvSuites)
+    dependsOn(testing.suites, stableSemconvSuites, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.httpurlconnection;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.javaagent.instrumentation.httpurlconnection.StreamUtils.readLines;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -338,13 +339,13 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
                         .hasKind(INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(attributes)));
   }
 }

--- a/instrumentation/hystrix-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/hystrix-1.4/javaagent/build.gradle.kts
@@ -39,8 +39,14 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.hystrix.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixSingletons.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixSingletons.java
@@ -7,8 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.hystrix;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class HystrixSingletons {
 
@@ -20,6 +22,9 @@ public final class HystrixSingletons {
     InstrumenterBuilder<HystrixRequest, Void> builder =
         Instrumenter.builder(
             GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, HystrixRequest::spanName);
+
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("hystrix.exception"));
 
     if (DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "hystrix")
         .getBoolean("experimental_span_attributes/development", false)) {

--- a/instrumentation/hystrix-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTest.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.hystrix;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.javaagent.instrumentation.hystrix.ExperimentalTestHelper.HYSTRIX_CIRCUIT_OPEN;
 import static io.opentelemetry.javaagent.instrumentation.hystrix.ExperimentalTestHelper.HYSTRIX_COMMAND;
 import static io.opentelemetry.javaagent.instrumentation.hystrix.ExperimentalTestHelper.HYSTRIX_GROUP;
@@ -108,7 +109,8 @@ class HystrixTest {
                     span.hasName("ExampleGroup.TestCommand.execute")
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(new IllegalArgumentException())
+                        .hasException(
+                            emitExceptionAsSpanEvents() ? new IllegalArgumentException() : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(HYSTRIX_COMMAND, experimental("TestCommand")),
                             equalTo(HYSTRIX_GROUP, experimental("ExampleGroup")),

--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -53,12 +53,18 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
+  }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
   }
 
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/jdbc/library/build.gradle.kts
+++ b/instrumentation/jdbc/library/build.gradle.kts
@@ -66,12 +66,17 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -47,12 +47,18 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -42,7 +42,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
@@ -9,9 +9,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 
@@ -24,7 +27,7 @@ public final class JedisSingletons {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
     JedisNetworkAttributesGetter netAttributesGetter = new JedisNetworkAttributesGetter();
 
-    INSTRUMENTER =
+    InstrumenterBuilder<JedisRequest, Void> builder =
         Instrumenter.<JedisRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
@@ -35,8 +38,9 @@ public final class JedisSingletons {
             .addAttributesExtractor(
                 ServicePeerAttributesExtractor.create(
                     netAttributesGetter, GlobalOpenTelemetry.get()))
-            .addOperationMetrics(DbClientMetrics.get())
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-4.0/javaagent/build.gradle.kts
@@ -35,12 +35,18 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -9,8 +9,11 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class JedisSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.jedis-4.0";
@@ -20,14 +23,15 @@ public final class JedisSingletons {
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
-    INSTRUMENTER =
+    InstrumenterBuilder<JedisRequest, Void> builder =
         Instrumenter.<JedisRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jfinal-3.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jfinal/JFinalTest.java
+++ b/instrumentation/jfinal-3.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jfinal/JFinalTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jfinal;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -112,7 +113,8 @@ class JFinalTest extends AbstractHttpServerTest<Server> {
 
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalStateException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalStateException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -73,8 +73,18 @@ tasks {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("Jms1SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+  }
+
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(testing.suites, testReceiveSpansDisabled, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
@@ -58,7 +58,17 @@ tasks {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("Jms3SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+  }
+
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(testing.suites, testReceiveSpansDisabled, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/jms/jms-common/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-common/javaagent/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
 
   bootstrap(project(":instrumentation:jms:jms-common:bootstrap"))
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/build.gradle.kts
@@ -16,3 +16,15 @@ dependencies {
   implementation(project(":instrumentation:kafka:kafka-clients:kafka-clients-common-0.11:library"))
   library("org.apache.kafka:connect-api:2.6.0")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
@@ -52,3 +52,15 @@ kotlin {
     javaParameters = true
   }
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/instrumentationannotations/AnnotationSingletons.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/instrumentationannotations/AnnotationSingletons.java
@@ -6,8 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.instrumentationannotations;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 
 public final class AnnotationSingletons {
@@ -21,10 +24,14 @@ public final class AnnotationSingletons {
   }
 
   private static Instrumenter<MethodRequest, Object> createInstrumenter() {
-    return Instrumenter.builder(
+    InstrumenterBuilder<MethodRequest, Object> builder =
+        Instrumenter.builder(
             GlobalOpenTelemetry.get(),
             INSTRUMENTATION_NAME,
-            AnnotationSingletons::spanNameFromMethodRequest)
+            AnnotationSingletons::spanNameFromMethodRequest);
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("withspan.exception"));
+    return builder
         .addAttributesExtractor(
             CodeAttributesExtractor.create(MethodRequestCodeAttributesGetter.INSTANCE))
         .buildInstrumenter(MethodRequest::getSpanKind);

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -145,13 +146,13 @@ class KubernetesClientTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(apiException),
+                        .hasException(emitExceptionAsSpanEvents() ? apiException : null),
                 span ->
                     span.hasName("get pods/proxy")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(apiException)
+                        .hasException(emitExceptionAsSpanEvents() ? apiException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 URL_FULL,
@@ -268,7 +269,7 @@ class KubernetesClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(exceptionReference.get())
+                        .hasException(emitExceptionAsSpanEvents() ? exceptionReference.get() : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 URL_FULL,

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientVer20Test.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientVer20Test.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -153,13 +154,13 @@ class KubernetesClientVer20Test {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(apiException),
+                        .hasException(emitExceptionAsSpanEvents() ? apiException : null),
                 span ->
                     span.hasName("get pods/proxy")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(apiException)
+                        .hasException(emitExceptionAsSpanEvents() ? apiException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 URL_FULL,
@@ -278,7 +279,7 @@ class KubernetesClientVer20Test {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(exceptionReference.get())
+                        .hasException(emitExceptionAsSpanEvents() ? exceptionReference.get() : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 URL_FULL,

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
@@ -42,7 +42,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -15,9 +15,12 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 
@@ -36,19 +39,20 @@ public final class LettuceSingletons {
   static {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
-    INSTRUMENTER =
+    InstrumenterBuilder<RedisCommand<?, ?, ?>, Void> builder =
         Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetworkAttributesGetter netAttributesGetter =
         new LettuceConnectNetworkAttributesGetter();
 
-    CONNECT_INSTRUMENTER =
+    InstrumenterBuilder<RedisURI, Void> connectBuilder =
         Instrumenter.<RedisURI, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, redisUri -> "CONNECT")
             .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
@@ -59,8 +63,9 @@ public final class LettuceSingletons {
             .setEnabled(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "lettuce")
                     .get("connection_telemetry")
-                    .getBoolean("enabled", false))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+                    .getBoolean("enabled", false));
+    Experimental.setExceptionEventExtractor(connectBuilder, DbExceptionEventExtractors.client());
+    CONNECT_INSTRUMENTER = connectBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
@@ -49,7 +49,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
+++ b/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.methods;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -63,7 +64,7 @@ class MethodTest {
                 span ->
                     span.hasName("InitialDirContext.search")
                         .hasKind(SpanKind.INTERNAL)
-                        .hasException(throwableReference.get())
+                        .hasException(emitExceptionAsSpanEvents() ? throwableReference.get() : null)
                         .hasAttributesSatisfyingExactly(
                             codeFunctionAssertions(InitialDirContext.class, "search"))));
   }

--- a/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
@@ -23,7 +23,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/nats/nats-2.17/library/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/library/build.gradle.kts
@@ -15,4 +15,14 @@ tasks {
   withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -8,9 +8,11 @@ package io.opentelemetry.instrumentation.nats.v2_17.internal;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.util.List;
 
 /**
@@ -22,17 +24,20 @@ public final class NatsInstrumenterFactory {
 
   public static Instrumenter<NatsRequest, NatsRequest> createProducerInstrumenter(
       OpenTelemetry openTelemetry, List<String> capturedHeaders) {
-    return Instrumenter.<NatsRequest, NatsRequest>builder(
-            openTelemetry,
-            INSTRUMENTATION_NAME,
-            MessagingSpanNameExtractor.create(
-                NatsRequestMessagingAttributesGetter.INSTANCE, MessageOperation.PUBLISH))
-        .addAttributesExtractor(
-            MessagingAttributesExtractor.builder(
-                    NatsRequestMessagingAttributesGetter.INSTANCE, MessageOperation.PUBLISH)
-                .setCapturedHeaders(capturedHeaders)
-                .build())
-        .buildProducerInstrumenter(NatsRequestTextMapSetter.INSTANCE);
+    InstrumenterBuilder<NatsRequest, NatsRequest> producerBuilder =
+        Instrumenter.<NatsRequest, NatsRequest>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                MessagingSpanNameExtractor.create(
+                    NatsRequestMessagingAttributesGetter.INSTANCE, MessageOperation.PUBLISH))
+            .addAttributesExtractor(
+                MessagingAttributesExtractor.builder(
+                        NatsRequestMessagingAttributesGetter.INSTANCE, MessageOperation.PUBLISH)
+                    .setCapturedHeaders(capturedHeaders)
+                    .build());
+    Experimental.setExceptionEventExtractor(
+        producerBuilder, MessagingExceptionEventExtractors.client());
+    return producerBuilder.buildProducerInstrumenter(NatsRequestTextMapSetter.INSTANCE);
   }
 
   public static Instrumenter<NatsRequest, Void> createConsumerProcessInstrumenter(
@@ -49,6 +54,7 @@ public final class NatsInstrumenterFactory {
                     .setCapturedHeaders(capturedHeaders)
                     .build());
 
+    Experimental.setExceptionEventExtractor(builder, MessagingExceptionEventExtractors.process());
     return builder.buildConsumerInstrumenter(NatsRequestTextMapGetter.INSTANCE);
   }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_0.client;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -95,7 +96,7 @@ class Netty40ClientSslTest {
                 span ->
                     span.hasName("parent")
                         .hasStatus(StatusData.error())
-                        .hasException(thrownException),
+                        .hasException(emitExceptionAsSpanEvents() ? thrownException : null),
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfyingExactly(

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_0.client;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -134,7 +135,11 @@ class Netty40ConnectionSpanTest {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent().hasException(thrown),
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span -> {
                   span.hasName("CONNECT").hasKind(INTERNAL).hasParent(trace.getSpan(0));
                   span.hasAttributesSatisfying(equalTo(NETWORK_TRANSPORT, "tcp"));

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -138,7 +139,8 @@ class Netty41ClientSslTest {
                     span.hasName("parent")
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(finalThrownException.getCause()),
+                        .hasException(
+                            emitExceptionAsSpanEvents() ? finalThrownException.getCause() : null),
                 span ->
                     span.hasName("RESOLVE")
                         .hasKind(SpanKind.INTERNAL)
@@ -164,7 +166,8 @@ class Netty41ClientSslTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(new SSLHandshakeException(null))
+                        .hasException(
+                            emitExceptionAsSpanEvents() ? new SSLHandshakeException(null) : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TRANSPORT, "tcp"),
                             equalTo(NETWORK_TYPE, "ipv4"),

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -164,7 +165,7 @@ class Netty41ConnectionSpanTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(finalThrownException),
+                        .hasException(emitExceptionAsSpanEvents() ? finalThrownException : null),
                 span ->
                     span.hasName("RESOLVE")
                         .hasKind(SpanKind.INTERNAL)
@@ -178,7 +179,7 @@ class Netty41ConnectionSpanTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(finalThrownException)
+                        .hasException(emitExceptionAsSpanEvents() ? finalThrownException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TRANSPORT, "tcp"),
                             satisfies(

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -42,8 +42,15 @@ testing {
 }
 
 tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites)
+    dependsOn(testing.suites, testExceptionSignalLogs)
   }
 
   test {

--- a/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
@@ -13,4 +13,14 @@ tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -5,8 +5,13 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_ENCODING_FORMATS;
@@ -28,7 +33,9 @@ import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
 import com.openai.errors.OpenAIIoException;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import java.util.concurrent.CompletionException;
@@ -241,7 +248,7 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                         span ->
                             span.hasName("embeddings text-embedding-3-small")
                                 .hasKind(SpanKind.CLIENT)
-                                .hasException(thrown)
+                                .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
@@ -256,6 +263,19 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                                 v ->
                                                     assertThat(v)
                                                         .isEqualTo(singletonList("base64"))))))));
+    if (emitExceptionAsLogs()) {
+      SpanContext spanCtx = getTesting().spans().get(0).getSpanContext();
+      getTesting()
+          .waitAndAssertLogRecords(
+              log ->
+                  log.hasSpanContext(spanCtx)
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("gen_ai.client.operation.exception")
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(EXCEPTION_TYPE, thrown.getClass().getName()),
+                          equalTo(EXCEPTION_MESSAGE, thrown.getMessage()),
+                          satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
+    }
 
     getTesting()
         .waitAndAssertMetrics(

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
@@ -46,7 +46,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
@@ -9,8 +9,11 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class OpenSearchSingletons {
   private static final Instrumenter<OpenSearchRequest, Void> INSTRUMENTER = createInstrumenter();
@@ -22,13 +25,15 @@ public final class OpenSearchSingletons {
   private static Instrumenter<OpenSearchRequest, Void> createInstrumenter() {
     OpenSearchAttributesGetter dbClientAttributesGetter = new OpenSearchAttributesGetter();
 
-    return Instrumenter.<OpenSearchRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            "io.opentelemetry.opensearch-java-3.0",
-            DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<OpenSearchRequest, Void> builder =
+        Instrumenter.<OpenSearchRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                "io.opentelemetry.opensearch-java-3.0",
+                DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private OpenSearchSingletons() {}

--- a/instrumentation/opensearch/opensearch-rest-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-rest-1.0/javaagent/build.gradle.kts
@@ -52,7 +52,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-rest-3.0/javaagent/build.gradle.kts
@@ -45,7 +45,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
 
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/TracerTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/TracerTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.api.trace.StatusCode.ERROR;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
@@ -216,7 +217,10 @@ class TracerTest {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("test").hasTotalAttributeCount(0).hasException(throwable)));
+                span ->
+                    span.hasName("test")
+                        .hasTotalAttributeCount(0)
+                        .hasException(emitExceptionAsSpanEvents() ? throwable : null)));
   }
 
   @Test

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/build.gradle.kts
@@ -36,6 +36,8 @@ tasks {
   compileTestJava {
     options.compilerArgs.add("-parameters")
   }
+
+  // not using withType<Test> because want testDeclarativeConfig to only get this from declarative-config.yaml
   test {
     jvmArgs("-Dotel.instrumentation.opentelemetry-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
   }
@@ -48,7 +50,14 @@ tasks {
     )
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.opentelemetry-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
+  }
+
   check {
-    dependsOn(testDeclarativeConfig)
+    dependsOn(testDeclarativeConfig, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanSingletons.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanSingletons.java
@@ -10,8 +10,11 @@ import static java.util.logging.Level.FINE;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.annotation.support.MethodSpanAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 import java.lang.reflect.Method;
 import java.util.logging.Logger;
@@ -36,17 +39,27 @@ public final class WithSpanSingletons {
   }
 
   private static Instrumenter<Method, Object> createInstrumenter() {
-    return Instrumenter.builder(
-            GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, WithSpanSingletons::spanNameFromMethod)
+    InstrumenterBuilder<Method, Object> builder =
+        Instrumenter.builder(
+            GlobalOpenTelemetry.get(),
+            INSTRUMENTATION_NAME,
+            WithSpanSingletons::spanNameFromMethod);
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("withspan.exception"));
+    return builder
         .addAttributesExtractor(CodeAttributesExtractor.create(MethodCodeAttributesGetter.INSTANCE))
         .buildInstrumenter(WithSpanSingletons::spanKindFromMethod);
   }
 
   private static Instrumenter<MethodRequest, Object> createInstrumenterWithAttributes() {
-    return Instrumenter.builder(
+    InstrumenterBuilder<MethodRequest, Object> builder =
+        Instrumenter.builder(
             GlobalOpenTelemetry.get(),
             INSTRUMENTATION_NAME,
-            WithSpanSingletons::spanNameFromMethodRequest)
+            WithSpanSingletons::spanNameFromMethodRequest);
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("withspan.exception"));
+    return builder
         .addAttributesExtractor(
             CodeAttributesExtractor.create(MethodRequestCodeAttributesGetter.INSTANCE))
         .addAttributesExtractor(

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.test.annotation;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -141,7 +142,7 @@ class WithSpanInstrumentationTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(exception)
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasAttributesSatisfyingExactly(
                             codeAttributeAssertions("completionStage"))));
   }
@@ -201,7 +202,7 @@ class WithSpanInstrumentationTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(exception)
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasAttributesSatisfyingExactly(
                             codeAttributeAssertions("completionStage"))));
   }
@@ -237,7 +238,7 @@ class WithSpanInstrumentationTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(exception)
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasAttributesSatisfyingExactly(
                             codeAttributeAssertions("completableFuture"))));
   }
@@ -297,7 +298,7 @@ class WithSpanInstrumentationTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(exception)
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasAttributesSatisfyingExactly(
                             codeAttributeAssertions("completableFuture"))));
   }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/build.gradle.kts
@@ -38,6 +38,8 @@ tasks {
   compileTestJava {
     options.compilerArgs.add("-parameters")
   }
+
+  // not using withType<Test> because want testDeclarativeConfig to only get this from declarative-config.yaml
   test {
     jvmArgs("-Dotel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
   }
@@ -50,7 +52,14 @@ tasks {
     )
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
+  }
+
   check {
-    dependsOn(testDeclarativeConfig)
+    dependsOn(testDeclarativeConfig, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationSingletons.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationSingletons.java
@@ -12,8 +12,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.annotation.support.MethodSpanAttributesExtractor;
 import io.opentelemetry.instrumentation.api.annotation.support.SpanAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -63,19 +66,27 @@ public final class AnnotationSingletons {
   }
 
   private static Instrumenter<Method, Object> createInstrumenter() {
-    return Instrumenter.builder(
+    InstrumenterBuilder<Method, Object> builder =
+        Instrumenter.builder(
             GlobalOpenTelemetry.get(),
             INSTRUMENTATION_NAME,
-            AnnotationSingletons::spanNameFromMethod)
+            AnnotationSingletons::spanNameFromMethod);
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("withspan.exception"));
+    return builder
         .addAttributesExtractor(CodeAttributesExtractor.create(MethodCodeAttributesGetter.INSTANCE))
         .buildInstrumenter(AnnotationSingletons::spanKindFromMethod);
   }
 
   private static Instrumenter<MethodRequest, Object> createInstrumenterWithAttributes() {
-    return Instrumenter.builder(
+    InstrumenterBuilder<MethodRequest, Object> builder =
+        Instrumenter.builder(
             GlobalOpenTelemetry.get(),
             INSTRUMENTATION_NAME,
-            AnnotationSingletons::spanNameFromMethodRequest)
+            AnnotationSingletons::spanNameFromMethodRequest);
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("withspan.exception"));
+    return builder
         .addAttributesExtractor(
             CodeAttributesExtractor.create(MethodRequestCodeAttributesGetter.INSTANCE))
         .addAttributesExtractor(

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.play.v2_4.server;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -132,7 +133,8 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     span.hasName("play.request").hasKind(INTERNAL);
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalArgumentException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalArgumentException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/server/PlayServerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.play.v2_4.server;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -117,7 +118,8 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     span.hasName("play.request").hasKind(INTERNAL);
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalArgumentException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalArgumentException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/latestDepTest/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayServerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.play.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -117,7 +118,8 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     span.hasName("play.request").hasKind(INTERNAL);
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalArgumentException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalArgumentException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayServerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.play.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
@@ -115,7 +116,8 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     span.hasName("play.request").hasKind(INTERNAL);
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasException(new IllegalArgumentException(EXCEPTION.getBody()));
+      span.hasException(
+          emitExceptionAsSpanEvents() ? new IllegalArgumentException(EXCEPTION.getBody()) : null);
     }
     return span;
   }

--- a/instrumentation/powerjob-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/powerjob-4.0/javaagent/build.gradle.kts
@@ -33,7 +33,13 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.powerjob.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/powerjob-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/powerjob/v4_0/PowerJobSingletons.java
+++ b/instrumentation/powerjob-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/powerjob/v4_0/PowerJobSingletons.java
@@ -5,10 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.powerjob.v4_0;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -16,6 +19,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import tech.powerjob.worker.core.processor.ProcessResult;
 
 public final class PowerJobSingletons {
@@ -55,6 +59,8 @@ public final class PowerJobSingletons {
       builder.addAttributesExtractor(new PowerJobExperimentalAttributeExtractor());
     }
 
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
     return builder.buildInstrumenter();
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/build.gradle.kts
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/build.gradle.kts
@@ -47,6 +47,17 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.pulsar.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("PulsarClientSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   test {
     filter {
       excludeTestsMatching("PulsarClientSuppressReceiveSpansTest")
@@ -55,7 +66,7 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpanDisabled, testExperimental)
+    dependsOn(testReceiveSpanDisabled, testExperimental, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/quartz-2.0/library/build.gradle.kts
+++ b/instrumentation/quartz-2.0/library/build.gradle.kts
@@ -17,7 +17,13 @@ tasks {
     jvmArgs("-Dotel.instrumentation.quartz.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.instrumentation.quartz.v2_0;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -90,6 +94,8 @@ public final class QuartzTelemetryBuilder {
     instrumenter.addAttributesExtractor(
         CodeAttributesExtractor.create(new QuartzCodeAttributesGetter()));
     instrumenter.addAttributesExtractors(additionalExtractors);
+    Experimental.setExceptionEventExtractor(
+        instrumenter, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
 
     return new QuartzTelemetry(new TracingJobListener(instrumenter.buildInstrumenter()));
   }

--- a/instrumentation/quartz-2.0/testing/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/AbstractQuartzTest.java
+++ b/instrumentation/quartz-2.0/testing/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/AbstractQuartzTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.quartz.v2_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.quartz.JobBuilder.newJob;
@@ -107,7 +108,10 @@ public abstract class AbstractQuartzTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(new IllegalStateException("Bad job"))
+                            .hasException(
+                                emitExceptionAsSpanEvents()
+                                    ? new IllegalStateException("Bad job")
+                                    : null)
                             .hasAttributesSatisfyingExactly(assertions)));
   }
 

--- a/instrumentation/r2dbc-1.0/library/build.gradle.kts
+++ b/instrumentation/r2dbc-1.0/library/build.gradle.kts
@@ -22,7 +22,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -39,12 +39,18 @@ tasks {
   val testExperimental by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true")
     systemProperty("metadataConfig", "otel.instrumentation.rabbitmq.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.Collections.emptySet;
@@ -220,12 +221,12 @@ abstract class AbstractReactorNettyHttpClientTest
                       .hasKind(INTERNAL)
                       .hasNoParent()
                       .hasStatus(StatusData.error())
-                      .hasException(thrown),
+                      .hasException(emitExceptionAsSpanEvents() ? thrown : null),
               span ->
                   span.hasKind(CLIENT)
                       .hasParent(parentSpan)
                       .hasStatus(StatusData.error())
-                      .hasException(thrown.getCause()));
+                      .hasException(emitExceptionAsSpanEvents() ? thrown.getCause() : null));
 
           assertSameSpan(parentSpan, onRequestErrorSpan);
         });

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -137,7 +138,7 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("RESOLVE")
                         .hasKind(INTERNAL)
@@ -151,7 +152,7 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(connectException)
+                        .hasException(emitExceptionAsSpanEvents() ? connectException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TRANSPORT, "tcp"),
                             satisfies(NETWORK_TYPE, val -> val.isIn(null, "ipv4")),

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -230,12 +231,12 @@ abstract class AbstractReactorNettyHttpClientTest
                       .hasKind(INTERNAL)
                       .hasNoParent()
                       .hasStatus(StatusData.error())
-                      .hasException(thrown),
+                      .hasException(emitExceptionAsSpanEvents() ? thrown : null),
               span ->
                   span.hasKind(CLIENT)
                       .hasParent(parentSpan)
                       .hasStatus(StatusData.error())
-                      .hasException(thrown.getCause()));
+                      .hasException(emitExceptionAsSpanEvents() ? thrown.getCause() : null));
 
           assertSameSpan(parentSpan, onRequestErrorSpan);
         });
@@ -307,7 +308,7 @@ abstract class AbstractReactorNettyHttpClientTest
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.AbstractReactorNettyHttpClientTest.USER_AGENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -94,7 +95,7 @@ class ReactorNettyClientSslTest {
                         .hasKind(INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.AbstractReactorNettyHttpClientTest.USER_AGENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -157,13 +158,13 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(connectException)
+                        .hasException(emitExceptionAsSpanEvents() ? connectException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(URL_FULL, uri),
@@ -184,7 +185,7 @@ class ReactorNettyConnectionSpanTest {
                         .hasKind(INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(connectException)
+                        .hasException(emitExceptionAsSpanEvents() ? connectException : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(SERVER_ADDRESS, "localhost"),
                             equalTo(SERVER_PORT, PortUtils.UNUSABLE_PORT),

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -71,13 +71,19 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/redisson/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson/redisson-3.0/javaagent/build.gradle.kts
@@ -39,7 +39,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/redisson/redisson-3.17/javaagent/build.gradle.kts
+++ b/instrumentation/redisson/redisson-3.17/javaagent/build.gradle.kts
@@ -38,8 +38,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {

--- a/instrumentation/redisson/redisson-common/javaagent/build.gradle.kts
+++ b/instrumentation/redisson/redisson-common/javaagent/build.gradle.kts
@@ -8,3 +8,15 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
@@ -9,21 +9,26 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class RedissonInstrumenterFactory {
 
   public static Instrumenter<RedissonRequest, Void> createInstrumenter(String instrumentationName) {
     RedissonDbAttributesGetter dbAttributesGetter = new RedissonDbAttributesGetter();
 
-    return Instrumenter.<RedissonRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            instrumentationName,
-            DbClientSpanNameExtractor.create(dbAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<RedissonRequest, Void> builder =
+        Instrumenter.<RedissonRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                instrumentationName,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private RedissonInstrumenterFactory() {}

--- a/instrumentation/rmi/javaagent/build.gradle.kts
+++ b/instrumentation/rmi/javaagent/build.gradle.kts
@@ -36,4 +36,15 @@ tasks {
     jvmArgs("-Djava.rmi.server.hostname=127.0.0.1")
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
@@ -7,9 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.rmi.client;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import java.lang.reflect.Method;
 
 public final class RmiClientSingletons {
@@ -19,13 +22,14 @@ public final class RmiClientSingletons {
   static {
     RmiClientAttributesGetter rpcAttributesGetter = RmiClientAttributesGetter.INSTANCE;
 
-    INSTRUMENTER =
+    InstrumenterBuilder<Method, Void> builder =
         Instrumenter.<Method, Void>builder(
                 GlobalOpenTelemetry.get(),
                 "io.opentelemetry.rmi",
                 RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter));
+    Experimental.setExceptionEventExtractor(builder, RpcExceptionEventExtractors.client());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
@@ -6,11 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.rmi.server;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class RmiServerSingletons {
 
@@ -19,13 +22,14 @@ public final class RmiServerSingletons {
   static {
     RmiServerAttributesGetter rpcAttributesGetter = RmiServerAttributesGetter.INSTANCE;
 
-    INSTRUMENTER =
+    InstrumenterBuilder<ClassAndMethod, Void> builder =
         Instrumenter.<ClassAndMethod, Void>builder(
                 GlobalOpenTelemetry.get(),
                 "io.opentelemetry.rmi",
                 RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer());
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    Experimental.setExceptionEventExtractor(builder, RpcExceptionEventExtractors.server());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
@@ -25,3 +25,15 @@ tasks.withType<Test>().configureEach {
   // used for experimental attributes test assertion logic which looks for this property
   jvmArgs("-Dotel.instrumentation.rocketmq-client.experimental-span-attributes=true")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -12,12 +12,14 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.List;
 import org.apache.rocketmq.client.hook.SendMessageContext;
@@ -53,6 +55,8 @@ class RocketMqInstrumenterFactory {
           RocketMqProducerExperimentalAttributeExtractor.INSTANCE);
     }
 
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, MessagingExceptionEventExtractors.client());
     return instrumenterBuilder.buildProducerInstrumenter(MapSetter.INSTANCE);
   }
 
@@ -67,6 +71,8 @@ class RocketMqInstrumenterFactory {
             .addAttributesExtractor(constant(MESSAGING_SYSTEM, "rocketmq"))
             .addAttributesExtractor(constant(MESSAGING_OPERATION, "receive"));
 
+    Experimental.setExceptionEventExtractor(
+        batchReceiveInstrumenterBuilder, MessagingExceptionEventExtractors.client());
     return new RocketMqConsumerInstrumenter(
         createProcessInstrumenter(
             openTelemetry, capturedHeaders, captureExperimentalSpanAttributes, false),
@@ -96,6 +102,7 @@ class RocketMqInstrumenterFactory {
       builder.addAttributesExtractor(RocketMqConsumerExperimentalAttributeExtractor.INSTANCE);
     }
 
+    Experimental.setExceptionEventExtractor(builder, MessagingExceptionEventExtractors.process());
     if (batch) {
       SpanLinksExtractor<MessageExt> spanLinksExtractor =
           new PropagatorBasedSpanLinksExtractor<>(

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -18,6 +19,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.List;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
@@ -45,6 +47,8 @@ final class RocketMqInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operation))
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(RocketMqProducerAttributeExtractor.INSTANCE);
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, MessagingExceptionEventExtractors.client());
     return instrumenterBuilder.buildProducerInstrumenter(MessageMapSetter.INSTANCE);
   }
 
@@ -65,6 +69,8 @@ final class RocketMqInstrumenterFactory {
             .setEnabled(enabled)
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(RocketMqConsumerReceiveAttributeExtractor.INSTANCE);
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, MessagingExceptionEventExtractors.client());
     return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
@@ -95,6 +101,8 @@ final class RocketMqInstrumenterFactory {
                   }
                 });
 
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, MessagingExceptionEventExtractors.process());
     if (receiveInstrumentationEnabled) {
       SpanLinksExtractor<MessageView> spanLinksExtractor =
           new PropagatorBasedSpanLinksExtractor<>(

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/java/BaseRxJava2WithSpanTest.java
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/java/BaseRxJava2WithSpanTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionSuffixAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,7 +107,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "completable"))));
   }
@@ -134,7 +135,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "completable"))));
   }
@@ -242,7 +243,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "maybe"))));
   }
@@ -271,7 +272,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "maybe"))));
   }
@@ -361,7 +362,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "single"))));
   }
@@ -390,7 +391,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "single"))));
   }
@@ -486,7 +487,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "observable"))));
   }
@@ -523,7 +524,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "observable"))));
   }
@@ -627,7 +628,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "flowable"))));
   }
@@ -664,7 +665,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "flowable"))));
   }
@@ -771,7 +772,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions(
                                     "TracedWithSpan", "parallelFlowable"))));
@@ -810,7 +811,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions(
                                     "TracedWithSpan", "parallelFlowable"))));
@@ -897,7 +898,7 @@ public abstract class BaseRxJava2WithSpanTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasStatus(StatusData.error())
-                            .hasException(error)
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)
                             .hasAttributesSatisfyingExactly(
                                 codeFunctionSuffixAssertions("TracedWithSpan", "publisher"))));
   }

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/HttpServletResponseTest.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/HttpServletResponseTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v2_2;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -122,13 +123,13 @@ class HttpServletResponseTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(ex),
+                        .hasException(emitExceptionAsSpanEvents() ? ex : null),
                 span ->
                     span.hasName("HttpServletResponseTest$2.sendRedirect")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(ex)));
+                        .hasException(emitExceptionAsSpanEvents() ? ex : null)));
   }
 
   /** Tests deprecated methods */

--- a/instrumentation/servlet/servlet-3.0/javaagent-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/HttpServletResponseTest.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/HttpServletResponseTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -122,13 +123,19 @@ class HttpServletResponseTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(new RuntimeException("some error")),
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new RuntimeException("some error")
+                                : null),
                 span ->
                     span.hasName("HttpServletResponseTest$2.sendRedirect")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(new RuntimeException("some error"))));
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new RuntimeException("some error")
+                                : null)));
   }
 
   /** Tests deprecated methods */

--- a/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
@@ -58,8 +58,19 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.spring-batch.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("*ChunkRootSpanTest")
+      excludeTestsMatching("*ItemLevelSpanTest")
+      excludeTestsMatching("*CustomSpanEventTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testChunkRootSpan, testItemLevelSpan)
+    dependsOn(testChunkRootSpan, testItemLevelSpan, testExceptionSignalLogs)
   }
 
   withType<Test>().configureEach {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/chunk/ChunkSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/chunk/ChunkSingletons.java
@@ -13,9 +13,11 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.builder.SimpleStepBuilder;
 
@@ -27,6 +29,9 @@ public class ChunkSingletons {
     InstrumenterBuilder<ChunkContextAndBuilder, Void> instrumenterBuilder =
         Instrumenter.builder(
             GlobalOpenTelemetry.get(), instrumentationName(), ChunkSingletons::spanName);
+
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder, ExceptionEventExtractor.create("spring_batch.exception"));
 
     if (shouldCreateRootSpanForChunk()) {
       instrumenterBuilder.addSpanLinksExtractor(ChunkSingletons::extractSpanLinks);

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/job/JobSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/job/JobSingletons.java
@@ -10,9 +10,11 @@ import static io.opentelemetry.javaagent.instrumentation.spring.batch.v3_0.Sprin
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import org.springframework.batch.core.JobExecution;
 
 public class JobSingletons {
@@ -27,6 +29,8 @@ public class JobSingletons {
     InstrumenterBuilder<JobExecution, Void> instrumenter =
         Instrumenter.builder(
             GlobalOpenTelemetry.get(), instrumentationName(), JobSingletons::extractSpanName);
+    Experimental.setExceptionEventExtractor(
+        instrumenter, ExceptionEventExtractor.create("spring_batch.exception"));
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       instrumenter.addAttributesExtractor(
           AttributesExtractor.constant(AttributeKey.stringKey("job.system"), "spring_batch"));

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/basic/SpringBatchTest.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/batch/v3_0/basic/SpringBatchTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.batch.v3_0.basic;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.singletonMap;
 
@@ -77,7 +78,10 @@ abstract class SpringBatchTest {
                         .hasParent(trace.getSpan(1))
                         .hasStatus(StatusData.error())
                         .hasTotalAttributeCount(0)
-                        .hasException(new IllegalStateException("fail"))));
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new IllegalStateException("fail")
+                                : null)));
   }
 
   @Test

--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -363,7 +363,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites, testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/scheduling/SpringSchedulingInstrumentationAspect.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/scheduling/SpringSchedulingInstrumentationAspect.java
@@ -5,11 +5,14 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.scheduling;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeSpanNameExtractor;
@@ -17,6 +20,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMetho
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -56,6 +60,8 @@ final class SpringSchedulingInstrumentationAspect {
       builder.addAttributesExtractor(
           AttributesExtractor.constant(AttributeKey.stringKey("job.system"), "spring_scheduling"));
     }
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
     instrumenter = builder.buildInstrumenter();
   }
 

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -41,3 +41,15 @@ configurations.testRuntimeClasspath {
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -227,7 +228,10 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
-                          .hasException(new IllegalArgumentException("boom"))
+                          .hasException(
+                              emitExceptionAsSpanEvents()
+                                  ? new IllegalArgumentException("boom")
+                                  : null)
                           .hasAttributesSatisfyingExactly(processAttributes),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(1)),
@@ -237,7 +241,10 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
-                          .hasException(new IllegalArgumentException("boom"))
+                          .hasException(
+                              emitExceptionAsSpanEvents()
+                                  ? new IllegalArgumentException("boom")
+                                  : null)
                           .hasAttributesSatisfyingExactly(processAttributes),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(4)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(4)),
@@ -284,7 +291,10 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
-                          .hasException(new IllegalArgumentException("boom"))
+                          .hasException(
+                              emitExceptionAsSpanEvents()
+                                  ? new IllegalArgumentException("boom")
+                                  : null)
                           .hasAttributesSatisfyingExactly(processAttributes),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
@@ -296,7 +306,10 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
-                          .hasException(new IllegalArgumentException("boom"))
+                          .hasException(
+                              emitExceptionAsSpanEvents()
+                                  ? new IllegalArgumentException("boom")
+                                  : null)
                           .hasAttributesSatisfyingExactly(processAttributes),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
@@ -499,7 +512,8 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
             satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     if (failed) {
-      span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
+      span.hasStatus(StatusData.error())
+          .hasException(emitExceptionAsSpanEvents() ? new IllegalArgumentException("boom") : null);
     }
   }
 }

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
@@ -9,10 +9,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import org.apache.pulsar.client.api.Message;
@@ -37,6 +39,7 @@ public final class SpringPulsarSingletons {
                 MessagingAttributesExtractor.builder(getter, operation)
                     .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build());
+    Experimental.setExceptionEventExtractor(builder, MessagingExceptionEventExtractors.process());
     if (messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
           new PropagatorBasedSpanLinksExtractor<>(

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -33,9 +33,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+  }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/build.gradle.kts
@@ -39,6 +39,19 @@ tasks.withType<Test>().configureEach {
   systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
 }
 
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}
+
 configurations.testRuntimeClasspath {
   resolutionStrategy {
     // requires old logback (and therefore also old slf4j)

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
@@ -7,11 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0.client.ClientAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0.server.ServerAttributesGetter;
 import java.lang.reflect.Method;
@@ -26,23 +29,27 @@ public final class SpringRmiSingletons {
   private static Instrumenter<Method, Void> buildClientInstrumenter() {
     ClientAttributesGetter rpcAttributesGetter = ClientAttributesGetter.INSTANCE;
 
-    return Instrumenter.<Method, Void>builder(
-            GlobalOpenTelemetry.get(),
-            INSTRUMENTATION_NAME,
-            RpcSpanNameExtractor.create(rpcAttributesGetter))
-        .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<Method, Void> builder =
+        Instrumenter.<Method, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter));
+    Experimental.setExceptionEventExtractor(builder, RpcExceptionEventExtractors.client());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private static Instrumenter<ClassAndMethod, Void> buildServerInstrumenter() {
     ServerAttributesGetter rpcAttributesGetter = ServerAttributesGetter.INSTANCE;
 
-    return Instrumenter.<ClassAndMethod, Void>builder(
-            GlobalOpenTelemetry.get(),
-            INSTRUMENTATION_NAME,
-            RpcSpanNameExtractor.create(rpcAttributesGetter))
-        .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
-        .buildInstrumenter(SpanKindExtractor.alwaysServer());
+    InstrumenterBuilder<ClassAndMethod, Void> builder =
+        Instrumenter.<ClassAndMethod, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    Experimental.setExceptionEventExtractor(builder, RpcExceptionEventExtractors.server());
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<Method, Void> clientInstrumenter() {

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/build.gradle.kts
@@ -37,8 +37,14 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.spring-scheduling.experimental-span-attributes=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingSingletons.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingSingletons.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class SpringSchedulingSingletons {
 
@@ -38,6 +42,8 @@ public final class SpringSchedulingSingletons {
           AttributesExtractor.constant(AttributeKey.stringKey("job.system"), "spring_scheduling"));
     }
 
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
     INSTRUMENTER = builder.buildInstrumenter();
   }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
@@ -91,8 +91,14 @@ tasks {
     )
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/WebfluxSingletons.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/WebfluxSingletons.java
@@ -6,9 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.spring.webflux.v5_0.server;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteGetter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import org.springframework.web.reactive.HandlerMapping;
@@ -24,6 +26,9 @@ public final class WebfluxSingletons {
     InstrumenterBuilder<Object, Void> builder =
         Instrumenter.builder(
             GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, new WebfluxSpanNameExtractor());
+
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("spring_webflux.exception"));
 
     INSTRUMENTER =
         builder

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractControllerSpringWebFluxServerTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractControllerSpringWebFluxServerTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.webflux.server;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.NOT_FOUND;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -35,49 +36,53 @@ public abstract class AbstractControllerSpringWebFluxServerTest
     span.hasName(handlerSpanName).hasKind(SpanKind.INTERNAL);
     if (endpoint == EXCEPTION) {
       span.hasStatus(StatusData.error());
-      span.hasEventsSatisfyingExactly(
-          event ->
-              event
-                  .hasName("exception")
-                  .hasAttributesSatisfyingExactly(
-                      equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
-                      equalTo(EXCEPTION_MESSAGE, EXCEPTION.getBody()),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
+      if (emitExceptionAsSpanEvents()) {
+        span.hasEventsSatisfyingExactly(
+            event ->
+                event
+                    .hasName("exception")
+                    .hasAttributesSatisfyingExactly(
+                        equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+                        equalTo(EXCEPTION_MESSAGE, EXCEPTION.getBody()),
+                        satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
+      }
     } else if (endpoint == NOT_FOUND) {
       span.hasStatus(StatusData.error());
-      if (Boolean.getBoolean("testLatestDeps")) {
-        span.hasEventsSatisfyingExactly(
-            event ->
-                event
-                    .hasName("exception")
-                    .hasAttributesSatisfyingExactly(
-                        equalTo(
-                            EXCEPTION_TYPE,
-                            "org.springframework.web.reactive.resource.NoResourceFoundException"),
-                        equalTo(
-                            EXCEPTION_MESSAGE, "404 NOT_FOUND \"No static resource notFound.\""),
-                        satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
-      } else {
-        span.hasEventsSatisfyingExactly(
-            event ->
-                event
-                    .hasName("exception")
-                    .hasAttributesSatisfyingExactly(
-                        satisfies(
-                            EXCEPTION_TYPE,
-                            val ->
-                                val.satisfiesAnyOf(
-                                    v ->
-                                        assertThat(v)
-                                            .isEqualTo(
-                                                "org.springframework.web.server.ResponseStatusException"),
-                                    // Changed in spring 7+
-                                    v ->
-                                        assertThat(v)
-                                            .isEqualTo(
-                                                "org.springframework.web.reactive.resource.NoResourceFoundException"))),
-                        satisfies(EXCEPTION_MESSAGE, val -> val.contains("404")),
-                        satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
+      if (emitExceptionAsSpanEvents()) {
+        if (Boolean.getBoolean("testLatestDeps")) {
+          span.hasEventsSatisfyingExactly(
+              event ->
+                  event
+                      .hasName("exception")
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(
+                              EXCEPTION_TYPE,
+                              "org.springframework.web.reactive.resource.NoResourceFoundException"),
+                          equalTo(
+                              EXCEPTION_MESSAGE, "404 NOT_FOUND \"No static resource notFound.\""),
+                          satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
+        } else {
+          span.hasEventsSatisfyingExactly(
+              event ->
+                  event
+                      .hasName("exception")
+                      .hasAttributesSatisfyingExactly(
+                          satisfies(
+                              EXCEPTION_TYPE,
+                              val ->
+                                  val.satisfiesAnyOf(
+                                      v ->
+                                          assertThat(v)
+                                              .isEqualTo(
+                                                  "org.springframework.web.server.ResponseStatusException"),
+                                      // Changed in spring 7+
+                                      v ->
+                                          assertThat(v)
+                                              .isEqualTo(
+                                                  "org.springframework.web.reactive.resource.NoResourceFoundException"))),
+                          satisfies(EXCEPTION_MESSAGE, val -> val.contains("404")),
+                          satisfies(EXCEPTION_STACKTRACE, val -> val.isInstanceOf(String.class))));
+        }
       }
     }
     return span;

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractSpringWebFluxServerTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractSpringWebFluxServerTest.java
@@ -60,6 +60,12 @@ public abstract class AbstractSpringWebFluxServerTest
   }
 
   @Override
+  protected void assertExceptionLogs(Throwable expectedException, String expectedEventName) {
+    // Spring WebFlux catches controller exceptions before they reach the HTTP server instrumenter
+    // (Netty), so http.server.request.exception logs are not emitted
+  }
+
+  @Override
   protected void configure(HttpServerTestOptions options) {
     options.setTestPathParam(true);
     options.setHasHandlerSpan(unused -> true);

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/AbstractSpringWebfluxClientInstrumentationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/AbstractSpringWebfluxClientInstrumentationTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.spring.webflux.client;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -194,7 +195,7 @@ public abstract class AbstractSpringWebfluxClientInstrumentationTest
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
-                        .hasException(thrown),
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null),
                 span ->
                     span.hasName("GET")
                         .hasKind(CLIENT)

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/wildfly-testing/src/test/java/AbstractOpenTelemetryHandlerMappingFilterTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/wildfly-testing/src/test/java/AbstractOpenTelemetryHandlerMappingFilterTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -67,6 +68,9 @@ public abstract class AbstractOpenTelemetryHandlerMappingFilterTest {
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
                         .hasNoParent()
-                        .hasException(new ServletException("exception"))));
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new ServletException("exception")
+                                : null)));
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
+++ b/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
@@ -41,7 +41,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/struts/struts-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/struts/v2_3/Struts2ActionSpanTest.java
+++ b/instrumentation/struts/struts-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/struts/v2_3/Struts2ActionSpanTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.struts.v2_3;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.NOT_FOUND;
@@ -137,7 +138,8 @@ class Struts2ActionSpanTest extends AbstractHttpServerTest<Server> {
 
     if (endpoint.equals(EXCEPTION)) {
       span.hasStatus(StatusData.error())
-          .hasException(new IllegalStateException(EXCEPTION.getBody()));
+          .hasException(
+              emitExceptionAsSpanEvents() ? new IllegalStateException(EXCEPTION.getBody()) : null);
     }
 
     span.hasAttributesSatisfyingExactly(

--- a/instrumentation/struts/struts-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/struts/v7_0/Struts2ActionSpanTest.java
+++ b/instrumentation/struts/struts-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/struts/v7_0/Struts2ActionSpanTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.struts.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.NOT_FOUND;
@@ -114,7 +115,8 @@ class Struts2ActionSpanTest extends AbstractHttpServerTest<Server> {
 
     if (endpoint.equals(EXCEPTION)) {
       span.hasStatus(StatusData.error())
-          .hasException(new IllegalStateException(EXCEPTION.getBody()));
+          .hasException(
+              emitExceptionAsSpanEvents() ? new IllegalStateException(EXCEPTION.getBody()) : null);
     }
 
     span.hasAttributesSatisfyingExactly(

--- a/instrumentation/tapestry-5.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestryTest.java
+++ b/instrumentation/tapestry-5.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestryTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.tapestry;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -143,6 +144,9 @@ class TapestryTest extends AbstractHttpServerUsingTest<Server> {
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasException(new IllegalStateException("expected"))));
+                        .hasException(
+                            emitExceptionAsSpanEvents()
+                                ? new IllegalStateException("expected")
+                                : null)));
   }
 }

--- a/instrumentation/twilio-6.6/javaagent/build.gradle.kts
+++ b/instrumentation/twilio-6.6/javaagent/build.gradle.kts
@@ -21,7 +21,20 @@ dependencies {
   latestDepTestLibrary("com.twilio.sdk:twilio:7.+") // documented limitation
 }
 
-tasks.withType<Test>().configureEach {
-  // TODO run tests both with and without experimental span attributes
-  jvmArgs("-Dotel.instrumentation.twilio.experimental-span-attributes=true")
+tasks {
+  withType<Test>().configureEach {
+    // TODO run tests both with and without experimental span attributes
+    jvmArgs("-Dotel.instrumentation.twilio.experimental-span-attributes=true")
+  }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSingletons.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSingletons.java
@@ -8,9 +8,12 @@ package io.opentelemetry.javaagent.instrumentation.twilio;
 import static io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor.alwaysClient;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 
 public final class TwilioSingletons {
@@ -29,6 +32,9 @@ public final class TwilioSingletons {
       instrumenterBuilder.addAttributesExtractor(new TwilioExperimentalAttributesExtractor());
     }
 
+    Experimental.setExceptionEventExtractor(
+        instrumenterBuilder,
+        ExceptionEventExtractor.create("twilio.client.request.exception", Severity.WARN));
     INSTRUMENTER = instrumenterBuilder.buildInstrumenter(alwaysClient());
   }
 

--- a/instrumentation/undertow-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/undertow-1.4/javaagent/build.gradle.kts
@@ -25,6 +25,19 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
 }
 
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}
+
 // since 2.3.x, undertow is compiled by JDK 11
 val latestDepTest = findProperty("testLatestDeps") as Boolean
 if (latestDepTest) {

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/build.gradle.kts
@@ -35,7 +35,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientSingletons.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/redis/VertxRedisClientSingletons.java
@@ -10,11 +10,13 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
@@ -55,6 +57,7 @@ public final class VertxRedisClientSingletons {
                     VertxRedisClientNetAttributesGetter.INSTANCE, GlobalOpenTelemetry.get()))
             .addOperationMetrics(DbClientMetrics.get());
 
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
     INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/build.gradle.kts
@@ -43,8 +43,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
@@ -5,16 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -33,7 +30,6 @@ import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgException;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.Tuple;
@@ -186,6 +182,8 @@ class VertxSqlClientTest {
 
     latch.await(30, SECONDS);
 
+    Throwable exception = result.handle((r, t) -> t).join();
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -195,18 +193,7 @@ class VertxSqlClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
-                        .hasEventsSatisfyingExactly(
-                            event ->
-                                event
-                                    .hasName("exception")
-                                    .hasAttributesSatisfyingExactly(
-                                        equalTo(EXCEPTION_TYPE, PgException.class.getName()),
-                                        satisfies(
-                                            EXCEPTION_MESSAGE,
-                                            val -> val.contains("syntax error at or near")),
-                                        satisfies(
-                                            EXCEPTION_STACKTRACE,
-                                            val -> val.isInstanceOf(String.class))))
+                        .hasException(emitExceptionAsSpanEvents() ? exception : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_NAME), DB),
                             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/build.gradle.kts
@@ -43,7 +43,13 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/build.gradle.kts
@@ -6,3 +6,15 @@ dependencies {
   compileOnly("io.vertx:vertx-sql-client:4.0.0")
   compileOnly("io.vertx:vertx-codegen:4.0.0")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlInstrumenterFactory.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sql/VertxSqlInstrumenterFactory.java
@@ -8,12 +8,14 @@ package io.opentelemetry.javaagent.instrumentation.vertx.sql;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbExceptionEventExtractors;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 
@@ -39,6 +41,7 @@ public final class VertxSqlInstrumenterFactory {
                     VertxSqlClientNetAttributesGetter.INSTANCE, GlobalOpenTelemetry.get()))
             .addOperationMetrics(DbClientMetrics.get());
 
+    Experimental.setExceptionEventExtractor(builder, DbExceptionEventExtractors.client());
     return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/xxl-job/xxl-job-1.9.2/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-1.9.2/javaagent/build.gradle.kts
@@ -40,3 +40,15 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
   jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/xxl-job/xxl-job-2.1.2/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.1.2/javaagent/build.gradle.kts
@@ -38,3 +38,15 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
   jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
@@ -66,7 +66,13 @@ tasks {
     }
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
   check {
-    dependsOn(testing.suites)
+    dependsOn(testing.suites, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/xxl-job/xxl-job-common/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-common/javaagent/build.gradle.kts
@@ -4,3 +4,15 @@ plugins {
 dependencies {
   compileOnly("com.xuxueli:xxl-job-core:2.1.2")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv.exception.signal.opt-in=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/xxl-job/xxl-job-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/common/XxlJobInstrumenterFactory.java
+++ b/instrumentation/xxl-job/xxl-job-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/xxljob/common/XxlJobInstrumenterFactory.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.xxljob.common;
 
+import static io.opentelemetry.api.logs.Severity.ERROR;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.incubator.instrumenter.ExceptionEventExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
 
 public final class XxlJobInstrumenterFactory {
 
@@ -38,6 +42,8 @@ public final class XxlJobInstrumenterFactory {
           AttributesExtractor.constant(AttributeKey.stringKey("job.system"), "xxl-job"));
       builder.addAttributesExtractor(new XxlJobExperimentalAttributeExtractor());
     }
+    Experimental.setExceptionEventExtractor(
+        builder, ExceptionEventExtractor.create("scheduled_job.run.exception", ERROR));
     return builder.buildInstrumenter();
   }
 


### PR DESCRIPTION
Span events are in the process of being deprecated.

This starts to add opt-in support for emitting exceptions as logs (as opposed to span events).

Follows semantic conventions proposal: https://github.com/open-telemetry/semantic-conventions/pull/3414

TODO: define event names for other semantic conventions