### PR TITLE
Static import: ElementMatchers

### DIFF
--- a/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
+++ b/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
@@ -5,7 +5,10 @@
 
 package com.example.javaagent.instrumentation;
 
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -16,7 +19,6 @@ import javax.servlet.http.HttpServletResponse;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public class DemoServlet3Instrumentation implements TypeInstrumentation {
   @Override
@@ -29,13 +31,9 @@ public class DemoServlet3Instrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer typeTransformer) {
     typeTransformer.applyAdviceToMethod(
         namedOneOf("doFilter", "service")
-            .and(
-                ElementMatchers.takesArgument(
-                    0, ElementMatchers.named("javax.servlet.ServletRequest")))
-            .and(
-                ElementMatchers.takesArgument(
-                    1, ElementMatchers.named("javax.servlet.ServletResponse")))
-            .and(ElementMatchers.isPublic()),
+            .and(takesArgument(0, named("javax.servlet.ServletRequest")))
+            .and(takesArgument(1, named("javax.servlet.ServletResponse")))
+            .and(isPublic()),
         this.getClass().getName() + "$DemoServlet3Advice");
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/RestClientWrapper.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/RestClientWrapper.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.elasticsearch.rest.v7_0;
 
+import static net.bytebuddy.matcher.ElementMatchers.any;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -20,7 +22,6 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.InvocationHandlerAdapter;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.apache.http.Header;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
@@ -42,7 +43,7 @@ class RestClientWrapper {
         // are in a child class loader of RestClient's class loader and Instrumenter is not visible
         // for RestClient
         .defineField("instrumenterSupplier", Supplier.class, Visibility.PUBLIC)
-        .method(ElementMatchers.any())
+        .method(any())
         .intercept(
             InvocationHandlerAdapter.of(
                 (proxy, method, args) -> {

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -39,7 +40,6 @@ import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
 
@@ -157,8 +157,7 @@ public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
                 GlobalOpenTelemetry.get(), "external_annotations"));
     for (Map.Entry<String, Set<String>> entry : excludedMethods.entrySet()) {
       String className = entry.getKey();
-      ElementMatcher.Junction<ByteCodeElement> matcher =
-          isDeclaredBy(ElementMatchers.named(className));
+      ElementMatcher.Junction<ByteCodeElement> matcher = isDeclaredBy(named(className));
 
       Set<String> methodNames = entry.getValue();
       if (!methodNames.isEmpty()) {

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/FilterInstrumentation.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/FilterInstrumentation.java
@@ -21,7 +21,6 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.glassfish.grizzly.filterchain.BaseFilter;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 
@@ -36,8 +35,8 @@ public class FilterInstrumentation implements TypeInstrumentation {
   public ElementMatcher<TypeDescription> typeMatcher() {
     return hasSuperClass(named("org.glassfish.grizzly.filterchain.BaseFilter"))
         // HttpCodecFilter is instrumented in the server instrumentation
-        .and(not(ElementMatchers.named("org.glassfish.grizzly.http.HttpCodecFilter")))
-        .and(not(ElementMatchers.named("org.glassfish.grizzly.http.HttpServerFilter")));
+        .and(not(named("org.glassfish.grizzly.http.HttpCodecFilter")))
+        .and(not(named("org.glassfish.grizzly.http.HttpServerFilter")));
   }
 
   @Override

--- a/instrumentation/guava-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/v10_0/GuavaListenableFutureInstrumentation.java
+++ b/instrumentation/guava-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/v10_0/GuavaListenableFutureInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.guava.v10_0;
 
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
@@ -19,7 +20,6 @@ import java.util.concurrent.Executor;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public class GuavaListenableFutureInstrumentation implements TypeInstrumentation {
   @Override
@@ -32,7 +32,7 @@ public class GuavaListenableFutureInstrumentation implements TypeInstrumentation
     transformer.applyAdviceToMethod(
         isConstructor(), this.getClass().getName() + "$AbstractFutureAdvice");
     transformer.applyAdviceToMethod(
-        named("addListener").and(ElementMatchers.takesArguments(Runnable.class, Executor.class)),
+        named("addListener").and(takesArguments(Runnable.class, Executor.class)),
         this.getClass().getName() + "$AddListenerAdvice");
   }
 

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanInstrumentation.java
@@ -38,7 +38,6 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public class WithSpanInstrumentation implements TypeInstrumentation {
 
@@ -102,8 +101,7 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
                 GlobalOpenTelemetry.get(), "opentelemetry_extension_annotations"));
     for (Map.Entry<String, Set<String>> entry : excludedMethods.entrySet()) {
       String className = entry.getKey();
-      ElementMatcher.Junction<ByteCodeElement> matcher =
-          isDeclaredBy(ElementMatchers.named(className));
+      ElementMatcher.Junction<ByteCodeElement> matcher = isDeclaredBy(named(className));
 
       Set<String> methodNames = entry.getValue();
       if (!methodNames.isEmpty()) {

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.test.annotation;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanId;
@@ -27,7 +28,6 @@ import net.bytebuddy.description.annotation.AnnotationDescription;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.This;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -352,7 +352,7 @@ class WithSpanInstrumentationTest {
                         AnnotationDescription.Builder.ofType(
                                 io.opentelemetry.extension.annotations.WithSpan.class)
                             .build())
-                    .on(ElementMatchers.named("run")))
+                    .on(named("run")))
             .make()
             .load(getClass().getClassLoader())
             .getLoaded();

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationExcludedMethods.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationExcludedMethods.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.instrumentationannotations;
 
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
@@ -17,7 +18,6 @@ import java.util.Set;
 import net.bytebuddy.description.ByteCodeElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 public final class AnnotationExcludedMethods {
 
@@ -34,8 +34,7 @@ public final class AnnotationExcludedMethods {
                 GlobalOpenTelemetry.get(), "opentelemetry_instrumentation_annotations"));
     for (Map.Entry<String, Set<String>> entry : excludedMethods.entrySet()) {
       String className = entry.getKey();
-      ElementMatcher.Junction<ByteCodeElement> matcher =
-          isDeclaredBy(ElementMatchers.named(className));
+      ElementMatcher.Junction<ByteCodeElement> matcher = isDeclaredBy(named(className));
 
       Set<String> methodNames = entry.getValue();
       if (!methodNames.isEmpty()) {

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.test.annotation;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -29,7 +30,6 @@ import net.bytebuddy.description.annotation.AnnotationDescription;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.This;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -365,7 +365,7 @@ class WithSpanInstrumentationTest {
             .visit(
                 new MemberAttributeExtension.ForMethod()
                     .annotateMethod(AnnotationDescription.Builder.ofType(WithSpan.class).build())
-                    .on(ElementMatchers.named("run")))
+                    .on(named("run")))
             .make()
             .load(getClass().getClassLoader())
             .getLoaded();

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
+import static net.bytebuddy.matcher.ElementMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,7 +35,6 @@ import java.util.jar.JarOutputStream;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.implementation.FixedValue;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -65,11 +65,11 @@ class InstrumentationModuleClassLoaderTest {
     ClassLoader dummyParent = new URLClassLoader(new URL[] {}, null);
 
     InstrumentationModuleClassLoader m1 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, ElementMatchers.any());
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, any());
     m1.installInjectedClasses(toInject);
 
     InstrumentationModuleClassLoader m2 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, ElementMatchers.any());
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, any());
     m2.installInjectedClasses(toInject);
 
     // MethodHandles.publicLookup() always succeeds on the first invocation
@@ -104,7 +104,7 @@ class InstrumentationModuleClassLoaderTest {
 
     ClassLoader dummyParent = new URLClassLoader(new URL[] {}, null);
     InstrumentationModuleClassLoader m1 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, ElementMatchers.any());
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, any());
     m1.installInjectedClasses(toInject);
 
     Class<?> injected = Class.forName(A.class.getName(), true, m1);
@@ -146,7 +146,7 @@ class InstrumentationModuleClassLoaderTest {
       toInject.put(C.class.getName(), BytecodeWithUrl.create(C.class.getName(), moduleSourceCl));
 
       InstrumentationModuleClassLoader moduleCl =
-          new InstrumentationModuleClassLoader(appCl, agentCl, ElementMatchers.any());
+          new InstrumentationModuleClassLoader(appCl, agentCl, any());
       moduleCl.installInjectedClasses(toInject);
 
       // Verify precedence for classloading
@@ -246,14 +246,14 @@ class InstrumentationModuleClassLoaderTest {
     ClassLoader agentCl = HideMe.class.getClassLoader();
 
     InstrumentationModuleClassLoader nothingHidden =
-        new InstrumentationModuleClassLoader(null, agentCl, ElementMatchers.any());
+        new InstrumentationModuleClassLoader(null, agentCl, any());
     nothingHidden.installModule(module);
 
     assertThat(nothingHidden.loadClass(HideMe.class.getName())).isSameAs(HideMe.class);
 
     module.hiddenPackages.add(HideMe.class.getPackage().getName());
     InstrumentationModuleClassLoader classHidden =
-        new InstrumentationModuleClassLoader(null, agentCl, ElementMatchers.any());
+        new InstrumentationModuleClassLoader(null, agentCl, any());
     classHidden.installModule(module);
 
     assertThatThrownBy(() -> classHidden.loadClass(HideMe.class.getName()))


### PR DESCRIPTION
To follow [style guide](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/style-guide.md#static-imports)

Autogenerated from

```
#!/bin/bash
# Convert qualified net.bytebuddy.matcher.ElementMatchers method references to static imports.
# Run ./gradlew spotlessApply afterward to fix import ordering.

set -e

# Discover all ElementMatchers.method references in the codebase (exclude .class)
METHODS=$(grep -roh --include="*.java" 'ElementMatchers\.\w\+' . \
  | sed 's/ElementMatchers\.//' \
  | sort -u \
  | grep -v '^class$')

grep -rl --include="*.java" -E 'ElementMatchers\.[a-z]' . | while read -r file; do
  # Only process files that import net.bytebuddy.matcher.ElementMatchers (non-static)
  if ! grep -q "import net\.bytebuddy\.matcher\.ElementMatchers;" "$file"; then
    continue
  fi

  echo "Processing (ElementMatchers): $file"

  for method in $METHODS; do
    # Check if the method is used as ElementMatchers.X (qualified, outside import lines)
    has_qualified=$(grep -v "^import " "$file" | grep -cP '(?<!\w)ElementMatchers\.'"$method" || true)

    if [ "$has_qualified" -gt 0 ]; then
      # Add static import if not already present
      if ! grep -q "import static net.bytebuddy.matcher.ElementMatchers\.$method;" "$file"; then
        sed -i "0,/^import /s//import static net.bytebuddy.matcher.ElementMatchers.$method;\nimport /" "$file"
      fi

      # Replace qualified references with unqualified (skip import lines)
      sed -i -E "/^import /!s/(^|[^[:alnum:]_])ElementMatchers\.$method\b/\1$method/g" "$file"
    fi
  done

  # Remove the non-static "import net.bytebuddy.matcher.ElementMatchers;" if no other ElementMatchers usage remains
  if ! grep -v "^import " "$file" | grep -q "ElementMatchers"; then
    sed -i "/^import net\.bytebuddy\.matcher\.ElementMatchers;$/d" "$file"
  fi
done

echo ""
echo "Done! Now run: ./gradlew spotlessApply"
```