### PR TITLE
Code review agent: fix test failure detection

### DIFF
--- a/.github/agents/code-review-and-fix.agent.md
+++ b/.github/agents/code-review-and-fix.agent.md
@@ -199,6 +199,11 @@ Comment formatting rules:
 this repository can take several minutes — never treat slow output as a hang. Always wait
 for completion.**
 
+**Never pipe Gradle output through `tail`, `head`, `grep`, or any other command** (e.g.,
+`./gradlew :foo:check 2>&1 | tail -30`). Piping masks the Gradle exit code because the
+shell reports the exit code of the last pipe segment, not Gradle. A failing build will
+appear to succeed. Always run Gradle commands directly without pipes.
+
 Execute these steps strictly in order — do not reorder:
 
 1. **Run the module's check task.** For every module whose source files were modified, run its

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,3 +23,7 @@ Never use `--rerun-tasks`. Use `--rerun` when needed.
 Builds and tests in this repository can take several minutes.
 Run Gradle commands with timeout `0` (no timeout), and wait for completion.
 Do not treat slow output as a hang by default.
+
+Never pipe Gradle output through `tail`, `head`, `grep`, or any other command.
+Piping masks the Gradle exit code — the shell reports the exit code of the last
+pipe segment, not Gradle, so a failing build silently appears to succeed.


### PR DESCRIPTION
It continues to open PRs that have failing tests... Tracked down why (hopefully)...