### PR TITLE
Add consumer group flag to experimental suite

### DIFF
--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -88,7 +88,6 @@ tasks {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", findProperty("collectMetadata")?.toString() ?: "false")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    systemProperty("hasConsumerGroup", testLatestDeps)
   }
 
   val testExperimental by registering(Test::class) {
@@ -97,6 +96,11 @@ tasks {
 
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
     systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
+    systemProperty("hasConsumerGroup", testLatestDeps)
+  }
+
+  test {
+    systemProperty("hasConsumerGroup", testLatestDeps)
   }
 
   check {


### PR DESCRIPTION
Related to #16395 where testLatestDeps2 is now [failing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/22738643660/job/65946421016)

apologies for the rapid fire updates