### PR TITLE
Remove special handling for indy instrumentation

### DIFF
--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/SpringBootActuatorInstrumentationModule.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/SpringBootActuatorInstrumentationModule.java
@@ -43,11 +43,8 @@ public class SpringBootActuatorInstrumentationModule extends InstrumentationModu
     // this line will make OpenTelemetryMeterRegistryAutoConfiguration available to all
     // classloaders, so that the bean class loader (different from the instrumented class loader)
     // can load it
-    if (!isIndyModule()) {
-      // For indy module the proxy-bytecode will be injected as resource by injectClasses()
-      helperResourceBuilder.registerForAllClassLoaders(
-          "io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.class");
-    }
+    helperResourceBuilder.registerForAllClassLoaders(
+        "io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.class");
   }
 
   @Override
@@ -55,7 +52,7 @@ public class SpringBootActuatorInstrumentationModule extends InstrumentationModu
     injector
         .proxyBuilder(
             "io.opentelemetry.javaagent.instrumentation.spring.actuator.v2_0.OpenTelemetryMeterRegistryAutoConfiguration")
-        .inject(InjectionMode.CLASS_AND_RESOURCE);
+        .inject(InjectionMode.CLASS_ONLY);
   }
 
   @Override

--- a/instrumentation/spring/spring-web/spring-web-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springweb/v3_1/SpringWebInstrumentationModule.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springweb/v3_1/SpringWebInstrumentationModule.java
@@ -34,17 +34,12 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 
   @Override
   public void registerHelperResources(HelperResourceBuilder helperResourceBuilder) {
-    if (!isIndyModule()) {
-      // make the filter class file loadable by ClassPathResource - in some cases (e.g.
-      // spring-guice,
-      // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7428)
-      // Spring
-      // might want to read the class file metadata; this line will make the filter class file
-      // visible
-      // to the bean class loader
-      helperResourceBuilder.register(
-          "org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.class");
-    }
+    // make the filter class file loadable by ClassPathResource - in some cases (e.g. spring-guice,
+    // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7428)
+    // Spring might want to read the class file metadata; this line will make the filter class file
+    // visible to the bean class loader
+    helperResourceBuilder.register(
+        "org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.class");
   }
 
   @Override

--- a/instrumentation/spring/spring-web/spring-web-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/web/v6_0/SpringWebInstrumentationModule.java
+++ b/instrumentation/spring/spring-web/spring-web-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/web/v6_0/SpringWebInstrumentationModule.java
@@ -32,17 +32,12 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 
   @Override
   public void registerHelperResources(HelperResourceBuilder helperResourceBuilder) {
-    if (!isIndyModule()) {
-      // make the filter class file loadable by ClassPathResource - in some cases (e.g.
-      // spring-guice,
-      // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7428)
-      // Spring
-      // might want to read the class file metadata; this line will make the filter class file
-      // visible
-      // to the bean class loader
-      helperResourceBuilder.register(
-          "org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.class");
-    }
+    // make the filter class file loadable by ClassPathResource - in some cases (e.g. spring-guice,
+    // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7428)
+    // Spring might want to read the class file metadata; this line will make the filter class file
+    // visible to the bean class loader
+    helperResourceBuilder.register(
+        "org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.class");
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v3_1/SpringWebMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v3_1/SpringWebMvcInstrumentationModule.java
@@ -41,7 +41,7 @@ public class SpringWebMvcInstrumentationModule extends InstrumentationModule
   public void injectClasses(ClassInjector injector) {
     injector
         .proxyBuilder("org.springframework.web.servlet.v3_1.OpenTelemetryHandlerMappingFilter")
-        .inject(InjectionMode.CLASS_AND_RESOURCE);
+        .inject(InjectionMode.CLASS_ONLY);
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v3_1/boot/SpringBootBasedTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v3_1/boot/SpringBootBasedTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spring.webmvc.v3_1.boot;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.EXCEPTION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.instrumentation.spring.webmvc.boot.AbstractSpringBootBasedTest;
@@ -13,6 +14,7 @@ import io.opentelemetry.instrumentation.spring.webmvc.boot.AppConfig;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -65,5 +67,15 @@ class SpringBootBasedTest extends AbstractSpringBootBasedTest {
     // older versions of Spring Boot don't properly propagate context to async calls,
     // resulting in a separate trace instead of a single trace
     return Boolean.getBoolean("testLatestDeps");
+  }
+
+  @Test
+  void handlerMappingFilterResourceAvailable() {
+    assertThat(
+            getClass()
+                .getClassLoader()
+                .getResource(
+                    "org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.class"))
+        .isNotNull();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/SpringWebMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/SpringWebMvcInstrumentationModule.java
@@ -41,7 +41,7 @@ public class SpringWebMvcInstrumentationModule extends InstrumentationModule
   public void injectClasses(ClassInjector injector) {
     injector
         .proxyBuilder("org.springframework.web.servlet.v6_0.OpenTelemetryHandlerMappingFilter")
-        .inject(InjectionMode.CLASS_AND_RESOURCE);
+        .inject(InjectionMode.CLASS_ONLY);
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/boot/SpringBootBasedTest.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webmvc/v6_0/boot/SpringBootBasedTest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.spring.webmvc.boot.AbstractSpringBootBasedTest;
@@ -24,6 +25,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -110,5 +112,15 @@ class SpringBootBasedTest extends AbstractSpringBootBasedTest {
     super.configure(options);
     options.setResponseCodeOnNonStandardHttpMethod(400);
     options.setExpectedException(new RuntimeException(EXCEPTION.getBody()));
+  }
+
+  @Test
+  void handlerMappingFilterResourceAvailable() {
+    assertThat(
+            getClass()
+                .getClassLoader()
+                .getResource(
+                    "org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.class"))
+        .isNotNull();
   }
 }


### PR DESCRIPTION
Both indy and injecting instrumentation can just expose the original class bytes when needed. This will get us closer to removing the `isIndyModule` method that we probably won't need (or at least will need to rename it). With indy the proxy and the original class won't match but that shouldn't be a problem. I think we can probably get rid of the proxy and just expose the helper class, that is in the instrumentation class loader, to the application class loader.