### PR TITLE
Add another lettuce test to telemetry collection

### DIFF
--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -167,6 +167,7 @@ readonly INSTRUMENTATIONS=(
   "lettuce:lettuce-5.0:javaagent:test"
   "lettuce:lettuce-5.0:javaagent:testExperimental"
   "lettuce:lettuce-5.0:javaagent:testStableSemconv"
+  "lettuce:lettuce-5.1:javaagent:test"
   "mongo:mongo-3.1:javaagent:test"
   "mongo:mongo-3.1:javaagent:testStableSemconv"
   "mongo:mongo-3.7:javaagent:test"


### PR DESCRIPTION
Related to #16290 

In order to get the `error` attribute we need to run the tests [without semconv stability opt in and without testLatestDeps](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java#L549-L554), so i'm adding this "vanilla" flavored `test` back into the non-testLatestDeps list so we can [re-capture that attribute](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16267/files?diff=unified#r2855629810)