### PR TITLE
Better fallbacks for apache http client `server.address` and `server.port` when uri is invalid

### DIFF
--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -79,13 +79,18 @@ public final class ApacheHttpClientRequest {
     return protocolVersion.getMajor() + "." + protocolVersion.getMinor();
   }
 
+  @Nullable
   public String getServerAddress() {
-    return uri != null ? uri.getHost() : null;
+    if (uri != null) {
+      return uri.getHost();
+    }
+    return target != null ? target.getHostName() : null;
   }
 
+  @Nullable
   public Integer getServerPort() {
     if (uri == null) {
-      return null;
+      return target != null ? target.getPort() : null;
     }
     int port = uri.getPort();
     if (port != -1) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -27,6 +27,7 @@ public final class ApacheHttpClientRequest {
   @Nullable private final URI uri;
 
   private final HttpRequest delegate;
+  @Nullable private final HttpHost target;
 
   public ApacheHttpClientRequest(HttpHost httpHost, HttpRequest httpRequest) {
     URI calculatedUri = getUri(httpRequest);
@@ -36,11 +37,13 @@ public final class ApacheHttpClientRequest {
       uri = calculatedUri;
     }
     delegate = httpRequest;
+    target = httpHost;
   }
 
   public ApacheHttpClientRequest(HttpUriRequest httpRequest) {
     uri = httpRequest.getURI();
     delegate = httpRequest;
+    target = null;
   }
 
   public List<String> getHeader(String name) {
@@ -85,12 +88,18 @@ public final class ApacheHttpClientRequest {
 
   @Nullable
   public String getServerAddress() {
-    return uri == null ? null : uri.getHost();
+    if (uri != null) {
+      return uri.getHost();
+    }
+    return target != null ? target.getHostName() : null;
   }
 
   @Nullable
   public Integer getServerPort() {
-    return uri == null ? null : uri.getPort();
+    if (uri != null) {
+      return uri.getPort();
+    }
+    return target != null ? target.getPort() : null;
   }
 
   @Nullable

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -89,12 +89,18 @@ public final class ApacheHttpClientRequest {
 
   @Nullable
   String getServerAddress() {
-    return uri == null ? null : uri.getHost();
+    if (uri != null) {
+      return uri.getHost();
+    }
+    return target != null ? target.getHostName() : null;
   }
 
   @Nullable
   Integer getServerPort() {
-    return uri == null ? null : uri.getPort();
+    if (uri != null) {
+      return uri.getPort();
+    }
+    return target != null ? target.getPort() : null;
   }
 
   @Nullable


### PR DESCRIPTION
Noticed while implementing #16388

TODO rebase on top of #16388 once that is merged