### PR TITLE
Fix Tomcat 7 Windows context leak

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -156,6 +156,7 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
     // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/787
     builder.ignoreTaskClass("org.apache.tomcat.util.net.NioEndpoint$SocketProcessor");
     builder.ignoreTaskClass("org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor");
+    builder.ignoreTaskClass("org.apache.tomcat.util.net.AprEndpoint$SocketProcessor");
 
     // HttpConnection implements Runnable. When async request is completed HttpConnection
     // may be sent to process next request while context from previous request hasn't been


### PR DESCRIPTION
Found via smoke test failure on Windows.