### PR TITLE
Add getDbName() to DbClientAttributesGetter to better support old / stable semconv split

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -108,7 +108,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
     if (emitOldDatabaseSemconv()) {
       attributes.put(DB_SYSTEM, getter.getDbSystemName(request));
       attributes.put(DB_USER, getter.getUser(request));
-      attributes.put(DB_NAME, getter.getDbNamespace(request));
+      attributes.put(DB_NAME, getter.getDbName(request));
       attributes.put(DB_CONNECTION_STRING, getter.getConnectionString(request));
       attributes.put(DB_STATEMENT, getter.getDbQueryText(request));
       attributes.put(DB_OPERATION, getter.getDbOperationName(request));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesGetter.java
@@ -45,6 +45,17 @@ public interface DbClientAttributesGetter<REQUEST, RESPONSE>
   String getDbNamespace(REQUEST request);
 
   /**
+   * Returns the old db.name value. This is only used for old semantic conventions.
+   *
+   * @deprecated Use {@link #getDbNamespace(Object)} instead.
+   */
+  @Deprecated // to be removed in 3.0
+  @Nullable
+  default String getDbName(REQUEST request) {
+    return getDbNamespace(request);
+  }
+
+  /**
    * Returns the database user name. This is only used for old semantic conventions.
    *
    * @deprecated There is no replacement at this time.


### PR DESCRIPTION
This will allow instrumentations to emit different values for `db.name` (old semconv) and `db.namespace` (new semconv), which is needed for a few databases where these values are different (e.g. postgresql, sqlserver).