### PR TITLE
Switch UCP test container for ARM compatibility

### DIFF
--- a/instrumentation-docs/instrumentations.sh
+++ b/instrumentation-docs/instrumentations.sh
@@ -191,6 +191,8 @@ readonly INSTRUMENTATIONS=(
   "opensearch:opensearch-rest-1.0:javaagent:testStableSemconv"
   "opensearch:opensearch-rest-3.0:javaagent:test"
   "opensearch:opensearch-rest-3.0:javaagent:testStableSemconv"
+  "oracle-ucp-11.2:javaagent:test"
+  "oracle-ucp-11.2:javaagent:testStableSemconv"
   "oshi:javaagent:test"
   "oshi:javaagent:testExperimental"
   "pekko:pekko-http-1.0:javaagent:test"
@@ -282,8 +284,6 @@ readonly COLIMA_INSTRUMENTATIONS=(
   "elasticsearch:elasticsearch-rest-6.4:javaagent:test"
   "elasticsearch:elasticsearch-rest-6.4:javaagent:testStableSemconv"
   "jms:jms-3.0:javaagent:test"
-  "oracle-ucp-11.2:javaagent:test"
-  "oracle-ucp-11.2:javaagent:testStableSemconv"
   "spring:spring-jms:spring-jms-6.0:javaagent:test"
 )
 

--- a/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
+++ b/instrumentation/oracle-ucp-11.2/testing/src/main/java/io/opentelemetry/instrumentation/oracleucp/AbstractOracleUcpInstrumentationTest.java
@@ -20,7 +20,6 @@ import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
 import oracle.ucp.jdbc.PoolDataSource;
 import oracle.ucp.jdbc.PoolDataSourceFactory;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -44,21 +43,11 @@ public abstract class AbstractOracleUcpInstrumentationTest {
 
   @BeforeAll
   static void setUp() {
-    // This docker image does not work on arm mac. To run this test on arm mac read
-    // https://blog.jdriven.com/2022/07/running-oracle-xe-with-testcontainers-on-apple-silicon/
-    // install colima with brew install colima
-    // colima start --arch x86_64 --memory 4
-    // export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-    // export DOCKER_HOST="unix://${HOME}/.colima/docker.sock"
-    String dockerHost = System.getenv("DOCKER_HOST");
-    if (!"aarch64".equals(System.getProperty("os.arch"))
-        || (dockerHost != null && dockerHost.contains("colima"))) {
-      oracle =
-          new OracleContainer("gvenzl/oracle-free:23.4-slim-faststart")
-              .withLogConsumer(new Slf4jLogConsumer(logger))
-              .withStartupTimeout(Duration.ofMinutes(2));
-      oracle.start();
-    }
+    oracle =
+        new OracleContainer("gvenzl/oracle-free:23-slim-faststart")
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+            .withStartupTimeout(Duration.ofMinutes(2));
+    oracle.start();
   }
 
   @AfterAll
@@ -71,7 +60,6 @@ public abstract class AbstractOracleUcpInstrumentationTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldReportMetrics(boolean setExplicitPoolName) throws Exception {
-    Assumptions.assumeTrue(oracle != null);
 
     // given
     PoolDataSource connectionPool = PoolDataSourceFactory.getPoolDataSource();


### PR DESCRIPTION
The [previous image (23.4-slim)](https://hub.docker.com/layers/gvenzl/oracle-free/23.4-slim/images/sha256-0af684d95000e98e643ab3423e3dff17a321bf1cb99ff2cb1738017ef803bc29) was not arm compatible


<img width="683" height="214" alt="image" src="https://github.com/user-attachments/assets/99bc5ca3-6ec3-40d5-bdf6-8cdfb49468ad" />


but [this one (23-slim-faststart)](https://hub.docker.com/layers/gvenzl/oracle-free/23-slim-faststart/images/sha256-8b053707d6e4267268445bf67240cd3a47bc2cdb8873451a247f6d168da868f0) is

<img width="630" height="257" alt="image" src="https://github.com/user-attachments/assets/39c315d9-2228-4770-a859-7883b79d6d81" />


