### PR TITLE
Remove unused stability opt-in flags

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -50,8 +50,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -34,8 +34,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/cassandra/cassandra-4.4/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.4/javaagent/build.gradle.kts
@@ -47,8 +47,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/build.gradle.kts
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/build.gradle.kts
@@ -33,8 +33,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/build.gradle.kts
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/build.gradle.kts
@@ -27,8 +27,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
@@ -50,8 +50,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/build.gradle.kts
@@ -51,8 +51,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   val testExperimental by registering(Test::class) {

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
@@ -52,8 +52,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
@@ -53,8 +53,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
@@ -54,8 +54,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/couchbase/couchbase-3.4/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.4/javaagent/build.gradle.kts
@@ -52,8 +52,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
@@ -63,8 +63,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   val testExperimental by registering(Test::class) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -83,8 +83,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,code,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database,code")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   val testExperimental by registering(Test::class) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -110,8 +110,8 @@ tasks {
       testClassesDirs = suite.sources.output.classesDirs
       classpath = suite.sources.runtimeClasspath
 
-      jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-      systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+      jvmArgs("-Dotel.semconv-stability.opt-in=database")
+      systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
     }
   }
 

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -32,8 +32,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -42,8 +42,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -38,8 +38,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -33,8 +33,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/redisson/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson/redisson-3.0/javaagent/build.gradle.kts
@@ -35,8 +35,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {

--- a/instrumentation/redisson/redisson-3.17/javaagent/build.gradle.kts
+++ b/instrumentation/redisson/redisson-3.17/javaagent/build.gradle.kts
@@ -34,8 +34,8 @@ tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {


### PR DESCRIPTION
Follow-up to @jaydeluca's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16101#discussion_r2768863418.

Several of the database instrumentations don't support peer service mapping.