### PR TITLE
Use val for satisfies lambdas

### DIFF
--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -39,6 +39,11 @@ Fluent assertion calls like `taskId.contains(jobName)` or `taskId.startsWith(pre
 already proper AssertJ assertions — they throw on failure. Do **not** wrap them in
 `assertThat(value.contains(x)).isTrue()`, which degrades the failure message.
 
+- For generic outer `satisfies(AttributeKey, lambda)` parameters, use `val`.
+  Do not use short generic alternatives like `k` or `v` for the outer parameter.
+- If a `satisfies(...)` lambda contains a nested inner lambda and a second parameter name is
+  required, keep the outer parameter as `val` and use `v` for the nested parameter.
+
 ## AssertJ Idiomatic Simplifications
 
 Prefer built-in AssertJ collection/list assertions over extracting values manually:

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/JmsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/JmsCamelTest.java
@@ -94,9 +94,7 @@ class JmsCamelTest {
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
                             equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue")),
-                            satisfies(
-                                MESSAGING_MESSAGE_ID,
-                                stringAssert -> stringAssert.isInstanceOf(String.class))),
+                            satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))),
                 span -> span.hasName("mock").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(2))));
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
@@ -85,7 +85,7 @@ class AwsSpanAssertions {
                 equalTo(HTTP_REQUEST_METHOD, "POST"),
                 equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
                 satisfies(URL_FULL, val -> val.isInstanceOf(String.class)),
-                satisfies(SERVER_ADDRESS, stringAssert -> stringAssert.isInstanceOf(String.class)),
+                satisfies(SERVER_ADDRESS, val -> val.isInstanceOf(String.class)),
                 satisfies(
                     SERVER_PORT,
                     val ->
@@ -94,7 +94,7 @@ class AwsSpanAssertions {
                             v -> assertThat(v).isInstanceOf(Number.class))),
                 equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
                 equalTo(RPC_SYSTEM, "aws-api"),
-                satisfies(RPC_METHOD, stringAssert -> stringAssert.isEqualTo(rpcMethod)),
+                satisfies(RPC_METHOD, val -> val.isEqualTo(rpcMethod)),
                 equalTo(RPC_SERVICE, "AmazonSQS")));
 
     if (spanName.endsWith("receive")

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/CamelSpanAssertions.java
@@ -51,8 +51,7 @@ class CamelSpanAssertions {
                 experimental(
                     "aws-sqs://" + queueName + "?amazonSQSClient=%23sqsClient&delay=" + delay)),
             equalTo(MESSAGING_DESTINATION_NAME, queueName),
-            satisfies(
-                MESSAGING_MESSAGE_ID, stringAssert -> stringAssert.isInstanceOf(String.class)));
+            satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
   }
 
   static SpanDataAssert snsPublish(SpanDataAssert span, String topicName) {

--- a/instrumentation/graphql-java/graphql-java-common-12.0/testing/src/main/java/io/opentelemetry/instrumentation/graphql/common/v12_0/AbstractGraphqlTest.java
+++ b/instrumentation/graphql-java/graphql-java-common-12.0/testing/src/main/java/io/opentelemetry/instrumentation/graphql/common/v12_0/AbstractGraphqlTest.java
@@ -349,8 +349,8 @@ public abstract class AbstractGraphqlTest {
       AttributeKey<String> key, String value) {
     return satisfies(
         key,
-        stringAssert ->
-            stringAssert.satisfies(
+        val ->
+            val.satisfies(
                 querySource -> {
                   String normalized = normalizeQuery(querySource);
                   String valueNormalized = normalizeQuery(value);

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
@@ -111,8 +111,7 @@ abstract class AbstractHibernateTest {
             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : "sa"),
             equalTo(DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : "h2:mem:"),
             satisfies(
-                maybeStable(DB_STATEMENT),
-                stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),
+                maybeStable(DB_STATEMENT), val -> val.startsWith(verb.toLowerCase(Locale.ROOT))),
             equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? verb + " Value" : null),
             equalTo(maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : verb),
             equalTo(maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : "Value"));

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaTest.java
@@ -86,9 +86,7 @@ class CriteriaTest extends AbstractHibernateTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "h2:mem:"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("select")),
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("select")),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "SELECT Value" : null),

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
@@ -870,9 +870,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "h2:mem:"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("insert")),
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("insert")),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "INSERT Value" : null),
@@ -915,9 +913,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "h2:mem:"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("insert")),
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("insert")),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "INSERT Value" : null),
@@ -938,9 +934,7 @@ class SessionTest extends AbstractHibernateTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "h2:mem:"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("delete")),
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("delete")),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "DELETE Value" : null),

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate6Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate6Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/SessionTest.java
@@ -847,8 +847,7 @@ class SessionTest extends AbstractHibernateTest {
             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : "sa"),
             equalTo(DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : "h2:mem:"),
             satisfies(
-                maybeStable(DB_STATEMENT),
-                stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),
+                maybeStable(DB_STATEMENT), val -> val.startsWith(verb.toLowerCase(Locale.ROOT))),
             equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? verb + " Value" : null),
             equalTo(maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : verb),
             equalTo(maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : "Value"));

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/hibernate7Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v7_0/SessionTest.java
@@ -757,8 +757,7 @@ class SessionTest extends AbstractHibernateTest {
             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : "sa"),
             equalTo(DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : "h2:mem:"),
             satisfies(
-                maybeStable(DB_STATEMENT),
-                stringAssert -> stringAssert.startsWith(verb.toLowerCase(Locale.ROOT))),
+                maybeStable(DB_STATEMENT), val -> val.startsWith(verb.toLowerCase(Locale.ROOT))),
             equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? verb + " Value" : null),
             equalTo(maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : verb),
             equalTo(maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : "Value"));

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/CriteriaTest.java
@@ -96,9 +96,7 @@ class CriteriaTest extends AbstractHibernateTest {
                             equalTo(
                                 DB_CONNECTION_STRING,
                                 emitStableDatabaseSemconv() ? null : "h2:mem:"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("select")),
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("select")),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "SELECT Value" : null),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
@@ -184,7 +184,7 @@ public abstract class KafkaClientBaseTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (messageKey != null) {
@@ -208,7 +208,7 @@ public abstract class KafkaClientBaseTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                 satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
     // consumer group is not available in version 0.11
     if (Boolean.getBoolean("testLatestDeps")) {
@@ -230,7 +230,7 @@ public abstract class KafkaClientBaseTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -46,9 +46,7 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
                             equalTo(MESSAGING_SYSTEM, "kafka"),
                             equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                             equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("producer"))),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))),
                 span ->
                     span.hasName(SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
@@ -64,9 +62,7 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
                             satisfies(
                                 MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"),
                             equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2")),
                 span ->

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
@@ -61,9 +61,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                           equalTo(MESSAGING_SYSTEM, "kafka"),
                           equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                           equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_CLIENT_ID,
-                              stringAssert -> stringAssert.startsWith("producer"))));
+                          satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
           SpanContext spanContext = trace.getSpan(1).getSpanContext();
           producerSpanContext.set(
               SpanContext.createFromRemoteParent(
@@ -87,9 +85,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                             equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                             equalTo(MESSAGING_OPERATION, "receive"),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
                 span ->
                     span.hasName(SHARED_TOPIC + " process")
@@ -110,9 +106,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
                             satisfies(
                                 MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer"))),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))),
                 span ->
                     span.hasName("process child")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -68,7 +68,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
@@ -91,8 +91,7 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative),
                 equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(
-                    MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer"))));
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
     if (testHeaders) {
       assertions.add(
           equalTo(stringArrayKey("messaging.header.Test_Message_Header"), singletonList("test")));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -91,7 +91,7 @@ class WrapperTest extends AbstractWrapperTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
@@ -114,8 +114,7 @@ class WrapperTest extends AbstractWrapperTest {
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                 satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative),
                 equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(
-                    MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer"))));
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
     if (testHeaders) {
       assertions.add(
           equalTo(stringArrayKey("messaging.header.Test_Message_Header"), singletonList("test")));
@@ -132,7 +131,7 @@ class WrapperTest extends AbstractWrapperTest {
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
                 equalTo(MESSAGING_OPERATION, "receive"),
                 equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                 equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
     if (testHeaders) {
       assertions.add(

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
@@ -113,8 +113,7 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                                       equalTo(maybeStable(DB_SYSTEM), REDIS),
                                       satisfies(
                                           maybeStable(DB_STATEMENT),
-                                          stringAssert ->
-                                              stringAssert.startsWith("CLIENT SETINFO lib-ver")),
+                                          val -> val.startsWith("CLIENT SETINFO lib-ver")),
                                       equalTo(maybeStable(DB_OPERATION), "CLIENT"),
                                       equalTo(
                                           ERROR_TYPE,
@@ -136,9 +135,7 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
                                       equalTo(maybeStable(DB_SYSTEM), REDIS),
                                       satisfies(
                                           maybeStable(DB_STATEMENT),
-                                          stringAssert ->
-                                              stringAssert.startsWith(
-                                                  "CLIENT MAINT_NOTIFICATIONS")),
+                                          val -> val.startsWith("CLIENT MAINT_NOTIFICATIONS")),
                                       equalTo(maybeStable(DB_OPERATION), "CLIENT"),
                                       equalTo(
                                           ERROR_TYPE,

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -457,8 +457,7 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                                       equalTo(maybeStable(DB_SYSTEM), REDIS),
                                       satisfies(
                                           maybeStable(DB_STATEMENT),
-                                          stringAssert ->
-                                              stringAssert.startsWith("CLIENT SETINFO lib-ver")),
+                                          val -> val.startsWith("CLIENT SETINFO lib-ver")),
                                       equalTo(maybeStable(DB_OPERATION), "CLIENT"),
                                       equalTo(
                                           ERROR_TYPE,
@@ -480,9 +479,7 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                                       equalTo(maybeStable(DB_SYSTEM), REDIS),
                                       satisfies(
                                           maybeStable(DB_STATEMENT),
-                                          stringAssert ->
-                                              stringAssert.startsWith(
-                                                  "CLIENT MAINT_NOTIFICATIONS")),
+                                          val -> val.startsWith("CLIENT MAINT_NOTIFICATIONS")),
                                       equalTo(maybeStable(DB_OPERATION), "CLIENT"),
                                       equalTo(
                                           ERROR_TYPE,

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -221,9 +221,7 @@ public abstract class AbstractReactorKafkaTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
                 equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(
-                    stringKey("messaging.client_id"),
-                    stringAssert -> stringAssert.startsWith("producer")),
+                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("producer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     String messageKey = record.key();
@@ -241,9 +239,7 @@ public abstract class AbstractReactorKafkaTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
                 equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(
-                    stringKey("messaging.client_id"),
-                    stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
                 equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
     if (Boolean.getBoolean("hasConsumerGroup")) {
       assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
@@ -260,9 +256,7 @@ public abstract class AbstractReactorKafkaTest {
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
                 equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(
-                    stringKey("messaging.client_id"),
-                    stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (Boolean.getBoolean("hasConsumerGroup")) {

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -443,9 +443,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_OPERATION), "EVAL"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("EVAL")))));
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("EVAL")))));
     traceAsserts.add(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -458,9 +456,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_PORT, (long) port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_OPERATION), "EVAL"),
-                            satisfies(
-                                maybeStable(DB_STATEMENT),
-                                stringAssert -> stringAssert.startsWith("EVAL")))));
+                            satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("EVAL")))));
     if (lockHas3Traces()) {
       traceAsserts.add(
           trace ->
@@ -474,9 +470,7 @@ public abstract class AbstractRedissonClientTest {
                               equalTo(NETWORK_PEER_PORT, (long) port),
                               equalTo(maybeStable(DB_SYSTEM), REDIS),
                               equalTo(maybeStable(DB_OPERATION), "DEL"),
-                              satisfies(
-                                  maybeStable(DB_STATEMENT),
-                                  stringAssert -> stringAssert.startsWith("DEL")))));
+                              satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("DEL")))));
     }
 
     testing.waitAndAssertSortedTraces(orderByRootSpanKind(SpanKind.CLIENT), traceAsserts);

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -93,9 +93,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           satisfies(
                               MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                           equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              MESSAGING_CLIENT_ID,
-                              stringAssert -> stringAssert.startsWith("producer"))));
+                          satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
 
           producer.set(trace.getSpan(1));
         },
@@ -110,9 +108,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
                             equalTo(MESSAGING_OPERATION, "receive"),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
                 span ->
                     span.hasName("testSingleTopic process")
@@ -132,9 +128,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                                 MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                             equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             satisfies(
                                 longKey("kafka.record.queue_time_ms"),
                                 val -> {
@@ -167,8 +161,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                     equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
                     equalTo(MESSAGING_OPERATION, "receive"),
                     equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                    satisfies(
-                        MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                    satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                     equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     List<AttributeAssertion> processAttributes =
         asList(
@@ -180,7 +173,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
             satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
             equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
             satisfies(
                 longKey("kafka.record.queue_time_ms"),
                 val -> {
@@ -212,9 +205,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             satisfies(
                                 MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                             equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("producer"))));
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
 
             producer.set(trace.getSpan(1));
           },
@@ -269,9 +260,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             satisfies(
                                 MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                             equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("producer"))));
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
 
             producer.set(trace.getSpan(1));
           },
@@ -340,9 +329,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           satisfies(
                               MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                           equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              MESSAGING_CLIENT_ID,
-                              stringAssert -> stringAssert.startsWith("producer"))),
+                          satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))),
               span ->
                   span.hasName("testBatchTopic publish")
                       .hasKind(SpanKind.PRODUCER)
@@ -356,9 +343,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           satisfies(
                               MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                           equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20"),
-                          satisfies(
-                              MESSAGING_CLIENT_ID,
-                              stringAssert -> stringAssert.startsWith("producer"))));
+                          satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
 
           producer1.set(trace.getSpan(1));
           producer2.set(trace.getSpan(2));
@@ -374,9 +359,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                             equalTo(MESSAGING_OPERATION, "receive"),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                 span ->
                     span.hasName("testBatchTopic process")
@@ -390,9 +373,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                             equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                             equalTo(MESSAGING_OPERATION, "process"),
                             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
@@ -429,9 +410,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           satisfies(
                               MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
                           equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              MESSAGING_CLIENT_ID,
-                              stringAssert -> stringAssert.startsWith("producer"))));
+                          satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))));
 
           producer.set(trace.getSpan(1));
         });
@@ -481,7 +460,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
             equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
             equalTo(MESSAGING_OPERATION, "receive"),
             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
   }
 
@@ -496,7 +475,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
             equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
             equalTo(MESSAGING_OPERATION, "process"),
             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     if (failed) {
       span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -66,9 +66,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                 equalTo(MESSAGING_SYSTEM, "kafka"),
                                 equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
                                 equalTo(MESSAGING_OPERATION, "publish"),
-                                satisfies(
-                                    MESSAGING_CLIENT_ID,
-                                    stringAssert -> stringAssert.startsWith("producer")),
+                                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                                 satisfies(
                                     MESSAGING_DESTINATION_PARTITION_ID,
                                     AbstractStringAssert::isNotEmpty),
@@ -94,9 +92,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                     AbstractLongAssert::isNotNegative),
                                 equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
                                 equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                                satisfies(
-                                    MESSAGING_CLIENT_ID,
-                                    stringAssert -> stringAssert.startsWith("consumer"))),
+                                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
@@ -123,7 +119,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
             equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")));
+            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")));
 
     testing()
         .waitAndAssertTraces(
@@ -141,8 +137,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                       equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
                                       equalTo(MESSAGING_OPERATION, "publish"),
                                       satisfies(
-                                          MESSAGING_CLIENT_ID,
-                                          stringAssert -> stringAssert.startsWith("producer")),
+                                          MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                                       satisfies(
                                           MESSAGING_DESTINATION_PARTITION_ID,
                                           AbstractStringAssert::isNotEmpty),
@@ -220,9 +215,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                               equalTo(MESSAGING_SYSTEM, "kafka"),
                               equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                               equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  MESSAGING_CLIENT_ID,
-                                  stringAssert -> stringAssert.startsWith("producer")),
+                              satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                               satisfies(
                                   MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),
@@ -238,9 +231,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                               equalTo(MESSAGING_SYSTEM, "kafka"),
                               equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                               equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  MESSAGING_CLIENT_ID,
-                                  stringAssert -> stringAssert.startsWith("producer")),
+                              satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                               satisfies(
                                   MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),
@@ -267,9 +258,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                 equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                                 equalTo(MESSAGING_OPERATION, "process"),
                                 equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                                satisfies(
-                                    MESSAGING_CLIENT_ID,
-                                    stringAssert -> stringAssert.startsWith("consumer")),
+                                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                                 equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
   }
@@ -295,7 +284,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
             equalTo(MESSAGING_OPERATION, "process"),
             equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
 
     testing()
@@ -312,9 +301,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                               equalTo(MESSAGING_SYSTEM, "kafka"),
                               equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
                               equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  MESSAGING_CLIENT_ID,
-                                  stringAssert -> stringAssert.startsWith("producer")),
+                              satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                               satisfies(
                                   MESSAGING_DESTINATION_PARTITION_ID,
                                   AbstractStringAssert::isNotEmpty),

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
@@ -180,7 +180,7 @@ public abstract class AbstractVertxKafkaTest {
                 equalTo(MESSAGING_SYSTEM, KAFKA),
                 equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
                 equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("producer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     String messageKey = record.key();
@@ -206,7 +206,7 @@ public abstract class AbstractVertxKafkaTest {
                 equalTo(MESSAGING_SYSTEM, KAFKA),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
                 equalTo(MESSAGING_OPERATION, operation),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                 satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
     if (hasConsumerGroup()) {
       assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
@@ -222,7 +222,7 @@ public abstract class AbstractVertxKafkaTest {
                 equalTo(MESSAGING_SYSTEM, KAFKA),
                 equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
                 equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(MESSAGING_CLIENT_ID, stringAssert -> stringAssert.startsWith("consumer")),
+                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
                 satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
     if (Boolean.getBoolean("otel.instrumentation.kafka.experimental-span-attributes")) {

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractKafkaSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractKafkaSpringStarterSmokeTest.java
@@ -71,9 +71,7 @@ abstract class AbstractKafkaSpringStarterSmokeTest extends AbstractSpringStarter
                             equalTo(MESSAGING_SYSTEM, "kafka"),
                             equalTo(MESSAGING_DESTINATION_NAME, "testTopic"),
                             equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("producer")),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
                             satisfies(
                                 MESSAGING_DESTINATION_PARTITION_ID,
                                 AbstractStringAssert::isNotEmpty),
@@ -100,9 +98,7 @@ abstract class AbstractKafkaSpringStarterSmokeTest extends AbstractSpringStarter
                             satisfies(
                                 longKey("kafka.record.queue_time_ms"),
                                 AbstractLongAssert::isNotNegative),
-                            satisfies(
-                                MESSAGING_CLIENT_ID,
-                                stringAssert -> stringAssert.startsWith("consumer"))),
+                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/AbstractOtelSpringStarterSmokeTest.java
@@ -181,7 +181,7 @@ abstract class AbstractOtelSpringStarterSmokeTest extends AbstractSpringStarterS
                     clientSpan
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfying(
-                            satisfies(URL_FULL, stringAssert -> stringAssert.endsWith("/ping")),
+                            satisfies(URL_FULL, val -> val.endsWith("/ping")),
                             equalTo(SERVER_ADDRESS, "localhost"),
                             satisfies(SERVER_PORT, val -> val.isNotZero())),
                 serverSpan ->


### PR DESCRIPTION
The repo-wide counts are:

val: 386
k: 74
stringAssert: 62
v: 60
id: 18
reasons: 18
s: 17
everything else: small tails

This PR adds the style guide and converts `stringAssert` to `val`.