### PR TITLE
Add dual-semconv support to RPC metrics

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetrics.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.OLD_RPC_METHOD_CONTEXT_KEY;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.RPC_METHOD;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
@@ -21,6 +26,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
@@ -30,24 +36,44 @@ import java.util.logging.Logger;
 public final class RpcClientMetrics implements OperationListener {
 
   private static final double NANOS_PER_MS = MILLISECONDS.toNanos(1);
+  private static final double NANOS_PER_S = SECONDS.toNanos(1);
 
   private static final ContextKey<RpcClientMetrics.State> RPC_CLIENT_REQUEST_METRICS_STATE =
       ContextKey.named("rpc-client-request-metrics-state");
 
   private static final Logger logger = Logger.getLogger(RpcClientMetrics.class.getName());
 
-  private final DoubleHistogram clientDurationHistogram;
-  private final LongHistogram clientRequestSize;
-  private final LongHistogram clientResponseSize;
+  @Nullable private final DoubleHistogram oldClientDurationHistogram;
+  @Nullable private final DoubleHistogram stableClientDurationHistogram;
+  private final LongHistogram oldClientRequestSize;
+  private final LongHistogram oldClientResponseSize;
 
   private RpcClientMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("rpc.client.duration")
-            .setDescription("The duration of an outbound RPC invocation.")
-            .setUnit("ms");
-    RpcMetricsAdvice.applyClientDurationAdvice(durationBuilder);
-    clientDurationHistogram = durationBuilder.build();
+    // Old metric (milliseconds)
+    if (emitOldRpcSemconv()) {
+      DoubleHistogramBuilder oldDurationBuilder =
+          meter
+              .histogramBuilder("rpc.client.duration")
+              .setDescription("The duration of an outbound RPC invocation.")
+              .setUnit("ms");
+      RpcMetricsAdvice.applyClientDurationAdvice(oldDurationBuilder, false);
+      oldClientDurationHistogram = oldDurationBuilder.build();
+    } else {
+      oldClientDurationHistogram = null;
+    }
+
+    // Stable metric (seconds)
+    if (emitStableRpcSemconv()) {
+      DoubleHistogramBuilder stableDurationBuilder =
+          meter
+              .histogramBuilder("rpc.client.call.duration")
+              .setDescription("Measures the duration of outbound remote procedure calls (RPC).")
+              .setUnit("s");
+      RpcMetricsAdvice.applyClientDurationAdvice(stableDurationBuilder, true);
+      stableClientDurationHistogram = stableDurationBuilder.build();
+    } else {
+      stableClientDurationHistogram = null;
+    }
 
     LongHistogramBuilder requestSizeBuilder =
         meter
@@ -55,8 +81,8 @@ public final class RpcClientMetrics implements OperationListener {
             .setUnit("By")
             .setDescription("Measures the size of RPC request messages (uncompressed).")
             .ofLongs();
-    RpcMetricsAdvice.applyClientRequestSizeAdvice(requestSizeBuilder);
-    clientRequestSize = requestSizeBuilder.build();
+    RpcMetricsAdvice.applyOldClientRequestSizeAdvice(requestSizeBuilder);
+    oldClientRequestSize = requestSizeBuilder.build();
 
     LongHistogramBuilder responseSizeBuilder =
         meter
@@ -64,8 +90,8 @@ public final class RpcClientMetrics implements OperationListener {
             .setUnit("By")
             .setDescription("Measures the size of RPC response messages (uncompressed).")
             .ofLongs();
-    RpcMetricsAdvice.applyClientRequestSizeAdvice(responseSizeBuilder);
-    clientResponseSize = responseSizeBuilder.build();
+    RpcMetricsAdvice.applyOldClientRequestSizeAdvice(responseSizeBuilder);
+    oldClientResponseSize = responseSizeBuilder.build();
   }
 
   /**
@@ -81,7 +107,8 @@ public final class RpcClientMetrics implements OperationListener {
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
     return context.with(
         RPC_CLIENT_REQUEST_METRICS_STATE,
-        new AutoValue_RpcClientMetrics_State(startAttributes, startNanos));
+        new AutoValue_RpcClientMetrics_State(
+            startAttributes, startNanos, context.get(OLD_RPC_METHOD_CONTEXT_KEY)));
   }
 
   @Override
@@ -95,18 +122,41 @@ public final class RpcClientMetrics implements OperationListener {
       return;
     }
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
-    clientDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_MS, attributes, context);
+    double durationNanos = endNanos - state.startTimeNanos();
 
-    Long rpcClientRequestBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE);
-    if (rpcClientRequestBodySize != null) {
-      clientRequestSize.record(rpcClientRequestBodySize, attributes, context);
+    // Record to old histogram (milliseconds)
+    if (oldClientDurationHistogram != null) {
+      Attributes oldAttributes = getOldAttributes(attributes, state);
+      oldClientDurationHistogram.record(durationNanos / NANOS_PER_MS, oldAttributes, context);
     }
 
-    Long rpcClientResponseBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE);
-    if (rpcClientResponseBodySize != null) {
-      clientResponseSize.record(rpcClientResponseBodySize, attributes, context);
+    // Record to stable histogram (seconds)
+    if (stableClientDurationHistogram != null) {
+      stableClientDurationHistogram.record(durationNanos / NANOS_PER_S, attributes, context);
     }
+
+    if (emitOldRpcSemconv()) {
+      Attributes oldAttributes = getOldAttributes(attributes, state);
+
+      Long rpcClientRequestBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE);
+      if (rpcClientRequestBodySize != null) {
+        oldClientRequestSize.record(rpcClientRequestBodySize, oldAttributes, context);
+      }
+
+      Long rpcClientResponseBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE);
+      if (rpcClientResponseBodySize != null) {
+        oldClientResponseSize.record(rpcClientResponseBodySize, oldAttributes, context);
+      }
+    }
+  }
+
+  private static Attributes getOldAttributes(Attributes attributes, State state) {
+    String oldRpcMethod = state.oldRpcMethod();
+    if (oldRpcMethod != null) {
+      // dup mode: replace stable rpc.method with old value
+      return attributes.toBuilder().put(RPC_METHOD, oldRpcMethod).build();
+    }
+    return attributes;
   }
 
   @AutoValue
@@ -115,5 +165,8 @@ public final class RpcClientMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+
+    @Nullable
+    abstract String oldRpcMethod();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
@@ -5,18 +5,47 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
 import javax.annotation.Nullable;
 
-abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
+public abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
 
-  // copied from RpcIncubatingAttributes
   static final AttributeKey<String> RPC_METHOD = AttributeKey.stringKey("rpc.method");
+
+  static final ContextKey<String> OLD_RPC_METHOD_CONTEXT_KEY =
+      ContextKey.named("otel-rpc-old-method");
+
+  @SuppressWarnings("deprecation") // for getMethod()
+  public static <REQUEST> ContextCustomizer<REQUEST> oldMethodContextCustomizer(
+      RpcAttributesGetter<REQUEST, ?> getter) {
+    return (context, request, startAttributes) -> {
+      if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+        String oldMethod = getter.getMethod(request);
+        if (oldMethod != null) {
+          return context.with(OLD_RPC_METHOD_CONTEXT_KEY, oldMethod);
+        }
+      }
+      return context;
+    };
+  }
+
+  // Stable semconv keys
+  static final AttributeKey<String> RPC_SYSTEM_NAME = AttributeKey.stringKey("rpc.system.name");
+
+  // removed in stable semconv (merged into rpc.method)
   static final AttributeKey<String> RPC_SERVICE = AttributeKey.stringKey("rpc.service");
+
+  // use RPC_SYSTEM_NAME for stable semconv
   static final AttributeKey<String> RPC_SYSTEM = AttributeKey.stringKey("rpc.system");
 
   private final RpcAttributesGetter<REQUEST, RESPONSE> getter;
@@ -25,12 +54,23 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
     this.getter = getter;
   }
 
-  @SuppressWarnings("deprecation") // for getMethod()
+  @SuppressWarnings("deprecation") // for getSystem(), getMethod()
   @Override
   public final void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    attributes.put(RPC_SYSTEM, getter.getSystem(request));
-    attributes.put(RPC_SERVICE, getter.getService(request));
-    attributes.put(RPC_METHOD, getter.getMethod(request));
+
+    if (emitStableRpcSemconv()) {
+      attributes.put(RPC_SYSTEM_NAME, getter.getRpcSystemName(request));
+      attributes.put(RPC_METHOD, getter.getRpcMethod(request));
+    }
+
+    if (emitOldRpcSemconv()) {
+      attributes.put(RPC_SYSTEM, getter.getSystem(request));
+      attributes.put(RPC_SERVICE, getter.getService(request));
+      if (!emitStableRpcSemconv()) {
+        // only set old rpc.method on spans when there's no clash with stable rpc.method
+        attributes.put(RPC_METHOD, getter.getMethod(request));
+      }
+    }
   }
 
   @Override
@@ -40,6 +80,13 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
-    // No response attributes
+    if (emitStableRpcSemconv()) {
+      String errorType = getter.getErrorType(request, response, error);
+      // fall back to exception class name
+      if (errorType == null && error != null) {
+        errorType = error.getClass().getName();
+      }
+      attributes.put(ERROR_TYPE, errorType);
+    }
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
@@ -5,69 +5,111 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
-import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
 final class RpcMetricsAdvice {
 
+  // Stable semconv key
+  private static final AttributeKey<String> RPC_RESPONSE_STATUS_CODE =
+      AttributeKey.stringKey("rpc.response.status_code");
+
   // copied from RpcIncubatingAttributes
+  @Deprecated // use RPC_RESPONSE_STATUS_CODE for stable semconv
   private static final AttributeKey<Long> RPC_GRPC_STATUS_CODE =
       AttributeKey.longKey("rpc.grpc.status_code");
-  private static final List<AttributeKey<?>> RPC_METRICS_ATTRIBUTE_KEYS =
-      asList(
-          RpcCommonAttributesExtractor.RPC_SYSTEM,
-          RpcCommonAttributesExtractor.RPC_SERVICE,
-          RpcCommonAttributesExtractor.RPC_METHOD,
-          RPC_GRPC_STATUS_CODE,
-          NETWORK_TYPE,
-          NETWORK_TRANSPORT,
-          SERVER_ADDRESS,
-          SERVER_PORT);
 
-  static void applyClientDurationAdvice(DoubleHistogramBuilder builder) {
+  private static final List<AttributeKey<?>> RPC_METRICS_OLD_ATTRIBUTE_KEYS =
+      buildAttributeKeysList(false);
+  private static final List<AttributeKey<?>> RPC_METRICS_STABLE_ATTRIBUTE_KEYS =
+      buildAttributeKeysList(true);
+
+  @SuppressWarnings("deprecation") // until old rpc semconv are dropped
+  private static List<AttributeKey<?>> buildAttributeKeysList(boolean stable) {
+    List<AttributeKey<?>> keys = new ArrayList<>();
+
+    // Add stable or old RPC system key
+    keys.add(
+        stable
+            ? RpcCommonAttributesExtractor.RPC_SYSTEM_NAME
+            : RpcCommonAttributesExtractor.RPC_SYSTEM);
+
+    // Add RPC service (old only)
+    if (!stable) {
+      keys.add(RpcCommonAttributesExtractor.RPC_SERVICE);
+    }
+
+    keys.add(RpcCommonAttributesExtractor.RPC_METHOD);
+
+    // Add status code key
+    if (emitStableRpcSemconv()) {
+      keys.add(RPC_RESPONSE_STATUS_CODE);
+    } else {
+      keys.add(RPC_GRPC_STATUS_CODE);
+    }
+
+    // Network type only for old semconv
+    if (!stable) {
+      keys.add(NETWORK_TYPE);
+    }
+
+    // Common attributes
+    keys.add(NETWORK_TRANSPORT);
+    keys.add(SERVER_ADDRESS);
+    keys.add(SERVER_PORT);
+
+    return keys;
+  }
+
+  private static List<AttributeKey<?>> getAttributeKeys(boolean stable) {
+    return stable ? RPC_METRICS_STABLE_ATTRIBUTE_KEYS : RPC_METRICS_OLD_ATTRIBUTE_KEYS;
+  }
+
+  static void applyClientDurationAdvice(DoubleHistogramBuilder builder, boolean stable) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
     // the list of recommended metrics attributes is from
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_ATTRIBUTE_KEYS);
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(getAttributeKeys(stable));
   }
 
-  static void applyServerDurationAdvice(DoubleHistogramBuilder builder) {
+  static void applyServerDurationAdvice(DoubleHistogramBuilder builder, boolean stable) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
     // the list of recommended metrics attributes is from
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_ATTRIBUTE_KEYS);
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(getAttributeKeys(stable));
   }
 
-  static void applyClientRequestSizeAdvice(LongHistogramBuilder builder) {
+  static void applyOldClientRequestSizeAdvice(LongHistogramBuilder builder) {
     if (!(builder instanceof ExtendedLongHistogramBuilder)) {
       return;
     }
     // the list of recommended metrics attributes is from
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
-    ((ExtendedLongHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_ATTRIBUTE_KEYS);
+    ((ExtendedLongHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_OLD_ATTRIBUTE_KEYS);
   }
 
-  static void applyServerRequestSizeAdvice(LongHistogramBuilder builder) {
+  static void applyOldServerRequestSizeAdvice(LongHistogramBuilder builder) {
     if (!(builder instanceof ExtendedLongHistogramBuilder)) {
       return;
     }
     // the list of recommended metrics attributes is from
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md
-    ((ExtendedLongHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_ATTRIBUTE_KEYS);
+    ((ExtendedLongHistogramBuilder) builder).setAttributesAdvice(RPC_METRICS_OLD_ATTRIBUTE_KEYS);
   }
 
   private RpcMetricsAdvice() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.OLD_RPC_METHOD_CONTEXT_KEY;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.RPC_METHOD;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
@@ -21,6 +26,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
@@ -30,24 +36,44 @@ import java.util.logging.Logger;
 public final class RpcServerMetrics implements OperationListener {
 
   private static final double NANOS_PER_MS = MILLISECONDS.toNanos(1);
+  private static final double NANOS_PER_S = SECONDS.toNanos(1);
 
   private static final ContextKey<RpcServerMetrics.State> RPC_SERVER_REQUEST_METRICS_STATE =
       ContextKey.named("rpc-server-request-metrics-state");
 
   private static final Logger logger = Logger.getLogger(RpcServerMetrics.class.getName());
 
-  private final DoubleHistogram serverDurationHistogram;
-  private final LongHistogram serverRequestSize;
-  private final LongHistogram serverResponseSize;
+  @Nullable private final DoubleHistogram oldServerDurationHistogram;
+  @Nullable private final DoubleHistogram stableServerDurationHistogram;
+  private final LongHistogram oldServerRequestSize;
+  private final LongHistogram oldServerResponseSize;
 
   private RpcServerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("rpc.server.duration")
-            .setDescription("The duration of an inbound RPC invocation.")
-            .setUnit("ms");
-    RpcMetricsAdvice.applyServerDurationAdvice(durationBuilder);
-    serverDurationHistogram = durationBuilder.build();
+    // Old metric (milliseconds)
+    if (emitOldRpcSemconv()) {
+      DoubleHistogramBuilder oldDurationBuilder =
+          meter
+              .histogramBuilder("rpc.server.duration")
+              .setDescription("The duration of an inbound RPC invocation.")
+              .setUnit("ms");
+      RpcMetricsAdvice.applyServerDurationAdvice(oldDurationBuilder, false);
+      oldServerDurationHistogram = oldDurationBuilder.build();
+    } else {
+      oldServerDurationHistogram = null;
+    }
+
+    // Stable metric (seconds)
+    if (emitStableRpcSemconv()) {
+      DoubleHistogramBuilder stableDurationBuilder =
+          meter
+              .histogramBuilder("rpc.server.call.duration")
+              .setDescription("Measures the duration of inbound remote procedure calls (RPC).")
+              .setUnit("s");
+      RpcMetricsAdvice.applyServerDurationAdvice(stableDurationBuilder, true);
+      stableServerDurationHistogram = stableDurationBuilder.build();
+    } else {
+      stableServerDurationHistogram = null;
+    }
 
     LongHistogramBuilder requestSizeBuilder =
         meter
@@ -55,8 +81,8 @@ public final class RpcServerMetrics implements OperationListener {
             .setUnit("By")
             .setDescription("Measures the size of RPC request messages (uncompressed).")
             .ofLongs();
-    RpcMetricsAdvice.applyServerRequestSizeAdvice(requestSizeBuilder);
-    serverRequestSize = requestSizeBuilder.build();
+    RpcMetricsAdvice.applyOldServerRequestSizeAdvice(requestSizeBuilder);
+    oldServerRequestSize = requestSizeBuilder.build();
 
     LongHistogramBuilder responseSizeBuilder =
         meter
@@ -64,8 +90,8 @@ public final class RpcServerMetrics implements OperationListener {
             .setUnit("By")
             .setDescription("Measures the size of RPC response messages (uncompressed).")
             .ofLongs();
-    RpcMetricsAdvice.applyServerRequestSizeAdvice(responseSizeBuilder);
-    serverResponseSize = responseSizeBuilder.build();
+    RpcMetricsAdvice.applyOldServerRequestSizeAdvice(responseSizeBuilder);
+    oldServerResponseSize = responseSizeBuilder.build();
   }
 
   /**
@@ -81,7 +107,8 @@ public final class RpcServerMetrics implements OperationListener {
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
     return context.with(
         RPC_SERVER_REQUEST_METRICS_STATE,
-        new AutoValue_RpcServerMetrics_State(startAttributes, startNanos));
+        new AutoValue_RpcServerMetrics_State(
+            startAttributes, startNanos, context.get(OLD_RPC_METHOD_CONTEXT_KEY)));
   }
 
   @Override
@@ -95,18 +122,41 @@ public final class RpcServerMetrics implements OperationListener {
       return;
     }
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
-    serverDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_MS, attributes, context);
+    double durationNanos = endNanos - state.startTimeNanos();
 
-    Long rpcServerRequestBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE);
-    if (rpcServerRequestBodySize != null) {
-      serverRequestSize.record(rpcServerRequestBodySize, attributes, context);
+    // Record to old histogram (milliseconds)
+    if (oldServerDurationHistogram != null) {
+      Attributes oldAttributes = getOldAttributes(attributes, state);
+      oldServerDurationHistogram.record(durationNanos / NANOS_PER_MS, oldAttributes, context);
     }
 
-    Long rpcServerResponseBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE);
-    if (rpcServerResponseBodySize != null) {
-      serverResponseSize.record(rpcServerResponseBodySize, attributes, context);
+    // Record to stable histogram (seconds)
+    if (stableServerDurationHistogram != null) {
+      stableServerDurationHistogram.record(durationNanos / NANOS_PER_S, attributes, context);
     }
+
+    if (emitOldRpcSemconv()) {
+      Attributes oldAttributes = getOldAttributes(attributes, state);
+
+      Long rpcServerRequestBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE);
+      if (rpcServerRequestBodySize != null) {
+        oldServerRequestSize.record(rpcServerRequestBodySize, oldAttributes, context);
+      }
+
+      Long rpcServerResponseBodySize = attributes.get(RpcSizeAttributesExtractor.RPC_RESPONSE_SIZE);
+      if (rpcServerResponseBodySize != null) {
+        oldServerResponseSize.record(rpcServerResponseBodySize, oldAttributes, context);
+      }
+    }
+  }
+
+  private static Attributes getOldAttributes(Attributes attributes, State state) {
+    String oldRpcMethod = state.oldRpcMethod();
+    if (oldRpcMethod != null) {
+      // dup mode: replace stable rpc.method with old value
+      return attributes.toBuilder().put(RPC_METHOD, oldRpcMethod).build();
+    }
+    return attributes;
   }
 
   @AutoValue
@@ -115,5 +165,8 @@ public final class RpcServerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+
+    @Nullable
+    abstract String oldRpcMethod();
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.OLD_RPC_METHOD_CONTEXT_KEY;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.RPC_SYSTEM_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
@@ -16,15 +20,23 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SE
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -39,19 +51,10 @@ class RpcClientMetricsTest {
     OperationListener listener = RpcClientMetrics.get().create(meterProvider.get("test"));
 
     Attributes requestAttributes1 =
-        Attributes.builder()
-            .put(RPC_SYSTEM, "grpc")
-            .put(RPC_SERVICE, "myservice.EchoService")
-            .put(RPC_METHOD, "exampleMethod")
-            .put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10)
-            .build();
+        buildRequestAttributes("grpc", "myservice.EchoService", "exampleMethod", true);
 
     Attributes requestAttributes2 =
-        Attributes.builder()
-            .put(RPC_SYSTEM, "grpc")
-            .put(RPC_SERVICE, "myservice.EchoService")
-            .put(RPC_METHOD, "exampleMethod")
-            .build();
+        buildRequestAttributes("grpc", "myservice.EchoService", "exampleMethod", false);
 
     Attributes responseAttributes1 =
         Attributes.builder()
@@ -74,114 +77,255 @@ class RpcClientMetricsTest {
                         "090a0b0c0d0e0f00",
                         TraceFlags.getSampled(),
                         TraceState.getDefault())));
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      parent = parent.with(OLD_RPC_METHOD_CONTEXT_KEY, "exampleMethod");
+    }
 
     Context context1 = listener.onStart(parent, requestAttributes1, nanos(100));
 
     assertThat(metricReader.collectAllMetrics()).isEmpty();
 
-    Context context2 = listener.onStart(Context.root(), requestAttributes2, nanos(150));
+    Context context2Root = Context.root();
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      context2Root = context2Root.with(OLD_RPC_METHOD_CONTEXT_KEY, "exampleMethod");
+    }
+    Context context2 = listener.onStart(context2Root, requestAttributes2, nanos(150));
 
     assertThat(metricReader.collectAllMetrics()).isEmpty();
 
     listener.onEnd(context1, responseAttributes1, nanos(250));
 
-    assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.client.response.size")
-                    .hasUnit("By")
-                    .hasDescription("Measures the size of RPC response messages (uncompressed).")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(20 /* bytes */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))),
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.client.request.size")
-                    .hasUnit("By")
-                    .hasDescription("Measures the size of RPC request messages (uncompressed).")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(10 /* bytes */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))),
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.client.duration")
-                    .hasUnit("ms")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(150 /* millis */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))));
+    // Calculate expected metric count:
+    // - dup mode: old duration + stable duration + request.size + response.size = 4
+    // - old-only mode: old duration + request.size + response.size = 3
+    // - stable-only mode: stable duration only = 1
+    int expectedMetricCount = 1; // At minimum, we always have one duration metric
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      expectedMetricCount = 4; // Both durations + both size metrics
+    } else if (emitOldRpcSemconv()) {
+      expectedMetricCount = 3; // Old duration + both size metrics
+    }
+
+    // Collect metrics once (delta reader consumes on each call)
+    Collection<MetricData> metrics1 = metricReader.collectAllMetrics();
+    assertThat(metrics1).hasSize(expectedMetricCount);
+
+    // Build expected attributes for OLD metrics (size + old duration) - alphabetically sorted
+    List<AttributeAssertion> oldMetricAttributes1 = new ArrayList<>();
+    if (emitOldRpcSemconv()) {
+      oldMetricAttributes1.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      oldMetricAttributes1.add(equalTo(NETWORK_TYPE, "ipv4"));
+      oldMetricAttributes1.add(equalTo(RPC_METHOD, "exampleMethod"));
+      oldMetricAttributes1.add(equalTo(RPC_SERVICE, "myservice.EchoService"));
+      oldMetricAttributes1.add(equalTo(RPC_SYSTEM, "grpc"));
+      oldMetricAttributes1.add(equalTo(SERVER_ADDRESS, "example.com"));
+      oldMetricAttributes1.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Size metrics are only recorded in old semconv mode
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.response.size")
+                      .hasUnit("By")
+                      .hasDescription("Measures the size of RPC response messages (uncompressed).")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(20 /* bytes */)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.request.size")
+                      .hasUnit("By")
+                      .hasDescription("Measures the size of RPC request messages (uncompressed).")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(10 /* bytes */)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
+
+    // Assert stable duration metric if emitting stable semconv
+    if (emitStableRpcSemconv()) {
+      // Build expected attributes for STABLE metrics - alphabetically sorted
+      List<AttributeAssertion> stableMetricAttributes1 = new ArrayList<>();
+      stableMetricAttributes1.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      stableMetricAttributes1.add(equalTo(RPC_METHOD, "myservice.EchoService/exampleMethod"));
+      stableMetricAttributes1.add(
+          equalTo(
+              AttributeKey.stringKey("rpc.system.name"),
+              SemconvStability.stableRpcSystemName("grpc")));
+      stableMetricAttributes1.add(equalTo(SERVER_ADDRESS, "example.com"));
+      stableMetricAttributes1.add(equalTo(SERVER_PORT, 8080));
+
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasAttributesSatisfyingExactly(
+                                              stableMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
+
+    // Assert old duration metric if emitting old semconv
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(150.0)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
 
     listener.onEnd(context2, responseAttributes2, nanos(300));
 
-    assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.client.duration")
-                    .hasUnit("ms")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(150 /* millis */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp")))));
+    // Collect metrics once (delta reader consumes on each call)
+    // Note: metrics2 doesn't include size metrics since context2 has no size attributes
+    int expectedMetricCount2 = emitOldRpcSemconv() && emitStableRpcSemconv() ? 2 : 1;
+    Collection<MetricData> metrics2 = metricReader.collectAllMetrics();
+    assertThat(metrics2).hasSize(expectedMetricCount2);
+
+    // Build expected attributes for OLD metrics (no server.address or network.type for context2) -
+    // alphabetically sorted
+    List<AttributeAssertion> oldMetricAttributes2 = new ArrayList<>();
+    if (emitOldRpcSemconv()) {
+      oldMetricAttributes2.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      oldMetricAttributes2.add(equalTo(RPC_METHOD, "exampleMethod"));
+      oldMetricAttributes2.add(equalTo(RPC_SERVICE, "myservice.EchoService"));
+      oldMetricAttributes2.add(equalTo(RPC_SYSTEM, "grpc"));
+      oldMetricAttributes2.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Build expected attributes for STABLE metrics (no server.address for context2) -
+    // alphabetically sorted
+    List<AttributeAssertion> stableMetricAttributes2 = new ArrayList<>();
+    if (emitStableRpcSemconv()) {
+      stableMetricAttributes2.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      stableMetricAttributes2.add(equalTo(RPC_METHOD, "myservice.EchoService/exampleMethod"));
+      stableMetricAttributes2.add(
+          equalTo(
+              AttributeKey.stringKey("rpc.system.name"),
+              SemconvStability.stableRpcSystemName("grpc")));
+      stableMetricAttributes2.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Assert stable duration metric if emitting stable semconv
+    if (emitStableRpcSemconv()) {
+      assertThat(metrics2)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasAttributesSatisfyingExactly(
+                                              stableMetricAttributes2.toArray(
+                                                  new AttributeAssertion[0])))));
+    }
+
+    // Assert old duration metric if emitting old semconv
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics2)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(150.0)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes2.toArray(
+                                                  new AttributeAssertion[0])))));
+    }
   }
 
   private static long nanos(int millis) {
     return MILLISECONDS.toNanos(millis);
+  }
+
+  private static Attributes buildRequestAttributes(
+      String system, String service, String method, boolean withSize) {
+    AttributesBuilder builder = Attributes.builder();
+
+    if (emitOldRpcSemconv()) {
+      builder.put(RPC_SYSTEM, system);
+      builder.put(RPC_SERVICE, service);
+      if (!emitStableRpcSemconv()) {
+        builder.put(RPC_METHOD, method);
+      }
+    }
+
+    if (emitStableRpcSemconv()) {
+      builder.put(RPC_SYSTEM_NAME, SemconvStability.stableRpcSystemName(system));
+      builder.put(RPC_METHOD, service + "/" + method);
+    }
+
+    if (withSize) {
+      builder.put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10);
+    }
+
+    return builder.build();
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.OLD_RPC_METHOD_CONTEXT_KEY;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcCommonAttributesExtractor.RPC_SYSTEM_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_LOCAL_ADDRESS;
@@ -17,15 +21,23 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SE
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -40,19 +52,10 @@ class RpcServerMetricsTest {
     OperationListener listener = RpcServerMetrics.get().create(meterProvider.get("test"));
 
     Attributes requestAttributes1 =
-        Attributes.builder()
-            .put(RPC_SYSTEM, "grpc")
-            .put(RPC_SERVICE, "myservice.EchoService")
-            .put(RPC_METHOD, "exampleMethod")
-            .put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10)
-            .build();
+        buildRequestAttributes("grpc", "myservice.EchoService", "exampleMethod", true);
 
     Attributes requestAttributes2 =
