### PR TITLE
Fix bridging complex attributes

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/ApplicationSpanBuilder.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/ApplicationSpanBuilder.java
@@ -11,6 +11,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.ValueBridging;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.context.AgentContextStorage;
 import java.util.concurrent.TimeUnit;
 
@@ -86,12 +87,19 @@ public class ApplicationSpanBuilder implements application.io.opentelemetry.api.
 
   @Override
   @CanIgnoreReturnValue
+  // unchecked: toAgent returns raw AttributeKey, VALUE bridging requires casting to Object key
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public <T> application.io.opentelemetry.api.trace.SpanBuilder setAttribute(
       application.io.opentelemetry.api.common.AttributeKey<T> applicationKey, T value) {
     @SuppressWarnings("unchecked") // toAgent uses raw AttributeKey
     AttributeKey<T> agentKey = Bridging.toAgent(applicationKey);
     if (agentKey != null) {
-      agentBuilder.setAttribute(agentKey, value);
+      // For VALUE type attributes, need to bridge the Value object as well
+      if (applicationKey.getType().name().equals("VALUE")) {
+        agentBuilder.setAttribute((AttributeKey) agentKey, ValueBridging.toAgent(value));
+      } else {
+        agentBuilder.setAttribute(agentKey, value);
+      }
     }
     return this;
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.27/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_27/logs/ApplicationLogRecordBuilder.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.27/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_27/logs/ApplicationLogRecordBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_27.logs;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.ValueBridging;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.context.AgentContextStorage;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.trace.Bridging;
 import java.time.Instant;
@@ -83,12 +84,19 @@ public class ApplicationLogRecordBuilder
 
   @Override
   @CanIgnoreReturnValue
+  // unchecked: toAgent returns raw AttributeKey, VALUE bridging requires casting to Object key
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public <T> application.io.opentelemetry.api.logs.LogRecordBuilder setAttribute(
-      application.io.opentelemetry.api.common.AttributeKey<T> attributeKey, T t) {
+      application.io.opentelemetry.api.common.AttributeKey<T> attributeKey, T value) {
     @SuppressWarnings("unchecked") // toAgent uses raw AttributeKey
     AttributeKey<T> agentKey = Bridging.toAgent(attributeKey);
     if (agentKey != null) {
-      agentLogRecordBuilder.setAttribute(agentKey, t);
+      // For VALUE type attributes, need to bridge the Value object as well
+      if (attributeKey.getType().name().equals("VALUE")) {
+        agentLogRecordBuilder.setAttribute((AttributeKey) agentKey, ValueBridging.toAgent(value));
+      } else {
+        agentLogRecordBuilder.setAttribute(agentKey, value);
+      }
     }
     return this;
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueBridging159.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueBridging159.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
  */
 public final class ValueBridging159 {
 
+  // used via reflection by
+  // io.opentelemetry.javaagent.instrumentation.opentelemetryapi.ValueBridging
   public static final Function<Object, Object> INSTANCE = ValueBridging159::toAgentValue;
 
   private static final Logger logger = Logger.getLogger(ValueBridging159.class.getName());

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueAttributeTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueAttributeTest.java
@@ -17,11 +17,14 @@ import static io.opentelemetry.api.common.AttributeKey.valueKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -292,5 +295,44 @@ class ValueAttributeTest {
                             equalTo(stringKey("string"), "hello"),
                             equalTo(longKey("long"), 42L),
                             equalTo(valueKey("bytes"), bytesValue))));
+  }
+
+  @Test
+  void spanBuilderWithValueAttribute() {
+    testing
+        .getOpenTelemetry()
+        .getTracer("test")
+        .spanBuilder("test-span")
+        .setAttribute(valueKey("key"), Value.of("test"))
+        .startSpan()
+        .end();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("test-span")
+                        .hasAttributesSatisfyingExactly(equalTo(stringKey("key"), "test"))));
+  }
+
+  @Test
+  void logRecordBuilderWithValueAttribute() {
+    Logger logger = testing.getOpenTelemetry().getLogsBridge().loggerBuilder("test").build();
+    logger
+        .logRecordBuilder()
+        .setBody("body")
+        .setAttribute(valueKey("key"), Value.of("test"))
+        .emit();
+
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(testing.logRecords())
+                    .satisfiesExactly(
+                        logRecordData -> {
+                          assertThat(logRecordData.getBodyValue().asString()).isEqualTo("body");
+                          assertThat(logRecordData.getAttributes())
+                              .isEqualTo(Attributes.builder().put("key", "test").build());
+                        }));
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16705
Implements bridging for `SpanBuilder.setAttribute` and `LogRecordBuilder.setAttribute`