### PR TITLE
Move test classes out of default package

### DIFF
--- a/testing-common/integration-tests/src/main/java/oldbytecode/IbmResourceLevelInstrumentationModule.java
+++ b/testing-common/integration-tests/src/main/java/oldbytecode/IbmResourceLevelInstrumentationModule.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package oldbytecode;
+
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;

--- a/testing-common/integration-tests/src/main/java/oldbytecode/ResourceLevelInstrumentation.java
+++ b/testing-common/integration-tests/src/main/java/oldbytecode/ResourceLevelInstrumentation.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package oldbytecode;
+
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;


### PR DESCRIPTION
This one's a bit odd, but there are several misc top-level package names in the module, so I think the new one level package name makes sense(?)