### PR TITLE
Remove unnecessary roocketmq-5.0 experimental span attr tests

### DIFF
--- a/.github/scripts/instrumentations.sh
+++ b/.github/scripts/instrumentations.sh
@@ -244,7 +244,6 @@ readonly INSTRUMENTATIONS=(
   "rocketmq:rocketmq-client-4.8:javaagent:test"
   "rocketmq:rocketmq-client-4.8:javaagent:testExperimental"
   "rocketmq:rocketmq-client-5.0:javaagent:test"
-  "rocketmq:rocketmq-client-5.0:javaagent:testExperimental"
   "runtime-telemetry:library:check"
   "servlet:servlet-2.2:javaagent:test"
   "servlet:servlet-3.0:javaagent-testing:test"

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
@@ -35,20 +35,6 @@ tasks {
     include("**/RocketMqClientSuppressReceiveSpanTest.*")
   }
 
-  val testExperimental by registering(Test::class) {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-
-    filter {
-      excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
-    }
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
-
-    jvmArgs("-Dotel.instrumentation.rocketmq-client.experimental-span-attributes=true")
-    systemProperty("metadataConfig", "otel.instrumentation.rocketmq-client.experimental-span-attributes=true")
-  }
-
   test {
     filter {
       excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
@@ -58,7 +44,7 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpanDisabled, testExperimental)
+    dependsOn(testReceiveSpanDisabled)
   }
 
   if (findProperty("denyUnsafe") as Boolean) {


### PR DESCRIPTION
This instrumentation doesn't support an experimental span attribute flag, (I added it in error in #15834)  so we can remove that test task

Noticed this from #17068 