### PR TITLE
Restrict secrets to protected branches

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -4,20 +4,29 @@ This document describes any changes that have been made to the
 settings in this repository outside the settings tracked in the
 private admin repo.
 
-## Secrets and variables > Actions
+## Environments
 
-### Repository secrets
+### `protected` environment
+
+Deployment branches: `main`, `release/*`
+
+Secrets:
 
 - `COPILOT_GITHUB_TOKEN` - owned by [@trask](https://github.com/trask)
-- `FLAKY_TEST_REPORTER_ACCESS_KEY` - owned by [@laurit](https://github.com/laurit)
 - `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
 - `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
 - `GRADLE_PUBLISH_KEY` - owned by [@trask](https://github.com/trask)
 - `GRADLE_PUBLISH_SECRET` - owned by [@trask](https://github.com/trask)
-- `SONATYPE_OSS_INDEX_USER` - owned by [@trask](https://github.com/trask)
-- `SONATYPE_OSS_INDEX_PASSWORD` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_KEY` - owned by [@trask](https://github.com/trask)
+- `SONATYPE_OSS_INDEX_PASSWORD` - owned by [@trask](https://github.com/trask)
+- `SONATYPE_OSS_INDEX_USER` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_USER` - owned by [@trask](https://github.com/trask)
+
+## Secrets and variables > Actions
+
+### Repository secrets
+
+- `FLAKY_TEST_REPORTER_ACCESS_KEY` - owned by [@laurit](https://github.com/laurit)
 
 ### Organization secrets
 

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -32,6 +32,7 @@ jobs:
     uses: ./.github/workflows/reusable-markdown-lint-check.yml
 
   publish-snapshots:
+    environment: protected
     needs:
       - common
     runs-on: ubuntu-latest

--- a/.github/workflows/code-review-sweep.yml
+++ b/.github/workflows/code-review-sweep.yml
@@ -53,6 +53,7 @@ jobs:
       matrix: ${{ fromJSON(needs.dispatch.outputs.matrix) }}
       fail-fast: false
       max-parallel: 2  # keep low to avoid Copilot API rate limits
+    environment: protected
     permissions:
       contents: write  # for git push
     env:

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   analyze:
+    environment: protected
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   # and this is not a reason to hold up the release
 
   release:
+    environment: protected
     permissions:
       contents: write # for creating the release
       id-token: write # for signing artifacts with Sigstore


### PR DESCRIPTION
Specifically motivated by wanting to enable new feature https://github.blog/changelog/2026-03-13-optionally-skip-approval-for-copilot-coding-agent-actions-workflows/

Which will allow CI to run automatically on copilot coding agent PRs (instead of having to hit Approve every time which is annoying).

The only downside to this is that copilot PRs could add workflows that access secrets (of course this relies on us reviewing the PR before hitting Approve).

Restricting secrets to `main` and `release/*` branches, which are already protected and can only be updated via PR merge, addresses this concern.

I have related IaC PR up: https://github.com/open-telemetry/admin/pull/595