### PR TITLE
Use flint for link checking

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -10,16 +10,12 @@ max_concurrency = 4
 include_fragments = true
 
 remap = [
-  # workaround for https://github.com/lycheeverse/lychee/issues/1729
-  "https://github.com/(.*?)/(.*?)/blob/(.*?)/(.*#.*)$ https://raw.githubusercontent.com/$1/$2/$3/$4",
   "https://docs.oracle.com/(.*)#.*$ https://docs.oracle.com/$1"
 ]
 
 # excluding links to pull requests and issues is done for performance
 # stackexchange link fails with 403 when accessed by lychee
 exclude = [
-  # workaround for https://github.com/lycheeverse/lychee/issues/1729
-  '^https://github.com/.*#issuecomment-.*$',
   '^https://github.com/open-telemetry/opentelemetry-java-instrumentation/(issues|pull)/\d+$',
   '^http://code.google.com/p/concurrentlinkedhashmap$',
   '^https://softwareengineering.stackexchange.com/questions/29727.*',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -353,6 +353,17 @@
   ],
   customManagers: [
     {
+      // keep SHA-pinned raw.githubusercontent.com URLs in mise.toml up to date
+      customType: 'regex',
+      datasourceTemplate: 'github-tags',
+      managerFilePatterns: [
+        '/^mise\\.toml$/',
+      ],
+      matchStrings: [
+        'https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentDigest>[a-f0-9]{40})/.*#\\s*(?<currentValue>v\\S+)',
+      ],
+    },
+    {
       customType: 'regex',
       datasourceTemplate: 'java-version',
       managerFilePatterns: [

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0 # needed for merge-base used in lint:links-in-modified-files
+          fetch-depth: 0 # needed for merge-base used in modified-files mode
 
       - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
 
@@ -20,12 +20,12 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          mise run lint:local-links
-          mise run lint:links-in-modified-files --base origin/${{ github.base_ref }} --head ${{ github.event.pull_request.head.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: mise run lint:links
 
       - name: Link check for pushes and scheduled workflows
         if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: mise run lint:links
+        run: mise run lint:links --full

--- a/mise.toml
+++ b/mise.toml
@@ -12,11 +12,7 @@ windows_executable_extensions = ["sh"]
 windows_default_file_shell_args = "bash"
 use_file_shell_for_executable_tasks = true
 
+# Pick the tasks you need from flint (https://github.com/grafana/flint)
 [tasks."lint:links"]
-file = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-contrib/refs/heads/main/.mise/tasks/lint/links.sh"
-
-[tasks."lint:local-links"]
-file = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-contrib/refs/heads/main/.mise/tasks/lint/local-links.sh"
-
-[tasks."lint:links-in-modified-files"]
-file = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-contrib/refs/heads/main/.mise/tasks/lint/links-in-modified-files.sh"
+description = "Check for broken links in changed files + all local links"
+file = "https://raw.githubusercontent.com/grafana/flint/8822bdc543f28f2c7dd1f697af4df6d89768c507/tasks/lint/links.sh" # v0.7.0


### PR DESCRIPTION
## Summary

Replace the three contrib-hosted link check scripts with [flint](https://github.com/grafana/flint)'s consolidated `lint:links` task.

**Benefits:**
- **SHA-pinned script deps** — the contrib URLs used `refs/heads/main` (mutable); flint pins to a commit SHA so builds are reproducible
- **Better PR link checking** — flint automatically remaps GitHub `/blob/main/` and `/tree/main/` URLs to the PR branch, preventing false failures when files are added or moved in a PR
- **Consolidated script** — 3 scripts → 1 script that auto-detects PR vs push mode
- **Renovate custom manager** — an inlined regex custom manager keeps the SHA-pinned script URL up to date automatically
- **Autofix support** — consistent `AUTOFIX=true mise run lint` across all lint tasks

**Changes:**
- `mise.toml`: replace 3 contrib-hosted task URLs with 1 flint URL (SHA-pinned to v0.7.0)
- `.github/workflows/reusable-link-check.yml`: simplify PR/push steps (flint handles mode detection)
- `.github/renovate.json5`: add inline custom manager to keep the SHA-pinned flint URL up to date

**Context:** I originally created the link check scripts in opentelemetry-java-contrib. Flint is a generalization of that work into a reusable toolbox — it's been adopted by several Grafana repos already.

## Test plan
- [ ] CI link check passes on this PR (exercises the PR code path)
- [ ] Verify `mise run lint:links --full` works locally (exercises the push code path)