### PR TITLE
Automated code review for `apache-httpclient-5.2:library`

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/metadata.yaml
@@ -1,2 +1,2 @@
-description: This instrumentation enables CLIENT spans and metrics for the Apache HttpAsyncClient.
+description: This instrumentation enables CLIENT spans and metrics for the Apache HttpClient.
 library_link: https://hc.apache.org/index.html

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientHttpAttributesGetter.java
@@ -96,11 +96,18 @@ enum ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public String getServerAddress(ApacheHttpClientRequest request) {
+    if (request.getRequest().getAuthority() == null) {
+      return null;
+    }
     return request.getRequest().getAuthority().getHostName();
   }
 
   @Override
+  @Nullable
   public Integer getServerPort(ApacheHttpClientRequest request) {
+    if (request.getRequest().getAuthority() == null) {
+      return null;
+    }
     return request.getRequest().getAuthority().getPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientRequest.java
@@ -49,7 +49,7 @@ public final class ApacheHttpClientRequest {
   private static URI getUri(HttpRequest httpRequest) {
     try {
       // this can be relative or absolute
-      return new URI(httpRequest.getUri().toString());
+      return httpRequest.getUri();
     } catch (URISyntaxException e) {
       logger.log(FINE, e.getMessage(), e);
       return null;

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/OtelExecChainHandler.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/OtelExecChainHandler.java
@@ -27,7 +27,7 @@ class OtelExecChainHandler implements ExecChainHandler {
   private final Instrumenter<ApacheHttpClientRequest, HttpResponse> instrumenter;
   private final ContextPropagators propagators;
 
-  public OtelExecChainHandler(
+  OtelExecChainHandler(
       Instrumenter<ApacheHttpClientRequest, HttpResponse> instrumenter,
       ContextPropagators propagators) {
     this.instrumenter = instrumenter;


### PR DESCRIPTION
Generated by the `code-review-and-fix.agent.md` from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16348

Specific fixes:

- Move collectMetadata to withType<Test>().configureEach for all test tasks
- Guard server address/port extraction when request authority is absent
- Fix metadata.yaml description: 'HttpAsyncClient' -> 'HttpClient' (copy-paste bug)
- Remove redundant 'public' modifier from OtelExecChainHandler constructor (class is package-private)
- Simplify getUri(): remove redundant new URI(httpRequest.getUri().toString()) double-conversion