### PR TITLE
Fix a couple more CodeQL warnings

### DIFF
--- a/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/GreetingServlet.java
+++ b/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/GreetingServlet.java
@@ -32,6 +32,7 @@ public class GreetingServlet extends HttpServlet {
     try (InputStream remoteInputStream = urlConnection.getInputStream()) {
       long bytesRead = transfer(remoteInputStream, buffer);
       String responseBody = buffer.toString("UTF-8");
+      resp.setContentType("text/plain");
       ServletOutputStream outputStream = resp.getOutputStream();
       outputStream.print(
           bytesRead + " bytes read by " + urlConnection.getClass().getName() + "\n" + responseBody);

--- a/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/HeaderDumpingServlet.java
+++ b/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/HeaderDumpingServlet.java
@@ -19,6 +19,7 @@ public class HeaderDumpingServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    resp.setContentType("text/plain");
     PrintWriter response = resp.getWriter();
     Enumeration<String> headerNames = req.getHeaderNames();
     while (headerNames.hasMoreElements()) {


### PR DESCRIPTION
E.g. https://github.com/open-telemetry/opentelemetry-java-instrumentation/security/code-scanning/18

I had previously closed these as "in tests", but this is better I think should resolve permanently.