### PR TITLE
Add OpenTelemetryAppender.resetForTest()

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
@@ -72,6 +73,14 @@ public class OpenTelemetryAppender extends AbstractAppender {
    * the {@link LoggerContext}.
    */
   public static void install(OpenTelemetry openTelemetry) {
+    forEachAppender(appender -> appender.setOpenTelemetry(openTelemetry));
+  }
+
+  static void resetForTest() {
+    forEachAppender(OpenTelemetryAppender::resetAppenderForTest);
+  }
+
+  private static void forEachAppender(Consumer<OpenTelemetryAppender> consumer) {
     org.apache.logging.log4j.spi.LoggerContext loggerContextSpi = LogManager.getContext(false);
     if (!(loggerContextSpi instanceof LoggerContext)) {
       return;
@@ -84,7 +93,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
         .forEach(
             appender -> {
               if (appender instanceof OpenTelemetryAppender) {
-                ((OpenTelemetryAppender) appender).setOpenTelemetry(openTelemetry);
+                consumer.accept((OpenTelemetryAppender) appender);
               }
             });
   }
@@ -292,6 +301,18 @@ public class OpenTelemetryAppender extends AbstractAppender {
     // now emit
     for (LogEventToReplay eventToReplay : eventsToReplay) {
       emit(openTelemetry, eventToReplay);
+    }
+  }
+
+  private void resetAppenderForTest() {
+    Lock writeLock = lock.writeLock();
+    writeLock.lock();
+    try {
+      openTelemetry = null;
+      eventsToReplay.clear();
+      replayLimitWarningLogged.set(false);
+    } finally {
+      writeLock.unlock();
     }
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
@@ -46,7 +46,7 @@ abstract class AbstractOpenTelemetryAppenderTest {
   @AfterAll
   static void cleanupAll() {
     // This is to make sure that other test classes don't have issues with the logger provider set
-    OpenTelemetryAppender.install(null);
+    OpenTelemetryAppender.resetForTest();
   }
 
   protected abstract InstrumentationExtension getTesting();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
@@ -26,7 +26,7 @@ class Log4j2Test extends AbstractLog4j2Test {
 
   @AfterAll
   static void cleanup() {
-    OpenTelemetryAppender.install(null);
+    OpenTelemetryAppender.resetForTest();
   }
 
   @Override

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
@@ -35,7 +35,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
 
   @AfterEach
   void resetOpenTelemetry() {
-    OpenTelemetryAppender.install(null);
+    OpenTelemetryAppender.resetForTest();
   }
 
   @Override

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppender.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppender.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -60,23 +61,34 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
    * the {@link LoggerContext}.
    */
   public static void install(OpenTelemetry openTelemetry) {
+    forEachAppender(appender -> appender.setOpenTelemetry(openTelemetry));
+  }
+
+  static void resetForTest() {
+    forEachAppender(OpenTelemetryAppender::resetAppenderForTest);
+  }
+
+  private static void forEachAppender(Consumer<OpenTelemetryAppender> consumer) {
     ILoggerFactory loggerFactorySpi = LoggerFactory.getILoggerFactory();
     if (!(loggerFactorySpi instanceof LoggerContext)) {
       return;
     }
     LoggerContext loggerContext = (LoggerContext) loggerFactorySpi;
     for (Logger logger : loggerContext.getLoggerList()) {
-      logger.iteratorForAppenders().forEachRemaining(appender -> install(openTelemetry, appender));
+      logger
+          .iteratorForAppenders()
+          .forEachRemaining(appender -> forEachAppender(consumer, appender));
     }
   }
 
-  private static void install(OpenTelemetry openTelemetry, Appender<?> appender) {
+  private static void forEachAppender(
+      Consumer<OpenTelemetryAppender> consumer, Appender<?> appender) {
     if (appender instanceof OpenTelemetryAppender) {
-      ((OpenTelemetryAppender) appender).setOpenTelemetry(openTelemetry);
+      consumer.accept((OpenTelemetryAppender) appender);
     } else if (appender instanceof AppenderAttachable) {
       ((AppenderAttachable<?>) appender)
           .iteratorForAppenders()
-          .forEachRemaining(a -> OpenTelemetryAppender.install(openTelemetry, a));
+          .forEachRemaining(a -> forEachAppender(consumer, a));
     }
   }
 
@@ -268,6 +280,18 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
     // now emit
     for (LoggingEventToReplay eventToReplay : eventsToReplay) {
       emit(openTelemetry, eventToReplay);
+    }
+  }
+
+  private void resetAppenderForTest() {
+    Lock writeLock = lock.writeLock();
+    writeLock.lock();
+    try {
+      openTelemetry = null;
+      eventsToReplay.clear();
+      replayLimitWarningLogged.set(false);
+    } finally {
+      writeLock.unlock();
     }
   }
 

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogbackTest.java
@@ -31,7 +31,7 @@ class LogbackTest extends AbstractLogbackTest {
 
   @AfterEach
   void tearDown() {
-    OpenTelemetryAppender.install(null);
+    OpenTelemetryAppender.resetForTest();
   }
 
   @Override


### PR DESCRIPTION
This way install() doesn't need to accept `@Nullable` param.

Related to
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17520
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17528