### PR TITLE
Rename Kafka receive telemetry builder option

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -103,10 +103,20 @@ public final class KafkaTelemetryBuilder {
    * connecting it to the producer trace.
    */
   @CanIgnoreReturnValue
-  public KafkaTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
+  public KafkaTelemetryBuilder setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setMessagingReceiveTelemetryEnabled(boolean)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public KafkaTelemetryBuilder setMessagingReceiveInstrumentationEnabled(
+      boolean messagingReceiveInstrumentationEnabled) {
+    return setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
   }
 
   public KafkaTelemetry build() {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
@@ -32,7 +32,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
 
   private static final KafkaTelemetry kafkaTelemetry =
       KafkaTelemetry.builder(testing.getOpenTelemetry())
-          .setMessagingReceiveInstrumentationEnabled(true)
+          .setMessagingReceiveTelemetryEnabled(true)
           .setCapturedHeaders(singletonList("Test-Message-Header"))
           .build();
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -31,7 +31,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
 
   @Override
   void configure(KafkaTelemetryBuilder builder) {
-    builder.setMessagingReceiveInstrumentationEnabled(false);
+    builder.setMessagingReceiveTelemetryEnabled(false);
   }
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -36,7 +36,7 @@ class WrapperTest extends AbstractWrapperTest {
 
   @Override
   void configure(KafkaTelemetryBuilder builder) {
-    builder.setMessagingReceiveInstrumentationEnabled(true);
+    builder.setMessagingReceiveTelemetryEnabled(true);
   }
 
   @Override


### PR DESCRIPTION
Matches builder option elsewhere: https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-java-instrumentation%20setMessagingReceiveTelemetryEnabled&type=code

and aligns with both declarative configuration and system property names

```
java:
  common:
    messaging:
      receive_telemetry/development:
        enabled: true
```

and

```
otel.instrumentation.messaging.experimental.receive-telemetry.enabled
```

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17069