### PR TITLE
Treat all advice as inline when indy is disabled

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/TypeTransformerImpl.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.tooling.instrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.AdviceInliningPoolStrategy;
 import io.opentelemetry.javaagent.tooling.instrumentation.indy.ForceDynamicallyTypedAssignReturnedFactory;
 import java.util.function.Function;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -33,6 +34,9 @@ final class TypeTransformerImpl implements TypeTransformer {
       ElementMatcher<? super MethodDescription> methodMatcher,
       Function<Advice.WithCustomMapping, Advice.WithCustomMapping> mappingCustomizer,
       String adviceClassName) {
+    // default strategy used by AgentBuilder.Transformer.ForAdvice
+    AgentBuilder.PoolStrategy poolStrategy = AgentBuilder.PoolStrategy.Default.FAST;
+
     agentBuilder =
         agentBuilder.transform(
             new AgentBuilder.Transformer.ForAdvice(mappingCustomizer.apply(adviceMapping))
@@ -40,6 +44,8 @@ final class TypeTransformerImpl implements TypeTransformer {
                     Utils.getBootstrapProxy(),
                     Utils.getAgentClassLoader(),
                     Utils.getExtensionsClassLoader())
+                // set the advice "inline" attribute to true
+                .with(new AdviceInliningPoolStrategy(poolStrategy, true))
                 .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
                 .advice(methodMatcher, adviceClassName));
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceInliningPoolStrategy.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/AdviceInliningPoolStrategy.java
@@ -24,21 +24,23 @@ import net.bytebuddy.pool.TypePool;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Pool strategy that sets "inline" attribute to false on {@link Advice.OnMethodEnter} and {@link
+ * Pool strategy that sets "inline" attribute on {@link Advice.OnMethodEnter} and {@link
  * Advice.OnMethodExit} annotations.
  */
-class AdviceUninliningPoolStrategy implements AgentBuilder.PoolStrategy {
+public class AdviceInliningPoolStrategy implements AgentBuilder.PoolStrategy {
   private final AgentBuilder.PoolStrategy poolStrategy;
+  private final boolean inline;
 
-  public AdviceUninliningPoolStrategy(AgentBuilder.PoolStrategy poolStrategy) {
+  public AdviceInliningPoolStrategy(AgentBuilder.PoolStrategy poolStrategy, boolean inline) {
     this.poolStrategy = poolStrategy;
+    this.inline = inline;
   }
 
   @NotNull
   @Override
   public TypePool typePool(@NotNull ClassFileLocator classFileLocator, ClassLoader classLoader) {
     TypePool typePool = poolStrategy.typePool(classFileLocator, classLoader);
-    return new TypePoolWrapper(typePool);
+    return new TypePoolWrapper(typePool, inline);
   }
 
   @NotNull
@@ -46,14 +48,16 @@ class AdviceUninliningPoolStrategy implements AgentBuilder.PoolStrategy {
   public TypePool typePool(
       @NotNull ClassFileLocator classFileLocator, ClassLoader classLoader, @NotNull String name) {
     TypePool typePool = poolStrategy.typePool(classFileLocator, classLoader, name);
-    return new TypePoolWrapper(typePool);
+    return new TypePoolWrapper(typePool, inline);
   }
 
   private static class TypePoolWrapper implements TypePool {
     private final TypePool typePool;
+    private final boolean inline;
 
-    TypePoolWrapper(TypePool typePool) {
+    TypePoolWrapper(TypePool typePool, boolean inline) {
       this.typePool = typePool;
+      this.inline = inline;
     }
 
     @NotNull
@@ -96,7 +100,7 @@ class AdviceUninliningPoolStrategy implements AgentBuilder.PoolStrategy {
 
                 @Override
                 public MethodDescription.InDefinedShape get(int index) {
-                  return new MethodDescriptionWrapper(methods.get(index));
+                  return new MethodDescriptionWrapper(methods.get(index), inline);
                 }
 
                 @Override
@@ -119,9 +123,11 @@ class AdviceUninliningPoolStrategy implements AgentBuilder.PoolStrategy {
   }
 
   private static class MethodDescriptionWrapper extends DelegatingMethodDescription {
+    private final boolean inline;
 
-    MethodDescriptionWrapper(MethodDescription.InDefinedShape method) {
+    MethodDescriptionWrapper(MethodDescription.InDefinedShape method, boolean inline) {
       super(method);
+      this.inline = inline;
     }
 
     @NotNull
@@ -141,9 +147,9 @@ class AdviceUninliningPoolStrategy implements AgentBuilder.PoolStrategy {
             return annotation;
           }
 
-          // replace value for "inline" attribute with false
+          // replace value for "inline" attribute
           return replaceAnnotationValue(
-              annotation, "inline", oldVal -> AnnotationValue.ForConstant.of(false));
+              annotation, "inline", oldVal -> AnnotationValue.ForConstant.of(inline));
         }
 
         @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyTypeTransformerImpl.java
@@ -62,7 +62,9 @@ public final class IndyTypeTransformerImpl implements TypeTransformer {
                 .advice(methodMatcher, adviceClassName)
                 // advice transformation already performs uninlining
                 .with(
-                    transformAdvice ? poolStrategy : new AdviceUninliningPoolStrategy(poolStrategy))
+                    transformAdvice
+                        ? poolStrategy
+                        : new AdviceInliningPoolStrategy(poolStrategy, false))
                 .include(getAdviceLocator(instrumentationModule.getClass().getClassLoader()))
                 .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler()));
   }


### PR DESCRIPTION
Currently all our advice is declared as `inline`. For indy advice we fake the inline attribute value to `false`. This PR make us fake the inline attribute value to `true` when not using indy. This will let us transition the indy ready modules to use `inline=false`. Eventually we could detect whether to use inline or non-inline style advice by inspecting the advice classes. For our built in instrumentations we may need to use some other means to communicate that they are indy ready as inspecting all advice classes can be a bit costly.