-        Attributes.builder()
-            .put(RPC_SYSTEM, "grpc")
-            .put(RPC_SERVICE, "myservice.EchoService")
-            .put(RPC_METHOD, "exampleMethod")
-            .build();
+        buildRequestAttributes("grpc", "myservice.EchoService", "exampleMethod", false);
 
     Attributes responseAttributes1 =
         Attributes.builder()
@@ -80,114 +83,255 @@ class RpcServerMetricsTest {
                         "090a0b0c0d0e0f00",
                         TraceFlags.getSampled(),
                         TraceState.getDefault())));
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      parent = parent.with(OLD_RPC_METHOD_CONTEXT_KEY, "exampleMethod");
+    }
 
     Context context1 = listener.onStart(parent, requestAttributes1, nanos(100));
 
     assertThat(metricReader.collectAllMetrics()).isEmpty();
 
-    Context context2 = listener.onStart(Context.root(), requestAttributes2, nanos(150));
+    Context context2Root = Context.root();
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      context2Root = context2Root.with(OLD_RPC_METHOD_CONTEXT_KEY, "exampleMethod");
+    }
+    Context context2 = listener.onStart(context2Root, requestAttributes2, nanos(150));
 
     assertThat(metricReader.collectAllMetrics()).isEmpty();
 
     listener.onEnd(context1, responseAttributes1, nanos(250));
 
