### PR TITLE
Make internal-application-logger independent of the default-enabled flag

### DIFF
--- a/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
+++ b/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
@@ -23,7 +23,7 @@ public class ApplicationLoggingInstrumentationModule extends InstrumentationModu
   @Override
   public boolean defaultEnabled() {
     // only enable this instrumentation if the application logger is enabled
-    return super.defaultEnabled() && "application".equals(EarlyInitAgentConfig.get().getLogging());
+    return "application".equals(EarlyInitAgentConfig.get().getLogging());
   }
 
   @Override


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/17650