### PR TITLE
Simplify connection pool shutdown assertions to filter by scope only

### DIFF
--- a/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
+++ b/instrumentation/alibaba-druid-1.0/testing/src/main/java/io/opentelemetry/instrumentation/alibabadruid/AbstractDruidInstrumentationTest.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.alibabadruid;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.alibaba.druid.pool.DruidDataSource;
@@ -14,8 +12,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.DbConnectionPoolMetricsAssertions;
 import io.opentelemetry.instrumentation.testing.junit.db.MockDriver;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Set;
 import javax.management.ObjectName;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,21 +64,10 @@ public abstract class AbstractDruidInstrumentationTest {
     Thread.sleep(100);
 
     // then
-    Set<String> metricNames =
-        new HashSet<>(
-            asList(
-                emitStableDatabaseSemconv()
-                    ? "db.client.connection.count"
-                    : "db.client.connections.usage",
-                "db.client.connections.idle.min",
-                "db.client.connections.idle.max",
-                "db.client.connections.max",
-                "db.client.connections.pending_requests"));
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->
-                metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME)
-                    && metricNames.contains(metricData.getName()))
+                metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME))
         .isEmpty();
   }
 }

--- a/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
+++ b/instrumentation/apache-dbcp-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachedbcp/AbstractApacheDbcpInstrumentationTest.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.apachedbcp;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -16,8 +14,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.DbConnectionPoolMetricsAssertions;
 import java.sql.Connection;
 import java.sql.Driver;
-import java.util.HashSet;
-import java.util.Set;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,20 +69,10 @@ public abstract class AbstractApacheDbcpInstrumentationTest {
     Thread.sleep(100);
 
     // then
-    Set<String> metricNames =
-        new HashSet<>(
-            asList(
-                emitStableDatabaseSemconv()
-                    ? "db.client.connection.count"
-                    : "db.client.connections.usage",
-                "db.client.connections.idle.min",
-                "db.client.connections.idle.max",
-                "db.client.connections.max"));
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->
-                metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME)
-                    && metricNames.contains(metricData.getName()))
+                metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME))
         .isEmpty();
   }
 }


### PR DESCRIPTION
Better fix compared to

- #16478
- #16480