### PR TITLE
Static import: semconv constants, at least in tests

### DIFF
--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/code/CodeAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/code/CodeAttributesExtractorTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.code;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.CodeAttributes.CODE_FUNCTION_NAME;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -13,8 +16,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
-import io.opentelemetry.semconv.CodeAttributes;
-import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,13 +66,12 @@ class CodeAttributesExtractorTest {
 
     if (SemconvStability.isEmitStableCodeSemconv()) {
       assertThat(attributes)
-          .containsEntry(
-              CodeAttributes.CODE_FUNCTION_NAME, TestClass.class.getName() + ".doSomething");
+          .containsEntry(CODE_FUNCTION_NAME, TestClass.class.getName() + ".doSomething");
     }
     if (SemconvStability.isEmitOldCodeSemconv()) {
       assertThat(attributes)
-          .containsEntry(CodeIncubatingAttributes.CODE_NAMESPACE, TestClass.class.getName())
-          .containsEntry(CodeIncubatingAttributes.CODE_FUNCTION, "doSomething");
+          .containsEntry(CODE_NAMESPACE, TestClass.class.getName())
+          .containsEntry(CODE_FUNCTION, "doSomething");
     }
     assertThat(endAttributes.build().isEmpty()).isTrue();
   }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
@@ -6,6 +6,17 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
@@ -13,8 +24,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
-import io.opentelemetry.semconv.DbAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +73,7 @@ class DbClientAttributesExtractorTest {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void shouldExtractAllAvailableAttributes() {
     // given
@@ -93,34 +102,34 @@ class DbClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
-              entry(DbAttributes.DB_SYSTEM_NAME, "myDb"),
-              entry(DbIncubatingAttributes.DB_USER, "username"),
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"),
-              entry(DbAttributes.DB_OPERATION_NAME, "SELECT"));
+              entry(DB_SYSTEM, "myDb"),
+              entry(DB_SYSTEM_NAME, "myDb"),
+              entry(DB_USER, "username"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_CONNECTION_STRING, "mydb:///potatoes"),
+              entry(DB_STATEMENT, "SELECT * FROM potato"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "SELECT * FROM potato"),
+              entry(DB_QUERY_SUMMARY, "SELECT potato"),
+              entry(DB_OPERATION_NAME, "SELECT"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
-              entry(DbIncubatingAttributes.DB_USER, "username"),
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"));
+              entry(DB_SYSTEM, "myDb"),
+              entry(DB_USER, "username"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_CONNECTION_STRING, "mydb:///potatoes"),
+              entry(DB_STATEMENT, "SELECT * FROM potato"),
+              entry(DB_OPERATION, "SELECT"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_SYSTEM_NAME, "myDb"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"),
-              entry(DbAttributes.DB_OPERATION_NAME, "SELECT"));
+              entry(DB_SYSTEM_NAME, "myDb"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "SELECT * FROM potato"),
+              entry(DB_QUERY_SUMMARY, "SELECT potato"),
+              entry(DB_OPERATION_NAME, "SELECT"));
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientMetricsTest.java
@@ -8,6 +8,17 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -20,10 +31,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.DbAttributes;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
 import org.junit.jupiter.api.Test;
 
 class DbClientMetricsTest {
@@ -43,21 +50,21 @@ class DbClientMetricsTest {
 
     Attributes operationAttributes =
         Attributes.builder()
-            .put(DbAttributes.DB_SYSTEM_NAME, "myDb")
-            .put(DbAttributes.DB_COLLECTION_NAME, "table")
-            .put(DbAttributes.DB_NAMESPACE, "potatoes")
-            .put(DbAttributes.DB_OPERATION_NAME, "SELECT")
-            .put(DbAttributes.DB_QUERY_SUMMARY, "SELECT table")
-            .put(ServerAttributes.SERVER_ADDRESS, "localhost")
-            .put(ServerAttributes.SERVER_PORT, 1234)
+            .put(DB_SYSTEM_NAME, "myDb")
+            .put(DB_COLLECTION_NAME, "table")
+            .put(DB_NAMESPACE, "potatoes")
+            .put(DB_OPERATION_NAME, "SELECT")
+            .put(DB_QUERY_SUMMARY, "SELECT table")
+            .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 1234)
             .build();
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put(DbAttributes.DB_RESPONSE_STATUS_CODE, "200")
-            .put(ErrorAttributes.ERROR_TYPE, "400")
-            .put(NetworkAttributes.NETWORK_PEER_ADDRESS, "1.2.3.4")
-            .put(NetworkAttributes.NETWORK_PEER_PORT, 8080)
+            .put(DB_RESPONSE_STATUS_CODE, "200")
+            .put(ERROR_TYPE, "400")
+            .put(NETWORK_PEER_ADDRESS, "1.2.3.4")
+            .put(NETWORK_PEER_PORT, 8080)
             .build();
 
     Context parent =
@@ -90,18 +97,17 @@ class DbClientMetricsTest {
                                     point
                                         .hasSum(0.15 /* seconds */)
                                         .hasAttributesSatisfying(
-                                            equalTo(DbAttributes.DB_SYSTEM_NAME, "myDb"),
-                                            equalTo(DbAttributes.DB_NAMESPACE, "potatoes"),
-                                            equalTo(DbAttributes.DB_OPERATION_NAME, "SELECT"),
-                                            equalTo(DbAttributes.DB_COLLECTION_NAME, "table"),
-                                            equalTo(DbAttributes.DB_QUERY_SUMMARY, "SELECT table"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 1234),
-                                            equalTo(DbAttributes.DB_RESPONSE_STATUS_CODE, "200"),
-                                            equalTo(ErrorAttributes.ERROR_TYPE, "400"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PEER_ADDRESS, "1.2.3.4"),
-                                            equalTo(NetworkAttributes.NETWORK_PEER_PORT, 8080))
+                                            equalTo(DB_SYSTEM_NAME, "myDb"),
+                                            equalTo(DB_NAMESPACE, "potatoes"),
+                                            equalTo(DB_OPERATION_NAME, "SELECT"),
+                                            equalTo(DB_COLLECTION_NAME, "table"),
+                                            equalTo(DB_QUERY_SUMMARY, "SELECT table"),
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            equalTo(SERVER_PORT, 1234),
+                                            equalTo(DB_RESPONSE_STATUS_CODE, "200"),
+                                            equalTo(ERROR_TYPE, "400"),
+                                            equalTo(NETWORK_PEER_ADDRESS, "1.2.3.4"),
+                                            equalTo(NETWORK_PEER_PORT, 8080))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -6,8 +6,20 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_QUERY_PARAMETER;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.entry;
@@ -17,8 +29,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
-import io.opentelemetry.semconv.DbAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -92,7 +102,7 @@ class SqlClientAttributesExtractorTest {
     }
   }
 
-  @SuppressWarnings("deprecation") // TODO DbIncubatingAttributes.DB_CONNECTION_STRING deprecation
+  @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void shouldExtractAllAttributes() {
     // given
@@ -119,34 +129,34 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
-              entry(DbAttributes.DB_SYSTEM_NAME, "myDb"),
-              entry(DbIncubatingAttributes.DB_USER, "username"),
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato WHERE id=?"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato WHERE id=?"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"));
+              entry(DB_SYSTEM, "myDb"),
+              entry(DB_SYSTEM_NAME, "myDb"),
+              entry(DB_USER, "username"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_CONNECTION_STRING, "mydb:///potatoes"),
+              entry(DB_STATEMENT, "SELECT * FROM potato WHERE id=?"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "SELECT * FROM potato WHERE id=?"),
+              entry(DB_QUERY_SUMMARY, "SELECT potato"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_SYSTEM, "myDb"),
-              entry(DbIncubatingAttributes.DB_USER, "username"),
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_CONNECTION_STRING, "mydb:///potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM potato WHERE id=?"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"));
+              entry(DB_SYSTEM, "myDb"),
+              entry(DB_USER, "username"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_CONNECTION_STRING, "mydb:///potatoes"),
+              entry(DB_STATEMENT, "SELECT * FROM potato WHERE id=?"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_SQL_TABLE, "potato"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_SYSTEM_NAME, "myDb"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM potato WHERE id=?"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT potato"));
+              entry(DB_SYSTEM_NAME, "myDb"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "SELECT * FROM potato WHERE id=?"),
+              entry(DB_QUERY_SUMMARY, "SELECT potato"));
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
@@ -171,20 +181,16 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(attributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT *"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT *"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT"));
+              entry(DB_STATEMENT, "SELECT *"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_QUERY_TEXT, "SELECT *"),
+              entry(DB_QUERY_SUMMARY, "SELECT"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(attributes.build())
-          .containsOnly(
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT *"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"));
+          .containsOnly(entry(DB_STATEMENT, "SELECT *"), entry(DB_OPERATION, "SELECT"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(attributes.build())
-          .containsOnly(
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT *"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT"));
+          .containsOnly(entry(DB_QUERY_TEXT, "SELECT *"), entry(DB_QUERY_SUMMARY, "SELECT"));
     }
   }
 
@@ -199,7 +205,7 @@ class SqlClientAttributesExtractorTest {
 
     AttributesExtractor<Map<String, Object>, Void> underTest =
         SqlClientAttributesExtractor.<Map<String, Object>, Void>builder(new TestAttributesGetter())
-            .setTableAttribute(DbIncubatingAttributes.DB_CASSANDRA_TABLE)
+            .setTableAttribute(DB_CASSANDRA_TABLE)
             .build();
 
     // when
@@ -210,22 +216,21 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(attributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM table"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbIncubatingAttributes.DB_CASSANDRA_TABLE, "table"),
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM table"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT table"));
+              entry(DB_STATEMENT, "SELECT * FROM table"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_CASSANDRA_TABLE, "table"),
+              entry(DB_QUERY_TEXT, "SELECT * FROM table"),
+              entry(DB_QUERY_SUMMARY, "SELECT table"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(attributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_STATEMENT, "SELECT * FROM table"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "SELECT"),
-              entry(DbIncubatingAttributes.DB_CASSANDRA_TABLE, "table"));
+              entry(DB_STATEMENT, "SELECT * FROM table"),
+              entry(DB_OPERATION, "SELECT"),
+              entry(DB_CASSANDRA_TABLE, "table"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(attributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_QUERY_TEXT, "SELECT * FROM table"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "SELECT table"));
+              entry(DB_QUERY_TEXT, "SELECT * FROM table"), entry(DB_QUERY_SUMMARY, "SELECT table"));
     }
   }
 
@@ -267,27 +272,27 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"));
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     }
 
@@ -320,20 +325,19 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_NAME, "potatoes"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
-      assertThat(startAttributes.build())
-          .containsOnly(entry(DbIncubatingAttributes.DB_NAME, "potatoes"));
+      assertThat(startAttributes.build()).containsOnly(entry(DB_NAME, "potatoes"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     }
 
@@ -364,26 +368,26 @@ class SqlClientAttributesExtractorTest {
     if (SemconvStability.emitStableDatabaseSemconv() && SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"),
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "INSERT potato"));
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "INSERT potato"));
     } else if (SemconvStability.emitOldDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbIncubatingAttributes.DB_NAME, "potatoes"),
