### PR TITLE
Automated code review for `akka-actor-fork-join-2.5:javaagent`

### DIFF
--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinPoolInstrumentation.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinPoolInstrumentation.java
@@ -23,7 +23,6 @@ public class AkkaForkJoinPoolInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    // This might need to be an extendsClass matcher...
     return named("akka.dispatch.forkjoin.ForkJoinPool");
   }
 
@@ -32,15 +31,15 @@ public class AkkaForkJoinPoolInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         named("execute")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
+        getClass().getName() + "$SetAkkaForkJoinStateAdvice");
     transformer.applyAdviceToMethod(
         named("submit")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
+        getClass().getName() + "$SetAkkaForkJoinStateAdvice");
     transformer.applyAdviceToMethod(
         named("invoke")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
+        getClass().getName() + "$SetAkkaForkJoinStateAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/AkkaForkJoinTaskInstrumentation.java
@@ -46,7 +46,7 @@ public class AkkaForkJoinTaskInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        AkkaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
+        getClass().getName() + "$ForkJoinTaskAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/VirtualFields.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaforkjoin/VirtualFields.java
@@ -12,8 +12,6 @@ import java.util.concurrent.Callable;
 
 public class VirtualFields {
 
-  private VirtualFields() {}
-
   public static final VirtualField<ForkJoinTask<?>, PropagatedContext>
       FORK_JOIN_TASK_PROPAGATED_CONTEXT =
           VirtualField.find(ForkJoinTask.class, PropagatedContext.class);
@@ -21,4 +19,6 @@ public class VirtualFields {
       VirtualField.find(Runnable.class, PropagatedContext.class);
   public static final VirtualField<Callable<?>, PropagatedContext> CALLABLE_PROPAGATED_CONTEXT =
       VirtualField.find(Callable.class, PropagatedContext.class);
+
+  private VirtualFields() {}
 }

--- a/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaAsyncChild.java
+++ b/instrumentation/akka/akka-actor-fork-join-2.5/javaagent/src/test/java/io/opentelemetry/instrumentation/akkaforkjoin/AkkaAsyncChild.java
@@ -19,7 +19,7 @@ final class AkkaAsyncChild extends ForkJoinTask<Object> implements TestTask {
   private final boolean doTraceableWork;
   private final CountDownLatch latch = new CountDownLatch(1);
 
-  public AkkaAsyncChild(boolean doTraceableWork, boolean blockThread) {
+  AkkaAsyncChild(boolean doTraceableWork, boolean blockThread) {
     this.doTraceableWork = doTraceableWork;
     this.blockThread = new AtomicBoolean(blockThread);
   }


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Replace advice class name references with getClass().getName() in instrumentation transforms
- Remove stale matcher TODO comment in ForkJoinPool instrumentation
- Narrow AkkaAsyncChild constructor visibility to package-private
- Move private constructor after static fields in VirtualFields (style-guide class organization)