### PR TITLE
Static import: jul Level constants

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -9,6 +9,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.nullsFirst;
+import static java.util.logging.Level.WARNING;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.OpenTelemetry;
@@ -21,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -58,14 +58,12 @@ public class ServicePeerResolver {
               String serviceNamespace = entry.getString("service_namespace");
               if (peer == null) {
                 logger.log(
-                    Level.WARNING,
-                    "Invalid service_peer_mapping entry - peer is required: {0}",
-                    entry);
+                    WARNING, "Invalid service_peer_mapping entry - peer is required: {0}", entry);
                 return;
               }
               if (serviceName == null && serviceNamespace == null) {
                 logger.log(
-                    Level.WARNING,
+                    WARNING,
                     "Invalid service_peer_mapping entry - at least one of service_name or service_namespace is required: {0}",
                     entry);
                 return;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/OperationMetricsUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/OperationMetricsUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.internal;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
@@ -14,7 +16,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -42,7 +43,7 @@ public class OperationMetricsUtil {
         factory,
         (s, histogramBuilder) ->
             logger.log(
-                Level.WARNING,
+                WARNING,
                 "Disabling {0} metrics because {1} does not implement {2}. This prevents using "
                     + "metrics advice, which could result in {0} metrics having high cardinality "
                     + "attributes.",

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/PluginImplUtil.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/PluginImplUtil.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11;
 
-import java.util.logging.Level;
+import static java.util.logging.Level.FINE;
+
 import java.util.logging.Logger;
 
 final class PluginImplUtil { // TODO: Copy & paste from v2
@@ -44,7 +45,7 @@ final class PluginImplUtil { // TODO: Copy & paste from v2
       // always be found) but a dependency failed to load (most likely because the corresponding SDK
       // dependency is not on the class path).
       logger.log(
-          Level.FINE,
+          FINE,
           () ->
               "Failed to load "
                   + implFullClassName

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/PluginImplUtil.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/PluginImplUtil.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
-import java.util.logging.Level;
+import static java.util.logging.Level.FINE;
+
 import java.util.logging.Logger;
 
 final class PluginImplUtil { // TODO: Copy & pasted to v1
@@ -44,7 +45,7 @@ final class PluginImplUtil { // TODO: Copy & pasted to v1
       // always be found) but a dependency failed to load (most likely because the corresponding SDK
       // dependency is not on the class path).
       logger.log(
-          Level.FINE,
+          FINE,
           () ->
               "Failed to load "
                   + implFullClassName

--- a/instrumentation/c3p0-0.9/library/src/main/java/io/opentelemetry/instrumentation/c3p0/v0_9/ConnectionPoolMetrics.java
+++ b/instrumentation/c3p0-0.9/library/src/main/java/io/opentelemetry/instrumentation/c3p0/v0_9/ConnectionPoolMetrics.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.c3p0.v0_9;
 
+import static java.util.logging.Level.FINE;
+
 import com.mchange.v2.c3p0.PooledDataSource;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -14,7 +16,6 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbConnectionPoo
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -67,7 +68,7 @@ final class ConnectionPoolMetrics {
             pendingRequestsForConnection.record(
                 dataSource.getNumThreadsAwaitingCheckoutDefaultUser(), attributes);
           } catch (SQLException e) {
-            logger.log(Level.FINE, "Failed to get C3P0 datasource metric", e);
+            logger.log(FINE, "Failed to get C3P0 datasource metric", e);
           }
         },
         connections,

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.cassandra.v4_4;
 
+import static java.util.logging.Level.FINE;
+
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -21,7 +23,6 @@ import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.semconv.ServerAttributes;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -166,7 +167,7 @@ final class CassandraAttributesExtractor
         object = proxyAddressField.get(sniEndPoint);
       } catch (Exception e) {
         logger.log(
-            Level.FINE,
+            FINE,
             "Error when accessing the private field proxyAddress of SniEndPoint using reflection.",
             e);
       }

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/DropwizardMetricsAdapter.java
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/DropwizardMetricsAdapter.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.dropwizardmetrics;
 
+import static java.util.logging.Level.WARNING;
+
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -21,7 +23,6 @@ import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -70,8 +71,7 @@ public final class DropwizardMetricsAdapter implements MetricRegistryListener {
    */
   private static String sanitizeInstrumentName(String name) {
     if (name == null || name.isEmpty()) {
-      logger.log(
-          Level.WARNING, "Dropwizard metric name is null or empty, skipping instrument creation");
+      logger.log(WARNING, "Dropwizard metric name is null or empty, skipping instrument creation");
       return null;
     }
 
@@ -80,7 +80,7 @@ public final class DropwizardMetricsAdapter implements MetricRegistryListener {
 
     if (sanitized.isEmpty()) {
       logger.log(
-          Level.WARNING,
+          WARNING,
           "Dropwizard metric name ''{0}'' contains no valid characters after sanitization, skipping instrument creation",
           name);
       return null;
@@ -89,7 +89,7 @@ public final class DropwizardMetricsAdapter implements MetricRegistryListener {
     // Ensure the name starts with a letter
     if (!Character.isLetter(sanitized.charAt(0))) {
       logger.log(
-          Level.WARNING,
+          WARNING,
           "Dropwizard metric name ''{0}'' does not start with a letter after sanitization, skipping instrument creation",
           name);
       return null;
@@ -98,7 +98,7 @@ public final class DropwizardMetricsAdapter implements MetricRegistryListener {
     // Ensure max length of 255 characters (OpenTelemetry specification limit)
     if (sanitized.length() > 255) {
       logger.log(
-          Level.WARNING,
+          WARNING,
           "Dropwizard metric name ''{0}'' exceeds 255 character limit, truncating to ''{1}''",
           new Object[] {name, sanitized.substring(0, 255)});
       sanitized = sanitized.substring(0, 255);
@@ -107,7 +107,7 @@ public final class DropwizardMetricsAdapter implements MetricRegistryListener {
     // Log if sanitization changed the name
     if (!sanitized.equals(name)) {
       logger.log(
-          Level.WARNING,
+          WARNING,
           "Dropwizard metric name ''{0}'' has been sanitized to ''{1}''",
           new Object[] {name, sanitized});
     }

--- a/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
+++ b/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
@@ -5,6 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.jul;
 
+import static java.util.logging.Level.CONFIG;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+
 import application.java.util.logging.Logger;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -101,25 +109,25 @@ public final class JavaUtilLoggingHelper {
 
   private static Severity levelToSeverity(Level level) {
     int lev = level.intValue();
-    if (lev <= Level.FINEST.intValue()) {
+    if (lev <= FINEST.intValue()) {
       return Severity.TRACE;
     }
-    if (lev <= Level.FINER.intValue()) {
+    if (lev <= FINER.intValue()) {
       return Severity.DEBUG;
     }
-    if (lev <= Level.FINE.intValue()) {
+    if (lev <= FINE.intValue()) {
       return Severity.DEBUG2;
     }
-    if (lev <= Level.CONFIG.intValue()) {
+    if (lev <= CONFIG.intValue()) {
       return Severity.DEBUG3;
     }
-    if (lev <= Level.INFO.intValue()) {
+    if (lev <= INFO.intValue()) {
       return Severity.INFO;
     }
-    if (lev <= Level.WARNING.intValue()) {
+    if (lev <= WARNING.intValue()) {
       return Severity.WARN;
     }
-    if (lev <= Level.SEVERE.intValue()) {
+    if (lev <= SEVERE.intValue()) {
       return Severity.ERROR;
     }
     return Severity.FATAL;

--- a/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
+++ b/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
@@ -11,6 +11,10 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -52,20 +56,12 @@ class JavaUtilLoggingTest {
   @MethodSource("provideParameters")
   public void test(boolean withParam, boolean logException, boolean withParent)
       throws InterruptedException {
-    test(Level.FINE, Logger::fine, withParam, logException, withParent, null, null, null);
+    test(FINE, Logger::fine, withParam, logException, withParent, null, null, null);
+    testing.clearData();
+    test(INFO, Logger::info, withParam, logException, withParent, "abc", Severity.INFO, "INFO");
     testing.clearData();
     test(
-        Level.INFO,
-        Logger::info,
-        withParam,
-        logException,
-        withParent,
-        "abc",
-        Severity.INFO,
-        "INFO");
-    testing.clearData();
-    test(
-        Level.WARNING,
+        WARNING,
         Logger::warning,
         withParam,
         logException,
@@ -75,7 +71,7 @@ class JavaUtilLoggingTest {
         "WARNING");
     testing.clearData();
     test(
-        Level.SEVERE,
+        SEVERE,
         Logger::severe,
         withParam,
         logException,

--- a/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jmx/JmxMetricInsightInstaller.java
+++ b/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jmx/JmxMetricInsightInstaller.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jmx;
 
 import static java.util.Collections.emptyList;
+import static java.util.logging.Level.SEVERE;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -19,7 +20,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** An {@link AgentListener} that enables JMX metrics during agent startup. */
@@ -58,7 +58,7 @@ public class JmxMetricInsightInstaller implements AgentListener {
       builder.addRules(path);
     } catch (RuntimeException e) {
       // for now only log JMX metric configuration errors as they do not prevent agent startup
-      logger.log(Level.SEVERE, "Error while loading JMX configuration from " + path, e);
+      logger.log(SEVERE, "Error while loading JMX configuration from " + path, e);
     }
   }
 
@@ -70,8 +70,7 @@ public class JmxMetricInsightInstaller implements AgentListener {
       builder.addRules(input);
     } catch (RuntimeException e) {
       // for now only log JMX metric configuration errors as they do not prevent agent startup
-      logger.log(
-          Level.SEVERE, "Error while loading JMX configuration from classpath " + resource, e);
+      logger.log(SEVERE, "Error while loading JMX configuration from classpath " + resource, e);
     }
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/BeanFinder.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/BeanFinder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.jmx.internal.engine;
 
+import static java.util.logging.Level.WARNING;
+
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -15,7 +17,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -122,7 +123,7 @@ class BeanFinder {
         try {
           allObjectNames.addAll(connection.queryNames(pattern, beans.getQueryExp()));
         } catch (IOException e) {
-          logger.log(Level.WARNING, "IO error while resolving mbean", e);
+          logger.log(WARNING, "IO error while resolving mbean", e);
         }
       }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/OpenTelemetryMetricsReporter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/OpenTelemetryMetricsReporter.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.util.logging.Level.FINEST;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.metrics.Meter;
@@ -16,7 +18,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -86,8 +87,7 @@ public final class OpenTelemetryMetricsReporter implements MetricsReporter {
     RegisteredObservable registeredObservable =
         KafkaMetricRegistry.getRegisteredObservable(currentMeter, metric);
     if (registeredObservable == null) {
-      logger.log(
-          Level.FINEST, "Metric changed but cannot map to instrument: {0}", metric.metricName());
+      logger.log(FINEST, "Metric changed but cannot map to instrument: {0}", metric.metricName());
       return;
     }
 
@@ -98,7 +98,7 @@ public final class OpenTelemetryMetricsReporter implements MetricsReporter {
         Set<AttributeKey<?>> curAttributeKeys =
             curRegisteredObservable.getAttributes().asMap().keySet();
         if (curRegisteredObservable.getKafkaMetricName().equals(metric.metricName())) {
-          logger.log(Level.FINEST, "Replacing instrument: {0}", curRegisteredObservable);
+          logger.log(FINEST, "Replacing instrument: {0}", curRegisteredObservable);
           closeInstrument(curRegisteredObservable.getObservable());
           it.remove();
         } else if (curRegisteredObservable
@@ -107,7 +107,7 @@ public final class OpenTelemetryMetricsReporter implements MetricsReporter {
             && attributeKeys.size() > curAttributeKeys.size()
             && attributeKeys.containsAll(curAttributeKeys)) {
           logger.log(
-              Level.FINEST,
+              FINEST,
               "Replacing instrument with higher dimension version: {0}",
               curRegisteredObservable);
           closeInstrument(curRegisteredObservable.getObservable());
@@ -121,7 +121,7 @@ public final class OpenTelemetryMetricsReporter implements MetricsReporter {
 
   @Override
   public void metricRemoval(KafkaMetric metric) {
-    logger.log(Level.FINEST, "Metric removed: {0}", metric.metricName());
+    logger.log(FINEST, "Metric removed: {0}", metric.metricName());
     synchronized (lock) {
       for (Iterator<RegisteredObservable> it = registeredObservables.iterator(); it.hasNext(); ) {
         RegisteredObservable current = it.next();

--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodConfiguration.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodConfiguration.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.methods;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -64,7 +64,7 @@ public class MethodConfiguration {
       DeclarativeConfigProperties config) {
     String clazz = config.getString("class");
     if (isNullOrEmpty(clazz)) {
-      logger.log(Level.WARNING, "Invalid methods configuration - class name missing: {0}", config);
+      logger.log(WARNING, "Invalid methods configuration - class name missing: {0}", config);
       return Stream.empty();
     }
 
@@ -72,8 +72,7 @@ public class MethodConfiguration {
     for (DeclarativeConfigProperties method : config.getStructuredList("methods", emptyList())) {
       String methodName = method.getString("name");
       if (isNullOrEmpty(methodName)) {
-        logger.log(
-            Level.WARNING, "Invalid methods configuration - method name missing: {0}", method);
+        logger.log(WARNING, "Invalid methods configuration - method name missing: {0}", method);
         continue;
       }
       String spanKind = method.getString("span_kind", "INTERNAL");
@@ -84,14 +83,14 @@ public class MethodConfiguration {
             .add(methodName);
       } catch (IllegalArgumentException e) {
         logger.log(
-            Level.WARNING,
+            WARNING,
             "Invalid methods configuration - unknown span_kind: {0} for method: {1}",
             new Object[] {spanKind, methodName});
       }
     }
 
     if (methodNames.isEmpty()) {
-      logger.log(Level.WARNING, "Invalid methods configuration - no methods defined: {0}", config);
+      logger.log(WARNING, "Invalid methods configuration - no methods defined: {0}", config);
       return Stream.empty();
     }
 

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/UnsupportedReadLogger.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/UnsupportedReadLogger.java
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
-import java.util.logging.Level;
+import static java.util.logging.Level.WARNING;
+
 import java.util.logging.Logger;
 
 final class UnsupportedReadLogger {
 
   static {
     Logger logger = Logger.getLogger(OpenTelemetryMeterRegistry.class.getName());
-    logger.log(Level.WARNING, "OpenTelemetry metrics bridge does not support reading measurements");
+    logger.log(WARNING, "OpenTelemetry metrics bridge does not support reading measurements");
   }
 
   static void logWarning() {

--- a/instrumentation/reactor/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/v3_1/ContextPropagationOperator.java
+++ b/instrumentation/reactor/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/v3_1/ContextPropagationOperator.java
@@ -23,6 +23,7 @@
 package io.opentelemetry.instrumentation.reactor.v3_1;
 
 import static java.lang.invoke.MethodType.methodType;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -32,7 +33,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
@@ -183,7 +183,7 @@ public final class ContextPropagationOperator {
     try {
       SCHEDULERS_HOOK_METHOD.invoke(key, function);
     } catch (Throwable throwable) {
-      logger.log(Level.WARNING, "Failed to install scheduler hook", throwable);
+      logger.log(WARNING, "Failed to install scheduler hook", throwable);
     }
   }
 

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/CgroupV1ContainerIdExtractor.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/CgroupV1ContainerIdExtractor.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.internal.OtelEncodingUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -56,7 +57,7 @@ final class CgroupV1ContainerIdExtractor {
           .findFirst()
           .orElse(Optional.empty());
     } catch (Exception e) {
-      logger.log(Level.WARNING, "Unable to read file", e);
+      logger.log(WARNING, "Unable to read file", e);
     }
     return Optional.empty();
   }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/CgroupV2ContainerIdExtractor.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/CgroupV2ContainerIdExtractor.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.instrumentation.resources;
 
 import static java.util.Optional.empty;
+import static java.util.logging.Level.WARNING;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -50,7 +50,7 @@ class CgroupV2ContainerIdExtractor {
     try {
       fileAsList = filesystem.lineList(V2_CGROUP_PATH);
     } catch (IOException e) {
-      logger.log(Level.WARNING, "Unable to read v2 cgroup path", e);
+      logger.log(WARNING, "Unable to read v2 cgroup path", e);
       return empty();
     }
 

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ContainerResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ContainerResource.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static java.util.logging.Level.WARNING;
+
 import com.google.errorprone.annotations.MustBeClosed;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -17,7 +19,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,7 +101,7 @@ public final class ContainerResource {
           return Files.lines(path, Charset.forName("Cp1047"));
         } catch (UnsupportedCharsetException e) {
           // What charsets are available depends on the instance of the JVM
-          logger.log(Level.WARNING, "Unable to find charset Cp1047", e);
+          logger.log(WARNING, "Unable to find charset Cp1047", e);
           return Stream.empty();
         }
       } else {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetrics.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetrics.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.runtimemetrics.java17.internal.RecordedEventHandler;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsUtil;
@@ -13,7 +15,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import jdk.jfr.EventSettings;
@@ -75,7 +76,7 @@ public final class RuntimeMetrics implements AutoCloseable {
   @Override
   public void close() {
     if (!isClosed.compareAndSet(false, true)) {
-      logger.log(Level.WARNING, "RuntimeMetrics is already closed");
+      logger.log(WARNING, "RuntimeMetrics is already closed");
       return;
     }
     if (jfrRuntimeMetrics != null) {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/GenerateDocs.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/GenerateDocs.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
+import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
@@ -20,7 +21,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -38,7 +38,7 @@ public class GenerateDocs {
 
   public static void main(String[] args) throws Exception {
     // Suppress info level logs
-    Logger.getLogger(RuntimeMetrics.class.getName()).setLevel(Level.WARNING);
+    Logger.getLogger(RuntimeMetrics.class.getName()).setLevel(WARNING);
 
     String jfrReadmePath = System.getProperty(JFR_README_PATH_KEY);
     if (jfrReadmePath == null) {

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimemetrics/java8/JarAnalyzer.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimemetrics/java8/JarAnalyzer.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.runtimemetrics.java8;
 import static io.opentelemetry.javaagent.instrumentation.runtimemetrics.java8.JarDetails.EAR_EXTENSION;
 import static io.opentelemetry.javaagent.instrumentation.runtimemetrics.java8.JarDetails.JAR_EXTENSION;
 import static io.opentelemetry.javaagent.instrumentation.runtimemetrics.java8.JarDetails.WAR_EXTENSION;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -31,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -109,7 +111,7 @@ final class JarAnalyzer implements ClassFileTransformer {
     try {
       locationUri = archiveUrl.toURI();
     } catch (URISyntaxException e) {
-      logger.log(Level.WARNING, "Unable to get URI for code location URL: " + archiveUrl, e);
+      logger.log(WARNING, "Unable to get URI for code location URL: " + archiveUrl, e);
       return;
     }
 
@@ -117,18 +119,18 @@ final class JarAnalyzer implements ClassFileTransformer {
       return;
     }
     if ("jrt".equals(archiveUrl.getProtocol())) {
-      logger.log(Level.FINEST, "Skipping processing for java runtime module: {0}", archiveUrl);
+      logger.log(FINEST, "Skipping processing for java runtime module: {0}", archiveUrl);
       return;
     }
     String file = archiveUrl.getFile();
     if (file.endsWith("/")) {
-      logger.log(Level.FINEST, "Skipping processing non-archive code location: {0}", archiveUrl);
+      logger.log(FINEST, "Skipping processing non-archive code location: {0}", archiveUrl);
       return;
     }
     if (!file.endsWith(JAR_EXTENSION)
         && !file.endsWith(WAR_EXTENSION)
         && !file.endsWith(EAR_EXTENSION)) {
-      logger.log(Level.INFO, "Skipping processing unrecognized code location: {0}", archiveUrl);
+      logger.log(INFO, "Skipping processing unrecognized code location: {0}", archiveUrl);
       return;
     }
 
@@ -144,7 +146,7 @@ final class JarAnalyzer implements ClassFileTransformer {
           archiveUrl = archiveFile.toURI().toURL();
         }
       } catch (Exception e) {
-        logger.log(Level.WARNING, "Unable to normalize location URL: " + archiveUrl, e);
+        logger.log(WARNING, "Unable to normalize location URL: " + archiveUrl, e);
       }
     }
 
@@ -190,7 +192,7 @@ final class JarAnalyzer implements ClassFileTransformer {
           // events
           processUrl(eventLogger, archiveUrl);
         } catch (Throwable e) {
-          logger.log(Level.WARNING, "Unexpected error processing archive URL: " + archiveUrl, e);
+          logger.log(WARNING, "Unexpected error processing archive URL: " + archiveUrl, e);
         }
       }
       logger.warning("JarAnalyzer stopped");
@@ -206,7 +208,7 @@ final class JarAnalyzer implements ClassFileTransformer {
     try {
       jarDetails = JarDetails.forUrl(archiveUrl);
     } catch (IOException e) {
-      logger.log(Level.WARNING, "Error reading package for archive URL: " + archiveUrl, e);
+      logger.log(WARNING, "Error reading package for archive URL: " + archiveUrl, e);
       return;
     }
     AttributesBuilder builder = Attributes.builder();

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetrics.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/RuntimeMetrics.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.instrumentation.runtimemetrics.java8;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.JmxRuntimeMetricsUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** The entry point class for runtime metrics support using JMX. */
@@ -50,7 +51,7 @@ public final class RuntimeMetrics implements AutoCloseable {
   @Override
   public void close() {
     if (!isClosed.compareAndSet(false, true)) {
-      logger.log(Level.WARNING, "RuntimeMetrics is already closed");
+      logger.log(WARNING, "RuntimeMetrics is already closed");
       return;
     }
 

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SystemHelper.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SystemHelper.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.resources;
 
+import static java.util.logging.Level.FINER;
+
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class SystemHelper {
@@ -25,7 +26,7 @@ class SystemHelper {
         contextClassLoader != null ? contextClassLoader : ClassLoader.getSystemClassLoader();
     addBootInfPrefix = classLoader.getResource("BOOT-INF/classes/") != null;
     if (addBootInfPrefix) {
-      logger.log(Level.FINER, "Detected presence of BOOT-INF/classes/");
+      logger.log(FINER, "Detected presence of BOOT-INF/classes/");
     }
   }
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
@@ -6,6 +6,7 @@
 package org.springframework.web.servlet.v3_1;
 
 import static io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource.CONTROLLER;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
@@ -20,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.servlet.Filter;
@@ -206,7 +206,7 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
       parseAndCacheMh.invoke(request);
       return true;
     } catch (Throwable throwable) {
-      logger.log(Level.FINE, "Failed calling parseAndCache", throwable);
+      logger.log(FINE, "Failed calling parseAndCache", throwable);
       return false;
     }
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
@@ -6,6 +6,7 @@
 package org.springframework.web.servlet.v6_0;
 
 import static io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource.CONTROLLER;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
@@ -26,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.springframework.core.Ordered;
@@ -46,7 +46,7 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
           try {
             ServletRequestPathUtils.parseAndCache(request);
           } catch (RuntimeException exception) {
-            logger.log(Level.FINE, "Failed calling parseAndCache", exception);
+            logger.log(FINE, "Failed calling parseAndCache", exception);
             return null;
           }
         }

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
@@ -5,6 +5,13 @@
 
 package io.opentelemetry.javaagent.bootstrap;
 
+import static java.util.logging.Level.CONFIG;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.function.Supplier;
@@ -169,28 +176,28 @@ public class PatchLogger {
 
   public Level getLevel() {
     if (internalLogger.isLoggable(InternalLogger.Level.ERROR)) {
-      return Level.SEVERE;
+      return SEVERE;
     } else if (internalLogger.isLoggable(InternalLogger.Level.WARN)) {
-      return Level.WARNING;
+      return WARNING;
     } else if (internalLogger.isLoggable(InternalLogger.Level.INFO)) {
-      return Level.CONFIG;
+      return CONFIG;
     } else if (internalLogger.isLoggable(InternalLogger.Level.DEBUG)) {
-      return Level.FINE;
+      return FINE;
     } else if (internalLogger.isLoggable(InternalLogger.Level.TRACE)) {
-      return Level.FINEST;
+      return FINEST;
     } else {
       return Level.OFF;
     }
   }
 
   private static InternalLogger.Level toInternalLevel(Level level) {
-    if (level.intValue() >= Level.SEVERE.intValue()) {
+    if (level.intValue() >= SEVERE.intValue()) {
       return InternalLogger.Level.ERROR;
-    } else if (level.intValue() >= Level.WARNING.intValue()) {
+    } else if (level.intValue() >= WARNING.intValue()) {
       return InternalLogger.Level.WARN;
-    } else if (level.intValue() >= Level.INFO.intValue()) {
+    } else if (level.intValue() >= INFO.intValue()) {
       return InternalLogger.Level.INFO;
-    } else if (level.intValue() >= Level.FINE.intValue()) {
+    } else if (level.intValue() >= FINE.intValue()) {
       return InternalLogger.Level.DEBUG;
     } else {
       return InternalLogger.Level.TRACE;

--- a/javaagent-bootstrap/src/test/java/io/opentelemetry/javaagent/bootstrap/PatchLoggerTest.java
+++ b/javaagent-bootstrap/src/test/java/io/opentelemetry/javaagent/bootstrap/PatchLoggerTest.java
@@ -5,6 +5,13 @@
 
 package io.opentelemetry.javaagent.bootstrap;
 
+import static java.util.logging.Level.CONFIG;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -110,13 +117,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.log(Level.SEVERE, "ereves");
-    logger.log(Level.WARNING, "gninraw");
-    logger.log(Level.INFO, "ofni");
-    logger.log(Level.CONFIG, "gifnoc");
-    logger.log(Level.FINE, "enif");
-    logger.log(Level.FINER, "renif");
-    logger.log(Level.FINEST, "tsenif");
+    logger.log(SEVERE, "ereves");
+    logger.log(WARNING, "gninraw");
+    logger.log(INFO, "ofni");
+    logger.log(CONFIG, "gifnoc");
+    logger.log(FINE, "enif");
+    logger.log(FINER, "renif");
+    logger.log(FINEST, "tsenif");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -138,13 +145,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.log(Level.SEVERE, "ereves: {0}", "a");
-    logger.log(Level.WARNING, "gninraw: {0}", "b");
-    logger.log(Level.INFO, "ofni: {0}", "c");
-    logger.log(Level.CONFIG, "gifnoc: {0}", "d");
-    logger.log(Level.FINE, "enif: {0}", "e");
-    logger.log(Level.FINER, "renif: {0}", "f");
-    logger.log(Level.FINEST, "tsenif: {0}", "g");
+    logger.log(SEVERE, "ereves: {0}", "a");
+    logger.log(WARNING, "gninraw: {0}", "b");
+    logger.log(INFO, "ofni: {0}", "c");
+    logger.log(CONFIG, "gifnoc: {0}", "d");
+    logger.log(FINE, "enif: {0}", "e");
+    logger.log(FINER, "renif: {0}", "f");
+    logger.log(FINEST, "tsenif: {0}", "g");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -173,13 +180,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.log(Level.SEVERE, "ereves: {0},{1}", new Object[] {"a", "b"});
-    logger.log(Level.WARNING, "gninraw: {0},{1}", new Object[] {"b", "c"});
-    logger.log(Level.INFO, "ofni: {0},{1}", new Object[] {"c", "d"});
-    logger.log(Level.CONFIG, "gifnoc: {0},{1}", new Object[] {"d", "e"});
-    logger.log(Level.FINE, "enif: {0},{1}", new Object[] {"e", "f"});
-    logger.log(Level.FINER, "renif: {0},{1}", new Object[] {"f", "g"});
-    logger.log(Level.FINEST, "tsenif: {0},{1}", new Object[] {"g", "h"});
+    logger.log(SEVERE, "ereves: {0},{1}", new Object[] {"a", "b"});
+    logger.log(WARNING, "gninraw: {0},{1}", new Object[] {"b", "c"});
+    logger.log(INFO, "ofni: {0},{1}", new Object[] {"c", "d"});
+    logger.log(CONFIG, "gifnoc: {0},{1}", new Object[] {"d", "e"});
+    logger.log(FINE, "enif: {0},{1}", new Object[] {"e", "f"});
+    logger.log(FINER, "renif: {0},{1}", new Object[] {"f", "g"});
+    logger.log(FINEST, "tsenif: {0},{1}", new Object[] {"g", "h"});
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -214,13 +221,13 @@ class PatchLoggerTest {
     Throwable g = new Throwable();
 
     // when
-    logger.log(Level.SEVERE, "ereves", a);
-    logger.log(Level.WARNING, "gninraw", b);
-    logger.log(Level.INFO, "ofni", c);
-    logger.log(Level.CONFIG, "gifnoc", d);
-    logger.log(Level.FINE, "enif", e);
-    logger.log(Level.FINER, "renif", f);
-    logger.log(Level.FINEST, "tsenif", g);
+    logger.log(SEVERE, "ereves", a);
+    logger.log(WARNING, "gninraw", b);
+    logger.log(INFO, "ofni", c);
+    logger.log(CONFIG, "gifnoc", d);
+    logger.log(FINE, "enif", e);
+    logger.log(FINER, "renif", f);
+    logger.log(FINEST, "tsenif", g);
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -244,13 +251,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // then
-    assertThat(logger.isLoggable(Level.SEVERE)).isTrue();
-    assertThat(logger.isLoggable(Level.WARNING)).isTrue();
-    assertThat(logger.isLoggable(Level.INFO)).isTrue();
-    assertThat(logger.isLoggable(Level.CONFIG)).isTrue();
-    assertThat(logger.isLoggable(Level.FINE)).isTrue();
-    assertThat(logger.isLoggable(Level.FINER)).isTrue();
-    assertThat(logger.isLoggable(Level.FINEST)).isTrue();
+    assertThat(logger.isLoggable(SEVERE)).isTrue();
+    assertThat(logger.isLoggable(WARNING)).isTrue();
+    assertThat(logger.isLoggable(INFO)).isTrue();
+    assertThat(logger.isLoggable(CONFIG)).isTrue();
+    assertThat(logger.isLoggable(FINE)).isTrue();
+    assertThat(logger.isLoggable(FINER)).isTrue();
+    assertThat(logger.isLoggable(FINEST)).isTrue();
   }
 
   @Test
@@ -264,13 +271,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // then
-    assertThat(logger.isLoggable(Level.SEVERE)).isTrue();
-    assertThat(logger.isLoggable(Level.WARNING)).isTrue();
-    assertThat(logger.isLoggable(Level.INFO)).isFalse();
-    assertThat(logger.isLoggable(Level.CONFIG)).isFalse();
-    assertThat(logger.isLoggable(Level.FINE)).isFalse();
-    assertThat(logger.isLoggable(Level.FINER)).isFalse();
-    assertThat(logger.isLoggable(Level.FINEST)).isFalse();
+    assertThat(logger.isLoggable(SEVERE)).isTrue();
+    assertThat(logger.isLoggable(WARNING)).isTrue();
+    assertThat(logger.isLoggable(INFO)).isFalse();
+    assertThat(logger.isLoggable(CONFIG)).isFalse();
+    assertThat(logger.isLoggable(FINE)).isFalse();
+    assertThat(logger.isLoggable(FINER)).isFalse();
+    assertThat(logger.isLoggable(FINEST)).isFalse();
   }
 
   @Test
@@ -282,13 +289,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // then
-    assertThat(logger.isLoggable(Level.SEVERE)).isFalse();
-    assertThat(logger.isLoggable(Level.WARNING)).isFalse();
-    assertThat(logger.isLoggable(Level.INFO)).isFalse();
-    assertThat(logger.isLoggable(Level.CONFIG)).isFalse();
-    assertThat(logger.isLoggable(Level.FINE)).isFalse();
-    assertThat(logger.isLoggable(Level.FINER)).isFalse();
-    assertThat(logger.isLoggable(Level.FINEST)).isFalse();
+    assertThat(logger.isLoggable(SEVERE)).isFalse();
+    assertThat(logger.isLoggable(WARNING)).isFalse();
+    assertThat(logger.isLoggable(INFO)).isFalse();
+    assertThat(logger.isLoggable(CONFIG)).isFalse();
+    assertThat(logger.isLoggable(FINE)).isFalse();
+    assertThat(logger.isLoggable(FINER)).isFalse();
+    assertThat(logger.isLoggable(FINEST)).isFalse();
   }
 
   @Test
@@ -299,7 +306,7 @@ class PatchLoggerTest {
     // when
     PatchLogger logger = new PatchLogger(internalLogger);
     // then
-    assertThat(logger.getLevel()).isEqualTo(Level.SEVERE);
+    assertThat(logger.getLevel()).isEqualTo(SEVERE);
   }
 
   @Test
@@ -310,7 +317,7 @@ class PatchLoggerTest {
     // when
     PatchLogger logger = new PatchLogger(internalLogger);
     // then
-    assertThat(logger.getLevel()).isEqualTo(Level.WARNING);
+    assertThat(logger.getLevel()).isEqualTo(WARNING);
   }
 
   @Test
@@ -321,7 +328,7 @@ class PatchLoggerTest {
     // when
     PatchLogger logger = new PatchLogger(internalLogger);
     // then
-    assertThat(logger.getLevel()).isEqualTo(Level.CONFIG);
+    assertThat(logger.getLevel()).isEqualTo(CONFIG);
   }
 
   @Test
@@ -332,7 +339,7 @@ class PatchLoggerTest {
     // when
     PatchLogger logger = new PatchLogger(internalLogger);
     // then
-    assertThat(logger.getLevel()).isEqualTo(Level.FINE);
+    assertThat(logger.getLevel()).isEqualTo(FINE);
   }
 
   @Test
@@ -343,7 +350,7 @@ class PatchLoggerTest {
     // when
     PatchLogger logger = new PatchLogger(internalLogger);
     // then
-    assertThat(logger.getLevel()).isEqualTo(Level.FINEST);
+    assertThat(logger.getLevel()).isEqualTo(FINEST);
   }
 
   @Test
@@ -363,13 +370,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logp(Level.SEVERE, null, null, "ereves");
-    logger.logp(Level.WARNING, null, null, "gninraw");
-    logger.logp(Level.INFO, null, null, "ofni");
-    logger.logp(Level.CONFIG, null, null, "gifnoc");
-    logger.logp(Level.FINE, null, null, "enif");
-    logger.logp(Level.FINER, null, null, "renif");
-    logger.logp(Level.FINEST, null, null, "tsenif");
+    logger.logp(SEVERE, null, null, "ereves");
+    logger.logp(WARNING, null, null, "gninraw");
+    logger.logp(INFO, null, null, "ofni");
+    logger.logp(CONFIG, null, null, "gifnoc");
+    logger.logp(FINE, null, null, "enif");
+    logger.logp(FINER, null, null, "renif");
+    logger.logp(FINEST, null, null, "tsenif");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -391,13 +398,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logp(Level.SEVERE, null, null, "ereves: {0}", "a");
-    logger.logp(Level.WARNING, null, null, "gninraw: {0}", "b");
-    logger.logp(Level.INFO, null, null, "ofni: {0}", "c");
-    logger.logp(Level.CONFIG, null, null, "gifnoc: {0}", "d");
-    logger.logp(Level.FINE, null, null, "enif: {0}", "e");
-    logger.logp(Level.FINER, null, null, "renif: {0}", "f");
-    logger.logp(Level.FINEST, null, null, "tsenif: {0}", "g");
+    logger.logp(SEVERE, null, null, "ereves: {0}", "a");
+    logger.logp(WARNING, null, null, "gninraw: {0}", "b");
+    logger.logp(INFO, null, null, "ofni: {0}", "c");
+    logger.logp(CONFIG, null, null, "gifnoc: {0}", "d");
+    logger.logp(FINE, null, null, "enif: {0}", "e");
+    logger.logp(FINER, null, null, "renif: {0}", "f");
+    logger.logp(FINEST, null, null, "tsenif: {0}", "g");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -426,13 +433,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logp(Level.SEVERE, null, null, "ereves: {0},{1}", new Object[] {"a", "b"});
-    logger.logp(Level.WARNING, null, null, "gninraw: {0},{1}", new Object[] {"b", "c"});
-    logger.logp(Level.INFO, null, null, "ofni: {0},{1}", new Object[] {"c", "d"});
-    logger.logp(Level.CONFIG, null, null, "gifnoc: {0},{1}", new Object[] {"d", "e"});
-    logger.logp(Level.FINE, null, null, "enif: {0},{1}", new Object[] {"e", "f"});
-    logger.logp(Level.FINER, null, null, "renif: {0},{1}", new Object[] {"f", "g"});
-    logger.logp(Level.FINEST, null, null, "tsenif: {0},{1}", new Object[] {"g", "h"});
+    logger.logp(SEVERE, null, null, "ereves: {0},{1}", new Object[] {"a", "b"});
+    logger.logp(WARNING, null, null, "gninraw: {0},{1}", new Object[] {"b", "c"});
+    logger.logp(INFO, null, null, "ofni: {0},{1}", new Object[] {"c", "d"});
+    logger.logp(CONFIG, null, null, "gifnoc: {0},{1}", new Object[] {"d", "e"});
+    logger.logp(FINE, null, null, "enif: {0},{1}", new Object[] {"e", "f"});
+    logger.logp(FINER, null, null, "renif: {0},{1}", new Object[] {"f", "g"});
+    logger.logp(FINEST, null, null, "tsenif: {0},{1}", new Object[] {"g", "h"});
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -467,13 +474,13 @@ class PatchLoggerTest {
     Throwable g = new Throwable();
 
     // when
-    logger.logp(Level.SEVERE, null, null, "ereves", a);
-    logger.logp(Level.WARNING, null, null, "gninraw", b);
-    logger.logp(Level.INFO, null, null, "ofni", c);
-    logger.logp(Level.CONFIG, null, null, "gifnoc", d);
-    logger.logp(Level.FINE, null, null, "enif", e);
-    logger.logp(Level.FINER, null, null, "renif", f);
-    logger.logp(Level.FINEST, null, null, "tsenif", g);
+    logger.logp(SEVERE, null, null, "ereves", a);
+    logger.logp(WARNING, null, null, "gninraw", b);
+    logger.logp(INFO, null, null, "ofni", c);
+    logger.logp(CONFIG, null, null, "gifnoc", d);
+    logger.logp(FINE, null, null, "enif", e);
+    logger.logp(FINER, null, null, "renif", f);
+    logger.logp(FINEST, null, null, "tsenif", g);
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -494,13 +501,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logrb(Level.SEVERE, null, null, null, "ereves");
-    logger.logrb(Level.WARNING, null, null, null, "gninraw");
-    logger.logrb(Level.INFO, null, null, null, "ofni");
-    logger.logrb(Level.CONFIG, null, null, null, "gifnoc");
-    logger.logrb(Level.FINE, null, null, null, "enif");
-    logger.logrb(Level.FINER, null, null, null, "renif");
-    logger.logrb(Level.FINEST, null, null, null, "tsenif");
+    logger.logrb(SEVERE, null, null, null, "ereves");
+    logger.logrb(WARNING, null, null, null, "gninraw");
+    logger.logrb(INFO, null, null, null, "ofni");
+    logger.logrb(CONFIG, null, null, null, "gifnoc");
+    logger.logrb(FINE, null, null, null, "enif");
+    logger.logrb(FINER, null, null, null, "renif");
+    logger.logrb(FINEST, null, null, null, "tsenif");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -522,13 +529,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logrb(Level.SEVERE, null, null, null, "ereves: {0}", "a");
-    logger.logrb(Level.WARNING, null, null, null, "gninraw: {0}", "b");
-    logger.logrb(Level.INFO, null, null, null, "ofni: {0}", "c");
-    logger.logrb(Level.CONFIG, null, null, null, "gifnoc: {0}", "d");
-    logger.logrb(Level.FINE, null, null, null, "enif: {0}", "e");
-    logger.logrb(Level.FINER, null, null, null, "renif: {0}", "f");
-    logger.logrb(Level.FINEST, null, null, null, "tsenif: {0}", "g");
+    logger.logrb(SEVERE, null, null, null, "ereves: {0}", "a");
+    logger.logrb(WARNING, null, null, null, "gninraw: {0}", "b");
+    logger.logrb(INFO, null, null, null, "ofni: {0}", "c");
+    logger.logrb(CONFIG, null, null, null, "gifnoc: {0}", "d");
+    logger.logrb(FINE, null, null, null, "enif: {0}", "e");
+    logger.logrb(FINER, null, null, null, "renif: {0}", "f");
+    logger.logrb(FINEST, null, null, null, "tsenif: {0}", "g");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -557,17 +564,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logrb(
-        Level.SEVERE, null, null, (String) null, "ereves: {0},{1}", new Object[] {"a", "b"});
-    logger.logrb(
-        Level.WARNING, null, null, (String) null, "gninraw: {0},{1}", new Object[] {"b", "c"});
-    logger.logrb(Level.INFO, null, null, (String) null, "ofni: {0},{1}", new Object[] {"c", "d"});
-    logger.logrb(
-        Level.CONFIG, null, null, (String) null, "gifnoc: {0},{1}", new Object[] {"d", "e"});
-    logger.logrb(Level.FINE, null, null, (String) null, "enif: {0},{1}", new Object[] {"e", "f"});
-    logger.logrb(Level.FINER, null, null, (String) null, "renif: {0},{1}", new Object[] {"f", "g"});
-    logger.logrb(
-        Level.FINEST, null, null, (String) null, "tsenif: {0},{1}", new Object[] {"g", "h"});
+    logger.logrb(SEVERE, null, null, (String) null, "ereves: {0},{1}", new Object[] {"a", "b"});
+    logger.logrb(WARNING, null, null, (String) null, "gninraw: {0},{1}", new Object[] {"b", "c"});
+    logger.logrb(INFO, null, null, (String) null, "ofni: {0},{1}", new Object[] {"c", "d"});
+    logger.logrb(CONFIG, null, null, (String) null, "gifnoc: {0},{1}", new Object[] {"d", "e"});
+    logger.logrb(FINE, null, null, (String) null, "enif: {0},{1}", new Object[] {"e", "f"});
+    logger.logrb(FINER, null, null, (String) null, "renif: {0},{1}", new Object[] {"f", "g"});
+    logger.logrb(FINEST, null, null, (String) null, "tsenif: {0},{1}", new Object[] {"g", "h"});
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -596,13 +599,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logrb(Level.SEVERE, (String) null, null, null, "ereves: {0},{1}", "a", "b");
-    logger.logrb(Level.WARNING, (String) null, null, null, "gninraw: {0},{1}", "b", "c");
-    logger.logrb(Level.INFO, (String) null, null, null, "ofni: {0},{1}", "c", "d");
-    logger.logrb(Level.CONFIG, (String) null, null, null, "gifnoc: {0},{1}", "d", "e");
-    logger.logrb(Level.FINE, (String) null, null, null, "enif: {0},{1}", "e", "f");
-    logger.logrb(Level.FINER, (String) null, null, null, "renif: {0},{1}", "f", "g");
-    logger.logrb(Level.FINEST, (String) null, null, null, "tsenif: {0},{1}", "g", "h");
+    logger.logrb(SEVERE, (String) null, null, null, "ereves: {0},{1}", "a", "b");
+    logger.logrb(WARNING, (String) null, null, null, "gninraw: {0},{1}", "b", "c");
+    logger.logrb(INFO, (String) null, null, null, "ofni: {0},{1}", "c", "d");
+    logger.logrb(CONFIG, (String) null, null, null, "gifnoc: {0},{1}", "d", "e");
+    logger.logrb(FINE, (String) null, null, null, "enif: {0},{1}", "e", "f");
+    logger.logrb(FINER, (String) null, null, null, "renif: {0},{1}", "f", "g");
+    logger.logrb(FINEST, (String) null, null, null, "tsenif: {0},{1}", "g", "h");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -631,13 +634,13 @@ class PatchLoggerTest {
     PatchLogger logger = new PatchLogger(internalLogger);
 
     // when
-    logger.logrb(Level.SEVERE, (ResourceBundle) null, "ereves: {0},{1}", "a", "b");
-    logger.logrb(Level.WARNING, (ResourceBundle) null, "gninraw: {0},{1}", "b", "c");
-    logger.logrb(Level.INFO, (ResourceBundle) null, "ofni: {0},{1}", "c", "d");
-    logger.logrb(Level.CONFIG, (ResourceBundle) null, "gifnoc: {0},{1}", "d", "e");
-    logger.logrb(Level.FINE, (ResourceBundle) null, "enif: {0},{1}", "e", "f");
-    logger.logrb(Level.FINER, (ResourceBundle) null, "renif: {0},{1}", "f", "g");
-    logger.logrb(Level.FINEST, (ResourceBundle) null, "tsenif: {0},{1}", "g", "h");
+    logger.logrb(SEVERE, (ResourceBundle) null, "ereves: {0},{1}", "a", "b");
+    logger.logrb(WARNING, (ResourceBundle) null, "gninraw: {0},{1}", "b", "c");
+    logger.logrb(INFO, (ResourceBundle) null, "ofni: {0},{1}", "c", "d");
+    logger.logrb(CONFIG, (ResourceBundle) null, "gifnoc: {0},{1}", "d", "e");
+    logger.logrb(FINE, (ResourceBundle) null, "enif: {0},{1}", "e", "f");
+    logger.logrb(FINER, (ResourceBundle) null, "renif: {0},{1}", "f", "g");
+    logger.logrb(FINEST, (ResourceBundle) null, "tsenif: {0},{1}", "g", "h");
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -672,13 +675,13 @@ class PatchLoggerTest {
     Throwable g = new Throwable();
 
     // when
-    logger.logrb(Level.SEVERE, null, null, (String) null, "ereves", a);
-    logger.logrb(Level.WARNING, null, null, (String) null, "gninraw", b);
-    logger.logrb(Level.INFO, null, null, (String) null, "ofni", c);
-    logger.logrb(Level.CONFIG, null, null, (String) null, "gifnoc", d);
-    logger.logrb(Level.FINE, null, null, (String) null, "enif", e);
-    logger.logrb(Level.FINER, null, null, (String) null, "renif", f);
-    logger.logrb(Level.FINEST, null, null, (String) null, "tsenif", g);
+    logger.logrb(SEVERE, null, null, (String) null, "ereves", a);
+    logger.logrb(WARNING, null, null, (String) null, "gninraw", b);
+    logger.logrb(INFO, null, null, (String) null, "ofni", c);
+    logger.logrb(CONFIG, null, null, (String) null, "gifnoc", d);
+    logger.logrb(FINE, null, null, (String) null, "enif", e);
+    logger.logrb(FINER, null, null, (String) null, "renif", f);
+    logger.logrb(FINEST, null, null, (String) null, "tsenif", g);
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -706,13 +709,13 @@ class PatchLoggerTest {
     Throwable g = new Throwable();
 
     // when
-    logger.logrb(Level.SEVERE, null, null, (ResourceBundle) null, "ereves", a);
-    logger.logrb(Level.WARNING, null, null, (ResourceBundle) null, "gninraw", b);
-    logger.logrb(Level.INFO, null, null, (ResourceBundle) null, "ofni", c);
-    logger.logrb(Level.CONFIG, null, null, (ResourceBundle) null, "gifnoc", d);
-    logger.logrb(Level.FINE, null, null, (ResourceBundle) null, "enif", e);
-    logger.logrb(Level.FINER, null, null, (ResourceBundle) null, "renif", f);
-    logger.logrb(Level.FINEST, null, null, (ResourceBundle) null, "tsenif", g);
+    logger.logrb(SEVERE, null, null, (ResourceBundle) null, "ereves", a);
+    logger.logrb(WARNING, null, null, (ResourceBundle) null, "gninraw", b);
+    logger.logrb(INFO, null, null, (ResourceBundle) null, "ofni", c);
+    logger.logrb(CONFIG, null, null, (ResourceBundle) null, "gifnoc", d);
+    logger.logrb(FINE, null, null, (ResourceBundle) null, "enif", e);
+    logger.logrb(FINER, null, null, (ResourceBundle) null, "renif", f);
+    logger.logrb(FINEST, null, null, (ResourceBundle) null, "tsenif", g);
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);
@@ -740,13 +743,13 @@ class PatchLoggerTest {
     Throwable g = new Throwable();
 
     // when
-    logger.logrb(Level.SEVERE, null, null, (ResourceBundle) null, "ereves", a);
-    logger.logrb(Level.WARNING, null, null, (ResourceBundle) null, "gninraw", b);
-    logger.logrb(Level.INFO, null, null, (ResourceBundle) null, "ofni", c);
-    logger.logrb(Level.CONFIG, null, null, (ResourceBundle) null, "gifnoc", d);
-    logger.logrb(Level.FINE, null, null, (ResourceBundle) null, "enif", e);
-    logger.logrb(Level.FINER, null, null, (ResourceBundle) null, "renif", f);
-    logger.logrb(Level.FINEST, null, null, (ResourceBundle) null, "tsenif", g);
+    logger.logrb(SEVERE, null, null, (ResourceBundle) null, "ereves", a);
+    logger.logrb(WARNING, null, null, (ResourceBundle) null, "gninraw", b);
+    logger.logrb(INFO, null, null, (ResourceBundle) null, "ofni", c);
+    logger.logrb(CONFIG, null, null, (ResourceBundle) null, "gifnoc", d);
+    logger.logrb(FINE, null, null, (ResourceBundle) null, "enif", e);
+    logger.logrb(FINER, null, null, (ResourceBundle) null, "renif", f);
+    logger.logrb(FINEST, null, null, (ResourceBundle) null, "tsenif", g);
 
     // then
     InOrder inOrder = Mockito.inOrder(internalLogger);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/LoggingFailSafeMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/LoggingFailSafeMatcher.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.javaagent.extension.matcher.internal.DelegatingMatcher;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -47,7 +48,7 @@ public class LoggingFailSafeMatcher<T> extends ElementMatcher.Junction.AbstractB
     try {
       return matcher.matches(target);
     } catch (Throwable e) {
-      logger.log(Level.FINE, description, e);
+      logger.log(FINE, description, e);
       return false;
     }
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.SEVERE;
+
 import io.opentelemetry.javaagent.bootstrap.IndyBootstrapDispatcher;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import java.lang.invoke.CallSite;
@@ -16,7 +19,6 @@ import java.lang.invoke.MutableCallSite;
 import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -152,7 +154,7 @@ public class IndyBootstrap {
           throw new IllegalArgumentException("Unknown bootstrapping kind: " + kind);
       }
     } catch (Exception e) {
-      logger.log(Level.SEVERE, e.getMessage(), e);
+      logger.log(SEVERE, e.getMessage(), e);
       return null;
     }
   }
@@ -207,7 +209,7 @@ public class IndyBootstrap {
         // There have been nested bootstrapping attempts
         // Update the callsite of those to run the actual instrumentation
         logger.log(
-            Level.FINE,
+            FINE,
             "Fixing nested instrumentation invokedynamic instruction bootstrapping for instrumented class {0} and advice {1}.{2}, the instrumentation should be active now",
             new Object[] {lookup.lookupClass().getName(), adviceClassName, adviceMethodName});
         nestedBootstrapCallSite.setTarget(methodHandle);

--- a/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
+++ b/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.agent.builder.AgentBuilder.Default.Transformation;
@@ -146,7 +145,7 @@ public class AgentBuilderUtil {
           getDelegateMatcher((AgentBuilder.RawMatcher.ForElementMatchers) matcher);
       Result result = inspect(elementMatcher);
       if (result == null && logger.isLoggable(FINE) && shouldLog(elementMatcher)) {
-        logger.log(Level.FINE, "Could not decompose matcher {0}", elementMatcher);
+        logger.log(FINE, "Could not decompose matcher {0}", elementMatcher);
       }
       return result;
     }

--- a/javaagent-tooling/src/testExceptionHandler/java/io/opentelemetry/javaagent/tooling/bytebuddy/ExceptionHandlerTest.java
+++ b/javaagent-tooling/src/testExceptionHandler/java/io/opentelemetry/javaagent/tooling/bytebuddy/ExceptionHandlerTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy;
 
+import static java.util.logging.Level.FINE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -16,7 +17,6 @@ import io.opentelemetry.javaagent.bootstrap.ExceptionLogger;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -68,7 +68,7 @@ class ExceptionHandlerTest {
     // keep logger in static field to ensure that it won't get gcd before ExceptionLogger
     // class is initialized which would reset logger back to default configuration
     exceptionLogger = Logger.getLogger(ExceptionLogger.class.getName());
-    exceptionLogger.setLevel(Level.FINE);
+    exceptionLogger.setLevel(FINE);
     exceptionLogger.addHandler(testHandler);
   }
 
@@ -95,7 +95,7 @@ class ExceptionHandlerTest {
         .last()
         .satisfies(
             event -> {
-              assertThat(event.getLevel()).isEqualTo(Level.FINE);
+              assertThat(event.getLevel()).isEqualTo(FINE);
               assertThat(event.getMessage())
                   .startsWith("Failed to handle exception in instrumentation for");
             });


### PR DESCRIPTION
To follow [style guide](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/style-guide.md#static-imports)

Autogenerated from 

```
#!/bin/bash
# Convert qualified java.util.logging.Level constant references to static imports.
# Run ./gradlew spotlessApply afterward to fix import ordering.

set -e

LEVEL_CONSTANTS="SEVERE WARNING INFO CONFIG FINE FINER FINEST"

grep -rl --include="*.java" -E 'Level\.(SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST)' . | while read -r file; do
  # Only process files that import java.util.logging.Level
  if ! grep -q "import java\.util\.logging\.Level;" "$file"; then
    continue
  fi

  echo "Processing (Level): $file"

  for constant in $LEVEL_CONSTANTS; do
    # Check if the constant is used as Level.X (qualified) or bare X (already converted)
    has_qualified=$(grep -v "^import " "$file" | grep -c "[^.]Level\.$constant" || true)
    has_bare=$(grep -v "^import " "$file" | grep -cw "$constant" || true)

    if [ "$has_qualified" -gt 0 ] || [ "$has_bare" -gt 0 ]; then
      # Add static import if not already present
      if ! grep -q "import static java.util.logging.Level\.$constant;" "$file"; then
        sed -i "/^package /a import static java.util.logging.Level.$constant;" "$file"
      fi

      # Replace qualified references with unqualified (skip import lines)
      # Use negative lookbehind-style match: only replace Level.X when NOT preceded by a dot
      # (avoids mangling e.g. InternalLogger.Level.INFO → InternalLogger.INFO)
      sed -i -E "/^import /!s/(^|[^.])Level\.$constant/\1$constant/g" "$file"
    fi
  done

  # Remove the non-static "import java.util.logging.Level;" if no other Level usage remains
  if ! grep -v "^import " "$file" | grep -q "Level"; then
    sed -i "/^import java\.util\.logging\.Level;$/d" "$file"
  fi
done

echo ""
echo "Done! Now run: ./gradlew spotlessApply"
```