### PR TITLE
Tell copilot that only advice classes need to be public

### DIFF
--- a/.github/agents/knowledge/javaagent-module-patterns.md
+++ b/.github/agents/knowledge/javaagent-module-patterns.md
@@ -254,9 +254,7 @@ sufficient for optimization.
 
 ### Rules
 
-- Do not flag or change the visibility or `final` modifier on `TypeInstrumentation`,
-  `InstrumentationModule`, or advice classes. Both `public class` and package-private `class`
-  (with or without `final`) are acceptable — this is not a style issue in javaagent code.
+- Do not flag or change the visibility or `final` modifier on advice classes.
 - `typeMatcher()` should match only the types the instrumentation genuinely needs. Prefer
   `named("fully.qualified.ClassName")` or `namedOneOf(...)` for single classes.
   `extendsClass(...)` and `implementsInterface(...)` are appropriate when the instrumentation


### PR DESCRIPTION
`InstrumentationModule` classes should be public, hopefully copilot can figure it out. If it can't then could add rule that all classes with `@AutoService` should be public. Advice classes need to be public for the non-inline advice. `TypeInstrumentation` classes could be package private as far as I understand.