### PR TITLE
Don't fail fast on native test matrix

### DIFF
--- a/.github/workflows/reusable-native-tests.yml
+++ b/.github/workflows/reusable-native-tests.yml
@@ -23,6 +23,7 @@ jobs:
           - 22
           - 23
           - 24
+      fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: read-java


### PR DESCRIPTION
It will be clearer that the failure was just sporadic if we let the others finish (hopefully successfully). And then only need to re-run the one that sporadically failed. I checked, all other matrixes are `fail-fast: false`.