### PR TITLE
Disable flaky assertion on jdk26

### DIFF
--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -259,6 +259,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
       return;
     }
 
+    double javaVersion = Double.parseDouble(System.getProperty("java.specification.version"));
     // JFR based metrics
     for (String metric :
         asList(
@@ -273,6 +274,10 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
             "jvm.memory.allocation",
             "jvm.network.io",
             "jvm.thread.count")) {
+      // gc duration is sometimes missing on jdk 26
+      if (javaVersion == 26 && "jvm.gc.duration".equals(metric)) {
+        continue;
+      }
       testing.waitAndAssertMetrics(
           "io.opentelemetry.runtime-telemetry-java17", metric, AbstractIterableAssert::isNotEmpty);
     }


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/fz2rwqt6sehai/tests/task/:smoke-tests-otel-starter:spring-boot-4:test/details/io.opentelemetry.spring.smoketest.OtelSpringStarterUserDataSourceBeanTest/shouldSendTelemetry()?expanded-stacktrace=WyIwIl0&top-execution=1