### PR TITLE
Decompose dicjunction matchers

### DIFF
--- a/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
+++ b/javaagent-tooling/src/main/java/net/bytebuddy/agent/builder/AgentBuilderUtil.java
@@ -6,6 +6,7 @@
 package net.bytebuddy.agent.builder;
 
 import static java.util.Collections.emptyIterator;
+import static java.util.Collections.singleton;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.javaagent.extension.matcher.internal.DelegatingMatcher;
@@ -48,6 +49,8 @@ public class AgentBuilderUtil {
   private static final Field erasureMatcherField = getField(ErasureMatcher.class, "matcher");
   private static final Field conjunctionMatchersField =
       getField(ElementMatcher.Junction.Conjunction.class, "matchers");
+  private static final Field disjunctionMatchersField =
+      getField(ElementMatcher.Junction.Disjunction.class, "matchers");
   private static final Field stringMatcherValueField = getField(StringMatcher.class, "value");
   private static final Field stringMatcherModeField = getField(StringMatcher.class, "mode");
   private static final Field stringSetMatcherValuesField =
@@ -173,10 +176,36 @@ public class AgentBuilderUtil {
       List<ElementMatcher<?>> matchers =
           getDelegateMatchers((ElementMatcher.Junction.Conjunction<?>) matcher);
       for (ElementMatcher<?> elementMatcher : matchers) {
+        // For conjunction to match all elements need to match, we can return result for any element
+        // here since we are using it as a negative match - if it does not match the whole matcher
+        // can't match.
         Result result = inspect(elementMatcher);
         if (result != null) {
           return result;
         }
+      }
+    } else if (matcher instanceof ElementMatcher.Junction.Disjunction) {
+      List<ElementMatcher<?>> matchers =
+          getDelegateMatchers((ElementMatcher.Junction.Disjunction<?>) matcher);
+      boolean subtype = false;
+      Set<String> names = new HashSet<>();
+      boolean failed = false;
+      for (ElementMatcher<?> elementMatcher : matchers) {
+        // For disjunction to match at least one element needs to match, we need to inspect all
+        // elements and combine results to be able to tell whether the whole matcher could match.
+        Result result = inspect(elementMatcher);
+        if (result == null) {
+          failed = true;
+          break;
+        }
+        // Subtype matcher covers named matcher, if we have at least one subtype matcher we can
+        // treat all named matchers as subtype matchers, if we have only named matchers we can treat
+        // them as named matchers.
+        subtype |= result.subtype;
+        names.addAll(result.names);
+      }
+      if (!failed) {
+        return subtype ? Result.subtype(names) : Result.named(names);
       }
     }
 
@@ -207,19 +236,17 @@ public class AgentBuilderUtil {
       this.subtype = subtype;
     }
 
-    private Result() {
-      this(false);
-    }
-
     @Nullable
     static Result subtype(@Nullable Result value) {
       if (value == null) {
         return null;
       }
+      return subtype(value.names);
+    }
 
-      Result result = new Result(true);
-      result.names.addAll(value.names);
-      return result;
+    @Nullable
+    static Result subtype(@Nullable Set<String> value) {
+      return result(true, value);
     }
 
     @Nullable
@@ -227,17 +254,20 @@ public class AgentBuilderUtil {
       if (value == null) {
         return null;
       }
-      Result result = new Result();
-      result.names.add(value);
-      return result;
+      return named(singleton(value));
     }
 
     @Nullable
     static Result named(@Nullable Set<String> value) {
+      return result(false, value);
+    }
+
+    @Nullable
+    private static Result result(boolean subtype, @Nullable Set<String> value) {
       if (value == null || value.isEmpty()) {
         return null;
       }
-      Result result = new Result();
+      Result result = new Result(subtype);
       result.names.addAll(value);
       return result;
     }
@@ -281,6 +311,12 @@ public class AgentBuilderUtil {
   private static List<ElementMatcher<?>> getDelegateMatchers(
       ElementMatcher.Junction.Conjunction<?> matcher) throws Exception {
     return (List<ElementMatcher<?>>) conjunctionMatchersField.get(matcher);
+  }
+
+  @SuppressWarnings("unchecked") // casting reflection result
+  private static List<ElementMatcher<?>> getDelegateMatchers(
+      ElementMatcher.Junction.Disjunction<?> matcher) throws Exception {
+    return (List<ElementMatcher<?>>) disjunctionMatchersField.get(matcher);
   }
 
   /**


### PR DESCRIPTION
Needed for
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/a2f70e6413389fd314897a1d47734a2b20ba5d09/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/client/ClientInstrumentation.java#L29-L30
We attempt to decompose the matchers to figure out which classes they are trying to match. For each matcher we try to get the class names it matches and the name of the supertype it matches. We use this information to avoid running the matchers when we know that they can't possibly match. For example when transforming the class named `Foo` we check whether there is a matcher that matches `Foo` or whether there is a subtype matcher that matches `Foo` or any of its super types. If there is a match we run all matchers for `Foo` otherwise we run only the matchers we were not able to decompose.