### PR TITLE
Fix javalin testLatestDeps compilation failure

### DIFF
--- a/instrumentation/javalin-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/javalin-5.0/javaagent/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
   testInstrumentation(project(":instrumentation:jetty:jetty-11.0:javaagent"))
 
   // TODO see https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16261
-  latestDepTestLibrary("io.javalin:javalin:6.+") // documented limitation
+  latestDepTestLibrary("io.javalin:javalin:5.+") // documented limitation
 }


### PR DESCRIPTION
## Summary
- Cap `latestDepTestLibrary` to `5.+` instead of `6.+` — Javalin 6.x changed the routing API (`app.get()` signature), breaking test compilation
- Proper Javalin 6+7 support is being added in #16261

## Test plan
- [ ] `testLatestDeps` CI job should pass for javalin-5.0 instrumentation
