### PR TITLE
Fix findProperty("testLatestDeps") always returning false

### DIFF
--- a/instrumentation/akka/akka-actor-2.3/javaagent/build.gradle.kts
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   latestDepTestLibrary("com.typesafe.akka:akka-actor_2.13:latest.release")
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // akka artifact name is different for regular and latest tests
     testImplementation {

--- a/instrumentation/akka/akka-http-10.0/javaagent/build.gradle.kts
+++ b/instrumentation/akka/akka-http-10.0/javaagent/build.gradle.kts
@@ -46,7 +46,7 @@ testing {
   suites {
     val javaRouteTest by registering(JvmTestSuite::class) {
       dependencies {
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           implementation("com.typesafe.akka:akka-http_2.13:latest.release")
           implementation("com.typesafe.akka:akka-stream_2.13:latest.release")
         } else {
@@ -86,7 +86,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // akka artifact name is different for regular and latest tests
     testImplementation {

--- a/instrumentation/apache-dubbo-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/javaagent/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   library("org.apache.dubbo:dubbo:2.7.0")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 (spring boot 3) requires java 17
 if (latestDepTest) {

--- a/instrumentation/armeria/armeria-grpc-1.14/javaagent/build.gradle.kts
+++ b/instrumentation/armeria/armeria-grpc-1.14/javaagent/build.gradle.kts
@@ -29,7 +29,7 @@ tasks.named<Checkstyle>("checkstyleTest") {
   exclude("**/example/**")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 protobuf {
   protoc {
     val protocVersion = if (latestDepTest) "3.25.5" else "3.19.2"

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:async-http-client:async-http-client-1.9:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 val testJavaVersion =
   gradle.startParameter.projectProperties["testJavaVersion"]?.let(JavaVersion::toVersion)
     ?: JavaVersion.current()

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -101,7 +101,7 @@ testing {
       dependencies {
         implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
 
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           // last version that does not use json protocol
           implementation("com.amazonaws:aws-java-sdk-sqs:1.12.583")
         } else {
@@ -122,7 +122,7 @@ testing {
       dependencies {
         implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
 
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           // last version that does not use json protocol
           implementation("com.amazonaws:aws-java-sdk-sqs:1.12.583")
         } else {
@@ -136,7 +136,7 @@ testing {
 val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
 
 tasks {
-  if (!(findProperty("testLatestDeps") == "true")) {
+  if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
     check {
       dependsOn(testing.suites)
     }
@@ -177,7 +177,7 @@ tasks {
   }
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.testRuntimeClasspath {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -51,7 +51,7 @@ tasks {
   }
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (!testLatestDeps) {
   configurations.testRuntimeClasspath {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   latestDepTestLibrary("com.amazonaws:aws-java-sdk-sqs:1.12.583") // documented limitation
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 if (!testLatestDeps) {
   configurations.testRuntimeClasspath {
     resolutionStrategy {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -130,7 +130,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
 
 testing {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:sfn:2.2.0")
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/azure-core/azure-core-1.14/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.14/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:azure-core:azure-core-1.53:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/azure-core/azure-core-1.19/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.19/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:azure-core:azure-core-1.53:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:azure-core:azure-core-1.53:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 tasks {
   withType<Test>().configureEach {

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:azure-core:azure-core-1.36:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 tasks {
   withType<Test>().configureEach {

--- a/instrumentation/cassandra/cassandra-4.4/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.4/javaagent/build.gradle.kts
@@ -16,7 +16,7 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 dependencies {
   implementation(project(":instrumentation:cassandra:cassandra-4.4:library"))
 

--- a/instrumentation/cassandra/cassandra-4.4/library/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.4/library/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("otel.library-instrumentation")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 dependencies {
   if (latestDepTest) {
     library("org.apache.cassandra:java-driver-core:4.18.0")

--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
   latestDepTestLibrary("co.elastic.clients:elasticsearch-java:7.17.19") // native on-by-default instrumentation after this version
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 testing {
   suites {
     val version8Test by registering(JvmTestSuite::class) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -28,7 +28,7 @@ muzzle {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   // when running on jdk 21 Elasticsearch53SpringRepositoryTest occasionally fails with timeout
   otelJava {
     maxJavaVersionForTests.set(JavaVersion.VERSION_17)

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   testImplementation("org.apache.logging.log4j:log4j-api:2.11.0")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/finatra-2.9/javaagent/build.gradle.kts
+++ b/instrumentation/finatra-2.9/javaagent/build.gradle.kts
@@ -67,7 +67,7 @@ configurations {
 }
 
 tasks {
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     // Separate task
     named("test") {
       enabled = false
@@ -99,7 +99,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations.named("latestDepTestRuntimeClasspath") {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/grails-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/grails-3.0/javaagent/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-tomcat:2.+") // related dependency
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (!latestDepTest) {
   configurations.configureEach {

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_11)
   }

--- a/instrumentation/graphql-java/graphql-java-20.0/library/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-20.0/library/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   testImplementation(project(":instrumentation:graphql-java:graphql-java-common-12.0:testing"))
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_11)
   }

--- a/instrumentation/grpc-1.6/javaagent/build.gradle.kts
+++ b/instrumentation/grpc-1.6/javaagent/build.gradle.kts
@@ -98,7 +98,7 @@ tasks {
   }
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.testRuntimeClasspath {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/grpc-1.6/library/build.gradle.kts
+++ b/instrumentation/grpc-1.6/library/build.gradle.kts
@@ -43,7 +43,7 @@ tasks {
   }
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.testRuntimeClasspath {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ sourceSets {
 
 dependencies {
   // these are needed for compileGwt task
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     compileOnly("org.gwtproject:gwt-user:latest.release")
     compileOnly("org.gwtproject:gwt-dev:latest.release")
     compileOnly("org.gwtproject:gwt-servlet:latest.release")
@@ -90,7 +90,7 @@ tasks {
 
     argumentProviders.add(CompilerArgumentsProvider(layout.buildDirectory.get()))
 
-    if (findProperty("testLatestDeps") == "true") {
+    if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
       javaLauncher.set(project.javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(11)
       })

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   latestDepTestLibrary("org.hibernate:hibernate-core:3.+") // see hibernate-4.0 module
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // Needed for test, but for latestDepTest this would otherwise bundle a second incompatible version of hibernate-core.
     testImplementation {

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   testImplementation("org.javassist:javassist:3.28.0-GA")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 testing {
   suites {
     val version5Test by registering(JvmTestSuite::class) {

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/build.gradle.kts
@@ -36,7 +36,7 @@ otelJava {
   minJavaVersionSupported.set(JavaVersion.VERSION_11)
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   testLibrary("io.vertx:vertx-codegen:4.4.2")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -44,7 +44,7 @@ tasks {
     systemProperty("collectMetadata", findProperty("collectMetadata"))
   }
 
-  if (!(findProperty("testLatestDeps") == "true")) {
+  if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
     check {
       dependsOn(testing.suites)
     }

--- a/instrumentation/internal/internal-application-logger/javaagent/build.gradle.kts
+++ b/instrumentation/internal/internal-application-logger/javaagent/build.gradle.kts
@@ -18,7 +18,7 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 dependencies {
   bootstrap(project(":instrumentation:internal:internal-application-logger:bootstrap"))
 

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/build.gradle.kts
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.withType<Test>().configureEach {
   jvmArgs("--add-opens=java.base/java.net=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 
-  val latestDepTest = findProperty("testLatestDeps") == "true"
+  val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
   systemProperty("testLatestDeps", latestDepTest)
   // in default configuration 3.6.7 retries http request in connectionErrorUnopenedPort test
   // which creates a duplicate span

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
   latestDepTestLibrary("org.glassfish.jersey.inject:jersey-hk2:2.+") // see jaxrs-3.0-jersey-3.0 module
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   // early jersey versions require old guava
   configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.google.guava:guava:14.0.1")
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
@@ -89,7 +89,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // artifact name changed from 'resteasy-jaxrs' to 'resteasy-core' starting from version 4.0.0
     testImplementation {

--- a/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jboss-logmanager/jboss-logmanager-appender-1.1/javaagent/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:java-util-logging:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (latestDepTest) {
   otelJava {

--- a/instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jboss-logmanager/jboss-logmanager-mdc-1.1/javaagent/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   library("org.jboss.logmanager:jboss-logmanager:1.1.0.GA")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (latestDepTest) {
   otelJava {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
@@ -25,7 +25,7 @@ testing {
       dependencies {
         implementation(project())
         implementation(project(":instrumentation:jetty-httpclient::jetty-httpclient-9.2:testing"))
-        val jettyVersion = if (findProperty("testLatestDeps") == "true") "9.4.43.v20210629" else "9.4.24.v20191120"
+        val jettyVersion = if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") "9.4.43.v20210629" else "9.4.24.v20191120"
         implementation("org.eclipse.jetty:jetty-client:$jettyVersion")
       }
     }

--- a/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 }
 
 // jetty-server 10+ requires Java 11
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 if (latestDepTest) {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_11)

--- a/instrumentation/jfinal-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/jfinal-3.2/javaagent/build.gradle.kts
@@ -11,7 +11,7 @@ muzzle {
   }
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   otelJava {
     // jfinal 3.2 doesn't work with Java 9+
     maxJavaVersionForTests.set(JavaVersion.VERSION_1_8)

--- a/instrumentation/jsf/jsf-mojarra-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-mojarra-1.2/javaagent/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:jsf:jsf-mojarra-3.0:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 testing {
   suites {
     val mojarra12Test by registering(JvmTestSuite::class) {

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:jsf:jsf-myfaces-3.0:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 testing {
   suites {
     val myfaces12Test by registering(JvmTestSuite::class) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
@@ -79,7 +79,7 @@ tasks {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // kafka 4.1 requires java 11
 if (latestDepTest) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
@@ -24,7 +24,7 @@ tasks {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // kafka 4.1 requires java 11
 if (latestDepTest) {

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
@@ -67,7 +67,7 @@ tasks {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // kafka 4.1 requires java 11
 if (latestDepTest) {

--- a/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ testing {
   suites {
     val version20Test by registering(JvmTestSuite::class) {
       dependencies {
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           implementation("io.kubernetes:client-java-api:latest.release")
         } else {
           implementation("io.kubernetes:client-java-api:20.0.0")

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
@@ -11,7 +11,7 @@ muzzle {
   }
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 dependencies {
   testInstrumentation(project(":instrumentation:log4j:log4j-appender-1.2:javaagent"))

--- a/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testLibrary("com.lmax:disruptor:3.3.4")
 
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     testCompileOnly("biz.aQute.bnd:biz.aQute.bnd.annotation:7.0.0")
     testCompileOnly("com.google.errorprone:error_prone_annotations")
   }

--- a/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     }
   }
 
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     testImplementation("ch.qos.logback:logback-classic:latest.release")
   } else {
     testImplementation("ch.qos.logback:logback-classic") {

--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     }
   }
 
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     testImplementation("ch.qos.logback:logback-classic:latest.release")
   } else {
     testImplementation("ch.qos.logback:logback-classic") {
@@ -64,7 +64,7 @@ tasks.named("collectReachabilityMetadata").configure {
   enabled = false
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 testing {
   suites {
     val slf4j2ApiTest by registering(JvmTestSuite::class) {

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
@@ -36,7 +36,7 @@ testing {
 
     withType(JvmTestSuite::class) {
       dependencies {
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           implementation("ch.qos.logback:logback-classic:latest.release")
         } else {
           implementation("ch.qos.logback:logback-classic") {

--- a/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
@@ -28,7 +28,7 @@ testing {
 
     withType(JvmTestSuite::class) {
       dependencies {
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           implementation("ch.qos.logback:logback-classic:latest.release")
         } else {
           implementation("ch.qos.logback:logback-classic") {

--- a/instrumentation/netty/netty-3.8/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-3.8/javaagent/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 }
 
 // We need to force the dependency to the earliest supported version because other libraries declare newer versions.
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.configureEach {
     if (!name.contains("muzzle")) {
       resolutionStrategy {

--- a/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
@@ -74,7 +74,7 @@ tasks {
 }
 
 // We need to force the dependency to the earliest supported version because other libraries declare newer versions.
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.configureEach {
     if (!name.contains("muzzle")) {
       resolutionStrategy {

--- a/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
@@ -83,7 +83,7 @@ tasks {
   }
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   // No BOM for 4.1.0 so we can't use enforcedPlatform to override our transitive version
   // management, so hook into the resolutionStrategy.
   configurations.configureEach {

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:okhttp:okhttp-2.2:javaagent"))
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   testImplementation(project(":instrumentation:okhttp:okhttp-3.0:testing"))
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0")
 }
 
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   // run tests against an early version of opentelemetry-extension-kotlin, latest dep tests will use
   // the current version
   configurations.configureEach {

--- a/instrumentation/oshi/library/build.gradle.kts
+++ b/instrumentation/oshi/library/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   testImplementation(project(":instrumentation:oshi:testing"))
 }
 
-if (osdetector.os == "osx" && osdetector.arch == "aarch_64" && !(findProperty("testLatestDeps") == "true")) {
+if (osdetector.os == "osx" && osdetector.arch == "aarch_64" && !(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   // 5.5.0 is the first version that works on arm mac
   configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.github.oshi:oshi-core:5.5.0")
 }

--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   testImplementation(project(":instrumentation:executors:testing"))
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // pekko artifact name is different for regular and latest tests
     testImplementation {

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -67,7 +67,7 @@ testing {
   suites {
     val tapirTest by registering(JvmTestSuite::class) {
       dependencies {
-        if (findProperty("testLatestDeps") == "true") {
+        if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
           implementation("com.typesafe.akka:akka-http_2.13:latest.release")
           implementation("com.typesafe.akka:akka-stream_2.13:latest.release")
           implementation("com.softwaremill.sttp.tapir:tapir-pekko-http-server_2.13:latest.release")
@@ -102,7 +102,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // pekko artifact name is different for regular and latest tests
     testImplementation {

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/build.gradle.kts
@@ -85,7 +85,7 @@ configurations.configureEach {
 
 // async-http-client 2.0 does not work with Netty versions newer than this due to referencing an
 // internal file.
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.configureEach {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/build.gradle.kts
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/build.gradle.kts
@@ -60,7 +60,7 @@ testing {
   }
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 tasks {
   if (testLatestDeps) {
     // disable regular test running and compiling tasks when latest dep test task is run

--- a/instrumentation/play/play-ws/play-ws-2.1/javaagent/build.gradle.kts
+++ b/instrumentation/play/play-ws/play-ws-2.1/javaagent/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:akka:akka-actor-2.3:javaagent"))
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/quarkus-resteasy-reactive/quarkus-3.0-testing/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/quarkus-3.0-testing/build.gradle.kts
@@ -25,7 +25,7 @@ otelJava {
 
 // io.quarkus.platform:quarkus-bom is missing for 3.0.0.Final
 var quarkusVersion = "3.0.1.Final"
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   quarkusVersion = "3.5.+"
 }
 

--- a/instrumentation/quarkus-resteasy-reactive/quarkus-3.9-testing/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/quarkus-3.9-testing/build.gradle.kts
@@ -24,7 +24,7 @@ otelJava {
 }
 
 var quarkusVersion = "3.9.1"
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   quarkusVersion = "3.9.+"
 }
 

--- a/instrumentation/ratpack/ratpack-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/ratpack/ratpack-1.4/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 }
 
 // Requires old Guava. Can't use enforcedPlatform since predates BOM
-if (!(findProperty("testLatestDeps") == "true")) {
+if (!(gradle.startParameter.projectProperties["testLatestDeps"] == "true")) {
   configurations.testRuntimeClasspath.get().resolutionStrategy.force("com.google.guava:guava:19.0")
 }
 

--- a/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   testLibrary("io.projectreactor.kafka:reactor-kafka:1.0.0.RELEASE")
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -87,7 +87,7 @@ tasks {
   }
 }
 
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations {
     // rediscala artifact name is different for regular and latest tests
     testImplementation {

--- a/instrumentation/restlet/restlet-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/restlet/restlet-2.0/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 }
 
 // restlet registers the first engine that is present on classpath, so we need to enforce the appropriate version
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations.configureEach {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/restlet/restlet-2.0/library/build.gradle.kts
+++ b/instrumentation/restlet/restlet-2.0/library/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 }
 
 // restlet registers the first engine that is present on classpath, so we need to enforce the appropriate version
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   configurations.configureEach {
     resolutionStrategy {
       eachDependency {

--- a/instrumentation/servlet/servlet-3.0/javaagent-testing/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/javaagent-testing/build.gradle.kts
@@ -35,7 +35,7 @@ tasks {
 // Servlet 3.0 in latest Jetty versions requires Java 11
 // However, projects that depend on this module are still be using Java 8 in testLatestDeps mode
 // Therefore, we need a separate project for servlet 3.0 tests
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (latestDepTest) {
   otelJava {

--- a/instrumentation/servlet/servlet-3.0/library/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/library/build.gradle.kts
@@ -28,7 +28,7 @@ tasks {
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
   }
 
-  if (findProperty("testLatestDeps") == "true") {
+  if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
     compileTestJava {
       options.release.set(11)
     }

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/build.gradle.kts
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   testLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:10.0.0")
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 if (testLatestDeps) {
   otelJava {

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/build.gradle.kts
@@ -13,7 +13,7 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 dependencies {
   library("org.springframework.boot:spring-boot-actuator-autoconfigure:2.0.0.RELEASE")

--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -158,7 +158,7 @@ dependencies {
   )
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 (spring boot 3) requires java 17
 if (latestDepTest) {

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.2/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-2.2/testing/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:3.+") // see spring-cloud-gateway-4.3* module
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.spring-cloud-gateway.experimental-span-attributes=true")

--- a/instrumentation/spring/spring-core-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-core-2.0/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 // spring 6 requires java 17
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_17)
   }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-kafka:latest.release")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.withType<Test>().configureEach {
   systemProperty("testLatestDeps", findProperty("testLatestDeps"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 (which spring-kafka 3.+ uses) requires java 17
 if (latestDepTest) {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -13,7 +13,7 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 dependencies {
   library("org.springframework.pulsar:spring-pulsar:1.0.0")

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -13,7 +13,7 @@ muzzle {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 dependencies {
   library("org.springframework.amqp:spring-rabbit:1.0.0.RELEASE")

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 requires java 17
 if (latestDepTest) {

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 requires java 17
 if (latestDepTest) {

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-reactor-netty:3.+") // see testing-webflux7 module
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 tasks {
   withType<Test>().configureEach {

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/build.gradle.kts
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter-reactor-netty:2.4.0")
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // spring 6 (which spring-kafka 3.+ uses) requires java 17
 if (latestDepTest) {

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
@@ -35,7 +35,7 @@ tasks {
 
 // Tomcat 10 uses deprecation annotation methods `forRemoval()` and `since()`
 // in jakarta.servlet.http.HttpServlet that don't work with Java 8
-if (findProperty("testLatestDeps") == "true") {
+if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_11)
   }

--- a/instrumentation/undertow-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/undertow-1.4/javaagent/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.withType<Test>().configureEach {
 }
 
 // since 2.3.x, undertow is compiled by JDK 11
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 if (latestDepTest) {
   otelJava {
     minJavaVersionSupported.set(JavaVersion.VERSION_11)

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -90,7 +90,7 @@ tasks {
   }
 
   check {
-    if (findProperty("testLatestDeps") == "true") {
+    if (gradle.startParameter.projectProperties["testLatestDeps"] == "true") {
       dependsOn(testing.suites.named("vaadin14LatestTest"), testing.suites.named("vaadinLatestTest"))
     } else {
       dependsOn(testing.suites.named("vaadin142Test"), testing.suites.named("vaadin16Test"))

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   latestDepTestLibrary("io.vertx:vertx-codegen:3.+") // documented limitation
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   latestDepTestLibrary("io.vertx:vertx-codegen:4.+") // documented limitation
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:vertx:vertx-kafka-client-3.6:javaagent"))
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:vertx:vertx-web-3.0:javaagent"))
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/build.gradle.kts
@@ -53,7 +53,7 @@ tasks {
   }
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 if (!latestDepTest) {
   // https://bugs.openjdk.org/browse/JDK-8320431
   otelJava {

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:jdbc:javaagent"))
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {

--- a/instrumentation/wicket-8.0/wicket8-testing/build.gradle.kts
+++ b/instrumentation/wicket-8.0/wicket8-testing/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   latestDepTestLibrary("org.apache.wicket:wicket:9.+") // see wicket10-testing module
 }
 
-val latestDepTest = findProperty("testLatestDeps") == "true"
+val latestDepTest = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 // Wicket 9 requires Java 11
 if (latestDepTest) {

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   latestDepTestLibrary("com.xuxueli:xxl-job-core:3.2.+") // documented limitation
 }
 
-val testLatestDeps = findProperty("testLatestDeps") == "true"
+val testLatestDeps = gradle.startParameter.projectProperties["testLatestDeps"] == "true"
 
 testing {
   suites {


### PR DESCRIPTION
## Summary

- The convention plugin (`otel.base-conventions`) stores `testLatestDeps` as a `Boolean` in `extra["testLatestDeps"]`
- `findProperty()` checks extra properties before Gradle's `-P` project properties, so `findProperty("testLatestDeps")` returns `Boolean(true)` instead of `String("true")`
- `Boolean(true) == "true"` is always `false` in Kotlin, so every `if (findProperty("testLatestDeps") == "true")` check in build scripts always evaluated to `false`

Fix: replace `findProperty("testLatestDeps") == "true"` with `gradle.startParameter.projectProperties["testLatestDeps"] == "true"` in all 99 affected files. This reads the `-P` flag directly, bypassing the shadowing extra property.

The most visible symptom was `async-http-client-2.0` forcing all Netty deps to `4.0.34.Final` even in latest-dep test builds (because the guard `if (!latestDepTest)` never fired), causing resolution failures for Netty modules that only exist in 4.1.x.

## Test plan

- [ ] CI passes on `testLatestDeps` jobs
- [ ] Verify `async-http-client-2.0` latest-dep test no longer fails with missing `netty-handler-proxy:4.0.34.Final`