### PR TITLE
Automated code review for `apache-dbcp-2.0:library`

### DIFF
--- a/instrumentation/apache-dbcp-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachedbcp/v2_0/DataSourceMetrics.java
+++ b/instrumentation/apache-dbcp-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachedbcp/v2_0/DataSourceMetrics.java
@@ -25,36 +25,34 @@ final class DataSourceMetrics {
 
   static void registerMetrics(
       OpenTelemetry openTelemetry, BasicDataSourceMXBean dataSource, String dataSourceName) {
-    DbConnectionPoolMetrics metrics =
-        DbConnectionPoolMetrics.create(openTelemetry, INSTRUMENTATION_NAME, dataSourceName);
+    dataSourceMetrics.computeIfAbsent(
+        dataSource,
+        ds -> {
+          DbConnectionPoolMetrics metrics =
+              DbConnectionPoolMetrics.create(openTelemetry, INSTRUMENTATION_NAME, dataSourceName);
 
-    ObservableLongMeasurement connections = metrics.connections();
-    ObservableLongMeasurement minIdleConnections = metrics.minIdleConnections();
-    ObservableLongMeasurement maxIdleConnections = metrics.maxIdleConnections();
-    ObservableLongMeasurement maxConnections = metrics.maxConnections();
+          ObservableLongMeasurement connections = metrics.connections();
+          ObservableLongMeasurement minIdleConnections = metrics.minIdleConnections();
+          ObservableLongMeasurement maxIdleConnections = metrics.maxIdleConnections();
+          ObservableLongMeasurement maxConnections = metrics.maxConnections();
 
-    Attributes attributes = metrics.getAttributes();
-    Attributes usedConnectionsAttributes = metrics.getUsedConnectionsAttributes();
-    Attributes idleConnectionsAttributes = metrics.getIdleConnectionsAttributes();
+          Attributes attributes = metrics.getAttributes();
+          Attributes usedConnectionsAttributes = metrics.getUsedConnectionsAttributes();
+          Attributes idleConnectionsAttributes = metrics.getIdleConnectionsAttributes();
 
-    BatchCallback callback =
-        metrics.batchCallback(
-            () -> {
-              connections.record(dataSource.getNumActive(), usedConnectionsAttributes);
-              connections.record(dataSource.getNumIdle(), idleConnectionsAttributes);
-              minIdleConnections.record(dataSource.getMinIdle(), attributes);
-              maxIdleConnections.record(dataSource.getMaxIdle(), attributes);
-              maxConnections.record(dataSource.getMaxTotal(), attributes);
-            },
-            connections,
-            minIdleConnections,
-            maxIdleConnections,
-            maxConnections);
-
-    BatchCallback previousCallback = dataSourceMetrics.put(dataSource, callback);
-    if (previousCallback != null) {
-      previousCallback.close();
-    }
+          return metrics.batchCallback(
+              () -> {
+                connections.record(ds.getNumActive(), usedConnectionsAttributes);
+                connections.record(ds.getNumIdle(), idleConnectionsAttributes);
+                minIdleConnections.record(ds.getMinIdle(), attributes);
+                maxIdleConnections.record(ds.getMaxIdle(), attributes);
+                maxConnections.record(ds.getMaxTotal(), attributes);
+              },
+              connections,
+              minIdleConnections,
+              maxIdleConnections,
+              maxConnections);
+        });
   }
 
   static void unregisterMetrics(BasicDataSourceMXBean dataSource) {


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Close previously registered BatchCallback when re-registering datasource metrics
- Reduce DataSourceMetrics helper method visibility to package-private