### PR TITLE
Update spring kafka metadata

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -12288,6 +12288,8 @@ libraries:
   - name: spring-kafka-2.7
     description: This instrumentation enables consumer messaging spans for Spring
       Kafka listeners.
+    semantic_conventions:
+    - MESSAGING_SPANS
     library_link: https://spring.io/projects/spring-kafka
     source_path: instrumentation/spring/spring-kafka-2.7
     scope:
@@ -12306,7 +12308,7 @@ libraries:
       type: list
       default: ''
     - name: otel.instrumentation.kafka.experimental-span-attributes
-      description: Enables capturing experimental span attribute `kafka.record.queue_time_ms`
+      description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
       type: boolean
       default: false
     telemetry:

--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -237,7 +237,7 @@ readonly INSTRUMENTATIONS=(
   "spring:spring-integration-4.1:javaagent:testWithRabbitInstrumentation"
   "spring:spring-jms:spring-jms-2.0:javaagent:test"
   "spring:spring-kafka-2.7:javaagent:test"
-  "spring:spring-kafka-2.7:javaagent:testNoReceiveTelemetry"
+  "spring:spring-kafka-2.7:javaagent:testExperimental"
   "spring:spring-pulsar-1.0:javaagent:test"
   "spring:spring-rabbit-1.0:javaagent:test"
   "spring:spring-rmi-4.0:javaagent:test"

--- a/instrumentation/spring/spring-kafka-2.7/metadata.yaml
+++ b/instrumentation/spring/spring-kafka-2.7/metadata.yaml
@@ -1,5 +1,7 @@
 description: This instrumentation enables consumer messaging spans for Spring Kafka listeners.
 library_link: https://spring.io/projects/spring-kafka
+semantic_conventions:
+  - MESSAGING_SPANS
 configurations:
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     description: >
@@ -12,6 +14,6 @@ configurations:
     type: list
     default: ''
   - name: otel.instrumentation.kafka.experimental-span-attributes
-    description: Enables capturing experimental span attribute `kafka.record.queue_time_ms`
+    description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
     type: boolean
     default: false


### PR DESCRIPTION
Previously we were using `testNoReceiveTelemetry` as the non-experimental "default" case for telemetry, but this splits the standard tests into normal vs experimental

Part of #14096 and #14128