### PR TITLE
Work around ktor server instrumentation leaking scope

### DIFF
--- a/instrumentation/ktor/ktor-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/ktor/ktor-2.0/javaagent/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:ktor:ktor-3.0:javaagent"))
+  testInstrumentation(project(":instrumentation:kotlinx-coroutines:kotlinx-coroutines-1.0:javaagent"))
+  testInstrumentation(project(":instrumentation:opentelemetry-extension-kotlin-1.0:javaagent"))
 
   testImplementation(project(":instrumentation:ktor:ktor-2.0:testing"))
   testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/instrumentation/ktor/ktor-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/ktor/ktor-3.0/javaagent/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:ktor:ktor-2.0:javaagent"))
+  testInstrumentation(project(":instrumentation:kotlinx-coroutines:kotlinx-coroutines-1.0:javaagent"))
+  testInstrumentation(project(":instrumentation:opentelemetry-extension-kotlin-1.0:javaagent"))
 
   testImplementation(project(":instrumentation:ktor:ktor-3.0:testing"))
   testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorServerTelemetryBuilder.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorServerTelemetryBuilder.kt
@@ -13,15 +13,35 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
 import io.opentelemetry.instrumentation.ktor.common.v2_0.AbstractKtorServerTelemetryBuilder
 import io.opentelemetry.instrumentation.ktor.common.v2_0.internal.KtorServerTelemetryUtil.configureTelemetry
 import io.opentelemetry.instrumentation.ktor.v3_0.InstrumentationProperties.INSTRUMENTATION_NAME
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
 
 class KtorServerTelemetryBuilder internal constructor(
   instrumentationName: String
 ) : AbstractKtorServerTelemetryBuilder(instrumentationName)
 
