### PR TITLE
Static import: StandardCharsets

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -465,7 +465,7 @@ public final class RedisCommandSanitizer {
 
   static String argToString(Object arg) {
     if (arg instanceof byte[]) {
-      return new String((byte[]) arg, StandardCharsets.UTF_8);
+      return new String((byte[]) arg, UTF_8);
     } else {
       return String.valueOf(arg);
     }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,7 @@ class AwsLambdaStreamHandlerTest {
 
   @Test
   void handlerTraced() throws Exception {
-    InputStream input = new ByteArrayInputStream("hello\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("hello\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
     RequestStreamHandlerTestImpl handler = new RequestStreamHandlerTestImpl();
     handler.handleRequest(input, output, context);
@@ -73,7 +73,7 @@ class AwsLambdaStreamHandlerTest {
 
   @Test
   void handlerTracedWithException() {
-    InputStream input = new ByteArrayInputStream("bye\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("bye\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
     RequestStreamHandlerTestImpl handler = new RequestStreamHandlerTestImpl();
 
@@ -96,10 +96,8 @@ class AwsLambdaStreamHandlerTest {
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context)
         throws IOException {
-      BufferedReader reader =
-          new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-      BufferedWriter writer =
-          new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(input, UTF_8));
+      BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, UTF_8));
       String line = reader.readLine();
       if (line.equals("hello")) {
         writer.write("world");

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +73,7 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
             + "},"
             + "\"body\" : \"hello\""
             + "}";
-    InputStream input = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream(content.getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
     TracingRequestStreamWrapper wrapper =
@@ -106,7 +106,7 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
             + "},"
             + "\"body\" : \"bye\""
             + "}";
-    InputStream input = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream(content.getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
     TracingRequestStreamWrapper wrapper =
@@ -154,8 +154,7 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
           break;
         }
       }
-      BufferedWriter writer =
-          new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+      BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, UTF_8));
       if (body.equals("hello")) {
         writer.write("world");
         writer.flush();

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
@@ -28,7 +29,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,7 +65,7 @@ class AwsLambdaStreamWrapperTest {
 
   @Test
   void handlerTraced() throws Exception {
-    InputStream input = new ByteArrayInputStream("hello\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("hello\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
     TracingRequestStreamWrapper wrapper =
@@ -89,7 +89,7 @@ class AwsLambdaStreamWrapperTest {
 
   @Test
   void handlerTracedWithException() {
-    InputStream input = new ByteArrayInputStream("bye\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("bye\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
 
     TracingRequestStreamWrapper wrapper =
@@ -120,10 +120,8 @@ class AwsLambdaStreamWrapperTest {
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context)
         throws IOException {
-      BufferedReader reader =
-          new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-      BufferedWriter writer =
-          new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(input, UTF_8));
+      BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, UTF_8));
       String line = reader.readLine();
       if (line.equals("hello")) {
         writer.write("world");

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,7 @@ class AwsLambdaStreamHandlerTest {
 
   @Test
   void handlerTraced() throws Exception {
-    InputStream input = new ByteArrayInputStream("hello\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("hello\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
     RequestStreamHandlerTestImpl handler = new RequestStreamHandlerTestImpl();
     handler.handleRequest(input, output, context);
@@ -73,7 +73,7 @@ class AwsLambdaStreamHandlerTest {
 
   @Test
   void handlerTracedWithException() {
-    InputStream input = new ByteArrayInputStream("bye\n".getBytes(StandardCharsets.UTF_8));
+    InputStream input = new ByteArrayInputStream("bye\n".getBytes(UTF_8));
     OutputStream output = new ByteArrayOutputStream();
     RequestStreamHandlerTestImpl handler = new RequestStreamHandlerTestImpl();
 
@@ -96,10 +96,8 @@ class AwsLambdaStreamHandlerTest {
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context)
         throws IOException {
-      BufferedReader reader =
-          new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-      BufferedWriter writer =
-          new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(input, UTF_8));
+      BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, UTF_8));
       String line = reader.readLine();
       if (line.equals("hello")) {
         writer.write("world");

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.MapUt
 import static io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.MapUtils.lowercaseMap;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
@@ -23,7 +24,6 @@ import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -90,8 +90,8 @@ final class ApiGatewayProxyAttributesExtractor
       boolean first = true;
       for (Map.Entry<String, String> entry :
           emptyIfNull(request.getQueryStringParameters()).entrySet()) {
-        String key = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name());
-        String value = URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name());
+        String key = URLEncoder.encode(entry.getKey(), UTF_8.name());
+        String value = URLEncoder.encode(entry.getValue(), UTF_8.name());
         str.append(first ? '?' : '&').append(key).append('=').append(value);
         first = false;
       }

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SerializationUtil.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SerializationUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
 import com.amazonaws.services.lambda.runtime.serialization.events.LambdaEventSerializers;
 import com.amazonaws.services.lambda.runtime.serialization.factories.JacksonFactory;
@@ -14,7 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -75,7 +76,7 @@ public final class SerializationUtil {
     PojoSerializer<T> serializer = getSerializer(obj.getClass());
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
     serializer.toJson(obj, outputStream);
-    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    return new String(outputStream.toByteArray(), UTF_8);
   }
 
   public static <T> byte[] toJsonData(T obj) {

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SerializationUtilTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SerializationUtilTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
@@ -14,7 +15,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.joda.time.DateTime;
@@ -218,7 +218,7 @@ class SerializationUtilTest {
     assertThat(record.getKinesis().getPartitionKey()).isEqualTo("1");
     assertThat(record.getKinesis().getSequenceNumber())
         .isEqualTo("49590338271490256608559692538361571095921575989136588898");
-    assertThat(new String(record.getKinesis().getData().array(), StandardCharsets.UTF_8))
+    assertThat(new String(record.getKinesis().getData().array(), UTF_8))
         .isEqualTo("Hello, this is a test.");
   }
 
@@ -278,8 +278,7 @@ class SerializationUtilTest {
     String eventBody = events.get(ScheduledEvent.class);
     ScheduledEvent event =
         SerializationUtil.fromJson(
-            new ByteArrayInputStream(eventBody.getBytes(StandardCharsets.UTF_8)),
-            ScheduledEvent.class);
+            new ByteArrayInputStream(eventBody.getBytes(UTF_8)), ScheduledEvent.class);
 
     assertScheduledEvent(event);
   }
@@ -297,8 +296,7 @@ class SerializationUtilTest {
     String eventBody = events.get(KinesisEvent.class);
     KinesisEvent event =
         SerializationUtil.fromJson(
-            new ByteArrayInputStream(eventBody.getBytes(StandardCharsets.UTF_8)),
-            KinesisEvent.class);
+            new ByteArrayInputStream(eventBody.getBytes(UTF_8)), KinesisEvent.class);
 
     assertKinesisEvent(event);
   }
@@ -316,7 +314,7 @@ class SerializationUtilTest {
     String eventBody = events.get(SQSEvent.class);
     SQSEvent event =
         SerializationUtil.fromJson(
-            new ByteArrayInputStream(eventBody.getBytes(StandardCharsets.UTF_8)), SQSEvent.class);
+            new ByteArrayInputStream(eventBody.getBytes(UTF_8)), SQSEvent.class);
 
     assertSqsEvent(event);
   }
@@ -334,7 +332,7 @@ class SerializationUtilTest {
     String eventBody = events.get(S3Event.class);
     S3Event event =
         SerializationUtil.fromJson(
-            new ByteArrayInputStream(eventBody.getBytes(StandardCharsets.UTF_8)), S3Event.class);
+            new ByteArrayInputStream(eventBody.getBytes(UTF_8)), S3Event.class);
 
     assertS3Event(event);
   }
@@ -352,7 +350,7 @@ class SerializationUtilTest {
     String eventBody = events.get(SNSEvent.class);
     SNSEvent event =
         SerializationUtil.fromJson(
-            new ByteArrayInputStream(eventBody.getBytes(StandardCharsets.UTF_8)), SNSEvent.class);
+            new ByteArrayInputStream(eventBody.getBytes(UTF_8)), SNSEvent.class);
 
     assertSnsEvent(event);
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Value;
@@ -19,7 +20,6 @@ import io.opentelemetry.context.Scope;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1750,7 +1750,7 @@ public final class BedrockRuntimeImpl {
     SdkJsonGenerator generator = new SdkJsonGenerator(JSON_FACTORY, "application/json");
     DocumentTypeJsonMarshaller marshaller = new DocumentTypeJsonMarshaller(generator);
     document.accept(marshaller);
-    return new String(generator.getBytes(), StandardCharsets.UTF_8);
+    return new String(generator.getBytes(), UTF_8);
   }
 
   private static Document deserializeDocument(String json) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/LambdaImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/LambdaImpl.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -63,8 +64,7 @@ final class LambdaImpl {
     String clientContextString = request.clientContext();
     String clientContextJsonString = "{}";
     if (clientContextString != null && !clientContextString.isEmpty()) {
-      clientContextJsonString =
-          new String(Base64.getDecoder().decode(clientContextString), StandardCharsets.UTF_8);
+      clientContextJsonString = new String(Base64.getDecoder().decode(clientContextString), UTF_8);
     }
     JsonNode jsonNode = JsonNode.parser().parse(clientContextJsonString);
     if (!jsonNode.isObject()) {
@@ -90,7 +90,7 @@ final class LambdaImpl {
     String newJson = jsonNode.toString();
 
     // turn it back into a base64 string
-    String newJson64 = Base64.getEncoder().encodeToString(newJson.getBytes(StandardCharsets.UTF_8));
+    String newJson64 = Base64.getEncoder().encodeToString(newJson.getBytes(UTF_8));
     // check it for length (err on the safe side with >=)
     if (newJson64.length() >= MAX_CLIENT_CONTEXT_LENGTH) {
       return null;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testLambda/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2LambdaTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testLambda/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2LambdaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.context.Context;
@@ -12,7 +13,6 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.AbstractAws2LambdaTest;
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ class Aws2LambdaTest extends AbstractAws2LambdaTest {
   }
 
   private static String base64ify(String json) {
-    return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return Base64.getEncoder().encodeToString(json.getBytes(UTF_8));
   }
 
   @Test
@@ -62,8 +62,7 @@ class Aws2LambdaTest extends AbstractAws2LambdaTest {
         (InvokeRequest) LambdaImpl.modifyOrAddCustomContextHeader(request, context);
 
     String newClientContext = newRequest.clientContext();
-    newClientContext =
-        new String(Base64.getDecoder().decode(newClientContext), StandardCharsets.UTF_8);
+    newClientContext = new String(Base64.getDecoder().decode(newClientContext), UTF_8);
     assertThat(newClientContext.contains("traceparent")).isTrue();
   }
 
@@ -78,8 +77,7 @@ class Aws2LambdaTest extends AbstractAws2LambdaTest {
         (InvokeRequest) LambdaImpl.modifyOrAddCustomContextHeader(request, context);
 
     String newClientContext = newRequest.clientContext();
-    newClientContext =
-        new String(Base64.getDecoder().decode(newClientContext), StandardCharsets.UTF_8);
+    newClientContext = new String(Base64.getDecoder().decode(newClientContext), UTF_8);
     assertThat(newClientContext.contains("traceparent")).isTrue();
     assertThat(newClientContext.contains("preExisting")).isTrue();
     assertThat(newClientContext.contains("otherStuff")).isTrue();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.java
@@ -30,6 +30,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -594,7 +594,7 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
                           .add("x-amzn-RequestId", "7a62c49f-347e-4fc4-9331-6e8e7a96aa73")
                           .build();
-                  return HttpResponse.of(headers, HttpData.of(StandardCharsets.UTF_8, content));
+                  return HttpResponse.of(headers, HttpData.of(UTF_8, content));
                 },
             (Function<SqsClient, Object>)
                 c -> c.createQueue(CreateQueueRequest.builder().queueName("somequeue").build())),
@@ -627,7 +627,7 @@ public abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest 
                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
                           .add("x-amzn-RequestId", "27daac76-34dd-47df-bd01-1f6e873584a0")
                           .build();
-                  return HttpResponse.of(headers, HttpData.of(StandardCharsets.UTF_8, content));
+                  return HttpResponse.of(headers, HttpData.of(UTF_8, content));
                 },
             (Function<SqsClient, Object>)
                 c ->

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2LambdaTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2LambdaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -13,7 +14,6 @@ import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -65,8 +65,7 @@ public abstract class AbstractAws2LambdaTest {
     String clientContextHeader =
         server.takeRequest().request().headers().get("x-amz-client-context");
     assertThat(clientContextHeader).isNotEmpty();
-    String clientContextJson =
-        new String(Base64.getDecoder().decode(clientContextHeader), StandardCharsets.UTF_8);
+    String clientContextJson = new String(Base64.getDecoder().decode(clientContextHeader), UTF_8);
     assertThat(clientContextJson).contains("traceparent");
 
     getTesting()

--- a/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/ViewRenderTest.java
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/ViewRenderTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.dropwizardviews;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.views.View;
@@ -16,7 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ class ViewRenderTest {
   @ParameterizedTest
   @MethodSource("provideParameters")
   void testSpan(ViewRenderer renderer, String template) throws IOException {
-    View view = new View(template, StandardCharsets.UTF_8) {};
+    View view = new View(template, UTF_8) {};
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     testing.runWithSpan(
         "parent",
@@ -59,7 +59,7 @@ class ViewRenderTest {
   @Test
   void testDoesNotCreateSpanWithoutParent() throws InterruptedException, IOException {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    View view = new View("/views/ftl/utf8.ftl", StandardCharsets.UTF_8) {};
+    View view = new View("/views/ftl/utf8.ftl", UTF_8) {};
     new FreemarkerViewRenderer().render(view, Locale.ENGLISH, outputStream);
     Thread.sleep(500);
     assertThat(testing.spans().size()).isEqualTo(0);

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbResponseStatusUtil.dbResponseStatusCode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -62,8 +62,7 @@ final class ElasticsearchDbAttributesGetter
       // Retrieve HTTP body for search-type Elasticsearch requests when CAPTURE_SEARCH_QUERY is
       // enabled.
       try {
-        return new BufferedReader(
-                new InputStreamReader(httpEntity.getContent(), StandardCharsets.UTF_8))
+        return new BufferedReader(new InputStreamReader(httpEntity.getContent(), UTF_8))
             .lines()
             .collect(Collectors.joining());
       } catch (IOException e) {

--- a/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -33,7 +34,6 @@ import io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -78,8 +78,7 @@ public abstract class AbstractGraphqlTest {
 
     try (Reader reader =
         new InputStreamReader(
-            this.getClass().getClassLoader().getResourceAsStream("schema.graphqls"),
-            StandardCharsets.UTF_8)) {
+            this.getClass().getClassLoader().getResourceAsStream("schema.graphqls"), UTF_8)) {
       graphqlSchema = buildSchema(reader);
       GraphQL.Builder graphqlBuilder = GraphQL.newGraphQL(graphqlSchema);
       configure(graphqlBuilder);

--- a/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyFilterchainServerTest.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyFilterchainServerTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static java.nio.charset.Charset.defaultCharset;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.glassfish.grizzly.memory.Buffers.wrap;
 
@@ -20,7 +21,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumenta
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -170,7 +170,7 @@ class GrizzlyFilterchainServerTest extends AbstractHttpServerTest<Transport> {
       if (endpoint == INDEXED_CHILD) {
         Parameters parameters = new Parameters();
         parameters.setQuery(request.getQueryStringDC());
-        parameters.setQueryStringEncoding(StandardCharsets.UTF_8);
+        parameters.setQueryStringEncoding(UTF_8);
         parameters.handleQueryParameters();
         closure =
             new Runnable() {

--- a/instrumentation/internal/internal-application-logger/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggerInstrumentationTest.java
+++ b/instrumentation/internal/internal-application-logger/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggerInstrumentationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.internal.logging;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -60,7 +60,7 @@ class ApplicationLoggerInstrumentationTest {
         CompletableFuture.supplyAsync(
             () -> {
               try (BufferedReader reader =
-                  new BufferedReader(new InputStreamReader(stdout, StandardCharsets.UTF_8))) {
+                  new BufferedReader(new InputStreamReader(stdout, UTF_8))) {
                 List<String> lines = new ArrayList<>();
                 String line;
                 while ((line = reader.readLine()) != null) {

--- a/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ResourceInjectionTest.java
+++ b/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ResourceInjectionTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.internal.classloader;
 
 import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.io.BufferedReader;
@@ -13,7 +14,6 @@ import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -26,7 +26,7 @@ class ResourceInjectionTest {
 
   private static String readLine(URL url) throws Exception {
     try (BufferedReader reader =
-        new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
+        new BufferedReader(new InputStreamReader(url.openStream(), UTF_8))) {
       return reader.readLine().trim();
     }
   }

--- a/instrumentation/internal/internal-class-loader/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/TomcatClassloadingTest.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/TomcatClassloadingTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.internal.classloader;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -19,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -73,7 +73,7 @@ class TomcatClassloadingTest {
     Path tmpFile = Files.createTempFile("hello", "tmp");
     tmpFile.toFile().deleteOnExit();
 
-    Files.write(tmpFile, "hello".getBytes(StandardCharsets.UTF_8));
+    Files.write(tmpFile, "hello".getBytes(UTF_8));
     URL url = tmpFile.toUri().toURL();
     HelperResources.register(classloader, "hello.txt", Collections.singletonList(url));
 
@@ -90,7 +90,7 @@ class TomcatClassloadingTest {
     assertThat(inputStream).isNotNull();
 
     String text =
-        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+        new BufferedReader(new InputStreamReader(inputStream, UTF_8))
             .lines()
             .collect(Collectors.joining("\n"));
 

--- a/instrumentation/java-http-server/testing/src/main/java/io/opentelemetry/instrumentation/javahttpserver/AbstractJavaHttpServerTest.java
+++ b/instrumentation/java-http-server/testing/src/main/java/io/opentelemetry/instrumentation/javahttpserver/AbstractJavaHttpServerTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
@@ -23,7 +24,6 @@ import io.opentelemetry.testing.internal.armeria.common.QueryParams;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +47,7 @@ public abstract class AbstractJavaHttpServerTest extends AbstractHttpServerTest<
       HttpExchange exchange, int status, Map<String, String> headers, String response)
       throws IOException {
 
-    byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+    byte[] bytes = response.getBytes(UTF_8);
 
     // -1 means no content, 0 means unknown content length
     long contentLength = bytes.length == 0 ? -1 : bytes.length;

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/ResteasyProxyClientTest.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/ResteasyProxyClientTest.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 import javax.ws.rs.core.Response;
@@ -41,7 +42,7 @@ class ResteasyProxyClientTest extends AbstractHttpClientTest<ResteasyProxyResour
         (method + "_" + uri.getPath()).toLowerCase(Locale.ROOT).replace("/", "").replace('-', '_');
 
     String param =
-        URLEncodedUtils.parse(uri, StandardCharsets.UTF_8.name()).stream()
+        URLEncodedUtils.parse(uri, UTF_8.name()).stream()
             .findFirst()
             .map(NameValuePair::getValue)
             .orElse(null);

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2JaxWs2Test.java
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2JaxWs2Test.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.axis2;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.javaagent.instrumentation.jaxws.v2_0.AbstractJaxWs2Test;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -25,8 +26,7 @@ class Axis2JaxWs2Test extends AbstractJaxWs2Test {
     // read default configuration file inside axis2 jar
     String configuration =
         IOUtils.toString(
-            Axis2JaxWs2Test.class.getClassLoader().getResourceAsStream("axis2.xml"),
-            StandardCharsets.UTF_8);
+            Axis2JaxWs2Test.class.getClassLoader().getResourceAsStream("axis2.xml"), UTF_8);
 
     // customize deployer so axis2 can find our services
     configuration =
@@ -45,6 +45,6 @@ class Axis2JaxWs2Test extends AbstractJaxWs2Test {
     File configurationDirectory = new File("build/axis-conf/");
     configurationDirectory.mkdirs();
     FileUtils.writeStringToFile(
-        new File(configurationDirectory, "axis2.xml"), configuration, StandardCharsets.UTF_8);
+        new File(configurationDirectory, "axis2.xml"), configuration, UTF_8);
   }
 }

--- a/instrumentation/jaxws/jaxws-3.0-axis2-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2JaxWs2Test.java
+++ b/instrumentation/jaxws/jaxws-3.0-axis2-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2JaxWs2Test.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.axis2;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.javaagent.instrumentation.jaxws.v3_0.AbstractJaxWs3Test;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -25,8 +26,7 @@ class Axis2JaxWs2Test extends AbstractJaxWs3Test {
     // read default configuration file inside axis2 jar
     String configuration =
         IOUtils.toString(
-            Axis2JaxWs2Test.class.getClassLoader().getResourceAsStream("axis2.xml"),
-            StandardCharsets.UTF_8);
+            Axis2JaxWs2Test.class.getClassLoader().getResourceAsStream("axis2.xml"), UTF_8);
 
     // customize deployer so axis2 can find our services
     configuration =
@@ -45,6 +45,6 @@ class Axis2JaxWs2Test extends AbstractJaxWs3Test {
     File configurationDirectory = new File("build/axis-conf/");
     configurationDirectory.mkdirs();
     FileUtils.writeStringToFile(
-        new File(configurationDirectory, "axis2.xml"), configuration, StandardCharsets.UTF_8);
+        new File(configurationDirectory, "axis2.xml"), configuration, UTF_8);
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisRequest.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
@@ -38,7 +39,7 @@ public abstract class JedisRequest {
     } else {
       // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
       // us if that changes
-      return new String(command.getRaw(), StandardCharsets.UTF_8);
+      return new String(command.getRaw(), UTF_8);
     }
   }
 

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisRequest.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import redis.clients.jedis.CommandArguments;
@@ -53,7 +54,7 @@ public abstract class JedisRequest {
     } else {
       // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
       // us if that changes
-      return new String(command.getRaw(), StandardCharsets.UTF_8);
+      return new String(command.getRaw(), UTF_8);
     }
   }
 

--- a/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
+++ b/instrumentation/jetty/jetty-12.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jetty/v12_0/Jetty12HandlerTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -95,31 +95,30 @@ class Jetty12HandlerTest extends AbstractHttpServerTest<Server> {
       throws IOException {
     if (SUCCESS.equals(endpoint)) {
       response.setStatus(endpoint.getStatus());
-      response.write(true, StandardCharsets.UTF_8.encode(endpoint.getBody()), Callback.NOOP);
+      response.write(true, UTF_8.encode(endpoint.getBody()), Callback.NOOP);
     } else if (QUERY_PARAM.equals(endpoint)) {
       response.setStatus(endpoint.getStatus());
-      response.write(
-          true, StandardCharsets.UTF_8.encode(request.getHttpURI().getQuery()), Callback.NOOP);
+      response.write(true, UTF_8.encode(request.getHttpURI().getQuery()), Callback.NOOP);
     } else if (REDIRECT.equals(endpoint)) {
       response.setStatus(endpoint.getStatus());
       response.getHeaders().add("Location", "http://localhost:" + port + endpoint.getBody());
     } else if (ERROR.equals(endpoint)) {
       response.setStatus(endpoint.getStatus());
-      response.write(true, StandardCharsets.UTF_8.encode(endpoint.getBody()), Callback.NOOP);
+      response.write(true, UTF_8.encode(endpoint.getBody()), Callback.NOOP);
     } else if (CAPTURE_HEADERS.equals(endpoint)) {
       response.getHeaders().add("X-Test-Response", request.getHeaders().get("X-Test-Request"));
       response.setStatus(endpoint.getStatus());
-      response.write(true, StandardCharsets.UTF_8.encode(endpoint.getBody()), Callback.NOOP);
+      response.write(true, UTF_8.encode(endpoint.getBody()), Callback.NOOP);
     } else if (EXCEPTION.equals(endpoint)) {
       throw new IllegalStateException(endpoint.getBody());
     } else if (INDEXED_CHILD.equals(endpoint)) {
       INDEXED_CHILD.collectSpanAttributes(
           name -> Request.extractQueryParameters(request).getValue(name));
       response.setStatus(endpoint.getStatus());
-      response.write(true, StandardCharsets.UTF_8.encode(endpoint.getBody()), Callback.NOOP);
+      response.write(true, UTF_8.encode(endpoint.getBody()), Callback.NOOP);
     } else {
       response.setStatus(NOT_FOUND.getStatus());
-      response.write(true, StandardCharsets.UTF_8.encode(NOT_FOUND.getBody()), Callback.NOOP);
+      response.write(true, UTF_8.encode(NOT_FOUND.getBody()), Callback.NOOP);
     }
   }
 

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/JmxTelemetryTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/JmxTelemetryTest.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.instrumentation.jmx;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -56,7 +56,7 @@ public class JmxTelemetryTest {
   @Test
   void invalidExternalYaml(@TempDir Path dir) throws Exception {
     Path invalid = Files.createTempFile(dir, "invalid", ".yaml");
-    Files.write(invalid, ":this !is /not YAML".getBytes(StandardCharsets.UTF_8));
+    Files.write(invalid, ":this !is /not YAML".getBytes(UTF_8));
     JmxTelemetryBuilder builder = JmxTelemetry.builder(OpenTelemetry.noop());
     assertThatThrownBy(() -> builder.addRules(invalid))
         .isInstanceOf(IllegalArgumentException.class);

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/engine/RuleParserTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/engine/RuleParserTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.jmx.internal.engine;
 // This test is put in the io.opentelemetry.instrumentation.jmx.engine package
 // because it needs to access package-private methods from a number of classes.
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -20,7 +21,6 @@ import io.opentelemetry.instrumentation.jmx.internal.yaml.Metric;
 import io.opentelemetry.instrumentation.jmx.internal.yaml.RuleParser;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import javax.management.MBeanAttributeInfo;
@@ -601,7 +601,7 @@ class RuleParserTest {
   }
 
   private static JmxConfig parseConf(String s) {
-    InputStream is = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    InputStream is = new ByteArrayInputStream(s.getBytes(UTF_8));
     JmxConfig jmxConfig = parser.loadConfig(is);
     assertThat(jmxConfig).isNotNull();
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
@@ -15,7 +16,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.ListIterator;
@@ -48,9 +48,7 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           ProducerRecord<Integer, String> producerRecord =
               new ProducerRecord<>(SHARED_TOPIC, 10, greeting);
           if (testHeaders) {
-            producerRecord
-                .headers()
-                .add("Test-Message-Header", "test".getBytes(StandardCharsets.UTF_8));
+            producerRecord.headers().add("Test-Message-Header", "test".getBytes(UTF_8));
           }
           producer
               .send(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -12,7 +13,6 @@ import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.Kafka
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientPropagationBaseTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -39,12 +39,8 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
           producerRecord
               .headers()
               // adding baggage header in w3c baggage format
-              .add(
-                  "baggage",
-                  "test-baggage-key-1=test-baggage-value-1".getBytes(StandardCharsets.UTF_8))
-              .add(
-                  "baggage",
-                  "test-baggage-key-2=test-baggage-value-2".getBytes(StandardCharsets.UTF_8));
+              .add("baggage", "test-baggage-key-1=test-baggage-value-1".getBytes(UTF_8))
+              .add("baggage", "test-baggage-key-2=test-baggage-value-2".getBytes(UTF_8));
           producer.send(
               producerRecord,
               (meta, ex) -> {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractOpenTelemetryMetricsReporterTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractOpenTelemetryMetricsReporterTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
 import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
@@ -20,7 +21,6 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -394,8 +394,8 @@ public abstract class AbstractOpenTelemetryMetricsReporterTest {
               TOPICS.get(RANDOM.nextInt(TOPICS.size())),
               0,
               System.currentTimeMillis(),
-              "key".getBytes(StandardCharsets.UTF_8),
-              "value".getBytes(StandardCharsets.UTF_8)));
+              "key".getBytes(UTF_8),
+              "value".getBytes(UTF_8)));
     }
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
@@ -18,11 +18,11 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -250,9 +250,7 @@ public abstract class KafkaClientBaseTest {
     if (messageValue == null) {
       assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true));
     } else {
-      assertions.add(
-          equalTo(
-              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
+      assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     if (testHeaders) {
       assertions.add(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -54,14 +54,10 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
           producerRecord
               .headers()
               // add header to test capturing header value as span attribute
-              .add("Test-Message-Header", "test".getBytes(StandardCharsets.UTF_8))
+              .add("Test-Message-Header", "test".getBytes(UTF_8))
               // adding baggage header in w3c baggage format
-              .add(
-                  "baggage",
-                  "test-baggage-key-1=test-baggage-value-1".getBytes(StandardCharsets.UTF_8))
-              .add(
-                  "baggage",
-                  "test-baggage-key-2=test-baggage-value-2".getBytes(StandardCharsets.UTF_8));
+              .add("baggage", "test-baggage-key-1=test-baggage-value-1".getBytes(UTF_8))
+              .add("baggage", "test-baggage-key-2=test-baggage-value-2".getBytes(UTF_8));
           producer.send(
               producerRecord,
               (meta, ex) -> {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -48,9 +48,7 @@ abstract class AbstractWrapperTest extends KafkaClientBaseTest {
           ProducerRecord<Integer, String> producerRecord =
               new ProducerRecord<>(SHARED_TOPIC, greeting);
           if (testHeaders) {
-            producerRecord
-                .headers()
-                .add("Test-Message-Header", "test".getBytes(StandardCharsets.UTF_8));
+            producerRecord.headers().add("Test-Message-Header", "test".getBytes(UTF_8));
           }
           wrappedProducer.send(
               producerRecord,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -14,10 +14,10 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
-import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 
@@ -57,9 +57,7 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
                             equalTo(MESSAGING_SYSTEM, "kafka"),
                             equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                             equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MESSAGING_MESSAGE_BODY_SIZE,
-                                greeting.getBytes(StandardCharsets.UTF_8).length),
+                            equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                             satisfies(
                                 MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
@@ -17,13 +17,13 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
@@ -103,9 +103,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                             equalTo(MESSAGING_SYSTEM, "kafka"),
                             equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                             equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(
-                                MESSAGING_MESSAGE_BODY_SIZE,
-                                greeting.getBytes(StandardCharsets.UTF_8).length),
+                            equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                             satisfies(
                                 MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -14,11 +14,11 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -87,8 +87,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "process"),
-                equalTo(
-                    MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(StandardCharsets.UTF_8).length),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -22,7 +23,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -110,8 +110,7 @@ class WrapperTest extends AbstractWrapperTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "process"),
-                equalTo(
-                    MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(StandardCharsets.UTF_8).length),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -82,7 +83,7 @@ enum KafkaConsumerAttributesGetter implements MessagingAttributesGetter<KafkaPro
   public List<String> getMessageHeader(KafkaProcessRequest request, String name) {
     return StreamSupport.stream(request.getRecord().headers().headers(name).spliterator(), false)
         .filter(header -> header.value() != null)
-        .map(header -> new String(header.value(), StandardCharsets.UTF_8))
+        .map(header -> new String(header.value(), UTF_8))
         .collect(Collectors.toList());
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerRecordGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -34,14 +35,14 @@ enum KafkaConsumerRecordGetter implements TextMapGetter<KafkaProcessRequest> {
     if (value == null) {
       return null;
     }
-    return new String(value, StandardCharsets.UTF_8);
+    return new String(value, UTF_8);
   }
 
   @Override
   public Iterator<String> getAll(@Nullable KafkaProcessRequest carrier, String key) {
     return StreamSupport.stream(carrier.getRecord().headers().headers(key).spliterator(), false)
         .filter(header -> header.value() != null)
-        .map(header -> new String(header.value(), StandardCharsets.UTF_8))
+        .map(header -> new String(header.value(), UTF_8))
         .iterator();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaHeadersSetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaHeadersSetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
 /**
@@ -18,6 +19,6 @@ public enum KafkaHeadersSetter implements TextMapSetter<Headers> {
 
   @Override
   public void set(Headers headers, String key, String value) {
-    headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
+    headers.remove(key).add(key, value.getBytes(UTF_8));
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerAttributesGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -89,7 +90,7 @@ enum KafkaProducerAttributesGetter
   public List<String> getMessageHeader(KafkaProducerRequest request, String name) {
     return StreamSupport.stream(request.getRecord().headers().headers(name).spliterator(), false)
         .filter(header -> header.value() != null)
-        .map(header -> new String(header.value(), StandardCharsets.UTF_8))
+        .map(header -> new String(header.value(), UTF_8))
         .collect(Collectors.toList());
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -91,7 +92,7 @@ enum KafkaReceiveAttributesGetter implements MessagingAttributesGetter<KafkaRece
             consumerRecord ->
                 StreamSupport.stream(consumerRecord.headers().headers(name).spliterator(), false))
         .filter(header -> header.value() != null)
-        .map(header -> new String(header.value(), StandardCharsets.UTF_8))
+        .map(header -> new String(header.value(), UTF_8))
         .collect(Collectors.toList());
   }
 }

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectAttributesGetter.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectAttributesGetter.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -93,7 +93,7 @@ enum KafkaConnectAttributesGetter implements MessagingAttributesGetter<KafkaConn
   private static String convertHeaderValue(Header header) {
     Object value = header.value();
     if (value instanceof byte[]) {
-      return new String((byte[]) value, StandardCharsets.UTF_8);
+      return new String((byte[]) value, UTF_8);
     }
     return value.toString();
   }

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/SinkRecordHeadersGetter.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/SinkRecordHeadersGetter.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.kafka.connect.header.Header;
@@ -43,7 +43,7 @@ enum SinkRecordHeadersGetter implements TextMapGetter<SinkRecord> {
 
     Object value = header.value();
     if (value instanceof byte[]) {
-      return new String((byte[]) value, StandardCharsets.UTF_8);
+      return new String((byte[]) value, UTF_8);
     }
     return value.toString();
   }

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsBaseTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsBaseTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkastreams;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 
@@ -15,7 +16,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -167,8 +167,7 @@ abstract class KafkaStreamsBaseTest {
 
   static Context getContext(Headers headers) {
     String traceparent =
-        new String(
-            headers.headers("traceparent").iterator().next().value(), StandardCharsets.UTF_8);
+        new String(headers.headers("traceparent").iterator().next().value(), UTF_8);
     return W3CTraceContextPropagator.getInstance()
         .extract(
             Context.root(),

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -18,6 +18,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 
@@ -30,7 +31,6 @@ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -249,9 +249,7 @@ public abstract class AbstractReactorKafkaTest {
     }
     String messageValue = record.value();
     if (messageValue != null) {
-      assertions.add(
-          equalTo(
-              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
+      assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
   }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -14,7 +15,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -159,8 +159,7 @@ public final class HostIdResource {
     List<String> result = new ArrayList<>();
 
     try (BufferedReader processOutputReader =
-        new BufferedReader(
-            new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
       String readLine;
 
       while ((readLine = processOutputReader.readLine()) != null) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ContainerResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ContainerResourceTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.resources;
 
 import static io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes.CONTAINER_ID;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -14,7 +15,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,7 +60,7 @@ class ContainerResourceTest {
     String containerId = "ac679f8a8319c8cf7d38e1adf263bc08d231f2ff81abda3915f6e8ba4d64156a";
     String line = "13:name=systemd:/podruntime/docker/kubepods/" + containerId + ".aaaa";
     Charset ibmCharset = Charset.forName("Cp1047");
-    byte[] utf8 = line.getBytes(StandardCharsets.UTF_8);
+    byte[] utf8 = line.getBytes(UTF_8);
     byte[] ibm = line.getBytes(ibmCharset);
     assertThat(ibm).isNotEqualTo(utf8);
 

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceDeclarativeConfigTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceDeclarativeConfigTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.resources.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,7 +16,6 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -45,8 +45,7 @@ class ResourceDeclarativeConfigTest {
 
     boolean java8 = "1.8".equals(System.getProperty("java.specification.version"));
     OpenTelemetrySdk openTelemetrySdk =
-        DeclarativeConfiguration.parseAndCreate(
-            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+        DeclarativeConfiguration.parseAndCreate(new ByteArrayInputStream(yaml.getBytes(UTF_8)));
     assertThat(openTelemetrySdk.getSdkTracerProvider())
         .extracting("sharedState.resource", as(InstanceOfAssertFactories.type(Resource.class)))
         .satisfies(

--- a/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
@@ -14,13 +14,13 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,7 +86,7 @@ public abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
               .build()) {
 
         String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-        byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+        byte[] body = "foobar".getBytes(UTF_8);
         Message message =
             provider
                 .newMessageBuilder()

--- a/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -19,6 +19,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
@@ -31,7 +32,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -123,7 +123,7 @@ public abstract class AbstractRocketMqClientTest {
   @Test
   void testSendAndConsumeNormalMessage() throws Throwable {
     String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-    byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+    byte[] body = "foobar".getBytes(UTF_8);
     Message message =
         provider
             .newMessageBuilder()
@@ -173,7 +173,7 @@ public abstract class AbstractRocketMqClientTest {
   @Test
   public void testSendAsyncMessage() throws Exception {
     String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-    byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+    byte[] body = "foobar".getBytes(UTF_8);
     Message message =
         provider
             .newMessageBuilder()
@@ -232,7 +232,7 @@ public abstract class AbstractRocketMqClientTest {
   @Test
   public void testSendAndConsumeFifoMessage() throws Throwable {
     String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-    byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+    byte[] body = "foobar".getBytes(UTF_8);
     String messageGroup = "yourMessageGroup";
     Message message =
         provider
@@ -286,7 +286,7 @@ public abstract class AbstractRocketMqClientTest {
   @Test
   public void testSendAndConsumeDelayMessage() throws Throwable {
     String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-    byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+    byte[] body = "foobar".getBytes(UTF_8);
     long deliveryTimestamp = System.currentTimeMillis();
     Message message =
         provider
@@ -340,7 +340,7 @@ public abstract class AbstractRocketMqClientTest {
   @Test
   public void testCapturedMessageHeaders() throws Throwable {
     String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
-    byte[] body = "foobar".getBytes(StandardCharsets.UTF_8);
+    byte[] body = "foobar".getBytes(UTF_8);
     Message message =
         provider
             .newMessageBuilder()

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/BufferMetricTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/BufferMetricTest.java
@@ -7,12 +7,12 @@ package io.opentelemetry.instrumentation.runtimemetrics.java17;
 
 import static io.opentelemetry.instrumentation.runtimemetrics.java17.internal.Constants.BYTES;
 import static io.opentelemetry.instrumentation.runtimemetrics.java17.internal.Constants.UNIT_BUFFERS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,7 +37,7 @@ class BufferMetricTest {
   @Test
   void shouldHaveJfrLoadedClassesCountEvents() {
     ByteBuffer buffer = ByteBuffer.allocateDirect(10000);
-    buffer.put("test".getBytes(StandardCharsets.UTF_8));
+    buffer.put("test".getBytes(UTF_8));
 
     AttributeKey<String> attrBufferPool = AttributeKey.stringKey("jvm.buffer.pool.name");
     Attributes directBuffer = Attributes.of(attrBufferPool, "direct");

--- a/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
@@ -16,12 +16,12 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import javax.servlet.AsyncContext;
 import javax.servlet.RequestDispatcher;
@@ -87,7 +87,7 @@ public class TestServlet3 {
               resp.setContentType("text/html");
               resp.setStatus(endpoint.getStatus());
               resp.setContentLength(endpoint.getBody().length());
-              byte[] body = endpoint.getBody().getBytes(StandardCharsets.UTF_8);
+              byte[] body = endpoint.getBody().getBytes(UTF_8);
               resp.getOutputStream().write(body, 0, body.length);
             }
             return null;

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5Test.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty12;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import jakarta.servlet.Servlet;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
@@ -40,7 +41,7 @@ public abstract class Jetty12Servlet5Test
         (request, response, callback) -> {
           String message = (String) request.getAttribute("org.eclipse.jetty.server.error_message");
           if (message != null) {
-            response.write(true, StandardCharsets.UTF_8.encode(message), Callback.NOOP);
+            response.write(true, UTF_8.encode(message), Callback.NOOP);
           }
           callback.succeeded();
           return true;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_PRINT_WRITER;
 import static io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_SERVLET_OUTPUT_STREAM;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
@@ -27,7 +28,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 public class TestServlet5 {
@@ -87,7 +87,7 @@ public class TestServlet5 {
               resp.setContentType("text/html");
               resp.setStatus(endpoint.getStatus());
               resp.setContentLength(endpoint.getBody().length());
-              byte[] body = endpoint.getBody().getBytes(StandardCharsets.UTF_8);
+              byte[] body = endpoint.getBody().getBytes(UTF_8);
               resp.getOutputStream().write(body, 0, body.length);
             }
             return null;

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/SpanLoggingCustomizerProviderTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/SpanLoggingCustomizerProviderTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.logging;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -50,8 +50,7 @@ class SpanLoggingCustomizerProviderTest {
 
     OpenTelemetryConfigurationModel model =
         applyCustomizer(
-            DeclarativeConfiguration.parse(
-                new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))),
+            DeclarativeConfiguration.parse(new ByteArrayInputStream(yaml.getBytes(UTF_8))),
             new DeclarativeConfigLoggingExporterAutoConfiguration.SpanLoggingCustomizerProvider());
 
     String console = "ConsoleExporterModel";

--- a/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/repository/PersistenceConfig.java
+++ b/instrumentation/spring/spring-data/spring-data-3.0/testing/src/reactiveTest/java/io/opentelemetry/javaagent/instrumentation/spring/data/v3_0/repository/PersistenceConfig.java
@@ -11,12 +11,12 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
-import java.nio.charset.StandardCharsets;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
@@ -53,7 +53,7 @@ public class PersistenceConfig {
             new ByteArrayResource(
                 ("CREATE TABLE customer (id INT PRIMARY KEY, firstname VARCHAR(100) NOT NULL, lastname VARCHAR(100) NOT NULL);"
                         + "INSERT INTO customer (id, firstname, lastname) VALUES ('1', 'First', 'Last');")
-                    .getBytes(StandardCharsets.UTF_8))));
+                    .getBytes(UTF_8))));
 
     return initializer;
   }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/MessageHeadersGetter.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/MessageHeadersGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.spring.integration.v4_1;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -46,7 +47,7 @@ enum MessageHeadersGetter implements TextMapGetter<MessageWithChannel> {
       return null;
     }
     if (headerValue instanceof byte[]) {
-      return new String((byte[]) headerValue, StandardCharsets.UTF_8);
+      return new String((byte[]) headerValue, UTF_8);
     }
     return headerValue.toString();
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/filter/FilteredAppConfig.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/filter/FilteredAppConfig.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc.filter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -123,10 +124,7 @@ public class FilteredAppConfig implements WebMvcConfigurer {
       @Override
       protected void writeInternal(
           Map<String, Object> stringObjectMap, HttpOutputMessage outputMessage) throws IOException {
-        StreamUtils.copy(
-            (String) stringObjectMap.get("message"),
-            StandardCharsets.UTF_8,
-            outputMessage.getBody());
+        StreamUtils.copy((String) stringObjectMap.get("message"), UTF_8, outputMessage.getBody());
       }
     };
   }

--- a/instrumentation/twilio-6.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioClientTest.java
+++ b/instrumentation/twilio-6.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioClientTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.twilio;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,7 +34,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpEntity;
@@ -144,9 +144,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                200));
+            new Response(new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(UTF_8)), 200));
 
     Message message =
         testing.runWithSpan(
@@ -183,9 +181,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(CALL_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                200));
+            new Response(new ByteArrayInputStream(CALL_RESPONSE_BODY.getBytes(UTF_8)), 200));
 
     Call call =
         testing.runWithSpan(
@@ -373,9 +369,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(ERROR_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                500));
+            new Response(new ByteArrayInputStream(ERROR_RESPONSE_BODY.getBytes(UTF_8)), 500));
 
     assertThatThrownBy(
             () ->
@@ -410,9 +404,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                200));
+            new Response(new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(UTF_8)), 200));
 
     Message message =
         Message.creator(
@@ -444,9 +436,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                200));
+            new Response(new ByteArrayInputStream(MESSAGE_RESPONSE_BODY.getBytes(UTF_8)), 200));
 
     Message message =
         testing.runWithSpan(
@@ -492,9 +482,7 @@ class TwilioClientTest {
     when(twilioRestClient.getObjectMapper()).thenReturn(new ObjectMapper());
     when(twilioRestClient.request(any()))
         .thenReturn(
-            new Response(
-                new ByteArrayInputStream(ERROR_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8)),
-                500));
+            new Response(new ByteArrayInputStream(ERROR_RESPONSE_BODY.getBytes(UTF_8)), 500));
 
     assertThatThrownBy(
             () ->
@@ -535,8 +523,7 @@ class TwilioClientTest {
   private static CloseableHttpResponse mockResponse(String body, int statusCode)
       throws IOException {
     HttpEntity httpEntity = mock(HttpEntity.class);
-    when(httpEntity.getContent())
-        .thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+    when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes(UTF_8)));
     when(httpEntity.isRepeatable()).thenReturn(true);
 
     StatusLine statusLine = mock(StatusLine.class);

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -29,7 +30,6 @@ import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -240,9 +240,7 @@ public abstract class AbstractVertxKafkaTest {
     }
     String messageValue = record.value();
     if (messageValue != null) {
-      assertions.add(
-          equalTo(
-              MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(StandardCharsets.UTF_8).length));
+      assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
   }

--- a/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/InMemoryLogStoreTest.java
+++ b/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/InMemoryLogStoreTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.logging.application;
 
 import static io.opentelemetry.javaagent.bootstrap.InternalLogger.Level.INFO;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,7 +16,6 @@ import io.opentelemetry.javaagent.bootstrap.InternalLogger;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
@@ -86,6 +86,6 @@ class InMemoryLogStoreTest {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     underTest.dump(new PrintStream(out));
-    assertThat(out.toString(StandardCharsets.UTF_8.name())).hasLineCount(2);
+    assertThat(out.toString(UTF_8.name())).hasLineCount(2);
   }
 }

--- a/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/InMemoryLogTest.java
+++ b/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/InMemoryLogTest.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.javaagent.logging.application;
 
 import static io.opentelemetry.javaagent.bootstrap.InternalLogger.Level.INFO;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class InMemoryLogTest {
@@ -23,7 +23,7 @@ class InMemoryLogTest {
 
     log.dump(new PrintStream(out));
 
-    assertThat(out.toString(StandardCharsets.UTF_8.name()))
+    assertThat(out.toString(UTF_8.name()))
         .startsWith(
             "[otel.javaagent] INFO test-logger - a"
                 + System.lineSeparator()

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 import io.opentelemetry.javaagent.bootstrap.DefineClassHelper.Handler;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,8 +26,7 @@ public class DefineClassHandler implements Handler {
     // with OpenJ9 class data sharing we don't get real class bytes
     if (classBytes == null
         || (classBytes.length == 40
-            && new String(classBytes, StandardCharsets.ISO_8859_1)
-                .startsWith("J9ROMCLASSCOOKIE"))) {
+            && new String(classBytes, ISO_8859_1).startsWith("J9ROMCLASSCOOKIE"))) {
       return null;
     }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFile.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFile.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static java.util.logging.Level.SEVERE;
 
@@ -13,7 +14,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -65,7 +65,7 @@ final class ConfigurationFile {
 
     Properties properties = new Properties();
     try (InputStreamReader reader =
-        new InputStreamReader(new FileInputStream(configurationFile), StandardCharsets.UTF_8)) {
+        new InputStreamReader(new FileInputStream(configurationFile), UTF_8)) {
       properties.load(reader);
     } catch (FileNotFoundException fnf) {
       fileLoadErrorMessage = "Configuration file \"" + configurationFilePath + "\" not found.";

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/SpanLoggingCustomizerProviderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/SpanLoggingCustomizerProviderTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -45,8 +45,7 @@ class SpanLoggingCustomizerProviderTest {
 
     OpenTelemetryConfigurationModel model =
         applyCustomizer(
-            DeclarativeConfiguration.parse(
-                new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))),
+            DeclarativeConfiguration.parse(new ByteArrayInputStream(yaml.getBytes(UTF_8))),
             new SpanLoggingCustomizerProvider());
 
     String console = "ConsoleExporterModel";

--- a/javaagent-tooling/src/testConfigFile/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.java
+++ b/javaagent-tooling/src/testConfigFile/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.javaagent.tooling.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -81,8 +81,7 @@ class ConfigurationFileTest {
 
   private String createFile(String name, String contents) throws IOException {
     File file = new File(tmpDir, name);
-    try (Writer writer =
-        new OutputStreamWriter(Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8)) {
+    try (Writer writer = new OutputStreamWriter(Files.newOutputStream(file.toPath()), UTF_8)) {
       writer.write(contents);
     }
     return file.getAbsolutePath();

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -16,7 +18,6 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -248,8 +249,7 @@ public class IntegrationTestUtils {
     @Override
     public void run() {
       try {
-        BufferedReader reader =
-            new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream, UTF_8));
         String line = null;
         while ((line = reader.readLine()) != null) {
           if (print) {

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/ByteArrayUrl.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/ByteArrayUrl.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -13,7 +15,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.net.URLStreamHandler;
-import java.nio.charset.StandardCharsets;
 import java.security.Permission;
 import java.security.PrivilegedAction;
 
@@ -38,7 +39,7 @@ public class ByteArrayUrl {
 
   private static URL doCreate(String contentName, byte[] data) {
     try {
-      String file = URLEncoder.encode(contentName, StandardCharsets.UTF_8.toString());
+      String file = URLEncoder.encode(contentName, UTF_8.toString());
       return new URL(URL_SCHEMA, null, -1, file, new ByteArrayUrlStreamHandler(data));
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException("Failed to generate URL for the provided arguments", e);

--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/windows/ContainerLogFrameConsumer.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/windows/ContainerLogFrameConsumer.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.smoketest.windows;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.github.dockerjava.api.async.ResultCallbackTemplate;
 import com.github.dockerjava.api.model.Frame;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class ContainerLogFrameConsumer
 
     if (lineType != null) {
       byte[] bytes = frame.getPayload();
-      String text = bytes == null ? "" : new String(bytes, StandardCharsets.UTF_8);
+      String text = bytes == null ? "" : new String(bytes, UTF_8);
 
       for (Listener listener : listeners) {
         listener.accept(lineType, text);

--- a/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
+++ b/test-report/src/main/java/io/opentelemetry/instrumentation/testreport/FlakyTestReporter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.testreport;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.FileVisitResult.CONTINUE;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -18,7 +19,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -264,8 +264,7 @@ public class FlakyTestReporter {
 
     NetHttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
     GoogleCredentials credentials =
-        GoogleCredentials.fromStream(
-                new ByteArrayInputStream(accessKey.getBytes(StandardCharsets.UTF_8)))
+        GoogleCredentials.fromStream(new ByteArrayInputStream(accessKey.getBytes(UTF_8)))
             .createScoped(Collections.singletonList(SheetsScopes.SPREADSHEETS));
     Sheets service =
         new Sheets.Builder(


### PR DESCRIPTION
To follow [style guide](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/style-guide.md#static-imports)

Autogenerated from


```
#!/bin/bash
# Convert qualified java.nio.charset.StandardCharsets constant references to static imports.
# Run ./gradlew spotlessApply afterward to fix import ordering.

set -e

CHARSET_CONSTANTS="US_ASCII ISO_8859_1 UTF_8 UTF_16BE UTF_16LE UTF_16"

grep -rl --include="*.java" -E 'StandardCharsets\.(US_ASCII|ISO_8859_1|UTF_8|UTF_16BE|UTF_16LE|UTF_16)' . | while read -r file; do
  # Only process files that import java.nio.charset.StandardCharsets
  if ! grep -q "import java\.nio\.charset\.StandardCharsets;" "$file"; then
    continue
  fi

  echo "Processing (StandardCharsets): $file"

  for constant in $CHARSET_CONSTANTS; do
    # Check if the constant is used as StandardCharsets.X (qualified)
    has_qualified=$(grep -v "^import " "$file" | grep -c "StandardCharsets\.$constant" || true)

    if [ "$has_qualified" -gt 0 ]; then
      # Add static import if not already present
      if ! grep -q "import static java.nio.charset.StandardCharsets\.$constant;" "$file"; then
        sed -i "0,/^import /s//import static java.nio.charset.StandardCharsets.$constant;\nimport /" "$file"
      fi

      # Replace qualified references with unqualified (skip import lines)
      sed -i -E "/^import /!s/StandardCharsets\.$constant/$constant/g" "$file"
    fi
  done

  # Remove the non-static "import java.nio.charset.StandardCharsets;" if no other StandardCharsets usage remains
  if ! grep -v "^import " "$file" | grep -q "StandardCharsets"; then
    sed -i "/^import java\.nio\.charset\.StandardCharsets;$/d" "$file"
  fi
done

echo ""
echo "Done! Now run: ./gradlew spotlessApply"
```