### PR TITLE
Fix failing ktor server metrics test

### DIFF
--- a/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/ServerMetricsTest.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/ServerMetricsTest.kt
@@ -32,6 +32,4 @@ class ServerMetricsTest : AbstractKtorServerMetricsTest() {
   }
 
   override fun instrumentationName(): String = INSTRUMENTATION_NAME
-
-  override fun errorDuringSendSupported() = !java.lang.Boolean.getBoolean("testLatestDeps")
 }

--- a/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorServerMetricsTest.kt
+++ b/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorServerMetricsTest.kt
@@ -84,16 +84,12 @@ abstract class AbstractKtorServerMetricsTest : AbstractHttpServerUsingTest<Embed
     server.stop(0, 10, TimeUnit.SECONDS)
   }
 
-  open fun errorDuringSendSupported() = true
-
   // regression test for
   // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15303
   // verify that active requests are counted correctly when there is a send error
   @ParameterizedTest
   @MethodSource("provideArguments")
   fun testActiveRequestsMetric(endpoint: ServerEndpoint) {
-    assumeTrue("errorDuringSend" != endpoint.name() || errorDuringSendSupported())
-
     val request = AggregatedHttpRequest.of(HttpMethod.valueOf("GET"), resolveAddress(endpoint))
     try {
       client.execute(request).aggregate().join()


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15976
Reverts the changes in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15452 but keeps the `processedKey` attribute to ensure end is called only once. https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15452 explains that using `on(ResponseSent)` could be better, but we can't use it if it is not called reliably.