### PR TITLE
Exclude camel.apache.org from link check

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -23,5 +23,6 @@ exclude = [
   # flaky links
   '^http://www.slf4j.org.*',
   '^https://logback.qos.ch/.*',
-  '^https://vaadin.com/$'
+  '^https://vaadin.com/$',
+  '^https://camel.apache.org/$'
 ]


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/23427260426/job/68144773541
This has been flaky for a while.