### PR TITLE
Simplify test cleanup loops

### DIFF
--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.COUCHBASE;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Named.named;
 
 import com.couchbase.client.java.Bucket;
@@ -84,8 +83,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
   }
 
   @AfterAll
-  void cleanUp() {
-    assertAll(cleanup.stream().map(closeable -> closeable::close));
+  void cleanUp() throws Exception {
+    for (AutoCloseable closeable : cleanup) {
+      closeable.close();
+    }
   }
 
   private static Stream<Arguments> templates() {

--- a/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/ProcessMetricsTest.java
+++ b/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/ProcessMetricsTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.oshi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -30,8 +29,10 @@ class ProcessMetricsTest extends AbstractProcessMetricsTest {
   }
 
   @AfterAll
-  static void tearDown() {
-    assertAll(observables.stream().map(observable -> observable::close));
+  static void tearDown() throws Exception {
+    for (AutoCloseable observable : observables) {
+      observable.close();
+    }
   }
 
   @Override

--- a/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/SystemMetricsTest.java
+++ b/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/SystemMetricsTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.oshi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -30,8 +29,10 @@ class SystemMetricsTest extends AbstractSystemMetricsTest {
   }
 
   @AfterAll
-  static void tearDown() {
-    assertAll(observables.stream().map(observable -> observable::close));
+  static void tearDown() throws Exception {
+    for (AutoCloseable observable : observables) {
+      observable.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
I agree with @laurit's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17121#discussion_r2999403058, I didn't get `assertAll` either and had to look it up. Not worth it. Failing fast during test cleanup is fine.