### PR TITLE
Logging appenders: KeyValue attributes should take priority over MDC

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
@@ -112,6 +112,8 @@ public final class LogEventMapper<T> {
       Supplier<StackTraceElement> sourceSupplier,
       Context context) {
 
+    captureContextDataAttributes(builder, contextData);
+
     captureMessage(builder, message);
 
     if (captureMarkerAttribute) {
@@ -129,8 +131,6 @@ public final class LogEventMapper<T> {
     if (throwable != null) {
       setThrowable(builder, throwable);
     }
-
-    captureContextDataAttributes(builder, contextData);
 
     if (captureExperimentalAttributes) {
       builder.setAttribute(THREAD_NAME, threadName);

--- a/instrumentation/logback/logback-appender-1.0/library/src/slf4j2ApiTest/java/io/opentelemetry/instrumentation/logback/appender/v1_0/Slf4j2Test.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/slf4j2ApiTest/java/io/opentelemetry/instrumentation/logback/appender/v1_0/Slf4j2Test.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.slf4j.MarkerFactory;
 
 class Slf4j2Test {
@@ -71,6 +72,22 @@ class Slf4j2Test {
                     equalTo(AttributeKey.longKey("long key"), 4),
                     equalTo(AttributeKey.doubleKey("float key"), 5.0),
                     equalTo(AttributeKey.doubleKey("double key"), 6.0)));
+  }
+
+  @Test
+  void keyValuePairWinsOverMdc() {
+    MDC.put("key1", "mdc-value");
+    try {
+      logger.atInfo().setMessage("test message").addKeyValue("key1", "kvp-value").log();
+    } finally {
+      MDC.clear();
+    }
+
+    testing.waitAndAssertLogRecords(
+        logRecord ->
+            logRecord
+                .hasBody("test message")
+                .hasAttributesSatisfying(equalTo(AttributeKey.stringKey("key1"), "kvp-value")));
   }
 
   @Test


### PR DESCRIPTION
Related to @lmolkova's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16220#discussion_r2820684580

This behavioral change is acceptable in minor version since these features are still under experimental flags:

- otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
- otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
- otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
- otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
