### PR TITLE
Always close RemoteWebDriver in gwt tests

### DIFF
--- a/instrumentation/gwt-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtTest.java
+++ b/instrumentation/gwt-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtTest.java
@@ -96,7 +96,7 @@ class GwtTest {
     return "/xyz";
   }
 
-  private RemoteWebDriver getDriver() {
+  private static RemoteWebDriver getDriver() {
     RemoteWebDriver driver =
         new RemoteWebDriver(browser.getSeleniumAddress(), new ChromeOptions(), false);
     driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));


### PR DESCRIPTION
Automated review wants to put try-finally around the test method