### PR TITLE
Propose slight change in convention

### DIFF
--- a/docs/contributing/writing-instrumentation-module.md
+++ b/docs/contributing/writing-instrumentation-module.md
@@ -209,7 +209,7 @@ public void transform(TypeTransformer transformer) {
         .and(takesArguments(2))
         .and(takesArgument(0, String.class))
         .and(takesArgument(1, named("org.my.library.MyLibraryClass"))),
-    this.getClass().getName() + "$MethodAdvice");
+    MyTypeInstrumentation.class.getName() + "$MethodAdvice");
 }
 ```
 
@@ -223,7 +223,7 @@ the `transform()` method.
 > You might have noticed in the example above that the advice class is being referenced as follows:
 >
 > ```java
-> this.getClass().getName() + "$MethodAdvice"
+> MyTypeInstrumentation.class.getName() + "$MethodAdvice"
 > ```
 >
 > Referring to the inner class and calling `getName()` would be easier to read and understand,

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejAsyncServletInstrumentation.java
@@ -47,7 +47,7 @@ public class ActivejAsyncServletInstrumentation implements TypeInstrumentation {
         isMethod()
             .and(named("serve"))
             .and(takesArguments(1).and(takesArgument(0, named("io.activej.http.HttpRequest")))),
-        this.getClass().getName() + "$ServeAdvice");
+        ActivejAsyncServletInstrumentation.class.getName() + "$ServeAdvice");
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
Noticed that a few instrumentations already do this and seems slightly more accurate (e.g. the reason to use getClass() over the class constant is in case it might be different due to subclassing).

If this is accepted, I'll update the code review agent in #16348 and we can let the change roll out module-by-module when that runs.