### PR TITLE
Use testLatestDeps for lettuce-5.1 in telemetry collection

### DIFF
--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -167,8 +167,6 @@ readonly INSTRUMENTATIONS=(
   "lettuce:lettuce-5.0:javaagent:test"
   "lettuce:lettuce-5.0:javaagent:testExperimental"
   "lettuce:lettuce-5.0:javaagent:testStableSemconv"
-  "lettuce:lettuce-5.1:javaagent:test"
-  "lettuce:lettuce-5.1:javaagent:testStableSemconv"
   "mongo:mongo-3.1:javaagent:test"
   "mongo:mongo-3.1:javaagent:testStableSemconv"
   "mongo:mongo-3.7:javaagent:test"
@@ -293,4 +291,6 @@ readonly TEST_LATEST_DEPS_INSTRUMENTATIONS=(
   "kafka:kafka-clients:kafka-clients-0.11:javaagent:testExperimental"
   "kafka:kafka-streams-0.11:javaagent:test"
   "kafka:kafka-streams-0.11:javaagent:testExperimental"
+  "lettuce:lettuce-5.1:javaagent:test"
+  "lettuce:lettuce-5.1:javaagent:testStableSemconv"
 )


### PR DESCRIPTION
Noticed in the recent [metadata update](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16267/files) it was removing the error attribute entirely for stable semconv opt-in, but it should have been updated to [error.type](https://opentelemetry.io/docs/specs/semconv/db/redis/#spans). Saw that we only have the tests that emit that attribute under [testLatestDeps tests](https://github.com/steverao/opentelemetry-java-instrumentation/blob/d4c60924c399ba98510366405bc83d78559bf7fc/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java#L74-L98), so I've updated our automation to use that flag when running the telemetry collector for this module