+val emptyInterceptor = object : ContinuationInterceptor {
+  override val key = ContinuationInterceptor
+
+  override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = object : Continuation<T> {
+    override val context = continuation.context
+
+    override fun resumeWith(result: Result<T>) {
+      continuation.resumeWith(result)
+    }
+  }
+}
+
 val KtorServerTelemetry = createRouteScopedPlugin("OpenTelemetry", { KtorServerTelemetryBuilder(INSTRUMENTATION_NAME) }) {
   require(pluginConfig.isOpenTelemetryInitialized()) { "OpenTelemetry must be set" }
 
-  configureTelemetry(pluginConfig, application)
+  configureTelemetry(pluginConfig, application) { action ->
+    // work around issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
+    withContext(emptyInterceptor) {
+      action()
+    }
+  }
 
   application.monitor.subscribe(RoutingRoot.RoutingCallStarted) { call ->
     HttpServerRoute.update(Context.current(), HttpServerRouteSource.SERVER, { _, arg -> arg!!.route.parent.toString() }, call)

--- a/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorServerTelemetryBuilder.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorServerTelemetryBuilder.kt
@@ -13,35 +13,15 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
 import io.opentelemetry.instrumentation.ktor.common.v2_0.AbstractKtorServerTelemetryBuilder
 import io.opentelemetry.instrumentation.ktor.common.v2_0.internal.KtorServerTelemetryUtil.configureTelemetry
 import io.opentelemetry.instrumentation.ktor.v3_0.InstrumentationProperties.INSTRUMENTATION_NAME
-import kotlinx.coroutines.withContext
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.ContinuationInterceptor
 
 class KtorServerTelemetryBuilder internal constructor(
   instrumentationName: String
 ) : AbstractKtorServerTelemetryBuilder(instrumentationName)
 
-val emptyInterceptor = object : ContinuationInterceptor {
-  override val key = ContinuationInterceptor
-
-  override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = object : Continuation<T> {
-    override val context = continuation.context
-
-    override fun resumeWith(result: Result<T>) {
-      continuation.resumeWith(result)
-    }
-  }
-}
-
 val KtorServerTelemetry = createRouteScopedPlugin("OpenTelemetry", { KtorServerTelemetryBuilder(INSTRUMENTATION_NAME) }) {
   require(pluginConfig.isOpenTelemetryInitialized()) { "OpenTelemetry must be set" }
 
-  configureTelemetry(pluginConfig, application) { action ->
-    // work around issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
-    withContext(emptyInterceptor) {
-      action()
-    }
-  }
+  configureTelemetry(pluginConfig, application)
 
   application.monitor.subscribe(RoutingRoot.RoutingCallStarted) { call ->
     HttpServerRoute.update(Context.current(), HttpServerRouteSource.SERVER, { _, arg -> arg!!.route.parent.toString() }, call)

--- a/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorHttpServerTest.kt
@@ -22,9 +22,12 @@ import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTes
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.semconv.ServerAttributes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 
 abstract class AbstractKtorHttpServerTest : AbstractHttpServerTest<EmbeddedServer<*, *>>() {
 
@@ -77,6 +80,10 @@ abstract class AbstractKtorHttpServerTest : AbstractHttpServerTest<EmbeddedServe
       }
 
       get("/child") {
+        // with ktor 3.0 triggers the issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
+        withContext(Dispatchers.IO) {
+          delay(1.milliseconds)
+        }
         controller(ServerEndpoint.INDEXED_CHILD) {
           ServerEndpoint.INDEXED_CHILD.collectSpanAttributes { call.request.queryParameters[it] }
           call.respondText(ServerEndpoint.INDEXED_CHILD.body, status = HttpStatusCode.fromValue(ServerEndpoint.INDEXED_CHILD.status))

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -18,14 +18,27 @@ import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil
 import io.opentelemetry.instrumentation.ktor.common.v2_0.AbstractKtorServerTelemetryBuilder
 import io.opentelemetry.instrumentation.ktor.common.v2_0.ApplicationRequestGetter
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 object KtorServerTelemetryUtil {
+  val emptyInterceptor = object : ContinuationInterceptor {
+    override val key = ContinuationInterceptor
 
-  fun configureTelemetry(builder: AbstractKtorServerTelemetryBuilder, application: Application, block: suspend (suspend () -> Unit) -> Unit = {}) {
+    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = object : Continuation<T> {
+      override val context = continuation.context
+
+      override fun resumeWith(result: Result<T>) {
+        continuation.resumeWith(result)
+      }
+    }
+  }
+
+  fun configureTelemetry(builder: AbstractKtorServerTelemetryBuilder, application: Application) {
     val contextKey = AttributeKey<Context>("OpenTelemetry")
     val errorKey = AttributeKey<Throwable>("OpenTelemetryException")
     val processedKey = AttributeKey<Unit>("OpenTelemetryProcessed")
@@ -40,7 +53,8 @@ object KtorServerTelemetryUtil {
 
       if (context != null) {
         call.attributes.put(contextKey, context)
-        block {
+        // work around issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
+        withContext(emptyInterceptor) {
           withContext(context.asContextElement()) {
             proceed()
           }

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.withContext
  */
 object KtorServerTelemetryUtil {
 
-  fun PluginBuilder<*>.configureTelemetry(builder: AbstractKtorServerTelemetryBuilder, application: Application) {
+  fun configureTelemetry(builder: AbstractKtorServerTelemetryBuilder, application: Application, block: suspend (suspend () -> Unit) -> Unit = {}) {
     val contextKey = AttributeKey<Context>("OpenTelemetry")
     val errorKey = AttributeKey<Throwable>("OpenTelemetryException")
     val processedKey = AttributeKey<Unit>("OpenTelemetryProcessed")
@@ -40,8 +40,10 @@ object KtorServerTelemetryUtil {
 
       if (context != null) {
         call.attributes.put(contextKey, context)
-        withContext(context.asContextElement()) {
-          proceed()
+        block {
+          withContext(context.asContextElement()) {
+            proceed()
+          }
         }
       } else {
         proceed()

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -26,6 +26,14 @@ import kotlin.coroutines.ContinuationInterceptor
  * any time.
  */
 object KtorServerTelemetryUtil {
+  // A no-op ContinuationInterceptor. There seems to be a bug in Ktor where when propagate otel
+  // context by using withContext(context.asContextElement()) updateThreadContext, that activates
+  // the otel scope, gets called in
+  // https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/kotlin/src/main/java/io/opentelemetry/extension/kotlin/KotlinContextElement.java
+  // but the restoreThreadContext is not always called, which causes the otel context to leak across
+  // requests. This issue can be worked around by adding -Dio.ktor.internal.disable.sfg=true to jvm
+  // arguments. Adding this no-op interceptor seems to also work around the issue.
+  // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
   val emptyInterceptor = object : ContinuationInterceptor {
     override val key = ContinuationInterceptor
 
@@ -53,7 +61,6 @@ object KtorServerTelemetryUtil {
 
       if (context != null) {
         call.attributes.put(contextKey, context)
-        // work around issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
         withContext(emptyInterceptor) {
           withContext(context.asContextElement()) {
             proceed()

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -295,6 +295,6 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
         .allowClass("com.fasterxml.jackson.databind.util.internal.PrivateMaxEntriesMap$AddTask");
 
     // kotlin, note we do not ignore kotlinx because we instrument coroutines code
-    builder.ignoreClass("kotlin.");
+    builder.ignoreClass("kotlin.").allowClass("kotlin.sequences.SequenceBuilderIterator");
   }
 }


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
Looks like calling s suspend function in traced ktor server causes a context leak. For some reason it does not reproduce any more when a continuation interceptor is added. Similar issue has also been reported in https://youtrack.jetbrains.com/issue/KTOR-6118/CallMonitoring-SuspendFunctionGun-sometimes-leaks-coroutine-context