### PR TITLE
Disable thread details by default under v3_preview flag

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
@@ -33,7 +33,8 @@ public class AgentTracerProviderConfigurer implements AutoConfigurationCustomize
       SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
 
     // Register additional thread details logging span processor
-    if (config.getBoolean(ADD_THREAD_DETAILS, true)) {
+    boolean v3Preview = config.getBoolean("otel.instrumentation.common.v3-preview", false);
+    if (config.getBoolean(ADD_THREAD_DETAILS, !v3Preview)) {
       sdkTracerProviderBuilder.addSpanProcessor(new AddThreadDetailsSpanProcessor());
     }
 


### PR DESCRIPTION
## Summary

When `otel.instrumentation.common.v3-preview` is enabled, thread details
(`thread.id`, `thread.name`) are no longer added to spans by default.
Users can still explicitly enable them via
`otel.javaagent.add-thread-details=true`.

Resolves #15334