-    assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.server.duration")
-                    .hasUnit("ms")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(150 /* millis */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))),
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.server.response.size")
-                    .hasUnit("By")
-                    .hasDescription("Measures the size of RPC response messages (uncompressed).")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(20 /* bytes */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))),
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.server.request.size")
-                    .hasUnit("By")
-                    .hasDescription("Measures the size of RPC request messages (uncompressed).")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(10 /* bytes */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_ADDRESS, "example.com"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp"),
-                                            equalTo(NETWORK_TYPE, "ipv4"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00")))));
+    // Calculate expected metric count:
+    // - dup mode: old duration + stable duration + request.size + response.size = 4
+    // - old-only mode: old duration + request.size + response.size = 3
+    // - stable-only mode: stable duration only = 1
+    int expectedMetricCount = 1; // At minimum, we always have one duration metric
+    if (emitOldRpcSemconv() && emitStableRpcSemconv()) {
+      expectedMetricCount = 4; // Both durations + both size metrics
+    } else if (emitOldRpcSemconv()) {
+      expectedMetricCount = 3; // Old duration + both size metrics
+    }
+
+    // Collect metrics once (delta reader consumes on each call)
+    Collection<MetricData> metrics1 = metricReader.collectAllMetrics();
+    assertThat(metrics1).hasSize(expectedMetricCount);
+
+    // Build expected attributes for OLD metrics (size + old duration) - alphabetically sorted
+    List<AttributeAssertion> oldMetricAttributes1 = new ArrayList<>();
+    if (emitOldRpcSemconv()) {
+      oldMetricAttributes1.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      oldMetricAttributes1.add(equalTo(NETWORK_TYPE, "ipv4"));
+      oldMetricAttributes1.add(equalTo(RPC_METHOD, "exampleMethod"));
+      oldMetricAttributes1.add(equalTo(RPC_SERVICE, "myservice.EchoService"));
+      oldMetricAttributes1.add(equalTo(RPC_SYSTEM, "grpc"));
+      oldMetricAttributes1.add(equalTo(SERVER_ADDRESS, "example.com"));
+      oldMetricAttributes1.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Size metrics are only recorded in old semconv mode
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.response.size")
+                      .hasUnit("By")
+                      .hasDescription("Measures the size of RPC response messages (uncompressed).")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(20 /* bytes */)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.request.size")
+                      .hasUnit("By")
+                      .hasDescription("Measures the size of RPC request messages (uncompressed).")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(10 /* bytes */)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
+
+    // Assert stable duration metric if emitting stable semconv
+    if (emitStableRpcSemconv()) {
+      // Build expected attributes for STABLE metrics - alphabetically sorted
+      List<AttributeAssertion> stableMetricAttributes1 = new ArrayList<>();
+      stableMetricAttributes1.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      stableMetricAttributes1.add(equalTo(RPC_METHOD, "myservice.EchoService/exampleMethod"));
+      stableMetricAttributes1.add(
+          equalTo(
+              AttributeKey.stringKey("rpc.system.name"),
+              SemconvStability.stableRpcSystemName("grpc")));
+      stableMetricAttributes1.add(equalTo(SERVER_ADDRESS, "example.com"));
+      stableMetricAttributes1.add(equalTo(SERVER_PORT, 8080));
+
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasAttributesSatisfyingExactly(
+                                              stableMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
+
+    // Assert old duration metric if emitting old semconv
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics1)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(150.0)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes1.toArray(
+                                                  new AttributeAssertion[0]))
+                                          .hasExemplarsSatisfying(
+                                              exemplar ->
+                                                  exemplar
+                                                      .hasTraceId(
+                                                          "ff01020304050600ff0a0b0c0d0e0f00")
+                                                      .hasSpanId("090a0b0c0d0e0f00")))));
+    }
 
     listener.onEnd(context2, responseAttributes2, nanos(300));
 
