### PR TITLE
Remove latest deps restriction for spring-cloud-aws

### DIFF
--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
@@ -22,10 +22,6 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-starter-test:3.0.0")
   testLibrary("org.springframework.boot:spring-boot-starter-web:3.0.0")
-
-  // tests don't work with spring boot 4 yet
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // documented limitation
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:3.+") // documented limitation
 }
 
 otelJava {


### PR DESCRIPTION
related to #14906


spring-cloud-aws released their [Spring boot 4 / Spring 7 compatible version](https://github.com/awspring/spring-cloud-aws/releases/tag/v4.0.0) yesterday

