### PR TITLE
Disable trace-id request attribute by default under v3_preview flag

### DIFF
--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
@@ -83,7 +83,7 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
             "enabled",
             deprecatedTraceIdRequestAttributeEnabled != null
                 ? deprecatedTraceIdRequestAttributeEnabled
-                : true);
+                : !AgentCommonConfig.get().isV3Preview());
   }
 
   public boolean shouldStart(Context parentContext, ServletRequestContext<REQUEST> requestContext) {


### PR DESCRIPTION
## Summary

When `otel.instrumentation.common.v3-preview` is enabled, the trace-id request attribute feature now defaults to `false` instead of `true`. Users can still explicitly enable it via `otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled`.

Resolves #15527