### PR TITLE
Camel: don't emit db spans under stable semconv

### DIFF
--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
   testInstrumentation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
   testInstrumentation(project(":instrumentation:aws-sdk:aws-sdk-1.11:javaagent"))
 
+  testInstrumentation(project(":instrumentation:cassandra:cassandra-3.0:javaagent"))
+
   testImplementation("org.apache.camel:camel-core:$camelversion")
   testImplementation("org.apache.camel:camel-spring-boot-starter:$camelversion")
   testImplementation("org.apache.camel:camel-jetty-starter:$camelversion")

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/DbSpanDecorator.java
@@ -58,6 +58,14 @@ class DbSpanDecorator extends BaseSpanDecorator {
   }
 
   @Override
+  public boolean shouldStartNewSpan() {
+    // Under stable database semconv, don't create Camel DB spans. The underlying database
+    // instrumentations (JDBC, Cassandra, MongoDB, etc.) produce more accurate spans with correct
+    // db.system.name, connection attributes, and dialect-aware query sanitization.
+    return !emitStableDatabaseSemconv();
+  }
+
+  @Override
   public String getOperationName(
       Exchange exchange, Endpoint endpoint, CamelDirection camelDirection) {
 


### PR DESCRIPTION
The underlying database instrumentations (JDBC, Cassandra, MongoDB, etc.) produce more accurate spans with correct `db.system.name` and dialect-aware query sanitization.

Motivated by #15582