### PR TITLE
Migrate smoke tests to new runtime-telemetry properties

### DIFF
--- a/smoke-tests-otel-starter/spring-boot-2/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-2/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestTemplate;
     properties = {
       // The headers are simply set here to make sure that headers can be parsed
       "otel.exporter.otlp.headers.c=3",
-      "otel.instrumentation.runtime-telemetry.emit-experimental-telemetry=true",
+      "otel.instrumentation.runtime-telemetry.emit-experimental-metrics=true",
       "otel.instrumentation.common.thread_details.enabled=true",
     })
 class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {

--- a/smoke-tests-otel-starter/spring-boot-3/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-3/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -27,14 +27,19 @@ import org.springframework.web.client.RestTemplate;
     properties = {
       // The headers are simply set here to make sure that headers can be parsed
       "otel.exporter.otlp.headers.c=3",
-      "otel.instrumentation.runtime-telemetry.emit-experimental-telemetry=true",
-      "otel.instrumentation.runtime-telemetry-java17.enable-all=true",
+      "otel.instrumentation.runtime-telemetry.emit-experimental-metrics=true",
+      "otel.instrumentation.runtime-telemetry.experimental.prefer-jfr=true",
       "otel.instrumentation.common.thread_details.enabled=true",
     })
 class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {
 
   @Autowired protected TestRestTemplate testRestTemplate;
   @Autowired private RestTemplateBuilder restTemplateBuilder;
+
+  @Override
+  protected boolean preferJfr() {
+    return true;
+  }
 
   @Override
   void makeClientCall() {
@@ -62,7 +67,7 @@ class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {
     // JFR based metrics
     for (String metric :
         List.of(
-            "jvm.cpu.limit",
+            "jvm.cpu.count",
             "jvm.buffer.count",
             "jvm.class.count",
             "jvm.cpu.context_switch",
@@ -75,7 +80,7 @@ class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {
             "jvm.network.io",
             "jvm.thread.count")) {
       testing.waitAndAssertMetrics(
-          "io.opentelemetry.runtime-telemetry-java17", metric, AbstractIterableAssert::isNotEmpty);
+          "io.opentelemetry.runtime-telemetry", metric, AbstractIterableAssert::isNotEmpty);
     }
   }
 

--- a/smoke-tests-otel-starter/spring-boot-4/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-4/src/test/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTest.java
@@ -31,8 +31,8 @@ import org.springframework.web.client.RestTemplate;
     properties = {
       // The headers are simply set here to make sure that headers can be parsed
       "otel.exporter.otlp.headers.c=3",
-      "otel.instrumentation.runtime-telemetry.emit-experimental-telemetry=true",
-      "otel.instrumentation.runtime-telemetry-java17.enable-all=true",
+      "otel.instrumentation.runtime-telemetry.emit-experimental-metrics=true",
+      "otel.instrumentation.runtime-telemetry.experimental.prefer-jfr=true",
       "otel.instrumentation.common.thread_details.enabled=true",
       "logging.level.org.springframework.boot.autoconfigure=DEBUG",
     })
@@ -42,6 +42,11 @@ class OtelSpringStarterSmokeTest extends AbstractOtelSpringStarterSmokeTest {
   @Autowired protected TestRestTemplate testRestTemplate;
   @Autowired private RestTemplateBuilder restTemplateBuilder;
   @Autowired private RestClient.Builder restClientBuilder;
+
+  @Override
+  protected boolean preferJfr() {
+    return true;
+  }
 
   @Override
   void makeClientCall() {

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -82,6 +82,10 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
 
   abstract void restTemplateCall(String path);
 
+  protected boolean preferJfr() {
+    return false;
+  }
+
   // can't use @LocalServerPort annotation since it moved packages between Spring Boot 2 and 3
   @Value("${local.server.port}")
   protected int port;
@@ -205,26 +209,27 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
         OtelSpringStarterSmokeTestController.TEST_HISTOGRAM,
         AbstractIterableAssert::isNotEmpty);
 
-    // JMX based metrics - test one per JMX bean
-    List<String> jmxMetrics =
+    // Runtime metrics - test one per JMX/JFR source
+    List<String> runtimeMetrics =
         new ArrayList<>(asList("jvm.thread.count", "jvm.memory.used", "jvm.memory.init"));
 
     double javaVersion = Double.parseDouble(System.getProperty("java.specification.version"));
     // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13503
     // Also not available on Windows (getSystemLoadAverage returns -1)
-    if (javaVersion < 23 && !OS.WINDOWS.isCurrentOs()) {
-      jmxMetrics.add("jvm.system.cpu.load_1m");
+    // Not available when prefer-jfr is enabled (JMX-only metric with no JFR equivalent)
+    if (javaVersion < 23 && !OS.WINDOWS.isCurrentOs() && !preferJfr()) {
+      runtimeMetrics.add("jvm.system.cpu.load_1m");
     }
 
     boolean nativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     if (!nativeImage) {
       // GraalVM native image does not support buffer pools - have to investigate why
-      jmxMetrics.add("jvm.buffer.memory.used");
+      runtimeMetrics.add("jvm.buffer.memory.used");
     }
-    jmxMetrics.forEach(
+    runtimeMetrics.forEach(
         metricName ->
             testing.waitAndAssertMetrics(
-                "io.opentelemetry.runtime-telemetry-java8",
+                "io.opentelemetry.runtime-telemetry",
                 metricName,
                 AbstractIterableAssert::isNotEmpty));
 
@@ -269,7 +274,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
     // JFR based metrics
     for (String metric :
         asList(
-            "jvm.cpu.limit",
+            "jvm.cpu.count",
             "jvm.buffer.count",
             "jvm.class.count",
             "jvm.cpu.context_switch",
@@ -285,7 +290,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
         continue;
       }
       testing.waitAndAssertMetrics(
-          "io.opentelemetry.runtime-telemetry-java17", metric, AbstractIterableAssert::isNotEmpty);
+          "io.opentelemetry.runtime-telemetry", metric, AbstractIterableAssert::isNotEmpty);
     }
   }
 

--- a/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-smoke-testing/src/main/java/io/opentelemetry/spring/smoketest/AbstractSpringStarterSmokeTest.java
@@ -33,10 +33,7 @@ public abstract class AbstractSpringStarterSmokeTest {
           "Registering converter from interface java.util.List to interface org.springframework.data.domain.Vector as reading converter although it doesn't convert from a store-supported type; You might want to check your annotation setup at the converter implementation",
           "Node may not be available.",
           "Could not configure topics",
-          "(id: -1 rack: null isFenced: false) disconnected",
-          // expected deprecation warnings from tests using old runtime-telemetry properties
-          "otel.instrumentation.runtime-telemetry-java17.enable-all is deprecated",
-          "otel.instrumentation.runtime-telemetry.emit-experimental-telemetry is deprecated");
+          "(id: -1 rack: null isFenced: false) disconnected");
 
   @Autowired protected OpenTelemetry openTelemetry;
 


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16819