### PR TITLE
Automated code review for `alibaba-druid-1.0:testing`

### DIFF
--- a/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
+++ b/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
@@ -77,10 +77,18 @@ public abstract class AbstractDruidInstrumentationTest {
                 emitStableDatabaseSemconv()
                     ? "db.client.connection.count"
                     : "db.client.connections.usage",
-                "db.client.connections.idle.min",
-                "db.client.connections.idle.max",
-                "db.client.connections.max",
-                "db.client.connections.pending_requests"));
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.idle.min"
+                    : "db.client.connections.idle.min",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.idle.max"
+                    : "db.client.connections.idle.max",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.max"
+                    : "db.client.connections.max",
+                emitStableDatabaseSemconv()
+                    ? "db.client.connection.pending_requests"
+                    : "db.client.connections.pending_requests"));
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Fix post-close metric name set to use stable semconv names when emitStableDatabaseSemconv() is true for idle.min, idle.max, max, and pending_requests metrics