### PR TITLE
Automated code review for `akka-http-10.0:javaagent`

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/PoolMasterActorInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/PoolMasterActorInstrumentation.java
@@ -29,7 +29,7 @@ public class PoolMasterActorInstrumentation implements TypeInstrumentation {
         namedOneOf(
             "akka$http$impl$engine$client$PoolMasterActor$$startPoolInterface",
             "akka$http$impl$engine$client$PoolMasterActor$$startPoolInterfaceActor"),
-        ClearContextAdvice.class.getName());
+        getClass().getName() + "$ClearContextAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/GraphInterpreterInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/GraphInterpreterInstrumentation.java
@@ -24,8 +24,7 @@ public class GraphInterpreterInstrumentation implements TypeInstrumentation {
 
   @Override
   public void transform(TypeTransformer transformer) {
-    transformer.applyAdviceToMethod(
-        named("processPush"), GraphInterpreterInstrumentation.class.getName() + "$PushAdvice");
+    transformer.applyAdviceToMethod(named("processPush"), getClass().getName() + "$PushAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/route/PathMatcherInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/route/PathMatcherInstrumentation.java
@@ -37,7 +37,7 @@ public class PathMatcherInstrumentation implements TypeInstrumentation {
   public static class ApplyAdvice {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void onEnter(
+    public static void onExit(
         @Advice.Argument(0) Uri.Path prefix, @Advice.Return PathMatcher<?> result) {
       // store the path being matched inside a VirtualField on the given matcher, so it can be used
       // for constructing the route


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Replace advice class literal references in client/server instrumentation transforms with getClass().getName() to avoid class loading side effects
- Keep ByteBuddy advice wiring aligned with javaagent module patterns
- Rename advice method onEnter to onExit in PathMatcherInstrumentation.ApplyAdvice to match its @Advice.OnMethodExit annotation