-    assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("rpc.server.duration")
-                    .hasUnit("ms")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(150 /* millis */)
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(RPC_SYSTEM, "grpc"),
-                                            equalTo(RPC_SERVICE, "myservice.EchoService"),
-                                            equalTo(RPC_METHOD, "exampleMethod"),
-                                            equalTo(SERVER_PORT, 8080),
-                                            equalTo(NETWORK_TRANSPORT, "tcp")))));
+    // Collect metrics once (delta reader consumes on each call)
+    // Note: metrics2 doesn't include size metrics since context2 has no size attributes
+    int expectedMetricCount2 = emitOldRpcSemconv() && emitStableRpcSemconv() ? 2 : 1;
+    Collection<MetricData> metrics2 = metricReader.collectAllMetrics();
+    assertThat(metrics2).hasSize(expectedMetricCount2);
+
+    // Build expected attributes for OLD metrics (no server.address or network.type for context2) -
+    // alphabetically sorted
+    List<AttributeAssertion> oldMetricAttributes2 = new ArrayList<>();
+    if (emitOldRpcSemconv()) {
+      oldMetricAttributes2.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      oldMetricAttributes2.add(equalTo(RPC_METHOD, "exampleMethod"));
+      oldMetricAttributes2.add(equalTo(RPC_SERVICE, "myservice.EchoService"));
+      oldMetricAttributes2.add(equalTo(RPC_SYSTEM, "grpc"));
+      oldMetricAttributes2.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Build expected attributes for STABLE metrics (no server.address for context2) -
+    // alphabetically sorted
+    List<AttributeAssertion> stableMetricAttributes2 = new ArrayList<>();
+    if (emitStableRpcSemconv()) {
+      stableMetricAttributes2.add(equalTo(NETWORK_TRANSPORT, "tcp"));
+      stableMetricAttributes2.add(equalTo(RPC_METHOD, "myservice.EchoService/exampleMethod"));
+      stableMetricAttributes2.add(
+          equalTo(
+              AttributeKey.stringKey("rpc.system.name"),
+              SemconvStability.stableRpcSystemName("grpc")));
+      stableMetricAttributes2.add(equalTo(SERVER_PORT, 8080));
+    }
+
+    // Assert stable duration metric if emitting stable semconv
+    if (emitStableRpcSemconv()) {
+      assertThat(metrics2)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasAttributesSatisfyingExactly(
+                                              stableMetricAttributes2.toArray(
+                                                  new AttributeAssertion[0])))));
+    }
+
+    // Assert old duration metric if emitting old semconv
+    if (emitOldRpcSemconv()) {
+      assertThat(metrics2)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(150.0)
+                                          .hasAttributesSatisfyingExactly(
+                                              oldMetricAttributes2.toArray(
+                                                  new AttributeAssertion[0])))));
+    }
   }
 
   private static long nanos(int millis) {
     return MILLISECONDS.toNanos(millis);
+  }
+
+  private static Attributes buildRequestAttributes(
+      String system, String service, String method, boolean withSize) {
+    AttributesBuilder builder = Attributes.builder();
+
+    if (emitOldRpcSemconv()) {
+      builder.put(RPC_SYSTEM, system);
+      builder.put(RPC_SERVICE, service);
+      if (!emitStableRpcSemconv()) {
+        builder.put(RPC_METHOD, method);
+      }
+    }
+
+    if (emitStableRpcSemconv()) {
+      builder.put(RPC_SYSTEM_NAME, SemconvStability.stableRpcSystemName(system));
+      builder.put(RPC_METHOD, service + "/" + method);
+    }
+
+    if (withSize) {
+      builder.put(RpcSizeAttributesExtractor.RPC_REQUEST_SIZE, 10);
+    }
+
+    return builder.build();
   }
 }


### PR DESCRIPTION
Part of #15932 — split into smaller reviewable PRs. This is PR 4 of 5 (depends on #16130).

- Add stable metric `rpc.client.call.duration` (seconds) alongside old `rpc.client.duration` (milliseconds)
- Add stable metric `rpc.server.call.duration` (seconds) alongside old `rpc.server.duration` (milliseconds)
- Update `RpcMetricsAdvice` with separate old/stable attribute key lists (`rpc.system.name`, `rpc.response.status_code` for stable)
- Add `OLD_RPC_METHOD_CONTEXT_KEY` infrastructure for correct `rpc.method` handling in dup mode
- Size metrics (`rpc.*.request.size`, `rpc.*.response.size`) remain old-only
- Tests validate all three modes: old-only, stable-only, and dup

https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15871