### PR TITLE
Undo elasticsearch muzzle skip

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/build.gradle.kts
@@ -21,9 +21,7 @@ muzzle {
     versions.set("[5.0.0,5.3.0)")
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    // 9.3.0 has missing org.elasticsearch:exponential-histogram
-    // see https://github.com/elastic/elasticsearch/issues/141846
-    skip("7.11.0", "9.3.0")
+    skip("7.11.0")
     // version 8.8.0 depends on elasticsearch:elasticsearch-preallocate which doesn't exist
     excludeDependency("org.elasticsearch:elasticsearch-preallocate")
     assertInverse.set(true)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -21,9 +21,7 @@ muzzle {
     versions.set("[5.3.0,6.0.0)")
     // version 7.11.0 depends on org.elasticsearch:elasticsearch-plugin-classloader:7.11.0
     // which does not exist
-    // 9.3.0 has missing org.elasticsearch:exponential-histogram
-    // see https://github.com/elastic/elasticsearch/issues/141846
-    skip("7.11.0", "9.3.0")
+    skip("7.11.0")
     // version 8.8.0 depends on elasticsearch:elasticsearch-preallocate which doesn't exist
     excludeDependency("org.elasticsearch:elasticsearch-preallocate")
     assertInverse.set(true)

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -21,9 +21,7 @@ muzzle {
     versions.set("[6.0.0,8.0.0)")
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    // 9.3.0 has missing org.elasticsearch:exponential-histogram
-    // see https://github.com/elastic/elasticsearch/issues/141846
-    skip("7.11.0", "9.3.0")
+    skip("7.11.0")
     // version 8.8.0 depends on elasticsearch:elasticsearch-preallocate which doesn't exist
     excludeDependency("org.elasticsearch:elasticsearch-preallocate")
     assertInverse.set(true)


### PR DESCRIPTION
Reverts #16100 now that the artifact is published.

Related to https://github.com/elastic/elasticsearch/issues/141846#issuecomment-3926367680

The remaining [muzzle failure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/22181043942/job/64142097143?pr=16231) is for something else and is unrelated to this change

```
* What went wrong:
Configuration cache state could not be cached: field `$configFiles` of `Io_opentelemetry_instrumentation_muzzle_check_gradle$addMuzzleTask$muzzleTask$1$1` bean found in field `action` of `org.gradle.api.internal.AbstractTask$TaskActionWrapper` bean found in field `actions` of task `:instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagent:muzzle-AssertPass-org.springframework.boot-spring-boot-actuator-autoconfigure-3.5.11` of type `org.gradle.api.DefaultTask`: error writing value of type 'org.gradle.api.internal.artifacts.configurations.ResolutionBackedFileCollection'
> Could not resolve all files for configuration ':instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagent:muzzle-AssertPass-org.springframework.boot-spring-boot-actuator-autoconfigure-3.5.11'.
   > Could not find org.springframework.boot:spring-boot-actuator:3.5.11.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-actuator/3.5.11/spring-boot-actuator-3.5.11.pom
       - file:/home/runner/.m2/repository/org/springframework/boot/spring-boot-actuator/3.5.11/spring-boot-actuator-3.5.11.pom
     Required by:
         project ':instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagent' > org.springframework.boot:spring-boot-actuator-autoconfigure:3.5.11
```