### PR TITLE
Automated code review for `apache-httpclient-4.0:javaagent`

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -90,7 +90,11 @@ public final class ApacheHttpClientRequest {
 
   @Nullable
   public Integer getServerPort() {
-    return uri == null ? null : uri.getPort();
+    if (uri == null) {
+      return null;
+    }
+    int port = uri.getPort();
+    return port != -1 ? port : null;
   }
 
   @Nullable

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientTest.java
@@ -76,7 +76,7 @@ class ApacheHttpClientTest {
   @Nested
   class ApacheClientHostRequestTest extends AbstractTest<BasicHttpRequest> {
     @Override
-    public BasicHttpRequest createRequest(String method, URI uri) {
+    BasicHttpRequest createRequest(String method, URI uri) {
       // also testing with an absolute path below
       return new BasicHttpRequest(method, fullPathFromUri(uri));
     }


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Move shared test system property configuration to withType<Test>().configureEach
- Make nested test override package-private for JUnit style consistency
- Fix getServerPort() returning -1 instead of null when URI has no explicit port