### PR TITLE
Enforce some static imports via checkstyle

### DIFF
--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -64,6 +64,26 @@
       <property name="message"
                 value="Please statically import methods from Assertions (OpenTelemetryAssertions extends Assertions)"/>
     </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^(?!.*import).*\bObjects\.requireNonNull\b"/>
+      <property name="message" value="Please statically import Objects.requireNonNull"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^(?!.*import).*\bElementMatchers\.[a-z]"/>
+      <property name="message" value="Please statically import methods from ElementMatchers"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^(?!.*import).*\bAgentElementMatchers\.[a-z]"/>
+      <property name="message" value="Please statically import methods from AgentElementMatchers"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^(?!.*import).*\bTimeUnit\.[A-Z]"/>
+      <property name="message" value="Please statically import constants from TimeUnit"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^(?!.*import).*\bStandardCharsets\.[A-Z]"/>
+      <property name="message" value="Please statically import constants from StandardCharsets"/>
+    </module>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/OtelUnnecessarilyFullyQualified.java
+++ b/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/OtelUnnecessarilyFullyQualified.java
@@ -30,6 +30,7 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isGeneratedConstructor;
 import static com.google.errorprone.util.FindIdentifiers.findIdent;
 import static com.sun.tools.javac.code.Kinds.KindSelector.VAL_TYP;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
 
 import com.google.auto.service.AutoService;
@@ -331,7 +332,7 @@ public final class OtelUnnecessarilyFullyQualified extends BugChecker
       if (EXEMPTED_NAMES.contains(nameString)) {
         continue;
       }
-      List<TreePath> pathsToFix = Objects.requireNonNull(getOnlyElement(types.values()));
+      List<TreePath> pathsToFix = requireNonNull(getOnlyElement(types.values()));
       Set<Symbol> meaningAtUsageSites =
           pathsToFix.stream()
               .map(path -> findIdent(nameString, state.withPath(path), VAL_TYP))
@@ -344,7 +345,7 @@ public final class OtelUnnecessarilyFullyQualified extends BugChecker
       // Only add the import if any of the usage sites don't already resolve to this type.
       if (meaningAtUsageSites.stream().anyMatch(Objects::isNull)) {
         fixBuilder.addImport(
-            Objects.requireNonNull(getOnlyElement(types.keySet())).getQualifiedName().toString());
+            requireNonNull(getOnlyElement(types.keySet())).getQualifiedName().toString());
       }
       for (TreePath path : pathsToFix) {
         fixBuilder.replace(path.getLeaf(), nameString);


### PR DESCRIPTION
Add enforcement of these static imports via checkstyle rule:

- `Objects.requireNonNull`
- `ElementMatchers` methods
- `AgentElementMatchers` methods
- `TimeUnit` constants (e.g. `MILLISECONDS`, `SECONDS`)
- `StandardCharsets` constants (e.g. `UTF_8`)