### PR TITLE
Rework ConfigProperties deprecation in IgnoredTypesConfigurer

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
@@ -23,9 +23,7 @@ public interface IgnoredTypesConfigurer extends Ordered {
    * instrumenting.
    */
   // TODO remove default implementation in next major release when deleting the deprecated method
-  default void configure(IgnoredTypesBuilder builder) {
-    throw new UnsupportedOperationException();
-  }
+  default void configure(IgnoredTypesBuilder builder) {}
 
   /**
    * Configure the passed {@code builder} and define which classes should be ignored when
@@ -34,5 +32,7 @@ public interface IgnoredTypesConfigurer extends Ordered {
    * @deprecated Use {@link #configure(IgnoredTypesBuilder)} instead.
    */
   @Deprecated
-  default void configure(IgnoredTypesBuilder builder, ConfigProperties config) {}
+  default void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
+    configure(builder);
+  }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -295,12 +295,7 @@ public class AgentInstaller {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
     for (IgnoredTypesConfigurer configurer :
         loadOrdered(IgnoredTypesConfigurer.class, extensionClassLoader)) {
-      try {
-        configurer.configure(builder);
-      } catch (UnsupportedOperationException e) {
-        // fall back to the deprecated method
-        configurer.configure(builder, config);
-      }
+      configurer.configure(builder, config != null ? config : EmptyConfigProperties.INSTANCE);
     }
 
     Trie<Boolean> ignoredTasksTrie = builder.buildIgnoredTasksTrie();

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -60,12 +60,7 @@ public class TestAgentListener implements AgentBuilder.Listener {
           || configurer instanceof GlobalIgnoredTypesConfigurer) {
         continue;
       }
-      try {
-        configurer.configure(builder);
-      } catch (UnsupportedOperationException e) {
-        // fall back to the deprecated method
-        configurer.configure(builder, EmptyConfigProperties.INSTANCE);
-      }
+      configurer.configure(builder, EmptyConfigProperties.INSTANCE);
     }
     return builder.buildIgnoredTypesTrie();
   }


### PR DESCRIPTION
We usually delegate from deprecated method to new method (here it is the other way around).