### PR TITLE
Add Collectors.* static importing to spotless

### DIFF
--- a/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt
+++ b/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt
@@ -61,6 +61,7 @@ class StaticImportFormatter : FormatterFunc, Serializable {
         "io.opentelemetry.instrumentation.api.internal.SemconvStability",
         "emit[a-zA-Z0-9]*"
       ),
+      Triple("Collectors", "java.util.stream.Collectors", "[a-z][a-zA-Z0-9]*"),
     )
 
     var content = input


### PR DESCRIPTION
normalizing them to static imports was already done in

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16217

just forgot to add this one to spotless