-              entry(DbIncubatingAttributes.DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
-              entry(DbIncubatingAttributes.DB_OPERATION, "INSERT"),
-              entry(DbIncubatingAttributes.DB_SQL_TABLE, "potato"));
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"));
     } else if (SemconvStability.emitStableDatabaseSemconv()) {
       assertThat(startAttributes.build())
           .containsOnly(
-              entry(DbAttributes.DB_NAMESPACE, "potatoes"),
-              entry(DbAttributes.DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
-              entry(DbAttributes.DB_QUERY_SUMMARY, "INSERT potato"));
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "INSERT potato"));
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpClientExperimentalMetricsTest.java
@@ -7,6 +7,20 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_QUERY;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,12 +32,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class HttpClientExperimentalMetricsTest {
@@ -39,24 +47,24 @@ class HttpClientExperimentalMetricsTest {
 
     Attributes requestAttributes =
         Attributes.builder()
-            .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
-            .put(UrlAttributes.URL_FULL, "https://localhost:1234/")
-            .put(UrlAttributes.URL_PATH, "/")
-            .put(UrlAttributes.URL_QUERY, "q=a")
-            .put(ServerAttributes.SERVER_ADDRESS, "localhost")
-            .put(ServerAttributes.SERVER_PORT, 1234)
+            .put(HTTP_REQUEST_METHOD, "GET")
+            .put(URL_FULL, "https://localhost:1234/")
+            .put(URL_PATH, "/")
+            .put(URL_QUERY, "q=a")
+            .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 1234)
             .build();
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200)
-            .put(ErrorAttributes.ERROR_TYPE, "400")
-            .put(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, 100)
-            .put(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, 200)
-            .put(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http")
-            .put(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0")
-            .put(NetworkAttributes.NETWORK_PEER_ADDRESS, "1.2.3.4")
-            .put(NetworkAttributes.NETWORK_PEER_PORT, 8080)
+            .put(HTTP_RESPONSE_STATUS_CODE, 200)
+            .put(ERROR_TYPE, "400")
+            .put(HTTP_REQUEST_BODY_SIZE, 100)
+            .put(HTTP_RESPONSE_BODY_SIZE, 200)
+            .put(NETWORK_PROTOCOL_NAME, "http")
+            .put(NETWORK_PROTOCOL_VERSION, "2.0")
+            .put(NETWORK_PEER_ADDRESS, "1.2.3.4")
+            .put(NETWORK_PEER_PORT, 8080)
             .build();
 
     Context parent =
@@ -93,15 +101,13 @@ class HttpClientExperimentalMetricsTest {
                                     point
                                         .hasSum(100 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                            equalTo(ErrorAttributes.ERROR_TYPE, "400"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 1234))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                            equalTo(ERROR_TYPE, "400"),
+                                            equalTo(NETWORK_PROTOCOL_NAME, "http"),
+                                            equalTo(NETWORK_PROTOCOL_VERSION, "2.0"),
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            equalTo(SERVER_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -119,15 +125,13 @@ class HttpClientExperimentalMetricsTest {
                                     point
                                         .hasSum(200 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                            equalTo(ErrorAttributes.ERROR_TYPE, "400"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 1234))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                            equalTo(ERROR_TYPE, "400"),
+                                            equalTo(NETWORK_PROTOCOL_NAME, "http"),
+                                            equalTo(NETWORK_PROTOCOL_VERSION, "2.0"),
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            equalTo(SERVER_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpExperimentalAttributesExtractorTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.UrlIncubatingAttributes.URL_TEMPLATE;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 
@@ -16,8 +19,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.UrlIncubatingAttributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +39,7 @@ class HttpExperimentalAttributesExtractorTest {
     runTest(
         clientGetter,
         HttpExperimentalAttributesExtractor.create(clientGetter),
-        Collections.singletonMap(UrlIncubatingAttributes.URL_TEMPLATE, "template"));
+        Collections.singletonMap(URL_TEMPLATE, "template"));
   }
 
   @Test
@@ -64,8 +65,8 @@ class HttpExperimentalAttributesExtractorTest {
 
     extractor.onEnd(attributes, Context.root(), "request", "response", null);
     Map<AttributeKey<?>, Object> expectedAttributes = new HashMap<>(expected);
-    expectedAttributes.put(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, 123L);
-    expectedAttributes.put(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, 42L);
+    expectedAttributes.put(HTTP_REQUEST_BODY_SIZE, 123L);
+    expectedAttributes.put(HTTP_RESPONSE_BODY_SIZE, 42L);
     assertThat(attributes.build().asMap()).containsExactlyInAnyOrderEntriesOf(expectedAttributes);
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/http/HttpServerExperimentalMetricsTest.java
@@ -7,6 +7,24 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_QUERY;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,12 +36,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class HttpServerExperimentalMetricsTest {
@@ -39,28 +51,28 @@ class HttpServerExperimentalMetricsTest {
 
     Attributes requestAttributes =
         Attributes.builder()
-            .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
-            .put(UrlAttributes.URL_SCHEME, "https")
-            .put(UrlAttributes.URL_PATH, "/")
-            .put(UrlAttributes.URL_QUERY, "q=a")
-            .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
-            .put(NetworkAttributes.NETWORK_TYPE, "ipv4")
-            .put(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http")
-            .put(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0")
-            .put(ServerAttributes.SERVER_ADDRESS, "localhost")
-            .put(ServerAttributes.SERVER_PORT, 1234)
+            .put(HTTP_REQUEST_METHOD, "GET")
+            .put(URL_SCHEME, "https")
+            .put(URL_PATH, "/")
+            .put(URL_QUERY, "q=a")
+            .put(NETWORK_TRANSPORT, "tcp")
+            .put(NETWORK_TYPE, "ipv4")
+            .put(NETWORK_PROTOCOL_NAME, "http")
+            .put(NETWORK_PROTOCOL_VERSION, "2.0")
+            .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 1234)
             .build();
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200)
-            .put(ErrorAttributes.ERROR_TYPE, "500")
-            .put(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE, 100)
-            .put(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, 200)
-            .put(NetworkAttributes.NETWORK_PEER_ADDRESS, "1.2.3.4")
-            .put(NetworkAttributes.NETWORK_PEER_PORT, 8080)
-            .put(NetworkAttributes.NETWORK_LOCAL_ADDRESS, "4.3.2.1")
-            .put(NetworkAttributes.NETWORK_LOCAL_PORT, 9090)
+            .put(HTTP_RESPONSE_STATUS_CODE, 200)
+            .put(ERROR_TYPE, "500")
+            .put(HTTP_REQUEST_BODY_SIZE, 100)
+            .put(HTTP_RESPONSE_BODY_SIZE, 200)
+            .put(NETWORK_PEER_ADDRESS, "1.2.3.4")
+            .put(NETWORK_PEER_PORT, 8080)
+            .put(NETWORK_LOCAL_ADDRESS, "4.3.2.1")
+            .put(NETWORK_LOCAL_PORT, 9090)
             .build();
 
     SpanContext spanContext1 =
@@ -93,8 +105,8 @@ class HttpServerExperimentalMetricsTest {
                                     point
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -116,8 +128,8 @@ class HttpServerExperimentalMetricsTest {
                                     point
                                         .hasValue(2)
                                         .hasAttributesSatisfying(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -138,8 +150,8 @@ class HttpServerExperimentalMetricsTest {
                                     point
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -157,14 +169,12 @@ class HttpServerExperimentalMetricsTest {
                                     point
                                         .hasSum(100 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                            equalTo(ErrorAttributes.ERROR_TYPE, "500"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                            equalTo(ERROR_TYPE, "500"),
+                                            equalTo(NETWORK_PROTOCOL_NAME, "http"),
+                                            equalTo(NETWORK_PROTOCOL_VERSION, "2.0"),
+                                            equalTo(URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -182,14 +192,12 @@ class HttpServerExperimentalMetricsTest {
                                     point
                                         .hasSum(200 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
-                                            equalTo(ErrorAttributes.ERROR_TYPE, "500"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-                                            equalTo(
-                                                NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
+                                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                            equalTo(ERROR_TYPE, "500"),
+                                            equalTo(NETWORK_PROTOCOL_NAME, "http"),
+                                            equalTo(NETWORK_PROTOCOL_VERSION, "2.0"),
+                                            equalTo(URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -6,6 +6,17 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_CONVERSATION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -13,7 +24,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,27 +81,21 @@ class MessagingAttributesExtractorTest {
 
     // then
     List<MapEntry<AttributeKey<?>, Object>> expectedEntries = new ArrayList<>();
-    expectedEntries.add(entry(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "myQueue"));
-    expectedEntries.add(
-        entry(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, expectedDestination));
+    expectedEntries.add(entry(MESSAGING_SYSTEM, "myQueue"));
+    expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, expectedDestination));
     if (temporary) {
-      expectedEntries.add(
-          entry(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, true));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPORARY, true));
     } else {
-      expectedEntries.add(
-          entry(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE, expectedDestination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, expectedDestination));
     }
     if (anonymous) {
-      expectedEntries.add(
-          entry(MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS, true));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_ANONYMOUS, true));
     }
-    expectedEntries.add(
-        entry(MessagingIncubatingAttributes.MESSAGING_MESSAGE_CONVERSATION_ID, "42"));
-    expectedEntries.add(entry(MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE, 100L));
-    expectedEntries.add(entry(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE, 120L));
+    expectedEntries.add(entry(MESSAGING_MESSAGE_CONVERSATION_ID, "42"));
+    expectedEntries.add(entry(MESSAGING_MESSAGE_BODY_SIZE, 100L));
+    expectedEntries.add(entry(MESSAGING_MESSAGE_ENVELOPE_SIZE, 120L));
     expectedEntries.add(entry(AttributeKey.stringKey("messaging.client_id"), "43"));
-    expectedEntries.add(
-        entry(MessagingIncubatingAttributes.MESSAGING_OPERATION, operation.operationName()));
+    expectedEntries.add(entry(MESSAGING_OPERATION, operation.operationName()));
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     MapEntry<? extends AttributeKey<?>, ?>[] expectedEntriesArr =
@@ -99,9 +103,7 @@ class MessagingAttributesExtractorTest {
     assertThat(startAttributes.build()).containsOnly(expectedEntriesArr);
 
     assertThat(endAttributes.build())
-        .containsOnly(
-            entry(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "42"),
-            entry(MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+        .containsOnly(entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
   }
 
   static Stream<Arguments> destinations() {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,8 +25,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class MessagingProducerMetricsTest {
@@ -38,19 +43,17 @@ class MessagingProducerMetricsTest {
 
     Attributes requestAttributes =
         Attributes.builder()
-            .put(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "pulsar")
-            .put(
-                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                "persistent://public/default/topic")
-            .put(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish")
-            .put(ServerAttributes.SERVER_PORT, 6650)
-            .put(ServerAttributes.SERVER_ADDRESS, "localhost")
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "persistent://public/default/topic")
+            .put(MESSAGING_OPERATION, "publish")
+            .put(SERVER_PORT, 6650)
+            .put(SERVER_ADDRESS, "localhost")
             .build();
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put(MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID, "1:1:0:0")
-            .put(MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID, "1")
+            .put(MESSAGING_MESSAGE_ID, "1:1:0:0")
+            .put(MESSAGING_DESTINATION_PARTITION_ID, "1")
             .build();
 
     Context parent =
@@ -87,19 +90,13 @@ class MessagingProducerMetricsTest {
                                     point
                                         .hasSum(0.15 /* seconds */)
                                         .hasAttributesSatisfying(
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
                                             equalTo(
-                                                MessagingIncubatingAttributes.MESSAGING_SYSTEM,
-                                                "pulsar"),
-                                            equalTo(
-                                                MessagingIncubatingAttributes
-                                                    .MESSAGING_DESTINATION_PARTITION_ID,
-                                                "1"),
-                                            equalTo(
-                                                MessagingIncubatingAttributes
-                                                    .MESSAGING_DESTINATION_NAME,
+                                                MESSAGING_DESTINATION_NAME,
                                                 "persistent://public/default/topic"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 6650),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"))
+                                            equalTo(SERVER_PORT, 6650),
+                                            equalTo(SERVER_ADDRESS, "localhost"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesExtractorTest.java
@@ -6,13 +6,15 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -61,14 +63,14 @@ class RpcAttributesExtractorTest {
     extractor.onStart(attributes, context, request);
     assertThat(attributes.build())
         .containsOnly(
-            entry(RpcIncubatingAttributes.RPC_SYSTEM, "test"),
-            entry(RpcIncubatingAttributes.RPC_SERVICE, "my.Service"),
-            entry(RpcIncubatingAttributes.RPC_METHOD, "Method"));
+            entry(RPC_SYSTEM, "test"),
+            entry(RPC_SERVICE, "my.Service"),
+            entry(RPC_METHOD, "Method"));
     extractor.onEnd(attributes, context, request, null, null);
     assertThat(attributes.build())
         .containsOnly(
-            entry(RpcIncubatingAttributes.RPC_SYSTEM, "test"),
-            entry(RpcIncubatingAttributes.RPC_SERVICE, "my.Service"),
-            entry(RpcIncubatingAttributes.RPC_METHOD, "Method"));
+            entry(RPC_SYSTEM, "test"),
+            entry(RPC_SERVICE, "my.Service"),
+            entry(RPC_METHOD, "Method"));
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
@@ -7,6 +7,13 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,9 +25,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -36,33 +40,30 @@ class RpcClientMetricsTest {
 
     Attributes requestAttributes1 =
         Attributes.builder()
-            .put(RpcIncubatingAttributes.RPC_SYSTEM, "grpc")
-            .put(RpcIncubatingAttributes.RPC_SERVICE, "myservice.EchoService")
-            .put(RpcIncubatingAttributes.RPC_METHOD, "exampleMethod")
+            .put(RPC_SYSTEM, "grpc")
+            .put(RPC_SERVICE, "myservice.EchoService")
+            .put(RPC_METHOD, "exampleMethod")
             .put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10)
             .build();
 
     Attributes requestAttributes2 =
         Attributes.builder()
-            .put(RpcIncubatingAttributes.RPC_SYSTEM, "grpc")
-            .put(RpcIncubatingAttributes.RPC_SERVICE, "myservice.EchoService")
-            .put(RpcIncubatingAttributes.RPC_METHOD, "exampleMethod")
+            .put(RPC_SYSTEM, "grpc")
+            .put(RPC_SERVICE, "myservice.EchoService")
+            .put(RPC_METHOD, "exampleMethod")
             .build();
 
     Attributes responseAttributes1 =
         Attributes.builder()
-            .put(ServerAttributes.SERVER_ADDRESS, "example.com")
-            .put(ServerAttributes.SERVER_PORT, 8080)
-            .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
-            .put(NetworkAttributes.NETWORK_TYPE, "ipv4")
+            .put(SERVER_ADDRESS, "example.com")
+            .put(SERVER_PORT, 8080)
+            .put(NETWORK_TRANSPORT, "tcp")
+            .put(NETWORK_TYPE, "ipv4")
             .put(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE, 20)
             .build();
 
     Attributes responseAttributes2 =
-        Attributes.builder()
-            .put(ServerAttributes.SERVER_PORT, 8080)
-            .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
-            .build();
+        Attributes.builder().put(SERVER_PORT, 8080).put(NETWORK_TRANSPORT, "tcp").build();
 
     Context parent =
         Context.root()
@@ -98,17 +99,13 @@ class RpcClientMetricsTest {
                                     point
                                         .hasSum(20 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -126,17 +123,13 @@ class RpcClientMetricsTest {
                                     point
                                         .hasSum(10 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -153,17 +146,13 @@ class RpcClientMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -185,15 +174,11 @@ class RpcClientMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp")))));
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp")))));
   }
 
   private static long nanos(int millis) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
@@ -7,6 +7,14 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,9 +26,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -36,34 +41,34 @@ class RpcServerMetricsTest {
 
     Attributes requestAttributes1 =
         Attributes.builder()
-            .put(RpcIncubatingAttributes.RPC_SYSTEM, "grpc")
-            .put(RpcIncubatingAttributes.RPC_SERVICE, "myservice.EchoService")
-            .put(RpcIncubatingAttributes.RPC_METHOD, "exampleMethod")
+            .put(RPC_SYSTEM, "grpc")
+            .put(RPC_SERVICE, "myservice.EchoService")
+            .put(RPC_METHOD, "exampleMethod")
             .put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10)
             .build();
 
     Attributes requestAttributes2 =
         Attributes.builder()
-            .put(RpcIncubatingAttributes.RPC_SYSTEM, "grpc")
-            .put(RpcIncubatingAttributes.RPC_SERVICE, "myservice.EchoService")
-            .put(RpcIncubatingAttributes.RPC_METHOD, "exampleMethod")
+            .put(RPC_SYSTEM, "grpc")
+            .put(RPC_SERVICE, "myservice.EchoService")
+            .put(RPC_METHOD, "exampleMethod")
             .build();
 
     Attributes responseAttributes1 =
         Attributes.builder()
-            .put(ServerAttributes.SERVER_ADDRESS, "example.com")
-            .put(ServerAttributes.SERVER_PORT, 8080)
-            .put(NetworkAttributes.NETWORK_LOCAL_ADDRESS, "127.0.0.1")
-            .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
-            .put(NetworkAttributes.NETWORK_TYPE, "ipv4")
+            .put(SERVER_ADDRESS, "example.com")
+            .put(SERVER_PORT, 8080)
+            .put(NETWORK_LOCAL_ADDRESS, "127.0.0.1")
+            .put(NETWORK_TRANSPORT, "tcp")
+            .put(NETWORK_TYPE, "ipv4")
             .put(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE, 20)
             .build();
 
     Attributes responseAttributes2 =
         Attributes.builder()
-            .put(ServerAttributes.SERVER_PORT, 8080)
-            .put(NetworkAttributes.NETWORK_LOCAL_ADDRESS, "127.0.0.1")
-            .put(NetworkAttributes.NETWORK_TRANSPORT, "tcp")
+            .put(SERVER_PORT, 8080)
+            .put(NETWORK_LOCAL_ADDRESS, "127.0.0.1")
+            .put(NETWORK_TRANSPORT, "tcp")
             .build();
 
     Context parent =
@@ -99,17 +104,13 @@ class RpcServerMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -127,17 +128,13 @@ class RpcServerMetricsTest {
                                     point
                                         .hasSum(20 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -155,17 +152,13 @@ class RpcServerMetricsTest {
                                     point
                                         .hasSum(10 /* bytes */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_ADDRESS, "example.com"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NetworkAttributes.NETWORK_TYPE, "ipv4"))
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_ADDRESS, "example.com"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp"),
+                                            equalTo(NETWORK_TYPE, "ipv4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -187,15 +180,11 @@ class RpcServerMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(RpcIncubatingAttributes.RPC_SYSTEM, "grpc"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_SERVICE,
-                                                "myservice.EchoService"),
-                                            equalTo(
-                                                RpcIncubatingAttributes.RPC_METHOD,
-                                                "exampleMethod"),
-                                            equalTo(ServerAttributes.SERVER_PORT, 8080),
-                                            equalTo(NetworkAttributes.NETWORK_TRANSPORT, "tcp")))));
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
+                                            equalTo(RPC_METHOD, "exampleMethod"),
+                                            equalTo(SERVER_PORT, 8080),
+                                            equalTo(NETWORK_TRANSPORT, "tcp")))));
   }
 
   private static long nanos(int millis) {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/InstrumenterContextTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/InstrumenterContextTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.internal;
 
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
@@ -18,7 +19,6 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuery;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -70,8 +70,7 @@ class InstrumenterContextTest {
     {
       AttributesBuilder builder = Attributes.builder();
       attributesExtractor.onStart(builder, Context.root(), null);
-      assertThat(builder.build().get(maybeStable(DbIncubatingAttributes.DB_SQL_TABLE)))
-          .isEqualTo("test2");
+      assertThat(builder.build().get(maybeStable(DB_SQL_TABLE))).isEqualTo("test2");
     }
 
     // clear cached value to see whether it gets recomputed correctly
@@ -79,8 +78,7 @@ class InstrumenterContextTest {
     {
       AttributesBuilder builder = Attributes.builder();
       attributesExtractor.onStart(builder, Context.root(), null);
-      assertThat(builder.build().get(maybeStable(DbIncubatingAttributes.DB_SQL_TABLE)))
-          .isEqualTo("test");
+      assertThat(builder.build().get(maybeStable(DB_SQL_TABLE))).isEqualTo("test");
     }
   }
 }

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
@@ -18,6 +18,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService;
@@ -25,7 +26,6 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.HelloServiceImpl;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.util.concurrent.CompletableFuture;
@@ -140,9 +140,7 @@ public abstract class AbstractDubboTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(RPC_SERVICE, "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RPC_METHOD, "$invoke"),
                                 equalTo(
@@ -163,9 +161,7 @@ public abstract class AbstractDubboTest {
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfying(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(
                                     RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
@@ -187,10 +183,7 @@ public abstract class AbstractDubboTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
@@ -210,10 +203,7 @@ public abstract class AbstractDubboTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "org.apache.dubbo.rpc.service.GenericService"),
@@ -274,9 +264,7 @@ public abstract class AbstractDubboTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(RPC_SERVICE, "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RPC_METHOD, "$invokeAsync"),
                                 equalTo(
@@ -297,9 +285,7 @@ public abstract class AbstractDubboTest {
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfying(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(
                                     RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
@@ -333,10 +319,7 @@ public abstract class AbstractDubboTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
@@ -356,10 +339,7 @@ public abstract class AbstractDubboTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "org.apache.dubbo.rpc.service.GenericService"),

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
@@ -19,6 +19,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
+import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService;
@@ -28,7 +29,6 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.MiddleServiceImpl;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import org.apache.dubbo.common.utils.NetUtils;
@@ -182,9 +182,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(RPC_SERVICE, "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RPC_METHOD, "$invoke"),
                                 equalTo(
@@ -205,9 +203,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfying(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(
                                     RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
@@ -219,9 +215,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(2))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(RPC_SERVICE, "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RPC_METHOD, "$invoke"),
                                 equalTo(
@@ -242,9 +236,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(3))
                             .hasAttributesSatisfying(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(
                                     RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
@@ -266,20 +258,14 @@ public abstract class AbstractDubboTraceChainTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
                                                 equalTo(RPC_METHOD, "hello")),
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
@@ -299,10 +285,7 @@ public abstract class AbstractDubboTraceChainTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "org.apache.dubbo.rpc.service.GenericService"),
@@ -315,10 +298,7 @@ public abstract class AbstractDubboTraceChainTest {
                                                     AbstractDubboTest::assertNetworkType)),
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "org.apache.dubbo.rpc.service.GenericService"),
@@ -385,9 +365,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(RPC_SERVICE, "org.apache.dubbo.rpc.service.GenericService"),
                                 equalTo(RPC_METHOD, "$invoke"),
                                 equalTo(
@@ -408,9 +386,7 @@ public abstract class AbstractDubboTraceChainTest {
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfying(
-                                equalTo(
-                                    RPC_SYSTEM,
-                                    RpcIncubatingAttributes.RpcSystemIncubatingValues.APACHE_DUBBO),
+                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                 equalTo(
                                     RPC_SERVICE,
                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
@@ -432,10 +408,7 @@ public abstract class AbstractDubboTraceChainTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
@@ -455,10 +428,7 @@ public abstract class AbstractDubboTraceChainTest {
                                     histogram.hasPointsSatisfying(
                                         point ->
                                             point.hasAttributesSatisfyingExactly(
-                                                equalTo(
-                                                    RPC_SYSTEM,
-                                                    RpcIncubatingAttributes
-                                                        .RpcSystemIncubatingValues.APACHE_DUBBO),
+                                                equalTo(RPC_SYSTEM, APACHE_DUBBO),
                                                 equalTo(
                                                     RPC_SERVICE,
                                                     "org.apache.dubbo.rpc.service.GenericService"),

--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/armeria/grpc/v1_14/ArmeriaGrpcTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.armeria.grpc.v1_14;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
@@ -24,7 +26,6 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -88,15 +89,13 @@ class ArmeriaGrpcTest {
                                 event
                                     .hasName("message")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                        equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                             event ->
                                 event
                                     .hasName("message")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(
-                                            MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                        equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                        equalTo(MESSAGE_ID, 1L))),
                 span ->
                     span.hasName("example.Greeter/SayHello")
                         .hasKind(SpanKind.SERVER)
@@ -113,14 +112,11 @@ class ArmeriaGrpcTest {
                                 event
                                     .hasName("message")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(
-                                            MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                        equalTo(MESSAGE_TYPE, "RECEIVED"), equalTo(MESSAGE_ID, 1L)),
                             event ->
                                 event
                                     .hasName("message")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                        equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                        equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)))));
   }
 }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -17,7 +18,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -67,8 +67,7 @@ class AwsLambdaStreamHandlerTest {
                 span ->
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                        .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -88,8 +87,7 @@ class AwsLambdaStreamHandlerTest {
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
                         .hasException(thrown)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                        .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   static final class RequestStreamHandlerTestImpl implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -15,7 +16,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AbstractAwsLambdaTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import lambdainternal.AwsLambdaLegacyInternalRequestHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class AwsLambdaTest extends AbstractAwsLambdaTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -72,7 +72,7 @@ class AwsLambdaTest extends AbstractAwsLambdaTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   private static final class TestRequestHandler implements RequestHandler<String, String> {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -21,8 +24,6 @@ import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambd
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -91,10 +92,10 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
                         .hasParentSpanId("0000000000000456")
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -128,10 +129,10 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
                         .hasException(thrown)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   public static final class TestRequestHandler implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -18,8 +21,6 @@ import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambd
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -81,10 +82,10 @@ class AwsLambdaStreamWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -109,10 +110,10 @@ class AwsLambdaStreamWrapperTest {
                         .hasException(thrown)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   public static final class TestRequestHandler implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
@@ -15,7 +16,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public abstract class AbstractAwsLambdaTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -86,7 +86,7 @@ public abstract class AbstractAwsLambdaTest {
                             .hasStatus(StatusData.error())
                             .hasException(thrown)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   /**
@@ -111,6 +111,6 @@ public abstract class AbstractAwsLambdaTest {
                             .hasNoParent()
                             .hasLinks()
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 }

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaApiGatewayHandlerTest.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_TRIGGER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -20,7 +22,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -83,8 +84,8 @@ class AwsLambdaApiGatewayHandlerTest {
                         .hasTraceId("ee13e7026227ebf4c74278ae29691d7a")
                         .hasParentSpanId("0000000000000456")
                         .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-2024"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-2024"),
+                            equalTo(FAAS_TRIGGER, "http"),
                             equalTo(HTTP_REQUEST_METHOD, "PUT"),
                             equalTo(USER_AGENT_ORIGINAL, "Clever Client"),
                             equalTo(URL_FULL, "http://localhost:2024/hello/world"),

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaStreamHandlerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -17,7 +18,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -67,8 +67,7 @@ class AwsLambdaStreamHandlerTest {
                 span ->
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                        .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -88,8 +87,7 @@ class AwsLambdaStreamHandlerTest {
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
                         .hasException(thrown)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                        .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   static final class RequestStreamHandlerTestImpl implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
@@ -7,8 +7,10 @@ package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -16,8 +18,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,16 +77,13 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333")),
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333")),
                     span ->
                         span.hasName("queue1 process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(
                                 links ->
@@ -126,16 +123,13 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                         span.hasName("my_function")
                             .hasKind(SpanKind.SERVER)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333")),
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333")),
                     span ->
                         span.hasName("multiple_sources process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParentSpanId(trace.getSpan(0).getSpanId())
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_OPERATION, "process"))
                             .hasLinksSatisfying(
                                 links ->

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaApiGatewayWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaApiGatewayWrapperTest.java
@@ -10,6 +10,10 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_TRIGGER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -21,8 +25,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambda;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -101,11 +103,11 @@ class AwsLambdaApiGatewayWrapperTest {
                         .hasParentSpanId("0000000000000456")
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"),
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"),
+                            equalTo(FAAS_TRIGGER, "http"),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(USER_AGENT_ORIGINAL, "Test Client"),
                             equalTo(URL_FULL, "http://localhost:123/hello/world?a=b&c=d"),
@@ -136,11 +138,11 @@ class AwsLambdaApiGatewayWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"),
+                            equalTo(FAAS_TRIGGER, "http"))));
   }
 
   @Test
@@ -167,11 +169,11 @@ class AwsLambdaApiGatewayWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"),
+                            equalTo(FAAS_TRIGGER, "http"))));
   }
 
   @Test
@@ -198,11 +200,11 @@ class AwsLambdaApiGatewayWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"),
+                            equalTo(FAAS_TRIGGER, "http"))));
   }
 
   @Test
@@ -232,11 +234,11 @@ class AwsLambdaApiGatewayWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"),
-                            equalTo(FaasIncubatingAttributes.FAAS_TRIGGER, "http"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"),
+                            equalTo(FAAS_TRIGGER, "http"))));
   }
 
   public static class TestRequestHandlerApiGateway

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventWrapperTest.java
@@ -7,8 +7,12 @@ package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -19,9 +23,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambda;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
@@ -80,18 +81,15 @@ class AwsLambdaSqsEventWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333")),
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333")),
                 span ->
                     span.hasName("otel process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             equalTo(MESSAGING_OPERATION, "process"))));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsMessageHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsMessageHandlerTest.java
@@ -7,10 +7,12 @@ package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -24,8 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.data.LinkData;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
@@ -88,17 +88,13 @@ class AwsLambdaSqsMessageHandlerTest {
                 span ->
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333")),
+                        .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333")),
                 span ->
                     span.hasName("queue1 process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(0).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             equalTo(MESSAGING_OPERATION, "process"))
                         .hasLinks(
                             LinkData.create(
@@ -118,10 +114,7 @@ class AwsLambdaSqsMessageHandlerTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(MESSAGING_MESSAGE_ID, "message1"),
                             equalTo(MESSAGING_DESTINATION_NAME, "queue1"))
@@ -137,10 +130,7 @@ class AwsLambdaSqsMessageHandlerTest {
                         .hasKind(SpanKind.CONSUMER)
                         .hasParentSpanId(trace.getSpan(1).getSpanId())
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(MESSAGING_MESSAGE_ID, "message2"),
                             equalTo(MESSAGING_DESTINATION_NAME, "queue1"))

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaWrapperTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
+import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
@@ -17,8 +20,6 @@ import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambd
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.CloudIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.FaasIncubatingAttributes;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,10 +70,10 @@ class AwsLambdaWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -96,10 +97,10 @@ class AwsLambdaWrapperTest {
                         .hasException(thrown)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -121,10 +122,10 @@ class AwsLambdaWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   @Test
@@ -149,10 +150,10 @@ class AwsLambdaWrapperTest {
                         .hasKind(SpanKind.SERVER)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
-                                CloudIncubatingAttributes.CLOUD_RESOURCE_ID,
+                                CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
-                            equalTo(CloudIncubatingAttributes.CLOUD_ACCOUNT_ID, "123456789"),
-                            equalTo(FaasIncubatingAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
+                            equalTo(CLOUD_ACCOUNT_ID, "123456789"),
+                            equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   public static final class TestRequestHandlerString implements RequestHandler<String, String> {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_DYNAMODB_TABLE_NAMES;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.AWS_DYNAMODB;
 import static java.util.Collections.singletonList;
 
@@ -23,7 +24,6 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
@@ -56,9 +56,7 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         Arrays.asList(
             equalTo(
                 maybeStable(DB_SYSTEM),
-                SemconvStability.emitStableDatabaseSemconv()
-                    ? AWS_DYNAMODB
-                    : DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB),
+                SemconvStability.emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
             equalTo(maybeStable(DB_OPERATION), "CreateTable"),
             equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")));
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
@@ -38,7 +39,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.Collections;
 import org.elasticmq.rest.sqs.SQSRestServer;
 import org.elasticmq.rest.sqs.SQSRestServerBuilder;
@@ -137,10 +137,7 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                 equalTo(SERVER_ADDRESS, "localhost"),
                                 equalTo(SERVER_PORT, sqsPort),
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                 equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
@@ -164,10 +161,7 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                 equalTo(SERVER_ADDRESS, "localhost"),
                                 equalTo(SERVER_PORT, sqsPort),
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                 equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(
@@ -240,10 +234,7 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                 equalTo(SERVER_ADDRESS, "localhost"),
                                 equalTo(SERVER_PORT, sqsPort),
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                 equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
@@ -267,10 +258,7 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                 equalTo(SERVER_ADDRESS, "localhost"),
                                 equalTo(SERVER_PORT, sqsPort),
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                 equalTo(MESSAGING_OPERATION, "process"),
                                 satisfies(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -22,6 +22,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
@@ -46,7 +47,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -170,10 +170,7 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                   equalTo(SERVER_ADDRESS, "localhost"),
                                   equalTo(SERVER_PORT, sqsPort),
-                                  equalTo(
-                                      MESSAGING_SYSTEM,
-                                      MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                          .AWS_SQS),
+                                  equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                   equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                   equalTo(MESSAGING_OPERATION, "publish"),
                                   satisfies(
@@ -211,10 +208,7 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                   equalTo(SERVER_ADDRESS, "localhost"),
                                   equalTo(SERVER_PORT, sqsPort),
-                                  equalTo(
-                                      MESSAGING_SYSTEM,
-                                      MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                          .AWS_SQS),
+                                  equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                   equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                   equalTo(MESSAGING_OPERATION, "receive"),
                                   equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
@@ -249,10 +243,7 @@ public abstract class AbstractSqsTracingTest {
                                   equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                   equalTo(SERVER_ADDRESS, "localhost"),
                                   equalTo(SERVER_PORT, sqsPort),
-                                  equalTo(
-                                      MESSAGING_SYSTEM,
-                                      MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                          .AWS_SQS),
+                                  equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                   equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                   equalTo(MESSAGING_OPERATION, "process"),
                                   satisfies(
@@ -337,10 +328,7 @@ public abstract class AbstractSqsTracingTest {
                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                 equalTo(SERVER_ADDRESS, "localhost"),
                                 equalTo(SERVER_PORT, sqsPort),
-                                equalTo(
-                                    MESSAGING_SYSTEM,
-                                    MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                        .AWS_SQS),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                 equalTo(MESSAGING_OPERATION, "publish"),
                                 satisfies(
@@ -400,16 +388,10 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                       equalTo(SERVER_ADDRESS, "localhost"),
                                       equalTo(SERVER_PORT, sqsPort),
-                                      equalTo(
-                                          MESSAGING_SYSTEM,
-                                          MessagingIncubatingAttributes
-                                              .MessagingSystemIncubatingValues.AWS_SQS),
+                                      equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                       equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                       equalTo(MESSAGING_OPERATION, "receive"),
-                                      equalTo(
-                                          MessagingIncubatingAttributes
-                                              .MESSAGING_BATCH_MESSAGE_COUNT,
-                                          1),
+                                      equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
                                       equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
                           span ->
                               span.hasName("testSdkSqs process")
@@ -432,10 +414,7 @@ public abstract class AbstractSqsTracingTest {
                                       equalTo(URL_FULL, "http://localhost:" + sqsPort),
                                       equalTo(SERVER_ADDRESS, "localhost"),
                                       equalTo(SERVER_PORT, sqsPort),
-                                      equalTo(
-                                          MESSAGING_SYSTEM,
-                                          MessagingIncubatingAttributes
-                                              .MessagingSystemIncubatingValues.AWS_SQS),
+                                      equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                       equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
                                       equalTo(MESSAGING_OPERATION, "process"),
                                       satisfies(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
@@ -13,7 +13,10 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_TOKEN_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.CHAT;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.AWS_BEDROCK;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.OUTPUT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -27,7 +30,6 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.AbstractAws2BedrockRuntimeTe
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -163,10 +165,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 415),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 162),
@@ -189,14 +188,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -204,14 +197,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -226,10 +213,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -317,10 +301,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 57),
@@ -343,14 +324,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -358,14 +333,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -380,10 +349,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -546,10 +512,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 415),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 162),
@@ -572,14 +535,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -587,14 +544,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -609,10 +560,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -719,10 +667,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
@@ -745,14 +690,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -760,14 +699,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -782,10 +715,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -995,10 +925,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 166),
@@ -1021,14 +948,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1036,14 +957,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1058,10 +973,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -1177,10 +1089,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 559),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
@@ -1203,14 +1112,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1218,14 +1121,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1240,10 +1137,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1473,10 +1367,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 165),
@@ -1499,14 +1390,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1514,14 +1399,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1536,10 +1415,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -1698,10 +1574,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 558),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 58),
@@ -1724,14 +1597,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1739,14 +1606,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1761,10 +1622,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1925,10 +1783,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 133),
@@ -1951,14 +1806,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1966,14 +1815,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1988,10 +1831,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -2085,10 +1925,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 590),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 132),
@@ -2111,14 +1948,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2126,14 +1957,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2148,10 +1973,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -2384,10 +2206,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 144),
@@ -2410,14 +2229,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2425,14 +2238,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2447,10 +2254,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -2584,10 +2388,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 601),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 145),
@@ -2610,14 +2411,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2625,14 +2420,8 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2647,10 +2436,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
@@ -18,7 +18,11 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_TOKEN_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.CHAT;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.TEXT_COMPLETION;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.AWS_BEDROCK;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.OUTPUT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +35,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.recording.RecordingExtension;
-import io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,10 +145,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 8),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 14),
@@ -168,14 +168,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -183,14 +177,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -205,10 +193,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -271,10 +256,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -303,14 +285,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -318,14 +294,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -340,10 +310,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -421,10 +388,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 415),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 162),
@@ -447,14 +411,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -462,14 +420,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -484,10 +436,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -589,10 +538,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 57),
@@ -615,14 +561,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -630,14 +570,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -652,10 +586,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -838,10 +769,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 415),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 162),
@@ -864,14 +792,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -879,14 +801,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -901,10 +817,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1025,10 +938,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
@@ -1051,14 +961,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1066,14 +970,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1088,10 +986,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1253,10 +1148,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 8),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 10),
@@ -1279,14 +1171,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1294,14 +1180,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1316,10 +1196,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1397,10 +1274,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 5),
                                 satisfies(
@@ -1483,10 +1357,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .TEXT_COMPLETION),
+                                equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -1515,15 +1386,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1531,15 +1395,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1554,11 +1411,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1648,10 +1501,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .TEXT_COMPLETION),
+                                equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 100),
                                 satisfies(
@@ -1680,15 +1530,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1696,15 +1539,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1719,11 +1555,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues
-                                                    .TEXT_COMPLETION),
+                                            equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -1822,10 +1654,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -1854,14 +1683,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -1869,14 +1692,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -1891,10 +1708,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -2004,10 +1818,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 100),
                                 satisfies(
@@ -2036,14 +1847,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2051,14 +1856,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2073,10 +1872,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -2161,10 +1957,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2193,14 +1986,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2208,14 +1995,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2230,10 +2011,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -2307,10 +2085,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2366,10 +2141,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2434,10 +2206,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2495,10 +2264,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2587,10 +2353,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
@@ -2619,14 +2382,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2634,14 +2391,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2656,10 +2407,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -2803,10 +2551,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 166),
@@ -2829,14 +2574,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -2844,14 +2583,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -2866,10 +2599,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -2999,10 +2729,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 559),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
@@ -3025,14 +2752,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -3040,14 +2761,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -3062,10 +2777,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -3316,10 +3028,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 165),
@@ -3342,14 +3051,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -3357,14 +3060,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -3379,10 +3076,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -3555,10 +3249,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 558),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 58),
@@ -3581,14 +3272,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -3596,14 +3281,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -3618,10 +3297,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -3804,10 +3480,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 133),
@@ -3830,14 +3503,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -3845,14 +3512,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -3867,10 +3528,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -3978,10 +3636,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 590),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 132),
@@ -4004,14 +3659,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -4019,14 +3668,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -4041,10 +3684,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
@@ -4301,10 +3941,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 144),
@@ -4327,14 +3964,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -4342,14 +3973,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -4364,10 +3989,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
     SpanContext spanCtx0 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
@@ -4515,10 +4137,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfying(
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                equalTo(
-                                    GEN_AI_OPERATION_NAME,
-                                    GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues
-                                        .CHAT),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 601),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 145),
@@ -4541,14 +4160,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.INPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, INPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)),
                                 point ->
                                     point
@@ -4556,14 +4169,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasCount(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_TOKEN_TYPE,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiTokenTypeIncubatingValues.OUTPUT),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_TOKEN_TYPE, OUTPUT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))),
             metric ->
                 metric
@@ -4578,10 +4185,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                         .hasSumGreaterThan(0.0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
-                                            equalTo(
-                                                GEN_AI_OPERATION_NAME,
-                                                GenAiIncubatingAttributes
-                                                    .GenAiOperationNameIncubatingValues.CHAT),
+                                            equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                             equalTo(GEN_AI_REQUEST_MODEL, modelId)))));
 
     SpanContext spanCtx1 = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/SanitizationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/SanitizationTest.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -12,8 +15,6 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
-import io.opentelemetry.semconv.DbAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.stream.Stream;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -117,11 +118,11 @@ class SanitizationTest {
     Attributes attributes = attributesBuilder.build();
 
     if (SemconvStability.emitStableDatabaseSemconv()) {
-      assertThat(attributes.get(DbAttributes.DB_QUERY_TEXT)).isEqualTo(expectedQueryText);
-      assertThat(attributes.get(DbAttributes.DB_QUERY_SUMMARY)).isEqualTo(expectedSummary);
+      assertThat(attributes.get(DB_QUERY_TEXT)).isEqualTo(expectedQueryText);
+      assertThat(attributes.get(DB_QUERY_SUMMARY)).isEqualTo(expectedSummary);
     }
     if (SemconvStability.emitOldDatabaseSemconv()) {
-      assertThat(attributes.get(DbIncubatingAttributes.DB_STATEMENT)).isEqualTo(expectedQueryText);
+      assertThat(attributes.get(DB_STATEMENT)).isEqualTo(expectedQueryText);
     }
   }
 }

--- a/instrumentation/graphql-java/graphql-java-20.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/v20_0/GraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/v20_0/GraphqlTest.java
@@ -7,6 +7,11 @@ package io.opentelemetry.instrumentation.graphql.v20_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -17,8 +22,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ExceptionAttributes;
-import io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -91,11 +94,10 @@ class GraphqlTest extends AbstractGraphqlTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME, "findBookById"),
-                            equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                            equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                            equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                             normalizedQueryEqualsTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                GRAPHQL_DOCUMENT,
                                 "query findBookById { bookById(id: ?) { name author { name } } }")),
                 span ->
                     span.hasName("bookById")
@@ -156,11 +158,10 @@ class GraphqlTest extends AbstractGraphqlTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME, "findBookById"),
-                            equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                            equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                            equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                             normalizedQueryEqualsTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                GRAPHQL_DOCUMENT,
                                 "query findBookById { bookById(id: ?) { name author { name } } }")),
                 span ->
                     span.hasName("bookById")
@@ -235,11 +236,10 @@ class GraphqlTest extends AbstractGraphqlTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME, "findBookById"),
-                            equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                            equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                            equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                             normalizedQueryEqualsTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                GRAPHQL_DOCUMENT,
                                 "query findBookById { bookById(id: ?) { name author { name } } }")),
                 span ->
                     span.hasName("fetchBookById")
@@ -287,11 +287,10 @@ class GraphqlTest extends AbstractGraphqlTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME, "findBookById"),
-                            equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                            equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                            equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                             normalizedQueryEqualsTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                GRAPHQL_DOCUMENT,
                                 "query findBookById { bookById(id: ?) { name author { name } } }"))
                         .hasStatus(StatusData.error())
                         .hasEventsSatisfyingExactly(
@@ -299,11 +298,9 @@ class GraphqlTest extends AbstractGraphqlTest {
                                 event
                                     .hasName("exception")
                                     .hasAttributesSatisfyingExactly(
+                                        equalTo(EXCEPTION_TYPE, "DataFetchingException"),
                                         equalTo(
-                                            ExceptionAttributes.EXCEPTION_TYPE,
-                                            "DataFetchingException"),
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_MESSAGE,
+                                            EXCEPTION_MESSAGE,
                                             "Exception while fetching data (/bookById) : fetching book failed"))),
                 span ->
                     span.hasName("bookById")
@@ -362,11 +359,10 @@ class GraphqlTest extends AbstractGraphqlTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME, "findBookById"),
-                            equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                            equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                            equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                             normalizedQueryEqualsTo(
-                                GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                GRAPHQL_DOCUMENT,
                                 "query findBookById { bookById(id: ?) { name author { name } } }"))
                         .hasStatus(StatusData.error())
                         .hasEventsSatisfyingExactly(
@@ -374,12 +370,8 @@ class GraphqlTest extends AbstractGraphqlTest {
                                 event
                                     .hasName("exception")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_TYPE,
-                                            "DataFetchingException"),
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_MESSAGE,
-                                            "failed to fetch book"))),
+                                        equalTo(EXCEPTION_TYPE, "DataFetchingException"),
+                                        equalTo(EXCEPTION_MESSAGE, "failed to fetch book"))),
                 span ->
                     span.hasName("bookById")
                         .hasKind(SpanKind.INTERNAL)
@@ -393,12 +385,8 @@ class GraphqlTest extends AbstractGraphqlTest {
                                 event
                                     .hasName("exception")
                                     .hasAttributesSatisfyingExactly(
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_TYPE,
-                                            "DataFetchingException"),
-                                        equalTo(
-                                            ExceptionAttributes.EXCEPTION_MESSAGE,
-                                            "failed to fetch book"))),
+                                        equalTo(EXCEPTION_TYPE, "DataFetchingException"),
+                                        equalTo(EXCEPTION_MESSAGE, "failed to fetch book"))),
                 span ->
                     span.hasName("fetchBookById")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common/testing/src/main/java/io/opentelemetry/instrumentation/graphql/AbstractGraphqlTest.java
@@ -11,6 +11,9 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import graphql.ExecutionResult;
@@ -30,7 +33,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -178,12 +180,10 @@ public abstract class AbstractGraphqlTest {
                           .hasKind(SpanKind.INTERNAL)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(
-                              equalTo(
-                                  GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME,
-                                  "findBookById"),
-                              equalTo(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "query"),
+                              equalTo(GRAPHQL_OPERATION_NAME, "findBookById"),
+                              equalTo(GRAPHQL_OPERATION_TYPE, "query"),
                               normalizedQueryEqualsTo(
-                                  GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                  GRAPHQL_DOCUMENT,
                                   "query findBookById { bookById(id: ?) { name } }")));
               if (includeDataFetcher()) {
                 assertions.add(
@@ -338,13 +338,10 @@ public abstract class AbstractGraphqlTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME,
-                                    "addNewBook"),
-                                equalTo(
-                                    GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE, "mutation"),
+                                equalTo(GRAPHQL_OPERATION_NAME, "addNewBook"),
+                                equalTo(GRAPHQL_OPERATION_TYPE, "mutation"),
                                 normalizedQueryEqualsTo(
-                                    GraphqlIncubatingAttributes.GRAPHQL_DOCUMENT,
+                                    GRAPHQL_DOCUMENT,
                                     "mutation addNewBook { addBook(id: ?, name: ?, author: ?) { id } }"))));
   }
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
@@ -17,6 +17,8 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
@@ -38,7 +40,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
 import io.opentelemetry.sdk.trace.data.EventData;
-import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -187,9 +188,8 @@ public abstract class AbstractGrpcStreamingTest {
                       attrs ->
                           assertThat(attrs)
                               .hasSize(2)
-                              .containsEntry(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT")
-                              .containsEntry(
-                                  MessageIncubatingAttributes.MESSAGE_ID, clientMessageId)));
+                              .containsEntry(MESSAGE_TYPE, "SENT")
+                              .containsEntry(MESSAGE_ID, clientMessageId)));
       serverEvents.add(
           event ->
               assertThat(event)
@@ -198,9 +198,8 @@ public abstract class AbstractGrpcStreamingTest {
                       attrs ->
                           assertThat(attrs)
                               .hasSize(2)
-                              .containsEntry(MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED")
-                              .containsEntry(
-                                  MessageIncubatingAttributes.MESSAGE_ID, clientMessageId)));
+                              .containsEntry(MESSAGE_TYPE, "RECEIVED")
+                              .containsEntry(MESSAGE_ID, clientMessageId)));
 
       for (long j = 0; j < serverMessageCount; j++) {
         long serverMessageId = i * serverMessageCount + j + 1;
@@ -212,9 +211,8 @@ public abstract class AbstractGrpcStreamingTest {
                         attrs ->
                             assertThat(attrs)
                                 .hasSize(2)
-                                .containsEntry(MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED")
-                                .containsEntry(
-                                    MessageIncubatingAttributes.MESSAGE_ID, serverMessageId)));
+                                .containsEntry(MESSAGE_TYPE, "RECEIVED")
+                                .containsEntry(MESSAGE_ID, serverMessageId)));
         serverEvents.add(
             event ->
                 assertThat(event)
@@ -223,9 +221,8 @@ public abstract class AbstractGrpcStreamingTest {
                         attrs ->
                             assertThat(attrs)
                                 .hasSize(2)
-                                .containsEntry(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT")
-                                .containsEntry(
-                                    MessageIncubatingAttributes.MESSAGE_ID, serverMessageId)));
+                                .containsEntry(MESSAGE_TYPE, "SENT")
+                                .containsEntry(MESSAGE_ID, serverMessageId)));
       }
     }
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -16,6 +16,8 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessageIncubatingAttributes.MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_GRPC_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
@@ -60,7 +62,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessageIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -161,17 +162,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -196,17 +193,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L)))));
 
     assertMetrics(server, Status.Code.OK);
   }
@@ -286,17 +280,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -321,17 +311,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -423,17 +410,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -458,17 +441,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -533,9 +513,8 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -562,9 +541,8 @@ public abstract class AbstractGrpcTest {
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
-                                          equalTo(
-                                              MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L));
+                                          equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                          equalTo(MESSAGE_ID, 1L));
                                   if (status.getCause() == null) {
                                     assertThat(events).hasSize(1);
                                   } else {
@@ -641,9 +619,8 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -665,9 +642,8 @@ public abstract class AbstractGrpcTest {
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
-                                          equalTo(
-                                              MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L));
+                                          equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                          equalTo(MESSAGE_ID, 1L));
                                   span.hasException(status.asRuntimeException());
                                 })));
 
@@ -838,17 +814,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -873,17 +845,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -971,14 +940,12 @@ public abstract class AbstractGrpcTest {
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L));
+                                          equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L));
                                   assertThat(events.get(1))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
-                                          equalTo(
-                                              MessageIncubatingAttributes.MESSAGE_TYPE, "RECEIVED"),
-                                          equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L));
+                                          equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                          equalTo(MESSAGE_ID, 1L));
                                   span.hasException(thrown);
                                 }),
                     span ->
@@ -1005,17 +972,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -1097,17 +1061,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName(
                                 "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo")
@@ -1133,17 +1093,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L)))));
   }
 
   @Test
@@ -1207,17 +1164,13 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "SENT"), equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L))),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L))),
                     span ->
                         span.hasName("example.Greeter/SayHello")
                             .hasKind(SpanKind.SERVER)
@@ -1242,17 +1195,14 @@ public abstract class AbstractGrpcTest {
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE,
-                                                "RECEIVED"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)),
+                                            equalTo(MESSAGE_TYPE, "RECEIVED"),
+                                            equalTo(MESSAGE_ID, 1L)),
                                 event ->
                                     event
                                         .hasName("message")
                                         .hasAttributesSatisfyingExactly(
-                                            equalTo(
-                                                MessageIncubatingAttributes.MESSAGE_TYPE, "SENT"),
-                                            equalTo(MessageIncubatingAttributes.MESSAGE_ID, 1L)))));
+                                            equalTo(MESSAGE_TYPE, "SENT"),
+                                            equalTo(MESSAGE_ID, 1L)))));
   }
 
   // Regression test for

--- a/instrumentation/java-http-client/testing/src/main/java/io/opentelemetry/instrumentation/javahttpclient/AbstractJavaHttpClientTest.java
+++ b/instrumentation/java-http-client/testing/src/main/java/io/opentelemetry/instrumentation/javahttpclient/AbstractJavaHttpClientTest.java
@@ -7,7 +7,12 @@ package io.opentelemetry.instrumentation.javahttpclient;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -18,10 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -172,12 +173,11 @@ public abstract class AbstractJavaHttpClientTest extends AbstractHttpClientTest<
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfying(
-                            equalTo(UrlAttributes.URL_FULL, uri.toString()),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, uri.getHost()),
-                            equalTo(ServerAttributes.SERVER_PORT, uri.getPort()),
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, method),
-                            equalTo(
-                                ErrorAttributes.ERROR_TYPE, CancellationException.class.getName())),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            equalTo(HTTP_REQUEST_METHOD, method),
+                            equalTo(ERROR_TYPE, CancellationException.class.getName())),
                 span ->
                     span.hasName("test-http-server")
                         .hasKind(SpanKind.SERVER)

--- a/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
+++ b/instrumentation/java-util-logging/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingTest.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
@@ -21,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import io.opentelemetry.testing.internal.armeria.common.annotation.Nullable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -116,12 +117,8 @@ class JavaUtilLoggingTest {
       if (logException) {
         assertThat(log)
             .hasAttributesSatisfyingExactly(
-                equalTo(
-                    ThreadIncubatingAttributes.THREAD_NAME,
-                    experimental(Thread.currentThread().getName())),
-                equalTo(
-                    ThreadIncubatingAttributes.THREAD_ID,
-                    experimental(Thread.currentThread().getId())),
+                equalTo(THREAD_NAME, experimental(Thread.currentThread().getName())),
+                equalTo(THREAD_ID, experimental(Thread.currentThread().getId())),
                 equalTo(EXCEPTION_TYPE, IllegalStateException.class.getName()),
                 equalTo(EXCEPTION_MESSAGE, "hello"),
                 satisfies(
@@ -129,12 +126,8 @@ class JavaUtilLoggingTest {
       } else {
         assertThat(log)
             .hasAttributesSatisfyingExactly(
-                equalTo(
-                    ThreadIncubatingAttributes.THREAD_NAME,
-                    experimental(Thread.currentThread().getName())),
-                equalTo(
-                    ThreadIncubatingAttributes.THREAD_ID,
-                    experimental(Thread.currentThread().getId())));
+                equalTo(THREAD_NAME, experimental(Thread.currentThread().getName())),
+                equalTo(THREAD_ID, experimental(Thread.currentThread().getId())));
       }
 
       if (withParent) {

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotations1InstrumentationTest.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotations1InstrumentationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.jaxrs.v1_0;
 import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ErrorAttributes.ErrorTypeValues.OTHER;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
@@ -16,7 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
 import io.opentelemetry.javaagent.instrumentation.jaxrs.v1_0.JavaInterfaces.Jax;
-import io.opentelemetry.semconv.ErrorAttributes;
 import java.util.stream.Stream;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -120,7 +120,7 @@ class JaxRsAnnotations1InstrumentationTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_ROUTE, path),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER)),
+                            equalTo(ERROR_TYPE, OTHER)),
                 span ->
                     span.hasName(className + ".call")
                         .hasParent(trace.getSpan(0))
@@ -146,8 +146,7 @@ class JaxRsAnnotations1InstrumentationTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"), equalTo(ERROR_TYPE, OTHER))));
   }
 
   @Path("/interface")

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRs2AnnotationsInstrumentationTest.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRs2AnnotationsInstrumentationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
 import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ErrorAttributes.ErrorTypeValues.OTHER;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
@@ -16,7 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
 import io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0.JavaInterfaces.Jax;
-import io.opentelemetry.semconv.ErrorAttributes;
 import java.util.stream.Stream;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -120,7 +120,7 @@ class JaxRs2AnnotationsInstrumentationTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_ROUTE, path),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER)),
+                            equalTo(ERROR_TYPE, OTHER)),
                 span ->
                     span.hasName(className + ".call")
                         .hasParent(trace.getSpan(0))
@@ -146,8 +146,7 @@ class JaxRs2AnnotationsInstrumentationTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"), equalTo(ERROR_TYPE, OTHER))));
   }
 
   @Path("/interface")

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxRs3AnnotationsInstrumentationTest.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxRs3AnnotationsInstrumentationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.jaxrs.v3_0;
 import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ErrorAttributes.ErrorTypeValues.OTHER;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
@@ -16,7 +17,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
 import io.opentelemetry.javaagent.instrumentation.jaxrs.v3_0.JavaInterfaces.Jax;
-import io.opentelemetry.semconv.ErrorAttributes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HEAD;
@@ -120,7 +120,7 @@ class JaxRs3AnnotationsInstrumentationTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(HTTP_ROUTE, path),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER)),
+                            equalTo(ERROR_TYPE, OTHER)),
                 span ->
                     span.hasName(className + ".call")
                         .hasParent(trace.getSpan(0))
@@ -146,8 +146,7 @@ class JaxRs3AnnotationsInstrumentationTest {
                         .hasKind(SpanKind.SERVER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(ERROR_TYPE, ErrorAttributes.ErrorTypeValues.OTHER))));
+                            equalTo(HTTP_REQUEST_METHOD, "GET"), equalTo(ERROR_TYPE, OTHER))));
   }
 
   @Path("/interface")

--- a/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/appender/v1_1/JbossLogmanagerTest.java
+++ b/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jbosslogmanager/appender/v1_1/JbossLogmanagerTest.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -20,7 +22,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,11 +149,8 @@ class JbossLogmanagerTest {
             List<AttributeAssertion> attributeAsserts =
                 new ArrayList<>(
                     Arrays.asList(
-                        equalTo(
-                            ThreadIncubatingAttributes.THREAD_NAME,
-                            Thread.currentThread().getName()),
-                        equalTo(
-                            ThreadIncubatingAttributes.THREAD_ID, Thread.currentThread().getId())));
+                        equalTo(THREAD_NAME, Thread.currentThread().getName()),
+                        equalTo(THREAD_ID, Thread.currentThread().getId())));
             if (logException) {
               attributeAsserts.addAll(
                   Arrays.asList(
@@ -219,9 +217,8 @@ class JbossLogmanagerTest {
                 .hasAttributesSatisfyingExactly(
                     equalTo(AttributeKey.stringKey("key1"), "val1"),
                     equalTo(AttributeKey.stringKey("key2"), "val2"),
-                    equalTo(
-                        ThreadIncubatingAttributes.THREAD_NAME, Thread.currentThread().getName()),
-                    equalTo(ThreadIncubatingAttributes.THREAD_ID, Thread.currentThread().getId())));
+                    equalTo(THREAD_NAME, Thread.currentThread().getName()),
+                    equalTo(THREAD_ID, Thread.currentThread().getId())));
   }
 
   @FunctionalInterface

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONN
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_QUERY_PARAMETER;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_TABLE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -24,7 +25,6 @@ import com.google.common.collect.Maps;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
@@ -637,7 +637,7 @@ public abstract class AbstractPreparedStatementParametersTest {
                                     maybeStable(DB_SQL_TABLE),
                                     emitStableDatabaseSemconv() ? null : table),
                                 equalTo(
-                                    DbIncubatingAttributes.DB_QUERY_SUMMARY,
+                                    DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? spanName : null),
                                 equalTo(
                                     DB_QUERY_PARAMETER.getAttributeKey("0"),

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -39,7 +40,6 @@ import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -649,7 +649,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
           span.hasAttributesSatisfying(
               equalTo(stringKey("rabbitmq.command"), "basic.publish"),
               satisfies(
-                  MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+                  MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
                   val ->
                       val.satisfiesAnyOf(
                           v -> assertThat(v).isNull(),
@@ -698,7 +698,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
         equalTo(MESSAGING_SYSTEM, "rabbitmq"),
         satisfies(MESSAGING_DESTINATION_NAME, val -> val.isIn(exchange, null)),
         satisfies(
-            MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+            MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
             val ->
                 val.satisfiesAnyOf(
                     v -> assertThat(v).isNull(),

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
@@ -103,7 +103,7 @@ class HostIdResourceTest {
     if (expectedValue == null) {
       that.isEmpty();
     } else {
-      that.containsEntry(HostIncubatingAttributes.HOST_ID, expectedValue);
+      that.containsEntry(HOST_ID, expectedValue);
     }
   }
 

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostResourceTest.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_ARCH;
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class HostResourceTest {
@@ -22,7 +23,7 @@ class HostResourceTest {
 
     // then
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(attributes.get(HostIncubatingAttributes.HOST_NAME)).isNotBlank();
-    assertThat(attributes.get(HostIncubatingAttributes.HOST_ARCH)).isNotBlank();
+    assertThat(attributes.get(HOST_NAME)).isNotBlank();
+    assertThat(attributes.get(HOST_ARCH)).isNotBlank();
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/OsResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/OsResourceTest.java
@@ -5,11 +5,23 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.AIX;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.DARWIN;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.DRAGONFLYBSD;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.FREEBSD;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.HPUX;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.LINUX;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.NETBSD;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.OPENBSD;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.SOLARIS;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.WINDOWS;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.ZOS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
@@ -20,9 +32,8 @@ class OsResourceTest {
   void linux() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.LINUX);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(LINUX);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -30,9 +41,8 @@ class OsResourceTest {
   void macos() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.DARWIN);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(DARWIN);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -40,9 +50,8 @@ class OsResourceTest {
   void windows() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.WINDOWS);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(WINDOWS);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -50,9 +59,8 @@ class OsResourceTest {
   void freebsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.FREEBSD);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(FREEBSD);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -60,9 +68,8 @@ class OsResourceTest {
   void netbsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.NETBSD);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(NETBSD);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -70,9 +77,8 @@ class OsResourceTest {
   void openbsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.OPENBSD);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(OPENBSD);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -80,9 +86,8 @@ class OsResourceTest {
   void dragonflybsd() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.DRAGONFLYBSD);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(DRAGONFLYBSD);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -90,9 +95,8 @@ class OsResourceTest {
   void hpux() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.HPUX);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(HPUX);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -100,9 +104,8 @@ class OsResourceTest {
   void aix() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.AIX);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(AIX);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -110,9 +113,8 @@ class OsResourceTest {
   void solaris() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.SOLARIS);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(SOLARIS);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -120,9 +122,8 @@ class OsResourceTest {
   void zos() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE))
-        .isEqualTo(OsIncubatingAttributes.OsTypeIncubatingValues.ZOS);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isEqualTo(ZOS);
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 
   @Test
@@ -130,7 +131,7 @@ class OsResourceTest {
   void unknown() {
     Resource resource = OsResource.buildResource();
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_TYPE)).isNull();
-    assertThat(resource.getAttribute(OsIncubatingAttributes.OS_DESCRIPTION)).isNotEmpty();
+    assertThat(resource.getAttribute(OS_TYPE)).isNull();
+    assertThat(resource.getAttribute(OS_DESCRIPTION)).isNotEmpty();
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -5,12 +5,15 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_LINE;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_PID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junitpioneer.jupiter.SetSystemProperty;
@@ -36,20 +39,20 @@ class ProcessResourceTest {
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
     Attributes attributes = resource.getAttributes();
 
-    assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_PID)).isGreaterThan(1);
-    assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH))
+    assertThat(attributes.get(PROCESS_PID)).isGreaterThan(1);
+    assertThat(attributes.get(PROCESS_EXECUTABLE_PATH))
         .matches(windows ? ".*[/\\\\]java\\.exe" : ".*[/\\\\]java");
 
     boolean java8 = "1.8".equals(System.getProperty("java.specification.version"));
     if (java8 || IS_WINDOWS) {
-      assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_COMMAND_LINE))
-          .contains(attributes.get(ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH))
+      assertThat(attributes.get(PROCESS_COMMAND_LINE))
+          .contains(attributes.get(PROCESS_EXECUTABLE_PATH))
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
           .contains("-DtestNotRedacted=test");
     } else {
-      assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS))
-          .contains(attributes.get(ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH))
+      assertThat(attributes.get(PROCESS_COMMAND_ARGS))
+          .contains(attributes.get(PROCESS_EXECUTABLE_PATH))
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
           .contains("-DtestNotRedacted=test");

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessRuntimeResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessRuntimeResourceTest.java
@@ -5,12 +5,14 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_DESCRIPTION;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_NAME;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_RUNTIME_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class ProcessRuntimeResourceTest {
@@ -22,9 +24,8 @@ class ProcessRuntimeResourceTest {
 
     // then
     assertThat(resource.getSchemaUrl()).isEqualTo(SchemaUrls.V1_24_0);
-    assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_RUNTIME_NAME)).isNotBlank();
-    assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_RUNTIME_VERSION)).isNotBlank();
-    assertThat(attributes.get(ProcessIncubatingAttributes.PROCESS_RUNTIME_DESCRIPTION))
-        .isNotBlank();
+    assertThat(attributes.get(PROCESS_RUNTIME_NAME)).isNotBlank();
+    assertThat(attributes.get(PROCESS_RUNTIME_VERSION)).isNotBlank();
+    assertThat(attributes.get(PROCESS_RUNTIME_DESCRIPTION)).isNotBlank();
   }
 }

--- a/instrumentation/resources/library/src/testSecurityManager/java/io/opentelemetry/instrumentation/resources/SecurityManagerResourceTest.java
+++ b/instrumentation/resources/library/src/testSecurityManager/java/io/opentelemetry/instrumentation/resources/SecurityManagerResourceTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_NAME;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_PID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.EnabledOnJre;
@@ -27,7 +27,7 @@ class SecurityManagerResourceTest {
   @Test
   void hostResourceTestEmpty() {
     Attributes attributes = HostResource.buildResource().getAttributes();
-    assertThat(attributes.asMap()).containsOnlyKeys(HostIncubatingAttributes.HOST_NAME);
+    assertThat(attributes.asMap()).containsOnlyKeys(HOST_NAME);
   }
 
   @Test
@@ -38,7 +38,7 @@ class SecurityManagerResourceTest {
   @Test
   void processResourceEmpty() {
     Attributes attributes = ProcessResource.buildResource().getAttributes();
-    assertThat(attributes.asMap()).containsOnlyKeys(ProcessIncubatingAttributes.PROCESS_PID);
+    assertThat(attributes.asMap()).containsOnlyKeys(PROCESS_PID);
   }
 
   @Test

--- a/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
@@ -10,17 +10,18 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.NORMAL;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -114,10 +115,7 @@ public abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                                     equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
-                                    equalTo(
-                                        MESSAGING_ROCKETMQ_MESSAGE_TYPE,
-                                        MessagingIncubatingAttributes
-                                            .MessagingRocketmqMessageTypeIncubatingValues.NORMAL),
+                                    equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, NORMAL),
                                     equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                                     equalTo(MESSAGING_SYSTEM, "rocketmq"),
                                     equalTo(
@@ -132,10 +130,7 @@ public abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                                 // As the child of send span.
                                 .hasParent(trace.getSpan(1))
                                 .hasAttributesSatisfyingExactly(
-                                    equalTo(
-                                        MessagingIncubatingAttributes
-                                            .MESSAGING_ROCKETMQ_CLIENT_GROUP,
-                                        consumerGroup),
+                                    equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
                                     equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                                     equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                                     equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),

--- a/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -19,6 +19,9 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.DELAY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.FIFO;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.NORMAL;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -30,7 +33,6 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -415,10 +417,7 @@ public abstract class AbstractRocketMqClientTest {
             Arrays.asList(
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
-                equalTo(
-                    MESSAGING_ROCKETMQ_MESSAGE_TYPE,
-                    MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues
-                        .NORMAL),
+                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, NORMAL),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
@@ -447,10 +446,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_GROUP, messageGroup),
-                equalTo(
-                    MESSAGING_ROCKETMQ_MESSAGE_TYPE,
-                    MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues
-                        .FIFO),
+                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, FIFO),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
@@ -479,10 +475,7 @@ public abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, Arrays.asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP, deliveryTimestamp),
-                equalTo(
-                    MESSAGING_ROCKETMQ_MESSAGE_TYPE,
-                    MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues
-                        .DELAY),
+                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, DELAY),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/aws/AwsSqsTest.java
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/aws/AwsSqsTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HttpRequestMethodValues.POST;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -18,6 +19,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
@@ -28,8 +30,6 @@ import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -95,8 +95,7 @@ class AwsSqsTest {
                             equalTo(RPC_SYSTEM, "aws-api"),
                             equalTo(RPC_METHOD, "GetQueueUrl"),
                             equalTo(RPC_SERVICE, "Sqs"),
-                            equalTo(
-                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_REQUEST_METHOD, POST),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
@@ -114,8 +113,7 @@ class AwsSqsTest {
                             equalTo(RPC_SYSTEM, "aws-api"),
                             equalTo(RPC_METHOD, "SendMessage"),
                             equalTo(RPC_SERVICE, "Sqs"),
-                            equalTo(
-                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_REQUEST_METHOD, POST),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
@@ -124,10 +122,7 @@ class AwsSqsTest {
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(MESSAGING_OPERATION, "publish"),
                             equalTo(MESSAGING_DESTINATION_NAME, "test-queue"),
@@ -145,8 +140,7 @@ class AwsSqsTest {
                             equalTo(RPC_SYSTEM, "aws-api"),
                             equalTo(RPC_METHOD, "ReceiveMessage"),
                             equalTo(RPC_SERVICE, "Sqs"),
-                            equalTo(
-                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_REQUEST_METHOD, POST),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
@@ -155,10 +149,7 @@ class AwsSqsTest {
                                 v ->
                                     v.startsWith(
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
-                            equalTo(
-                                MESSAGING_SYSTEM,
-                                MessagingIncubatingAttributes.MessagingSystemIncubatingValues
-                                    .AWS_SQS),
+                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(MESSAGING_DESTINATION_NAME, "test-queue")),
@@ -172,8 +163,7 @@ class AwsSqsTest {
                             equalTo(RPC_SYSTEM, "aws-api"),
                             equalTo(RPC_METHOD, "DeleteMessageBatch"),
                             equalTo(RPC_SERVICE, "Sqs"),
-                            equalTo(
-                                HTTP_REQUEST_METHOD, HttpAttributes.HttpRequestMethodValues.POST),
+                            equalTo(HTTP_REQUEST_METHOD, POST),
                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
@@ -15,13 +15,13 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -79,8 +79,7 @@ class SpringIntegrationAndRabbitTest {
                             equalTo(MESSAGING_OPERATION, "publish"),
                             satisfies(MESSAGING_MESSAGE_BODY_SIZE, l -> l.isInstanceOf(Long.class)),
                             satisfies(
-                                MessagingIncubatingAttributes
-                                    .MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+                                MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
                                 s -> s.isInstanceOf(String.class))),
                 // spring-cloud-stream-binder-rabbit listener puts all messages into a BlockingQueue
                 // immediately after receiving
@@ -104,8 +103,7 @@ class SpringIntegrationAndRabbitTest {
                             equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(MESSAGING_MESSAGE_BODY_SIZE, l -> l.isInstanceOf(Long.class)),
                             satisfies(
-                                MessagingIncubatingAttributes
-                                    .MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+                                MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
                                 s -> s.isInstanceOf(String.class))),
                 // spring-integration will detect that spring-rabbit has already created a consumer
                 // span and back off

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -24,7 +24,6 @@ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -71,8 +70,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                     MESSAGING_CLIENT_ID,
                                     stringAssert -> stringAssert.startsWith("producer")),
                                 satisfies(
-                                    MessagingIncubatingAttributes
-                                        .MESSAGING_DESTINATION_PARTITION_ID,
+                                    MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
                                 satisfies(
                                     MESSAGING_KAFKA_MESSAGE_OFFSET,
@@ -89,8 +87,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                 satisfies(
                                     MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                                 satisfies(
-                                    MessagingIncubatingAttributes
-                                        .MESSAGING_DESTINATION_PARTITION_ID,
+                                    MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
                                 satisfies(
                                     MESSAGING_KAFKA_MESSAGE_OFFSET,
@@ -147,8 +144,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                           MESSAGING_CLIENT_ID,
                                           stringAssert -> stringAssert.startsWith("producer")),
                                       satisfies(
-                                          MessagingIncubatingAttributes
-                                              .MESSAGING_DESTINATION_PARTITION_ID,
+                                          MESSAGING_DESTINATION_PARTITION_ID,
                                           AbstractStringAssert::isNotEmpty),
                                       satisfies(
                                           MESSAGING_KAFKA_MESSAGE_OFFSET,

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -26,7 +26,6 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -242,8 +241,7 @@ class SpringRabbitMqTest {
                         span.hasName("<generated> process")
                             .hasAttribute(
                                 equalTo(
-                                    MessagingIncubatingAttributes
-                                        .MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+                                    MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
                                     anonymousQueueName))),
             trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.qos")),
             trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.consume")),

--- a/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/EnduserAttributesCapturerTest.java
+++ b/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/EnduserAttributesCapturerTest.java
@@ -5,13 +5,16 @@
 
 package io.opentelemetry.instrumentation.spring.security.config.v6_0;
 
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ID;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ROLE;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_SCOPE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import org.assertj.core.api.Condition;
@@ -45,9 +48,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ID))
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ROLE))
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_SCOPE)));
+            span.doesNotHave(attribute(ENDUSER_ID))
+                .doesNotHave(attribute(ENDUSER_ROLE))
+                .doesNotHave(attribute(ENDUSER_SCOPE)));
   }
 
   @Test
@@ -69,9 +72,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ROLE))
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_SCOPE, "scope1,scope2"));
+            span.hasAttribute(ENDUSER_ID, "principal")
+                .doesNotHave(attribute(ENDUSER_ROLE))
+                .hasAttribute(ENDUSER_SCOPE, "scope1,scope2"));
   }
 
   @Test
@@ -93,9 +96,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_ROLE, "role1,role2")
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_SCOPE)));
+            span.hasAttribute(ENDUSER_ID, "principal")
+                .hasAttribute(ENDUSER_ROLE, "role1,role2")
+                .doesNotHave(attribute(ENDUSER_SCOPE)));
   }
 
   @Test
@@ -117,9 +120,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ROLE))
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_SCOPE)));
+            span.hasAttribute(ENDUSER_ID, "principal")
+                .doesNotHave(attribute(ENDUSER_ROLE))
+                .doesNotHave(attribute(ENDUSER_SCOPE)));
   }
 
   @Test
@@ -141,9 +144,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ID))
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_ROLE, "role1,role2")
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_SCOPE)));
+            span.doesNotHave(attribute(ENDUSER_ID))
+                .hasAttribute(ENDUSER_ROLE, "role1,role2")
+                .doesNotHave(attribute(ENDUSER_SCOPE)));
   }
 
   @Test
@@ -165,9 +168,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ID))
-                .doesNotHave(attribute(EnduserIncubatingAttributes.ENDUSER_ROLE))
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_SCOPE, "scope1,scope2"));
+            span.doesNotHave(attribute(ENDUSER_ID))
+                .doesNotHave(attribute(ENDUSER_ROLE))
+                .hasAttribute(ENDUSER_SCOPE, "scope1,scope2"));
   }
 
   @Test
@@ -193,9 +196,9 @@ class EnduserAttributesCapturerTest {
         capturer,
         authentication,
         span ->
-            span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_ROLE, "role1,role2")
-                .hasAttribute(EnduserIncubatingAttributes.ENDUSER_SCOPE, "scope1,scope2"));
+            span.hasAttribute(ENDUSER_ID, "principal")
+                .hasAttribute(ENDUSER_ROLE, "role1,role2")
+                .hasAttribute(ENDUSER_SCOPE, "scope1,scope2"));
   }
 
   void test(

--- a/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/servlet/EnduserAttributesCapturingServletFilterTest.java
+++ b/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/servlet/EnduserAttributesCapturingServletFilterTest.java
@@ -5,10 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.security.config.v6_0.servlet;
 
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ID;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ROLE;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_SCOPE;
+
 import io.opentelemetry.instrumentation.spring.security.config.v6_0.EnduserAttributesCapturer;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -76,8 +79,8 @@ class EnduserAttributesCapturingServletFilterTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                        .hasAttribute(EnduserIncubatingAttributes.ENDUSER_ROLE, "role1,role2")
-                        .hasAttribute(EnduserIncubatingAttributes.ENDUSER_SCOPE, "scope1,scope2")));
+                    span.hasAttribute(ENDUSER_ID, "principal")
+                        .hasAttribute(ENDUSER_ROLE, "role1,role2")
+                        .hasAttribute(ENDUSER_SCOPE, "scope1,scope2")));
   }
 }

--- a/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/webflux/EnduserAttributesCapturingWebFilterTest.java
+++ b/instrumentation/spring/spring-security-config-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/security/config/v6_0/webflux/EnduserAttributesCapturingWebFilterTest.java
@@ -5,12 +5,15 @@
 
 package io.opentelemetry.instrumentation.spring.security.config.v6_0.webflux;
 
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ID;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_ROLE;
+import static io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes.ENDUSER_SCOPE;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.reactor.v3_1.ContextPropagationOperator;
 import io.opentelemetry.instrumentation.spring.security.config.v6_0.EnduserAttributesCapturer;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.semconv.incubating.EnduserIncubatingAttributes;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -74,8 +77,8 @@ class EnduserAttributesCapturingWebFilterTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasAttribute(EnduserIncubatingAttributes.ENDUSER_ID, "principal")
-                        .hasAttribute(EnduserIncubatingAttributes.ENDUSER_ROLE, "role1,role2")
-                        .hasAttribute(EnduserIncubatingAttributes.ENDUSER_SCOPE, "scope1,scope2")));
+                    span.hasAttribute(ENDUSER_ID, "principal")
+                        .hasAttribute(ENDUSER_ROLE, "role1,role2")
+                        .hasAttribute(ENDUSER_SCOPE, "scope1,scope2")));
   }
 }

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/thread/internal/AddThreadDetailsSpanProcessorTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/thread/internal/AddThreadDetailsSpanProcessorTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.thread.internal;
 
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -13,7 +15,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 class AddThreadDetailsSpanProcessorTest {
@@ -32,8 +33,8 @@ class AddThreadDetailsSpanProcessorTest {
     Thread thread = Thread.currentThread();
     spanProcessor.onStart(Context.root(), span);
 
-    verify(span).setAttribute(ThreadIncubatingAttributes.THREAD_ID, thread.getId());
-    verify(span).setAttribute(ThreadIncubatingAttributes.THREAD_NAME, thread.getName());
+    verify(span).setAttribute(THREAD_ID, thread.getId());
+    verify(span).setAttribute(THREAD_NAME, thread.getName());
     verifyNoMoreInteractions(span);
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-2/src/testDeclarativeConfig/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -6,12 +6,13 @@
 package io.opentelemetry.spring.smoketest;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SERVICE_INSTANCE_ID;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServiceAttributes;
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,24 +57,22 @@ class OtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest {
                                 r.hasAttribute(
                                     // to make sure the declarative config is picked up
                                     // in application.yaml
-                                    ServiceAttributes.SERVICE_NAME,
-                                    "declarative-config-spring-boot-2")),
+                                    SERVICE_NAME, "declarative-config-spring-boot-2")),
                 span ->
                     span.hasKind(SpanKind.SERVER)
                         .hasResourceSatisfying(
                             r ->
                                 r.hasAttribute(
-                                        TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME,
-                                        "opentelemetry-spring-boot-starter")
+                                        TELEMETRY_DISTRO_NAME, "opentelemetry-spring-boot-starter")
                                     .hasAttribute(
                                         satisfies(
-                                            TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION,
+                                            TELEMETRY_DISTRO_VERSION,
                                             AbstractCharSequenceAssert::isNotBlank))
                                     .hasAttribute(
                                         satisfies(
-                                            ServiceIncubatingAttributes.SERVICE_INSTANCE_ID,
+                                            SERVICE_INSTANCE_ID,
                                             AbstractCharSequenceAssert::isNotBlank)))
-                        .hasAttribute(HttpAttributes.HTTP_ROUTE, "/ping"),
+                        .hasAttribute(HTTP_ROUTE, "/ping"),
                 AbstractSpringStarterSmokeTest::withSpanAssert));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-3.2/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-3.2/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.spring.smoketest;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.HttpAttributes;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,8 +44,7 @@ class OtelSpringStarterSmokeTest extends AbstractSpringStarterSmokeTest {
         traceAssert ->
             traceAssert.hasSpansSatisfyingExactly(
                 span -> HttpSpanDataAssert.create(span).assertClientGetRequest("/ping"),
-                span ->
-                    span.hasKind(SpanKind.SERVER).hasAttribute(HttpAttributes.HTTP_ROUTE, "/ping"),
+                span -> span.hasKind(SpanKind.SERVER).hasAttribute(HTTP_ROUTE, "/ping"),
                 span -> withSpanAssert(span)));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-4/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-4/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.spring.smoketest;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,8 +69,7 @@ class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {
         traceAssert ->
             traceAssert.hasSpansSatisfyingExactly(
                 span -> HttpSpanDataAssert.create(span).assertClientGetRequest("/ping"),
-                span ->
-                    span.hasKind(SpanKind.SERVER).hasAttribute(HttpAttributes.HTTP_ROUTE, "/ping"),
+                span -> span.hasKind(SpanKind.SERVER).hasAttribute(HTTP_ROUTE, "/ping"),
                 AbstractSpringStarterSmokeTest::withSpanAssert));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractKafkaSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractKafkaSpringStarterSmokeTest.java
@@ -7,11 +7,18 @@ package io.opentelemetry.spring.smoketest;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.assertj.core.api.AbstractLongAssert;
@@ -60,46 +67,35 @@ abstract class AbstractKafkaSpringStarterSmokeTest extends AbstractSpringStarter
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "publish"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
+                            equalTo(MESSAGING_OPERATION, "publish"),
                             satisfies(
                                 MESSAGING_CLIENT_ID,
                                 stringAssert -> stringAssert.startsWith("producer")),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
                 span ->
                     span.hasName("testTopic process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfying(
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME,
-                                "testTopic"),
-                            equalTo(MessagingIncubatingAttributes.MESSAGING_OPERATION, "process"),
+                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
+                            equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE,
-                                AbstractLongAssert::isNotNegative),
+                                MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID,
+                                MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
                             satisfies(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                AbstractLongAssert::isNotNegative),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(
-                                MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP,
-                                "testListener"),
+                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
+                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
+                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testListener"),
                             satisfies(
                                 AttributeKey.longKey("kafka.record.queue_time_ms"),
                                 AbstractLongAssert::isNotNegative),

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractMongodbSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractMongodbSpringStarterSmokeTest.java
@@ -7,10 +7,11 @@ package io.opentelemetry.spring.smoketest;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.stableDbSystemName;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.MONGODB;
 
 import com.mongodb.client.MongoClient;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +36,6 @@ abstract class AbstractMongodbSpringStarterSmokeTest extends AbstractSpringStart
                 span ->
                     span.hasKind(SpanKind.CLIENT)
                         .hasName("listDatabases admin")
-                        .hasAttribute(
-                            maybeStable(DbIncubatingAttributes.DB_SYSTEM),
-                            stableDbSystemName(
-                                DbIncubatingAttributes.DbSystemNameIncubatingValues.MONGODB))));
+                        .hasAttribute(maybeStable(DB_SYSTEM), stableDbSystemName(MONGODB))));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -7,6 +7,20 @@ package io.opentelemetry.spring.smoketest;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.CodeAttributes.CODE_FUNCTION_NAME;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION;
+import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_NAMESPACE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SERVICE_INSTANCE_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -22,15 +36,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.CodeAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -156,7 +161,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                     spanDataAssert
                         .hasKind(SpanKind.CLIENT)
                         .hasAttribute(
-                            DbIncubatingAttributes.DB_STATEMENT,
+                            DB_STATEMENT,
                             "create table customer (id bigint not null, name varchar not null, primary key (id))")),
         traceAssert ->
             traceAssert.hasSpansSatisfyingExactly(
@@ -164,11 +169,9 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                     clientSpan
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfying(
-                            satisfies(
-                                UrlAttributes.URL_FULL,
-                                stringAssert -> stringAssert.endsWith("/ping")),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            satisfies(ServerAttributes.SERVER_PORT, val -> val.isNotZero())),
+                            satisfies(URL_FULL, stringAssert -> stringAssert.endsWith("/ping")),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            satisfies(SERVER_PORT, val -> val.isNotZero())),
                 serverSpan ->
                     HttpSpanDataAssert.create(serverSpan)
                         .assertServerGetRequest("/ping")
@@ -179,24 +182,19 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                                     .hasAttribute(
                                         AttributeKey.stringKey("attributeFromYaml"), "true")
                                     .hasAttribute(
-                                        satisfies(
-                                            ServiceIncubatingAttributes.SERVICE_INSTANCE_ID,
-                                            val -> val.isNotBlank())))
+                                        satisfies(SERVICE_INSTANCE_ID, val -> val.isNotBlank())))
                         .hasAttributesSatisfying(
-                            equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(HttpAttributes.HTTP_ROUTE, "/ping"),
-                            equalTo(ServerAttributes.SERVER_ADDRESS, "localhost"),
-                            satisfies(
-                                ClientAttributes.CLIENT_ADDRESS,
-                                s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                            equalTo(HTTP_ROUTE, "/ping"),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            satisfies(CLIENT_ADDRESS, s -> s.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
                             equalTo(
                                 AttributeKey.stringArrayKey("http.request.header.key"),
                                 Collections.singletonList("value")),
-                            satisfies(ServerAttributes.SERVER_PORT, val -> val.isNotZero()),
-                            satisfies(ThreadIncubatingAttributes.THREAD_ID, val -> val.isNotZero()),
-                            satisfies(
-                                ThreadIncubatingAttributes.THREAD_NAME, val -> val.isNotBlank())),
+                            satisfies(SERVER_PORT, val -> val.isNotZero()),
+                            satisfies(THREAD_ID, val -> val.isNotZero()),
+                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
                 val -> withSpanAssert(val)));
 
     // Metric
@@ -246,15 +244,12 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
 
       if (SemconvStability.emitStableDatabaseSemconv()) {
         attributesAssert.containsEntry(
-            CodeAttributes.CODE_FUNCTION_NAME,
-            "org.springframework.boot.StartupInfoLogger.logStarting");
+            CODE_FUNCTION_NAME, "org.springframework.boot.StartupInfoLogger.logStarting");
       }
       if (SemconvStability.isEmitOldCodeSemconv()) {
         attributesAssert
-            .containsEntry(
-                CodeIncubatingAttributes.CODE_NAMESPACE,
-                "org.springframework.boot.StartupInfoLogger")
-            .containsEntry(CodeIncubatingAttributes.CODE_FUNCTION, "logStarting");
+            .containsEntry(CODE_NAMESPACE, "org.springframework.boot.StartupInfoLogger")
+            .containsEntry(CODE_FUNCTION, "logStarting");
       }
     }
   }
@@ -308,9 +303,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                 span -> span.hasName("server"),
                 span ->
                     span.hasKind(SpanKind.CLIENT)
-                        .hasAttribute(
-                            DbIncubatingAttributes.DB_STATEMENT,
-                            "select name from customer where id = 1")));
+                        .hasAttribute(DB_STATEMENT, "select name from customer where id = 1")));
   }
 
   @Test
@@ -321,8 +314,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
         traceAssert ->
             traceAssert.hasSpansSatisfyingExactly(
                 span -> HttpSpanDataAssert.create(span).assertClientGetRequest("/ping"),
-                span ->
-                    span.hasKind(SpanKind.SERVER).hasAttribute(HttpAttributes.HTTP_ROUTE, "/ping"),
+                span -> span.hasKind(SpanKind.SERVER).hasAttribute(HTTP_ROUTE, "/ping"),
                 span -> withSpanAssert(span)));
   }
 
@@ -336,8 +328,6 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                 span ->
                     HttpSpanDataAssert.create(span)
                         .assertClientGetRequest("/test?X-Goog-Signature=REDACTED"),
-                span ->
-                    span.hasKind(SpanKind.SERVER)
-                        .hasAttribute(HttpAttributes.HTTP_ROUTE, "/test")));
+                span -> span.hasKind(SpanKind.SERVER).hasAttribute(HTTP_ROUTE, "/test")));
   }
 }

--- a/smoke-tests-otel-starter/spring-boot-reactive-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelReactiveSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-reactive-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelReactiveSpringStarterSmokeTest.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.spring.smoketest;
 
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,14 +61,14 @@ public class AbstractOtelReactiveSpringStarterSmokeTest extends AbstractSpringSt
                             s ->
                                 assertThat(s.getName())
                                     .isEqualToIgnoringCase("SELECT testdb.PLAYER"))
-                        .hasAttribute(DbIncubatingAttributes.DB_NAME, "testdb")
+                        .hasAttribute(DB_NAME, "testdb")
                         // 2 is not replaced by ?,
                         // otel.instrumentation.common.db-statement-sanitizer.enabled=false
                         .hasAttributesSatisfying(
                             a ->
-                                assertThat(a.get(DbIncubatingAttributes.DB_STATEMENT))
+                                assertThat(a.get(DB_STATEMENT))
                                     .isEqualToIgnoringCase(
                                         "SELECT PLAYER.* FROM PLAYER WHERE PLAYER.ID = $1 LIMIT 2"))
-                        .hasAttribute(DbIncubatingAttributes.DB_SYSTEM, "h2")));
+                        .hasAttribute(DB_SYSTEM, "h2")));
   }
 }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/DeclarativeConfigurationSmokeTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/DeclarativeConfigurationSmokeTest.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.smoketest;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes.CONTAINER_ID;
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_NAME;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME;
 
-import io.opentelemetry.semconv.ServiceAttributes;
-import io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,21 +43,11 @@ class DeclarativeConfigurationSmokeTest extends AbstractSmokeTest<Integer> {
                     span.hasResourceSatisfying(
                         resource ->
                             resource
+                                .hasAttribute(SERVICE_NAME, "declarative-config-smoke-test")
+                                .hasAttribute(satisfies(CONTAINER_ID, v -> v.isNotBlank()))
                                 .hasAttribute(
-                                    ServiceAttributes.SERVICE_NAME, "declarative-config-smoke-test")
-                                .hasAttribute(
-                                    satisfies(
-                                        ContainerIncubatingAttributes.CONTAINER_ID,
-                                        v -> v.isNotBlank()))
-                                .hasAttribute(
-                                    satisfies(
-                                        ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH,
-                                        v -> v.isNotBlank()))
-                                .hasAttribute(
-                                    satisfies(
-                                        HostIncubatingAttributes.HOST_NAME, v -> v.isNotBlank()))
-                                .hasAttribute(
-                                    TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME,
-                                    "opentelemetry-javaagent"))));
+                                    satisfies(PROCESS_EXECUTABLE_PATH, v -> v.isNotBlank()))
+                                .hasAttribute(satisfies(HOST_NAME, v -> v.isNotBlank()))
+                                .hasAttribute(TELEMETRY_DISTRO_NAME, "opentelemetry-javaagent"))));
   }
 }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/GrpcSmokeTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/GrpcSmokeTest.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.smoketest;
 
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 import java.time.Duration;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,8 +50,7 @@ class GrpcSmokeTest extends AbstractSmokeTest<Integer> {
                           .hasResourceSatisfying(
                               resource ->
                                   resource.hasAttribute(
-                                      TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION,
-                                      getAgentVersion())),
+                                      TELEMETRY_DISTRO_VERSION, getAgentVersion())),
                   span -> span.hasName("TestService.withSpan")));
 
       // Verify correct traceIds are logged via MDC instrumentation

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/PlaySmokeTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/PlaySmokeTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.smoketest;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.time.Duration;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,7 +44,7 @@ class PlaySmokeTest extends AbstractSmokeTest<Integer> {
                 span ->
                     span.hasName("GET /welcome")
                         .hasKind(SpanKind.SERVER)
-                        .hasAttribute(HttpAttributes.HTTP_ROUTE, "/welcome"),
+                        .hasAttribute(HTTP_ROUTE, "/welcome"),
                 span -> span.hasName("/welcome").hasKind(SpanKind.INTERNAL)));
   }
 }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/QuarkusSmokeTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/QuarkusSmokeTest.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.smoketest;
 
-import io.opentelemetry.semconv.ServiceAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
+
 import java.time.Duration;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,10 +43,8 @@ class QuarkusSmokeTest extends AbstractSmokeTest<Integer> {
                         .hasResourceSatisfying(
                             resource -> {
                               resource
-                                  .hasAttribute(
-                                      TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION,
-                                      getAgentVersion())
-                                  .hasAttribute(ServiceAttributes.SERVICE_NAME, "quarkus");
+                                  .hasAttribute(TELEMETRY_DISTRO_VERSION, getAgentVersion())
+                                  .hasAttribute(SERVICE_NAME, "quarkus");
                             })));
   }
 }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/SpringBootSmokeTest.java
@@ -7,12 +7,14 @@ package io.opentelemetry.smoketest;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.semconv.ServiceAttributes;
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -42,23 +44,16 @@ class SpringBootSmokeTest extends AbstractSmokeTest<Integer> {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("GET /greeting")
-                        .hasAttribute(
-                            satisfies(ThreadIncubatingAttributes.THREAD_ID, a -> a.isNotNull()))
-                        .hasAttribute(
-                            satisfies(ThreadIncubatingAttributes.THREAD_NAME, a -> a.isNotBlank()))
+                        .hasAttribute(satisfies(THREAD_ID, a -> a.isNotNull()))
+                        .hasAttribute(satisfies(THREAD_NAME, a -> a.isNotBlank()))
                         .hasResourceSatisfying(
                             resource ->
                                 resource
-                                    .hasAttribute(
-                                        TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION,
-                                        getAgentVersion())
-                                    .hasAttribute(
-                                        satisfies(
-                                            OsIncubatingAttributes.OS_TYPE, a -> a.isNotNull()))
+                                    .hasAttribute(TELEMETRY_DISTRO_VERSION, getAgentVersion())
+                                    .hasAttribute(satisfies(OS_TYPE, a -> a.isNotNull()))
                                     .hasAttribute(AttributeKey.stringKey("foo"), "bar")
-                                    .hasAttribute(
-                                        ServiceAttributes.SERVICE_NAME, "otel-spring-test-app")
-                                    .hasAttribute(ServiceAttributes.SERVICE_VERSION, "1.2.3")),
+                                    .hasAttribute(SERVICE_NAME, "otel-spring-test-app")
+                                    .hasAttribute(SERVICE_VERSION, "1.2.3")),
                 span -> span.hasName("WebController.withSpan")));
 
     // Check agent version is logged on startup

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/appserver/AppServerTest.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/appserver/AppServerTest.java
@@ -7,9 +7,14 @@ package io.opentelemetry.smoketest.appserver;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE;
 import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.LINUX;
 import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OsTypeIncubatingValues.WINDOWS;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -17,10 +22,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 import io.opentelemetry.smoketest.AbstractSmokeTest;
 import io.opentelemetry.smoketest.TestContainerManager;
 import io.opentelemetry.smoketest.TestImageVersions;
@@ -107,10 +108,10 @@ public abstract class AppServerTest extends AbstractSmokeTest<AppServerImage> {
                     assertSpan(span)
                         .hasName("GET")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttribute(UrlAttributes.URL_FULL, "http://localhost:8080/app/headers"),
+                        .hasAttribute(URL_FULL, "http://localhost:8080/app/headers"),
                 span ->
                     assertServerSpan(span, "/app/headers")
-                        .hasAttribute(ClientAttributes.CLIENT_ADDRESS, "127.0.0.1")));
+                        .hasAttribute(CLIENT_ADDRESS, "127.0.0.1")));
 
     // trace id is present in the HTTP headers as reported by the called endpoint
     assertThat(responseBody).contains(getSpanTraceIds().iterator().next());
@@ -225,16 +226,15 @@ public abstract class AppServerTest extends AbstractSmokeTest<AppServerImage> {
             resource ->
                 resource
                     .hasAttribute(OS_TYPE, getExpectedOsType())
-                    .hasAttribute(
-                        TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION, getAgentVersion()))
-        .hasAttribute(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1");
+                    .hasAttribute(TELEMETRY_DISTRO_VERSION, getAgentVersion()))
+        .hasAttribute(NETWORK_PROTOCOL_VERSION, "1.1");
   }
 
   private SpanDataAssert assertServerSpan(SpanDataAssert span, String path) {
     return assertSpan(span)
         .hasName(getSpanName(path))
         .hasKind(SpanKind.SERVER)
-        .hasAttribute(UrlAttributes.URL_PATH, path);
+        .hasAttribute(URL_PATH, path);
   }
 
   private static void getAndAssertServerSpan(Consumer<SpanDataAssert> assertion) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -10,6 +10,23 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.co
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD_ORIGINAL;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_RESEND_COUNT;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME;
+import static io.opentelemetry.semconv.incubating.UrlIncubatingAttributes.URL_TEMPLATE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -26,15 +43,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.UrlIncubatingAttributes;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -151,7 +160,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
                 span ->
                     assertClientSpan(span, uri, HttpConstants._OTHER, responseCode, null)
                         .hasNoParent()
-                        .hasAttribute(HttpAttributes.HTTP_REQUEST_METHOD_ORIGINAL, method)));
+                        .hasAttribute(HTTP_REQUEST_METHOD_ORIGINAL, method)));
   }
 
   @ParameterizedTest
@@ -275,7 +284,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     if (options.isLowLevelInstrumentation()) {
       testing.waitAndAssertSortedTraces(
-          comparingRootSpanAttribute(HttpAttributes.HTTP_REQUEST_RESEND_COUNT),
+          comparingRootSpanAttribute(HTTP_REQUEST_RESEND_COUNT),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -315,7 +324,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     if (options.isLowLevelInstrumentation()) {
       testing.waitAndAssertSortedTraces(
-          comparingRootSpanAttribute(HttpAttributes.HTTP_REQUEST_RESEND_COUNT),
+          comparingRootSpanAttribute(HTTP_REQUEST_RESEND_COUNT),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -374,7 +383,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     if (options.isLowLevelInstrumentation()) {
       testing.waitAndAssertSortedTraces(
-          comparingRootSpanAttribute(HttpAttributes.HTTP_REQUEST_RESEND_COUNT),
+          comparingRootSpanAttribute(HTTP_REQUEST_RESEND_COUNT),
           IntStream.range(0, options.getMaxRedirects())
               .mapToObj(i -> makeCircularRedirectAssertForLolLevelTrace(uri, method, i))
               .collect(Collectors.toList()));
@@ -421,7 +430,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     if (options.isLowLevelInstrumentation()) {
       testing.waitAndAssertSortedTraces(
-          comparingRootSpanAttribute(HttpAttributes.HTTP_REQUEST_RESEND_COUNT),
+          comparingRootSpanAttribute(HTTP_REQUEST_RESEND_COUNT),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -1071,10 +1080,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
         .hasAttributesSatisfying(
             attrs -> {
               // Check for service.peer.name when running with javaagent instrumentation
-              String distroName =
-                  span.actual()
-                      .getResource()
-                      .getAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME);
+              String distroName = span.actual().getResource().getAttribute(TELEMETRY_DISTRO_NAME);
               if ("opentelemetry-java-instrumentation".equals(distroName)) {
                 String expectedServicePeerName = options.getExpectedServicePeerName().apply(uri);
                 if (expectedServicePeerName != null) {
@@ -1085,83 +1091,78 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
               // we're opting out of these attributes in the new semconv
               assertThat(attrs)
-                  .doesNotContainKey(NetworkAttributes.NETWORK_TRANSPORT)
-                  .doesNotContainKey(NetworkAttributes.NETWORK_TYPE)
-                  .doesNotContainKey(NetworkAttributes.NETWORK_PROTOCOL_NAME);
-              if (httpClientAttributes.contains(NetworkAttributes.NETWORK_PROTOCOL_VERSION)) {
+                  .doesNotContainKey(NETWORK_TRANSPORT)
+                  .doesNotContainKey(NETWORK_TYPE)
+                  .doesNotContainKey(NETWORK_PROTOCOL_NAME);
+              if (httpClientAttributes.contains(NETWORK_PROTOCOL_VERSION)) {
                 assertThat(attrs)
                     .containsEntry(
-                        NetworkAttributes.NETWORK_PROTOCOL_VERSION,
-                        options.getHttpProtocolVersion().apply(uri));
+                        NETWORK_PROTOCOL_VERSION, options.getHttpProtocolVersion().apply(uri));
               }
 
-              if (httpClientAttributes.contains(ServerAttributes.SERVER_ADDRESS)) {
-                assertThat(attrs).containsEntry(ServerAttributes.SERVER_ADDRESS, uri.getHost());
+              if (httpClientAttributes.contains(SERVER_ADDRESS)) {
+                assertThat(attrs).containsEntry(SERVER_ADDRESS, uri.getHost());
               }
-              if (httpClientAttributes.contains(ServerAttributes.SERVER_PORT)) {
+              if (httpClientAttributes.contains(SERVER_PORT)) {
                 int uriPort = uri.getPort();
                 if (uriPort <= 0) {
-                  if (attrs.get(ServerAttributes.SERVER_PORT) != null) {
+                  if (attrs.get(SERVER_PORT) != null) {
                     int effectivePort = "https".equals(uri.getScheme()) ? 443 : 80;
-                    assertThat(attrs).containsEntry(ServerAttributes.SERVER_PORT, effectivePort);
+                    assertThat(attrs).containsEntry(SERVER_PORT, effectivePort);
                   }
                   // alternatively, peer port is not emitted -- and that's fine too
                 } else {
-                  assertThat(attrs).containsEntry(ServerAttributes.SERVER_PORT, uriPort);
+                  assertThat(attrs).containsEntry(SERVER_PORT, uriPort);
                 }
               }
 
               if (uri.getPort() != PortUtils.UNUSABLE_PORT && !uri.getHost().equals("192.0.2.1")) {
                 // TODO: Move to test knob rather than always treating as optional
-                if (attrs.get(NetworkAttributes.NETWORK_PEER_ADDRESS) != null) {
+                if (attrs.get(NETWORK_PEER_ADDRESS) != null) {
                   assertThat(attrs)
                       .hasEntrySatisfying(
-                          NetworkAttributes.NETWORK_PEER_ADDRESS,
+                          NETWORK_PEER_ADDRESS,
                           addr -> assertThat(addr).isIn("127.0.0.1", "0:0:0:0:0:0:0:1"));
                 }
-                if (attrs.get(NetworkAttributes.NETWORK_PEER_PORT) != null) {
+                if (attrs.get(NETWORK_PEER_PORT) != null) {
                   assertThat(attrs)
                       .containsEntry(
-                          NetworkAttributes.NETWORK_PEER_PORT,
+                          NETWORK_PEER_PORT,
                           Objects.equals(uri.getScheme(), "https")
                               ? server.httpsPort()
                               : server.httpPort());
                 }
               }
 
-              if (httpClientAttributes.contains(UrlAttributes.URL_FULL)) {
-                assertThat(attrs).containsEntry(UrlAttributes.URL_FULL, uri.toString());
+              if (httpClientAttributes.contains(URL_FULL)) {
+                assertThat(attrs).containsEntry(URL_FULL, uri.toString());
               }
               String expectedUrlTemplate = options.getExpectedUrlTemplateMapper().apply(uri);
               if (expectedUrlTemplate != null) {
-                assertThat(attrs)
-                    .containsEntry(UrlIncubatingAttributes.URL_TEMPLATE, expectedUrlTemplate);
+                assertThat(attrs).containsEntry(URL_TEMPLATE, expectedUrlTemplate);
               }
-              if (httpClientAttributes.contains(HttpAttributes.HTTP_REQUEST_METHOD)) {
-                assertThat(attrs).containsEntry(HttpAttributes.HTTP_REQUEST_METHOD, method);
+              if (httpClientAttributes.contains(HTTP_REQUEST_METHOD)) {
+                assertThat(attrs).containsEntry(HTTP_REQUEST_METHOD, method);
               }
 
               // opt-in, not collected by default
-              assertThat(attrs).doesNotContainKey(UserAgentAttributes.USER_AGENT_ORIGINAL);
+              assertThat(attrs).doesNotContainKey(USER_AGENT_ORIGINAL);
 
               if (responseCode != null) {
-                assertThat(attrs)
-                    .containsEntry(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, (long) responseCode);
+                assertThat(attrs).containsEntry(HTTP_RESPONSE_STATUS_CODE, (long) responseCode);
                 if (responseCode >= 400) {
-                  assertThat(attrs)
-                      .containsEntry(ErrorAttributes.ERROR_TYPE, String.valueOf(responseCode));
+                  assertThat(attrs).containsEntry(ERROR_TYPE, String.valueOf(responseCode));
                 }
               } else {
-                assertThat(attrs).doesNotContainKey(HttpAttributes.HTTP_RESPONSE_STATUS_CODE);
+                assertThat(attrs).doesNotContainKey(HTTP_RESPONSE_STATUS_CODE);
                 // TODO: add more detailed assertions, per url
-                assertThat(attrs).containsKey(ErrorAttributes.ERROR_TYPE);
+                assertThat(attrs).containsKey(ERROR_TYPE);
               }
 
               if (resendCount != null) {
-                assertThat(attrs)
-                    .containsEntry(HttpAttributes.HTTP_REQUEST_RESEND_COUNT, (long) resendCount);
+                assertThat(attrs).containsEntry(HTTP_REQUEST_RESEND_COUNT, (long) resendCount);
               } else {
-                assertThat(attrs).doesNotContainKey(HttpAttributes.HTTP_REQUEST_RESEND_COUNT);
+                assertThat(attrs).doesNotContainKey(HTTP_REQUEST_RESEND_COUNT);
               }
             })
         .satisfies(

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -17,6 +17,25 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
+import static io.opentelemetry.semconv.ClientAttributes.CLIENT_PORT;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD_ORIGINAL;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.UrlAttributes.URL_QUERY;
+import static io.opentelemetry.semconv.UrlAttributes.URL_SCHEME;
+import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -38,14 +57,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.ClientAttributes;
-import io.opentelemetry.semconv.ErrorAttributes;
-import io.opentelemetry.semconv.HttpAttributes;
-import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.SchemaUrls;
-import io.opentelemetry.semconv.ServerAttributes;
-import io.opentelemetry.semconv.UrlAttributes;
-import io.opentelemetry.semconv.UserAgentAttributes;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpData;
@@ -553,7 +565,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
                               HttpConstants._OTHER,
                               SUCCESS,
                               options.responseCodeOnNonStandardHttpMethod)
-                          .hasAttribute(HttpAttributes.HTTP_REQUEST_METHOD_ORIGINAL, method)));
+                          .hasAttribute(HTTP_REQUEST_METHOD_ORIGINAL, method)));
     } finally {
       eventLoopGroup.shutdownGracefully().await(10, SECONDS);
     }
@@ -855,62 +867,59 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
         attrs -> {
           // we're opting out of these attributes in the new semconv
           assertThat(attrs)
-              .doesNotContainKey(NetworkAttributes.NETWORK_TRANSPORT)
-              .doesNotContainKey(NetworkAttributes.NETWORK_TYPE)
-              .doesNotContainKey(NetworkAttributes.NETWORK_PROTOCOL_NAME);
+              .doesNotContainKey(NETWORK_TRANSPORT)
+              .doesNotContainKey(NETWORK_TYPE)
+              .doesNotContainKey(NETWORK_PROTOCOL_NAME);
 
-          if (attrs.get(NetworkAttributes.NETWORK_PROTOCOL_VERSION) != null) {
+          if (attrs.get(NETWORK_PROTOCOL_VERSION) != null) {
             assertThat(attrs)
-                .containsEntry(
-                    NetworkAttributes.NETWORK_PROTOCOL_VERSION, options.useHttp2 ? "2" : "1.1");
+                .containsEntry(NETWORK_PROTOCOL_VERSION, options.useHttp2 ? "2" : "1.1");
           }
 
-          assertThat(attrs).containsEntry(ServerAttributes.SERVER_ADDRESS, "localhost");
+          assertThat(attrs).containsEntry(SERVER_ADDRESS, "localhost");
           // TODO: Move to test knob rather than always treating as optional
           // TODO: once httpAttributes test knob is used, verify default port values
-          if (attrs.get(ServerAttributes.SERVER_PORT) != null) {
-            assertThat(attrs).containsEntry(ServerAttributes.SERVER_PORT, port);
+          if (attrs.get(SERVER_PORT) != null) {
+            assertThat(attrs).containsEntry(SERVER_PORT, port);
           }
 
-          if (attrs.get(NetworkAttributes.NETWORK_PEER_ADDRESS) != null) {
+          if (attrs.get(NETWORK_PEER_ADDRESS) != null) {
             assertThat(attrs)
-                .containsEntry(
-                    NetworkAttributes.NETWORK_PEER_ADDRESS, options.sockPeerAddr.apply(endpoint));
+                .containsEntry(NETWORK_PEER_ADDRESS, options.sockPeerAddr.apply(endpoint));
           }
-          if (attrs.get(NetworkAttributes.NETWORK_PEER_PORT) != null) {
+          if (attrs.get(NETWORK_PEER_PORT) != null) {
             assertThat(attrs)
                 .hasEntrySatisfying(
-                    NetworkAttributes.NETWORK_PEER_PORT,
+                    NETWORK_PEER_PORT,
                     value ->
                         assertThat(value)
                             .isInstanceOf(Long.class)
                             .isNotEqualTo(Long.valueOf(port)));
           }
 
-          assertThat(attrs).containsEntry(ClientAttributes.CLIENT_ADDRESS, TEST_CLIENT_IP);
+          assertThat(attrs).containsEntry(CLIENT_ADDRESS, TEST_CLIENT_IP);
           // client.port is opt-in
-          assertThat(attrs).doesNotContainKey(ClientAttributes.CLIENT_PORT);
+          assertThat(attrs).doesNotContainKey(CLIENT_PORT);
 
-          assertThat(attrs).containsEntry(HttpAttributes.HTTP_REQUEST_METHOD, method);
+          assertThat(attrs).containsEntry(HTTP_REQUEST_METHOD, method);
 
-          assertThat(attrs).containsEntry(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, statusCode);
+          assertThat(attrs).containsEntry(HTTP_RESPONSE_STATUS_CODE, statusCode);
           if (statusCode >= 500) {
-            assertThat(attrs).containsEntry(ErrorAttributes.ERROR_TYPE, String.valueOf(statusCode));
+            assertThat(attrs).containsEntry(ERROR_TYPE, String.valueOf(statusCode));
           }
 
-          assertThat(attrs).containsEntry(UserAgentAttributes.USER_AGENT_ORIGINAL, TEST_USER_AGENT);
+          assertThat(attrs).containsEntry(USER_AGENT_ORIGINAL, TEST_USER_AGENT);
 
-          assertThat(attrs).containsEntry(UrlAttributes.URL_SCHEME, "http");
+          assertThat(attrs).containsEntry(URL_SCHEME, "http");
           if (endpoint != INDEXED_CHILD) {
-            assertThat(attrs)
-                .containsEntry(UrlAttributes.URL_PATH, endpoint.resolvePath(address).getPath());
+            assertThat(attrs).containsEntry(URL_PATH, endpoint.resolvePath(address).getPath());
             if (endpoint.getQuery() != null) {
-              assertThat(attrs).containsEntry(UrlAttributes.URL_QUERY, endpoint.getQuery());
+              assertThat(attrs).containsEntry(URL_QUERY, endpoint.getQuery());
             }
           }
 
-          if (httpAttributes.contains(HttpAttributes.HTTP_ROUTE) && expectedRoute != null) {
-            assertThat(attrs).containsEntry(HttpAttributes.HTTP_ROUTE, expectedRoute);
+          if (httpAttributes.contains(HTTP_ROUTE) && expectedRoute != null) {
+            assertThat(attrs).containsEntry(HTTP_ROUTE, expectedRoute);
           }
 
           if (endpoint == CAPTURE_HEADERS) {
@@ -938,8 +947,8 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
     String method = "GET";
     return assertServerSpan(span, method, endpoint, endpoint.status)
         .hasAttributesSatisfying(
-            equalTo(UrlAttributes.URL_PATH, endpoint.resolvePath(address).getPath()),
-            equalTo(UrlAttributes.URL_QUERY, "id=" + requestId));
+            equalTo(URL_PATH, endpoint.resolvePath(address).getPath()),
+            equalTo(URL_QUERY, "id=" + requestId));
   }
 
   @CanIgnoreReturnValue
@@ -958,7 +967,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
   }
 
   public final boolean hasHttpRouteAttribute(ServerEndpoint endpoint) {
-    return options.httpAttributes.apply(endpoint).contains(HttpAttributes.HTTP_ROUTE);
+    return options.httpAttributes.apply(endpoint).contains(HTTP_ROUTE);
   }
 
   public final boolean hasHandlerSpan(ServerEndpoint endpoint) {


### PR DESCRIPTION
Probably everywhere, but at least starting in tests where it makes the most improvement.

Used (and then `git add '*Test.java'`):

```
#!/bin/bash
# Convert qualified io.opentelemetry.semconv.** constant references to static imports,
# except for io.opentelemetry.semconv.SchemaUrls.* constants.
# Run ./gradlew spotlessApply afterward to fix import ordering.

set -e

# ── Phase 1: Convert non-static class imports to static member imports ──
# e.g. import io.opentelemetry.semconv.HttpAttributes;
#      HttpAttributes.HTTP_REQUEST_METHOD  →  HTTP_REQUEST_METHOD

grep -rl --include="*.java" -P 'import io\.opentelemetry\.semconv\.' . \
  | sort -u | while read -r file; do

  # Extract non-static semconv imports from this file (exclude SchemaUrls)
  IMPORTS=$(grep -P '^import io\.opentelemetry\.semconv\.' "$file" \
    | grep -v '^import static ' \
    | grep -v '\.SchemaUrls;' \
    | sed 's/^import \(.*\);$/\1/' || true)

  if [ -z "$IMPORTS" ]; then
    continue
  fi

  echo "Processing (phase 1): $file"

  for fqcn in $IMPORTS; do
    # Extract simple class name (e.g. HttpAttributes from io.opentelemetry.semconv.HttpAttributes)
    classname="${fqcn##*.}"

    # Discover all members referenced as ClassName.MEMBER in the file (outside import lines)
    MEMBERS=$(grep -v "^import " "$file" \
      | grep -oP "(?<![\\w.])${classname}\\.\w+" \
      | sed "s/${classname}\\.//" \
      | sort -u \
      | grep -v '^class$' || true)

    if [ -z "$MEMBERS" ]; then
      continue
    fi

    for member in $MEMBERS; do
      # Check if the member is used qualified (outside import lines)
      has_qualified=$(grep -v "^import " "$file" \
        | grep -cP "(?<![\w.])${classname}\.${member}(?!\w)" || true)

      if [ "$has_qualified" -gt 0 ]; then
        # If the member is an inner *Values class (starts uppercase, ends with "Values"),
        # use a non-static import (static import of types triggers UnnecessaryStaticImport).
        if echo "$member" | grep -qP '^[A-Z].*Values$'; then
          if ! grep -q "import ${fqcn}\\.${member};" "$file"; then
            sed -i "0,/^import /s//import ${fqcn}.${member};\nimport /" "$file"
          fi
        else
          # Add static import if not already present
          if ! grep -q "import static ${fqcn}\\.${member};" "$file"; then
            sed -i "0,/^import /s//import static ${fqcn}.${member};\nimport /" "$file"
          fi
        fi

        # Replace qualified references with unqualified (skip import lines)
        sed -i -E "/^import /!s/(^|[^[:alnum:]_.])${classname}\\.${member}\\b/\1${member}/g" "$file"
      fi
    done

    # Remove the non-static import if no other qualified usage of the class remains outside imports
    if ! grep -v "^import " "$file" | grep -qP "(?<![\w.])${classname}(?!\w)"; then
      sed -i "/^import ${fqcn//./\\.};$/d" "$file"
    fi
  done
done

# ── Phase 2: Convert inner *Values class imports to static constant imports ──
# Handles:
#   a) import ...OuterAttributes.InnerValues;          InnerValues.CONST  →  CONST
#   b) import static ...OuterAttributes.InnerValues;   InnerValues.CONST  →  CONST
# Also handles fully-qualified OuterAttributes.InnerValues.CONST left over from phase 1 clean-up.

grep -rl --include="*.java" -P '(import static |import )io\.opentelemetry\.semconv\.' . \
  | sort -u | while read -r file; do

  # Find imports of inner *Values classes (both static and non-static)
  # e.g. import static ...RpcIncubatingAttributes.RpcSystemIncubatingValues;
  #      import ...MessagingIncubatingAttributes.MessagingSystemIncubatingValues;
  VALUES_IMPORTS=$(grep -P '^import (static )?io\.opentelemetry\.semconv\..*\.[A-Z]\w*Values;$' "$file" \
    | grep -v '\.SchemaUrls;' \
    | sed 's/^import static \(.*\);$/\1/' \
    | sed 's/^import \(.*\);$/\1/' \
    | sort -u || true)

  for fqinner in $VALUES_IMPORTS; do
    innername="${fqinner##*.}"

    # Discover constant references as InnerValues.CONST in the file body
    CONSTS=$(grep -v "^import " "$file" \
      | grep -oP "(?<![\\w.])${innername}\\.[A-Z_]\\w*" \
      | sed "s/${innername}\\.//" \
      | sort -u || true)

    if [ -z "$CONSTS" ]; then
      continue
    fi

    echo "Processing (phase 2 - values class): $file  [$innername]"

    for cst in $CONSTS; do
      has_qualified=$(grep -v "^import " "$file" \
        | grep -cP "(?<![\w.])${innername}\\.${cst}(?!\w)" || true)

      if [ "$has_qualified" -gt 0 ]; then
        # Add static import of the individual constant if not already present
        if ! grep -q "import static ${fqinner}\\.${cst};" "$file"; then
          sed -i "0,/^import /s//import static ${fqinner}.${cst};\nimport /" "$file"
        fi

        # Replace InnerValues.CONST with CONST (skip import lines)
        sed -i -E "/^import /!s/(^|[^[:alnum:]_.])${innername}\\.${cst}\\b/\1${cst}/g" "$file"
      fi
    done

    # Remove the inner-class import (static or non-static) if no other qualified usage remains
    if ! grep -v "^import " "$file" | grep -qP "(?<![\w.])${innername}(?!\w)"; then
      sed -i "/^import static ${fqinner//./\\.};$/d" "$file"
      sed -i "/^import ${fqinner//./\\.};$/d" "$file"
    fi
  done
done

echo ""
echo "Done! Now run: ./gradlew spotlessApply"
```