### PR TITLE
Fix codeql warning

### DIFF
--- a/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/RequestDispatcherServlet.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/RequestDispatcherServlet.java
@@ -25,7 +25,7 @@ public class RequestDispatcherServlet {
       String target = req.getServletPath().replace("/dispatch", "");
       ServerEndpoint endpoint = ServerEndpoint.forPath(target);
       if (endpoint == null) {
-        throw new IllegalStateException("missing endpoint " + target);
+        throw new IllegalStateException("Unexpected endpoint: " + target);
       }
       ServletContext context = getServletContext();
       RequestDispatcher dispatcher = context.getRequestDispatcher(target);
@@ -43,7 +43,7 @@ public class RequestDispatcherServlet {
       RequestDispatcher dispatcher = context.getRequestDispatcher(target);
       ServerEndpoint endpoint = ServerEndpoint.forPath(target);
       if (endpoint == null) {
-        throw new IllegalStateException("missing endpoint " + target);
+        throw new IllegalStateException("Unexpected endpoint: " + target);
       }
       // for HTML test case, set the content type before calling include because
       // setContentType will be rejected if called inside include

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/RequestDispatcherServlet.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/RequestDispatcherServlet.java
@@ -27,7 +27,7 @@ public class RequestDispatcherServlet {
       String target = req.getServletPath().replace("/dispatch", "");
       ServerEndpoint endpoint = ServerEndpoint.forPath(target);
       if (endpoint == null) {
-        throw new IllegalStateException("missing endpoint " + target);
+        throw new IllegalStateException("Unexpected endpoint: " + target);
       }
       ServletContext context = getServletContext();
       RequestDispatcher dispatcher = context.getRequestDispatcher(target);
@@ -47,7 +47,7 @@ public class RequestDispatcherServlet {
       RequestDispatcher dispatcher = context.getRequestDispatcher(target);
       ServerEndpoint endpoint = ServerEndpoint.forPath(target);
       if (endpoint == null) {
-        throw new IllegalStateException("missing endpoint " + target);
+        throw new IllegalStateException("Unexpected endpoint: " + target);
       }
       // For the HTML test cases, set the content type before include() because the response is
       // already committed for header updates inside the included resource.


### PR DESCRIPTION
Untrusted URL forward depends on a user-provided value.