### PR TITLE
Include static imports in spotlessApply

### DIFF
--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -64,26 +64,6 @@
       <property name="message"
                 value="Please statically import methods from Assertions (OpenTelemetryAssertions extends Assertions)"/>
     </module>
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="^(?!.*import).*\bObjects\.requireNonNull\b"/>
-      <property name="message" value="Please statically import Objects.requireNonNull"/>
-    </module>
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="^(?!.*import).*\bElementMatchers\.[a-z]"/>
-      <property name="message" value="Please statically import methods from ElementMatchers"/>
-    </module>
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="^(?!.*import).*\bAgentElementMatchers\.[a-z]"/>
-      <property name="message" value="Please statically import methods from AgentElementMatchers"/>
-    </module>
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="^(?!.*import).*\bTimeUnit\.[A-Z]"/>
-      <property name="message" value="Please statically import constants from TimeUnit"/>
-    </module>
-    <module name="RegexpSinglelineJava">
-      <property name="format" value="^(?!.*import).*\bStandardCharsets\.[A-Z]"/>
-      <property name="message" value="Please statically import constants from StandardCharsets"/>
-    </module>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt
+++ b/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle
+
+import com.diffplug.spotless.FormatterFunc
+import java.io.Serializable
+
+/**
+ * Spotless custom step that rewrites qualified references (e.g. {@code Objects.requireNonNull})
+ * into unqualified references and adds the corresponding static import. Runs before
+ * googleJavaFormat so that imports are sorted and any newly-unused regular imports are removed.
+ */
+class StaticImportFormatter : FormatterFunc, Serializable {
+
+  override fun apply(input: String): String {
+    // (className, fullyQualifiedName, memberPattern)
+    val rules = listOf(
+      Triple("Objects", "java.util.Objects", "requireNonNull"),
+      Triple(
+        "ElementMatchers",
+        "net.bytebuddy.matcher.ElementMatchers",
+        "[a-z][a-zA-Z0-9]*"
+      ),
+      Triple(
+        "AgentElementMatchers",
+        "io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers",
+        "[a-z][a-zA-Z0-9]*"
+      ),
+      Triple("TimeUnit", "java.util.concurrent.TimeUnit", "[A-Z][A-Z_0-9]*"),
+      Triple(
+        "StandardCharsets",
+        "java.nio.charset.StandardCharsets",
+        "[A-Z][A-Z_0-9]*"
+      ),
+    )
+
+    var content = input
+    val importsToAdd = mutableSetOf<String>()
+
+    for ((className, pkg, memberPattern) in rules) {
+      val regex = Regex("\\b${className}\\.(${memberPattern})\\b")
+      val lines = content.lines().toMutableList()
+      for (i in lines.indices) {
+        if (lines[i].trimStart().startsWith("import ")) continue
+        for (match in regex.findAll(lines[i])) {
+          importsToAdd.add("import static ${pkg}.${match.groupValues[1]};")
+        }
+        lines[i] = regex.replace(lines[i], "$1")
+      }
+      content = lines.joinToString("\n")
+    }
+
+    if (importsToAdd.isNotEmpty()) {
+      val lines = content.lines().toMutableList()
+      val firstImportIndex = lines.indexOfFirst { it.trimStart().startsWith("import ") }
+      if (firstImportIndex >= 0) {
+        for ((offset, imp) in importsToAdd.sorted().withIndex()) {
+          lines.add(firstImportIndex + offset, imp)
+        }
+        content = lines.joinToString("\n")
+      }
+    }
+
+    return content
+  }
+
+  companion object {
+    private const val serialVersionUID = 1L
+  }
+}

--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import io.opentelemetry.instrumentation.gradle.StaticImportFormatter
 
 plugins {
   id("com.diffplug.spotless")
@@ -6,6 +7,7 @@ plugins {
 
 spotless {
   java {
+    custom("staticImports", StaticImportFormatter())
     googleJavaFormat()
     licenseHeaderFile(
       rootProject.file("buildscripts/spotless.license.java"),


### PR DESCRIPTION
People are already used to running spotlessApply.

I tested it several times and it doesn't add any noticeable time to spotlessApply.