### PR TITLE
Automated code review for `apache-dbcp-2.0:javaagent`

### DIFF
--- a/instrumentation/apache-dbcp-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-dbcp-2.0/javaagent/build.gradle.kts
@@ -19,20 +19,17 @@ dependencies {
   testImplementation(project(":instrumentation:apache-dbcp-2.0:testing"))
 }
 
-val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
-
 tasks {
+  withType<Test>().configureEach {
+    systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
+  }
+
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
-    systemProperty("collectMetadata", collectMetadata)
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
-  }
-
-  test {
-    systemProperty("collectMetadata", collectMetadata)
   }
 
   check {


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Move collectMetadata system property to withType<Test>().configureEach so all test tasks (test and testStableSemconv) receive the property