### PR TITLE
Remove unnecessary semconv opt-ins

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -81,8 +81,8 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,code")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,code")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   val testExperimental by registering(Test::class) {

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
@@ -67,8 +67,8 @@ tasks {
     filter {
       excludeTestsMatching("OpenSearchDisabledCaptureSearchQueryTest")
     }
-    jvmArgs("-Dotel.semconv-stability.opt-in=database,service.peer")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
   check {


### PR DESCRIPTION
elasticsearch-transport-5.3 [does not emit the code attributes](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/instrumentation-list.yaml#L4198-L4222)

opensearch-java-3.0 [does not emit the peer attribute](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/instrumentation-list.yaml#L10581-L10601)