### PR TITLE
Exclude broken javalin version from muzzle

### DIFF
--- a/instrumentation/javalin/javalin-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/javalin/javalin-7.0/javaagent/build.gradle.kts
@@ -7,6 +7,8 @@ muzzle {
     group.set("io.javalin")
     module.set("javalin")
     versions.set("[7.0.0,)")
+    // 3.2.0 depends on org.meteogroup.jbrotli:jbrotli:0.5.0 that is not available in central
+    skip("3.2.0")
     assertInverse.set(true)
   }
 }


### PR DESCRIPTION
copied from javalin-5.0 module