### PR TITLE
Automated cod review for `apache-httpclient-5.0:javaagent`

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/build.gradle.kts
@@ -7,6 +7,7 @@ muzzle {
     group.set("org.apache.httpcomponents.client5")
     module.set("httpclient5")
     versions.set("[5.0,)")
+    assertInverse.set(true)
   }
 }
 
@@ -22,9 +23,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
-  }
-
-  test {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -118,12 +118,21 @@ final class ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public String getServerAddress(HttpRequest request) {
-    return request.getAuthority().getHostName();
+    URIAuthority authority = request.getAuthority();
+    if (authority == null) {
+      return null;
+    }
+    return authority.getHostName();
   }
 
   @Override
+  @Nullable
   public Integer getServerPort(HttpRequest request) {
-    return request.getAuthority().getPort();
+    URIAuthority authority = request.getAuthority();
+    if (authority == null) {
+      return null;
+    }
+    return authority.getPort();
   }
 
   private static ProtocolVersion getVersion(HttpRequest request, @Nullable HttpResponse response) {

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientInstrumentation.java
@@ -345,8 +345,8 @@ class ApacheHttpClientInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(
-        @Advice.Return Object result,
-        @Advice.Thrown Throwable throwable,
+        @Advice.Return @Nullable Object result,
+        @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Enter Object[] enterResult) {
 
       AdviceScope scope = (AdviceScope) enterResult[0];

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/WrappingStatusSettingResponseHandler.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/WrappingStatusSettingResponseHandler.java
@@ -16,10 +16,10 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 
 public class WrappingStatusSettingResponseHandler<T> implements HttpClientResponseHandler<T> {
-  final Context context;
-  final Context parentContext;
-  final ClassicHttpRequest request;
-  final HttpClientResponseHandler<T> handler;
+  private final Context context;
+  private final Context parentContext;
+  private final ClassicHttpRequest request;
+  private final HttpClientResponseHandler<T> handler;
 
   public WrappingStatusSettingResponseHandler(
       Context context,


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Add missing muzzle assertInverse for httpclient5 pass range
- Apply collectMetadata to all test tasks via withType<Test>().configureEach
- Fix NPE in getServerAddress() and getServerPort() when request.getAuthority() is null
- Make WrappingStatusSettingResponseHandler fields private final
- Add missing @Nullable on @Advice.Return and @Advice.Thrown params in RequestWithHostAndContextAndHandlerAdvice.methodExit