### PR TITLE
Exclude flaky vaadin.com from lychee link checks

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -26,7 +26,8 @@ exclude = [
   '^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io/opentelemetry/$',
   # new artifact, remove after 2.21.0 release
   '^https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-helidon-4.3$',
-  # flaky link
+  # flaky links
   '^http://www.slf4j.org.*',
-  '^https://logback.qos.ch/.*'
+  '^https://logback.qos.ch/.*',
+  '^https://vaadin.com/$'
 ]


### PR DESCRIPTION
## Summary
- Exclude `vaadin.com` from lychee link checks — it consistently returns 502 Bad Gateway

## Test plan
- [ ] CI link check passes