### PR TITLE
Automated code review for `akka-actor-2.3:javaagent`

### DIFF
--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorCellInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorCellInstrumentation.java
@@ -29,10 +29,10 @@ public class AkkaActorCellInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         named("invoke").and(takesArgument(0, named("akka.dispatch.Envelope"))),
-        AkkaActorCellInstrumentation.class.getName() + "$InvokeAdvice");
+        getClass().getName() + "$InvokeAdvice");
     transformer.applyAdviceToMethod(
         named("systemInvoke").and(takesArgument(0, named("akka.dispatch.sysmsg.SystemMessage"))),
-        AkkaActorCellInstrumentation.class.getName() + "$SystemInvokeAdvice");
+        getClass().getName() + "$SystemInvokeAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDefaultSystemMessageQueueInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDefaultSystemMessageQueueInstrumentation.java
@@ -38,7 +38,7 @@ public class AkkaDefaultSystemMessageQueueInstrumentation implements TypeInstrum
         named("systemEnqueue")
             .and(takesArgument(0, named("akka.actor.ActorRef")))
             .and(takesArgument(1, named("akka.dispatch.sysmsg.SystemMessage"))),
-        AkkaDefaultSystemMessageQueueInstrumentation.class.getName() + "$DispatchSystemAdvice");
+        getClass().getName() + "$DispatchSystemAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
@@ -32,7 +32,7 @@ public class AkkaDispatcherInstrumentation implements TypeInstrumentation {
         named("dispatch")
             .and(takesArgument(0, named("akka.actor.ActorCell")))
             .and(takesArgument(1, named("akka.dispatch.Envelope"))),
-        AkkaDispatcherInstrumentation.class.getName() + "$DispatchEnvelopeAdvice");
+        getClass().getName() + "$DispatchEnvelopeAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaScheduleInstrumentation.java
@@ -31,13 +31,13 @@ public class AkkaScheduleInstrumentation implements TypeInstrumentation {
             .and(takesArgument(1, named("scala.concurrent.duration.FiniteDuration")))
             .and(takesArgument(2, named("java.lang.Runnable")))
             .and(takesArgument(3, named("scala.concurrent.ExecutionContext"))),
-        AkkaScheduleInstrumentation.class.getName() + "$ScheduleAdvice");
+        getClass().getName() + "$ScheduleAdvice");
     transformer.applyAdviceToMethod(
         named("scheduleOnce")
             .and(takesArgument(0, named("scala.concurrent.duration.FiniteDuration")))
             .and(takesArgument(1, named("java.lang.Runnable")))
             .and(takesArgument(2, named("scala.concurrent.ExecutionContext"))),
-        AkkaScheduleInstrumentation.class.getName() + "$ScheduleOnceAdvice");
+        getClass().getName() + "$ScheduleOnceAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaSchedulerTaskWrapper.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaSchedulerTaskWrapper.java
@@ -18,10 +18,6 @@ public final class AkkaSchedulerTaskWrapper {
     }
   }
 
-  private static boolean isRunOnCloseTask(Runnable runnable) {
-    return RUN_ON_CLOSE_TASK_CLASS != null && RUN_ON_CLOSE_TASK_CLASS.isInstance(runnable);
-  }
-
   public static Runnable wrap(Runnable runnable) {
     // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13066
     // Skip wrapping shutdown tasks. Shutdown process hangs when shutdown tasks are wrapped here.
@@ -31,6 +27,10 @@ public final class AkkaSchedulerTaskWrapper {
 
     Context context = Context.current();
     return context.wrap(runnable);
+  }
+
+  private static boolean isRunOnCloseTask(Runnable runnable) {
+    return RUN_ON_CLOSE_TASK_CLASS != null && RUN_ON_CLOSE_TASK_CLASS.isInstance(runnable);
   }
 
   private AkkaSchedulerTaskWrapper() {}

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/VirtualFields.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/VirtualFields.java
@@ -12,11 +12,11 @@ import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
 
 public class VirtualFields {
 
-  private VirtualFields() {}
-
   public static final VirtualField<Envelope, PropagatedContext> ENVELOPE_PROPAGATED_CONTEXT =
       VirtualField.find(Envelope.class, PropagatedContext.class);
   public static final VirtualField<SystemMessage, PropagatedContext>
       SYSTEM_MESSAGE_PROPAGATED_CONTEXT =
           VirtualField.find(SystemMessage.class, PropagatedContext.class);
+
+  private VirtualFields() {}
 }


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Replace advice class name wiring from .class literals to getClass().getName() in TypeInstrumentation transform methods.
- Move private constructor after fields in VirtualFields (style guide: static utility class)
- Reorder wrap() above isRunOnCloseTask() in AkkaSchedulerTaskWrapper (style guide: calling methods above called methods)