### PR TITLE
Add `service.peer.name` testing for remaining HTTP client library instrumentations

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/build.gradle.kts
@@ -16,4 +16,15 @@ tasks {
   test {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/build.gradle.kts
@@ -12,4 +12,15 @@ tasks {
   test {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/armeria/armeria-1.3/library/build.gradle.kts
+++ b/instrumentation/armeria/armeria-1.3/library/build.gradle.kts
@@ -16,4 +16,14 @@ tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/java-http-client/library/build.gradle.kts
+++ b/instrumentation/java-http-client/library/build.gradle.kts
@@ -10,3 +10,15 @@ otelJava {
 dependencies {
   testImplementation(project(":instrumentation:java-http-client:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/build.gradle.kts
@@ -11,3 +11,15 @@ dependencies {
 
   testImplementation(project(":instrumentation:jetty-httpclient::jetty-httpclient-12.0:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
@@ -12,3 +12,15 @@ dependencies {
 
   latestDepTestLibrary("org.eclipse.jetty:jetty-client:9.+") // documented limitation
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/ktor/ktor-2.0/library/build.gradle.kts
+++ b/instrumentation/ktor/ktor-2.0/library/build.gradle.kts
@@ -38,6 +38,19 @@ kotlin {
   }
 }
 
-tasks.test {
-  systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+tasks {
+  test {
+    systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+  }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/ktor/ktor-3.0/library/build.gradle.kts
+++ b/instrumentation/ktor/ktor-3.0/library/build.gradle.kts
@@ -48,7 +48,14 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.http.server.emit-experimental-telemetry=true")
   }
 
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testStableSemconv)
   }
 }

--- a/instrumentation/netty/netty-4.1/library/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/library/build.gradle.kts
@@ -12,3 +12,15 @@ dependencies {
 
   testImplementation(project(":instrumentation:netty:netty-4.1:testing"))
 }
+
+tasks {
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
+}

--- a/instrumentation/ratpack/ratpack-1.7/library/build.gradle.kts
+++ b/instrumentation/ratpack/ratpack-1.7/library/build.gradle.kts
@@ -22,4 +22,15 @@ tasks {
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
@@ -24,4 +24,15 @@ tasks {
   test {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/build.gradle.kts
@@ -39,4 +39,15 @@ tasks {
   test {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
+
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=service.peer")
+  }
+
+  check {
+    dependsOn(testStableSemconv)
+  }
 }


### PR DESCRIPTION
See #16047

There's probably not too much point in testing all of these, I'd be fine closing as well.