### PR TITLE
Fix geode-1.4 build on JDK 23+ by excluding broken jna:4.0.0

### DIFF
--- a/instrumentation/geode-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/geode-1.4/javaagent/build.gradle.kts
@@ -11,8 +11,10 @@ muzzle {
 }
 
 dependencies {
-  library("org.apache.geode:geode-core:1.4.0")
-
+  library("org.apache.geode:geode-core:1.4.0") {
+    // jna 4.0.0 has invalid ZIP64 headers, broken on JDK 23+ (JDK-8313765)
+    exclude(group = "net.java.dev.jna", module = "jna")
+  }
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 }


### PR DESCRIPTION
Fixes #16280

`jna:4.0.0` (transitive from `geode-core:1.4.0`) has invalid ZIP64 headers
that cause a ZipException on JDK 23+ (JDK-8313765). Exclude it and add
`jna:4.1.0` instead.