### PR TITLE
Fix empty response body on Jetty HttpClient 9.4.24–9.4.43

### DIFF
--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
@@ -13,6 +13,25 @@ dependencies {
   latestDepTestLibrary("org.eclipse.jetty:jetty-client:9.+") // documented limitation
 }
 
+testing {
+  suites {
+    // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16405
+    val testDemandedContentListener by registering(JvmTestSuite::class) {
+      sources {
+        java {
+          setSrcDirs(listOf("src/test/java"))
+        }
+      }
+      dependencies {
+        implementation(project())
+        implementation(project(":instrumentation:jetty-httpclient::jetty-httpclient-9.2:testing"))
+        val jettyVersion = if (findProperty("testLatestDeps") as Boolean) "9.4.43.v20210629" else "9.4.24.v20191120"
+        implementation("org.eclipse.jetty:jetty-client:$jettyVersion")
+      }
+    }
+  }
+}
+
 tasks {
   val testStableSemconv by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -21,6 +40,6 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testing.suites, testStableSemconv)
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
 
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
@@ -13,7 +14,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Response;
 
 /**
@@ -22,36 +22,29 @@ import org.eclipse.jetty.client.api.Response;
  */
 public final class JettyClientWrapUtil {
 
-  // Response.DemandedContentListener was added in Jetty 9.4.24. In versions 9.4.24–9.4.43,
-  // AsyncContentListener and ContentListener do NOT extend DemandedContentListener, but Jetty's
-  // HttpReceiver.ContentListeners filters via instanceof DemandedContentListener. Without
-  // explicitly including it, the proxy fails the instanceof check and content is never delivered.
-  @Nullable
-  private static final Class<?> demandedContentListenerClass = loadDemandedContentListener();
-
   private static final Class<?>[] listenerInterfaces = buildListenerInterfaces();
 
-  @Nullable
-  private static Class<?> loadDemandedContentListener() {
-    try {
-      return Class.forName("org.eclipse.jetty.client.api.Response$DemandedContentListener");
-    } catch (ClassNotFoundException e) {
-      return null;
-    }
-  }
-
   private static Class<?>[] buildListenerInterfaces() {
-    List<Class<?>> interfaces = new ArrayList<>();
-    interfaces.add(Response.CompleteListener.class);
-    interfaces.add(Response.FailureListener.class);
-    interfaces.add(Response.SuccessListener.class);
-    interfaces.add(Response.AsyncContentListener.class);
-    interfaces.add(Response.ContentListener.class);
-    interfaces.add(Response.HeadersListener.class);
-    interfaces.add(Response.HeaderListener.class);
-    interfaces.add(Response.BeginListener.class);
-    if (demandedContentListenerClass != null) {
-      interfaces.add(demandedContentListenerClass);
+    List<Class<?>> interfaces =
+        new ArrayList<>(
+            asList(
+                Response.CompleteListener.class,
+                Response.FailureListener.class,
+                Response.SuccessListener.class,
+                Response.AsyncContentListener.class,
+                Response.ContentListener.class,
+                Response.HeadersListener.class,
+                Response.HeaderListener.class,
+                Response.BeginListener.class));
+    // Response.DemandedContentListener was added in Jetty 9.4.24. In versions 9.4.24–9.4.43,
+    // AsyncContentListener and ContentListener do NOT extend DemandedContentListener, but Jetty's
+    // HttpReceiver.ContentListeners filters via instanceof DemandedContentListener. Without
+    // explicitly including it, the proxy fails the instanceof check and content is never delivered.
+    try {
+      interfaces.add(
+          Class.forName("org.eclipse.jetty.client.api.Response$DemandedContentListener"));
+    } catch (ClassNotFoundException ignored) {
+      // ignored
     }
     return interfaces.toArray(new Class<?>[0]);
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HttpCallTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HttpCallTest.java
@@ -24,8 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Regression test for empty response body when OTel instrumentation wraps Jetty HttpClient
- * listeners on Jetty 9.4.24–~9.4.43.
+ * Regression test for
+ * https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16405 Empty response
+ * body when OTel instrumentation wraps Jetty HttpClient listeners on Jetty 9.4.24–~9.4.43.
  *
  * <p>In those versions, {@code AsyncContentListener} and {@code ContentListener} do NOT extend
  * {@code DemandedContentListener}. Jetty's {@code HttpReceiver.ContentListeners} filters via {@code


### PR DESCRIPTION
Fixes #16405

## Summary

- Reflectively load `Response.DemandedContentListener` (introduced in Jetty 9.4.24) and include it in the proxy's interface list in `JettyClientWrapUtil`
- Add regression test covering both `ContentResponse` and `InputStreamResponseListener` content delivery

## Problem

In Jetty 9.4.24–~9.4.43, `Response.DemandedContentListener` is a standalone interface — `AsyncContentListener` and `ContentListener` do **not** extend it. Jetty's `HttpReceiver.ContentListeners` filters listeners via `instanceof DemandedContentListener` before delivering content.

`JettyClientWrapUtil` wraps response listeners in a `java.lang.reflect.Proxy` whose interface list does not include `DemandedContentListener`. The proxy fails the `instanceof` check, gets filtered out, and response content is never delivered — resulting in empty response bodies.

In later Jetty versions (~9.4.44+), `AsyncContentListener extends DemandedContentListener`, so the proxy inherits it automatically and the bug does not manifest.

## Fix

`DemandedContentListener` does not exist in Jetty 9.2 (the compile target), so it is loaded reflectively via `Class.forName()`. If present, it is added to the `listenerInterfaces` array. If absent (pre-9.4.24), it is a no-op.

## Test plan

- [x] `JettyHttpClient9HttpCallTest.contentResponseBodyIsDelivered` — synchronous `ContentResponse` path
- [x] `JettyHttpClient9HttpCallTest.inputStreamListenerBodyIsDelivered` — async `InputStreamResponseListener` path
- [x] Existing `JettyHttpClient9LibraryTest` suite passes
- [x] Verified against Jetty 9.2 base (no `DemandedContentListener` — reflective load returns null, no-op)
- [x] Verified against Jetty 9.4.24 + agent (previously failed, now passes)
- [x] Verified against Jetty 9.4.56 (latest 9.x — already worked, still works)

Made with [Cursor](https://cursor.com)