### PR TITLE
ci: add lint meta-task, fix, and pre-commit hook

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,7 @@ exit $failed
 description = "Run all lints"
 depends = ["lint:links", "lint:markdown", "lint:java"]
 
-[tasks.fix]
+[tasks."lint:fix"]
 description = "Auto-fix lint issues"
 run = """
 files=$(git diff --name-only --diff-filter=d origin/main...HEAD -- '*.java')


### PR DESCRIPTION
## Summary
- Bump flint from v0.8.0 to v0.9.1
- Add `lint:java` task using `google-java-format` native binary (~42ms for changed files vs minutes via Gradle spotless)
- Add `lint` meta-task running links + markdown + java formatting in parallel
- Add `fix` task (google-java-format + markdownlint --fix)
- Add `pre-commit` + `setup:pre-commit-hook` tasks via `mise generate git-pre-commit`
- CI still runs the full `spotlessCheck` via Gradle as the authoritative check

## Test plan
- [x] `mise run lint` passes (links, markdown, java all green)
- [ ] CI passes