### PR TITLE
Fix flaky spring starter smoke test

### DIFF
--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelResourceProperties;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.properties.OtelSpringProperties;
@@ -45,6 +46,7 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.MapAssert;
 import org.junit.jupiter.api.MethodOrderer;
@@ -233,7 +235,11 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
     assertThat(exportedLogRecords).as("No log record exported.").isNotEmpty();
     if (!nativeImage) {
       // log records differ in native image mode due to different startup timing
-      LogRecordData firstLog = exportedLogRecords.get(0);
+      Optional<LogRecordData> firstInfo =
+          exportedLogRecords.stream().filter(log -> log.getSeverity() == Severity.INFO).findFirst();
+      assertThat(firstInfo.isPresent()).as("No INFO log record exported.").isTrue();
+
+      LogRecordData firstLog = firstInfo.get();
       assertThat(firstLog.getBodyValue().asString())
           .as("Should instrument logs")
           .startsWith("Starting ")


### PR DESCRIPTION
https://scans.gradle.com/s/5luptjav25yum
Initially I wanted to convert the test to new properties for enabling the runtime metrics to avoid the warning, but I think the old and new properties aren't equivalent so more work would be needed to make this test work with the new properties.