### PR TITLE
Update flint to v0.7.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -15,4 +15,4 @@ use_file_shell_for_executable_tasks = true
 # Pick the tasks you need from flint (https://github.com/grafana/flint)
 [tasks."lint:links"]
 description = "Check for broken links in changed files + all local links"
-file = "https://raw.githubusercontent.com/grafana/flint/8822bdc543f28f2c7dd1f697af4df6d89768c507/tasks/lint/links.sh" # v0.7.0
+file = "https://raw.githubusercontent.com/grafana/flint/0ac131d7832bd8964f6ca9e5af73207dca6a85ba/tasks/lint/links.sh" # v0.7.1


### PR DESCRIPTION
## Summary
- Update flint from v0.7.0 to [v0.7.1](https://github.com/grafana/flint/releases/tag/v0.7.1)
- Strips Scroll to Text Fragment anchors in link checks ([#86](https://github.com/grafana/flint/issues/86))

This should fix the failing daily build https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/22560996279/job/65347333881