### PR TITLE
Follow semconv for SQLServer `db.namespace`

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -110,7 +110,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
     if (SemconvStability.emitOldDatabaseSemconv()) {
       internalSet(attributes, DB_SYSTEM, getter.getDbSystemName(request));
       internalSet(attributes, DB_USER, getter.getUser(request));
-      internalSet(attributes, DB_NAME, getter.getDbNamespace(request));
+      internalSet(attributes, DB_NAME, getter.getDbName(request));
       internalSet(attributes, DB_CONNECTION_STRING, getter.getConnectionString(request));
       internalSet(attributes, DB_STATEMENT, getter.getDbQueryText(request));
       internalSet(attributes, DB_OPERATION, getter.getDbOperationName(request));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
@@ -44,6 +44,19 @@ public interface DbClientAttributesGetter<REQUEST, RESPONSE>
   String getDbNamespace(REQUEST request);
 
   /**
+   * Returns the database name for old semantic conventions. This is only used for the old {@code
+   * db.name} attribute. Override this if the old semconv value differs from the new {@code
+   * db.namespace} value.
+   *
+   * @deprecated This method is only for backward compatibility with old semantic conventions.
+   */
+  @Deprecated // will be removed in 3.0.0
+  @Nullable
+  default String getDbName(REQUEST request) {
+    return getDbNamespace(request);
+  }
+
+  /**
    * Returns the database user name. This is only used for old semantic conventions.
    *
    * @deprecated There is no replacement at this time.

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -39,6 +39,24 @@ public final class JdbcAttributesGetter
   @Override
   public String getDbNamespace(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
+    String db = dbInfo.getDb();
+    String name = dbInfo.getName();
+
+    // SQL Server: combine instance and database per semconv
+    // Format: {instance_name}|{database_name} for named instances
+    // https://opentelemetry.io/docs/specs/semconv/db/sql-server/
+    if ("mssql".equals(dbInfo.getSystem()) && name != null && db != null) {
+      return name + "|" + db;
+    }
+
+    return name == null ? db : name;
+  }
+
+  @Deprecated
+  @Nullable
+  @Override
+  public String getDbName(DbRequest request) {
+    DbInfo dbInfo = request.getDbInfo();
     return dbInfo.getName() == null ? dbInfo.getDb() : dbInfo.getName();
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jdbc.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation") // testing deprecated getDbName method
+class JdbcAttributesGetterTest {
+
+  private final JdbcAttributesGetter getter = JdbcAttributesGetter.INSTANCE;
+
+  @Test
+  void testSqlServerNamedInstanceWithDatabase() {
+    // SQL Server with named instance and database should combine: instance|database
+    DbInfo dbInfo =
+        DbInfo.builder().system("mssql").name("ssinstance").db("ssdb").host("ss.host").build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    // New semconv db.namespace: combined format per SQL Server semconv
+    assertThat(getter.getDbNamespace(request)).isEqualTo("ssinstance|ssdb");
+    // Old semconv db.name: returns instance name (takes precedence over db)
+    assertThat(getter.getDbName(request)).isEqualTo("ssinstance");
+  }
+
+  @Test
+  void testSqlServerDefaultInstanceWithDatabase() {
+    // SQL Server default instance (no name) with database - no combining needed
+    DbInfo dbInfo = DbInfo.builder().system("mssql").db("ssdb").host("ss.host").build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    assertThat(getter.getDbNamespace(request)).isEqualTo("ssdb");
+    assertThat(getter.getDbName(request)).isEqualTo("ssdb");
+  }
+
+  @Test
+  void testSqlServerNamedInstanceWithoutDatabase() {
+    // SQL Server named instance without database - no combining needed
+    DbInfo dbInfo = DbInfo.builder().system("mssql").name("ssinstance").host("ss.host").build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    assertThat(getter.getDbNamespace(request)).isEqualTo("ssinstance");
+    assertThat(getter.getDbName(request)).isEqualTo("ssinstance");
+  }
+
+  @Test
+  void testNonSqlServerWithNameAndDb() {
+    // Non-SQL Server databases should NOT use combined format even with both name and db
+    DbInfo dbInfo =
+        DbInfo.builder()
+            .system("oracle")
+            .name("orclsn")
+            .db("orcldb")
+            .host("oracle.host")
+            .port(1521)
+            .build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    // Both return just name (no combining)
+    assertThat(getter.getDbNamespace(request)).isEqualTo("orclsn");
+    assertThat(getter.getDbName(request)).isEqualTo("orclsn");
+  }
+}


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/sql-server.md

> When connected to a default instance, `db.namespace` SHOULD be set to the name of the database.