### PR TITLE
Fix flaky elasticjob test

### DIFF
--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobTest.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobTest.java
@@ -154,7 +154,7 @@ class ElasticJobTest {
             regCenter,
             job,
             JobConfiguration.newBuilder("simpleElasticJob", 2)
-                .cron("0/30 * * * * ?")
+                .cron("0/15 * * * * ?")
                 .shardingItemParameters("0=A,1=B")
                 .build());
 


### PR DESCRIPTION
Hopefully fixes https://develocity.opentelemetry.io/s/34qzzmjrgb2es/tests/task/:instrumentation:apache-elasticjob-3.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.apacheelasticjob.v3_0.ElasticJobTest/testSimpleJob()?expanded-stacktrace=WyIwLTEiXQ&page=eyJvdXRwdXQiOnsiMCI6Mn19&top-execution=1
It is probably a regression from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15420 I suspect that running jobs every 30 seconds is too long and may allow waiting for traces to time out before the job is executed.