### PR TITLE
Automated code review for `apache-httpclient-2.0:javaagent`

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -34,7 +34,7 @@ final class ApacheHttpClientHttpAttributesGetter
       if (queryString == null) {
         return request.getPath();
       } else {
-        return request.getPath() + "?" + request.getQueryString();
+        return request.getPath() + "?" + queryString;
       }
     } else {
       StringBuilder url = new StringBuilder();
@@ -50,7 +50,7 @@ final class ApacheHttpClientHttpAttributesGetter
       String queryString = request.getQueryString();
       if (queryString != null) {
         url.append("?");
-        url.append(request.getQueryString());
+        url.append(queryString);
       }
       return url.toString();
     }


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Fix redundant getQueryString() calls in getUrlFull(): use already-assigned local variable instead of calling the getter twice