### PR TITLE
Make more workflow steps use read-only cache

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Spotless
         env:
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Generate license report
         env:
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Generate FOSSA configuration
         run: ./gradlew generateFossaConfiguration
@@ -303,8 +303,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # only push cache for one matrix option since github action cache space is limited
-          cache-read-only: ${{ inputs.cache-read-only || matrix.test-java-version != 11 || matrix.vm != 'hotspot' }}
+          cache-read-only: true
 
       - name: List tests
         env:
@@ -444,8 +443,7 @@ jobs:
       - name: Set up Gradle cache
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # only push cache for one matrix option per OS since github action cache space is limited
-          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
+          cache-read-only: true
 
       - name: Build
         env:
@@ -523,7 +521,7 @@ jobs:
       - name: Set up Gradle cache
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Local publish of artifacts
         run: ./gradlew publishToMavenLocal


### PR DESCRIPTION
I think `test` and `smoke-test` step can use read-only cache and reuse the cache from the `build` step since `build` downloads all dependencies anyway. Currently, since we use too much, caches for some of these steps would get evicted anyway.