### PR TITLE
Deprecate setPeerService in favor of addAttributesExtractor

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/builder/internal/DefaultHttpClientInstrumenterBuilder.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.api.incubator.builder.internal;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.CommonConfig;
@@ -45,9 +44,6 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DefaultHttpClientInstrumenterBuilder<REQUEST, RESPONSE> {
-
-  // copied from PeerIncubatingAttributes
-  private static final AttributeKey<String> PEER_SERVICE = AttributeKey.stringKey("peer.service");
 
   private final String instrumentationName;
   private final OpenTelemetry openTelemetry;
@@ -205,13 +201,6 @@ public final class DefaultHttpClientInstrumenterBuilder<REQUEST, RESPONSE> {
       PeerServiceResolver peerServiceResolver) {
     return addAttributesExtractor(
         HttpClientPeerServiceAttributesExtractor.create(attributesGetter, peerServiceResolver));
-  }
-
-  /** Sets the {@code peer.service} attribute for http client spans. */
-  @CanIgnoreReturnValue
-  public DefaultHttpClientInstrumenterBuilder<REQUEST, RESPONSE> setPeerService(
-      String peerService) {
-    return addAttributesExtractor(AttributesExtractor.constant(PEER_SERVICE, peerService));
   }
 
   @CanIgnoreReturnValue

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -47,7 +47,16 @@ public final class DubboTelemetryBuilder {
     this.openTelemetry = openTelemetry;
   }
 
-  /** Sets the {@code peer.service} attribute for http client spans. */
+  /**
+   * Sets the {@code peer.service} attribute for http client spans.
+   *
+   * @deprecated Use {@link #addAttributesExtractor(AttributesExtractor)} instead:
+   *     <pre>{@code
+   * builder.addAttributesExtractor(
+   *     AttributesExtractor.constant(AttributeKey.stringKey("peer.service"), "service-name"));
+   * }</pre>
+   */
+  @Deprecated
   public void setPeerService(String peerService) {
     this.peerService = peerService;
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/Experimental.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/Experimental.java
@@ -59,7 +59,11 @@ public final class Experimental {
    *
    * @param builder the client telemetry builder
    * @param peerService the peer service name
+   * @deprecated Use {@code
+   *     builder.addAttributesExtractor(AttributesExtractor.constant(AttributeKey.stringKey("peer.service"),
+   *     "service-name"))} instead.
    */
+  @Deprecated
   public static void setClientPeerService(
       ArmeriaClientTelemetryBuilder builder, String peerService) {
     if (setClientPeerService != null) {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -116,7 +116,16 @@ public final class GrpcTelemetryBuilder {
     return this;
   }
 
-  /** Sets the {@code peer.service} attribute for http client spans. */
+  /**
+   * Sets the {@code peer.service} attribute for http client spans.
+   *
+   * @deprecated Use {@link #addAttributesExtractor(AttributesExtractor)} instead:
+   *     <pre>{@code
+   * builder.addAttributesExtractor(
+   *     AttributesExtractor.constant(AttributeKey.stringKey("peer.service"), "service-name"));
+   * }</pre>
+   */
+  @Deprecated
   @CanIgnoreReturnValue
   public GrpcTelemetryBuilder setPeerService(String peerService) {
     this.peerService = peerService;


### PR DESCRIPTION
This method was only added on a couple of the `*TelemetryBuilder` classes, but it is not needed since it is simple to use addAttributesExtractor instead.

Also helps with #16047.