### PR TITLE
Add commons-lang3 dependency to the build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
 buildscript {
   dependencies {
     classpath("com.squareup.okhttp3:okhttp:5.3.2")
+    classpath("org.apache.commons:commons-lang3:3.20.0")
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/17240
currently we have a weird situation where classes for commons-lang3 are loaded from different versions. `SystemProperties` is loaded from 3.16.0 and `StringUtils` from `3.5`