### PR TITLE
Add NullAway to javaagent-tooling and javaagent

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/DefineClassHelper.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/DefineClassHelper.java
@@ -7,17 +7,19 @@ package io.opentelemetry.javaagent.bootstrap;
 
 import io.opentelemetry.instrumentation.api.internal.Initializer;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 
 public class DefineClassHelper {
 
   /** Helper class for {@code ClassLoader.defineClass} callbacks. */
   public interface Handler {
+    @Nullable
     DefineClassContext beforeDefineClass(
         ClassLoader classLoader, String className, byte[] classBytes, int offset, int length);
 
     DefineClassContext beforeDefineLambdaClass(Class<?> lambdaInterface);
 
-    void afterDefineClass(DefineClassContext context);
+    void afterDefineClass(@Nullable DefineClassContext context);
 
     /** Context returned from {@code beforeDefineClass} and passed to {@code afterDefineClass}. */
     interface DefineClassContext {
@@ -27,11 +29,13 @@ public class DefineClassHelper {
 
   private static volatile Handler handler;
 
+  @Nullable
   public static Handler.DefineClassContext beforeDefineClass(
       ClassLoader classLoader, String className, byte[] classBytes, int offset, int length) {
     return handler.beforeDefineClass(classLoader, className, classBytes, offset, length);
   }
 
+  @Nullable
   public static Handler.DefineClassContext beforeDefineClass(
       ClassLoader classLoader, String className, ByteBuffer byteBuffer) {
     // see how ClassLoader handles ByteBuffer
@@ -55,7 +59,7 @@ public class DefineClassHelper {
     return handler.beforeDefineLambdaClass(lambdaInterface);
   }
 
-  public static void afterDefineClass(Handler.DefineClassContext context) {
+  public static void afterDefineClass(@Nullable Handler.DefineClassContext context) {
     handler.afterDefineClass(context);
   }
 

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -2,6 +2,7 @@ import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
   id("otel.java-conventions")
+  id("otel.nullaway-conventions")
   id("otel.publish-conventions")
   id("otel.jmh-conventions")
 }

--- a/javaagent-tooling/javaagent-tooling-java9/build.gradle.kts
+++ b/javaagent-tooling/javaagent-tooling-java9/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.java-conventions")
+  id("otel.nullaway-conventions")
   id("otel.publish-conventions")
 }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -18,6 +18,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
 import java.security.ProtectionDomain;
 import java.util.ServiceLoader;
+import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -34,7 +35,7 @@ public class AgentStarterImpl implements AgentStarter {
   private final Instrumentation instrumentation;
   private final File javaagentFile;
   private final boolean isSecurityManagerSupportEnabled;
-  private ClassLoader extensionClassLoader;
+  @Nullable private ClassLoader extensionClassLoader;
 
   public AgentStarterImpl(
       Instrumentation instrumentation,
@@ -143,6 +144,7 @@ public class AgentStarterImpl implements AgentStarter {
             + "'. The agent will use the no-op implementation.");
   }
 
+  @Nullable
   @Override
   public ClassLoader getExtensionClassLoader() {
     return extensionClassLoader;
@@ -157,6 +159,7 @@ public class AgentStarterImpl implements AgentStarter {
     boolean hookInserted = false;
     boolean transformed = false;
 
+    @Nullable
     @Override
     public byte[] transform(
         ClassLoader loader,
@@ -203,6 +206,7 @@ public class AgentStarterImpl implements AgentStarter {
   private static class InetAddressClassFileTransformer implements ClassFileTransformer {
     boolean hookInserted = false;
 
+    @Nullable
     @Override
     public byte[] transform(
         ClassLoader loader,

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -262,6 +262,7 @@ public class AgentStarterImpl implements AgentStarter {
 
   private static class AgentBuilderDefaultClassFileTransformer implements ClassFileTransformer {
 
+    @Nullable
     @Override
     public byte[] transform(
         ClassLoader loader,
@@ -296,6 +297,7 @@ public class AgentStarterImpl implements AgentStarter {
 
   private static class CallbackRegistrationClassFileTransformer implements ClassFileTransformer {
 
+    @Nullable
     @Override
     public byte[] transform(
         ClassLoader loader,

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
@@ -29,6 +29,7 @@ public class DefineClassHandler implements Handler {
   }
 
   @Override
+  @Nullable
   public DefineClassContext beforeDefineClass(
       ClassLoader classLoader, String className, byte[] classBytes, int offset, int length) {
     // with OpenJ9 class data sharing we don't get real class bytes
@@ -97,8 +98,10 @@ public class DefineClassHandler implements Handler {
   }
 
   @Override
-  public void afterDefineClass(DefineClassContext context) {
-    context.exit();
+  public void afterDefineClass(@Nullable DefineClassContext context) {
+    if (context != null) {
+      context.exit();
+    }
   }
 
   /**

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
@@ -12,6 +12,7 @@ import io.opentelemetry.javaagent.bootstrap.DefineClassHelper.Handler;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 
 public class DefineClassHandler implements Handler {
@@ -97,9 +98,7 @@ public class DefineClassHandler implements Handler {
 
   @Override
   public void afterDefineClass(DefineClassContext context) {
-    if (context != null) {
-      context.exit();
-    }
+    context.exit();
   }
 
   /**
@@ -119,17 +118,24 @@ public class DefineClassHandler implements Handler {
   }
 
   private static class DefineClassContextImpl implements DefineClassContext {
-    private static final DefineClassContextImpl NOP = new DefineClassContextImpl();
+    // NOP is returned from beforeDefineClass without calling enter() (no frame pushed),
+    // so exit() must not mutate the ThreadLocal — otherwise a nested J9 defineClass would
+    // clobber an outer frame that is still active.
+    private static final DefineClassContextImpl NOP =
+        new DefineClassContextImpl() {
+          @Override
+          public void exit() {}
+        };
 
-    private final DefineClassContextImpl previous;
-    String failedClassDotName;
-    Set<String> superDotNames;
+    @Nullable private final DefineClassContextImpl previous;
+    @Nullable String failedClassDotName;
+    @Nullable Set<String> superDotNames;
 
     private DefineClassContextImpl() {
       previous = null;
     }
 
-    private DefineClassContextImpl(DefineClassContextImpl previous) {
+    private DefineClassContextImpl(@Nullable DefineClassContextImpl previous) {
       this.previous = previous;
     }
 
@@ -142,7 +148,7 @@ public class DefineClassHandler implements Handler {
 
     @Override
     public void exit() {
-      defineClassContext.set(previous);
+      defineClassContext.set(previous != null ? previous : NOP);
     }
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
@@ -138,7 +138,7 @@ public class DefineClassHandler implements Handler {
       previous = null;
     }
 
-    private DefineClassContextImpl(@Nullable DefineClassContextImpl previous) {
+    private DefineClassContextImpl(DefineClassContextImpl previous) {
       this.previous = previous;
     }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DefineClassHandler.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.javaagent.bootstrap.DefineClassHelper.Handler;
 import java.util.HashSet;
@@ -18,7 +19,7 @@ import org.objectweb.asm.ClassReader;
 public class DefineClassHandler implements Handler {
   public static final DefineClassHandler INSTANCE = new DefineClassHandler();
   private static final ThreadLocal<DefineClassContextImpl> defineClassContext =
-      ThreadLocal.withInitial(() -> DefineClassContextImpl.NOP);
+      ThreadLocal.withInitial(() -> DefineClassContextImpl.ROOT);
 
   private static Predicate<ClassLoader> ignoredClassLoaders = (classLoader) -> false;
 
@@ -121,14 +122,7 @@ public class DefineClassHandler implements Handler {
   }
 
   private static class DefineClassContextImpl implements DefineClassContext {
-    // NOP is returned from beforeDefineClass without calling enter() (no frame pushed),
-    // so exit() must not mutate the ThreadLocal — otherwise a nested J9 defineClass would
-    // clobber an outer frame that is still active.
-    private static final DefineClassContextImpl NOP =
-        new DefineClassContextImpl() {
-          @Override
-          public void exit() {}
-        };
+    private static final DefineClassContextImpl ROOT = new DefineClassContextImpl();
 
     @Nullable private final DefineClassContextImpl previous;
     @Nullable String failedClassDotName;
@@ -151,7 +145,9 @@ public class DefineClassHandler implements Handler {
 
     @Override
     public void exit() {
-      defineClassContext.set(previous != null ? previous : NOP);
+      // ROOT itself has no previous context but is never returned to callers. Every returned
+      // context is created by enter(), which captures ROOT or an outer context as its predecessor.
+      defineClassContext.set(requireNonNull(previous));
     }
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -109,7 +109,7 @@ public class ExtensionClassLoader extends URLClassLoader {
     }
   }
 
-  private static File ensureTempDirectoryExists(File tempDirectory) throws IOException {
+  private static File ensureTempDirectoryExists(@Nullable File tempDirectory) throws IOException {
     if (tempDirectory == null) {
       tempDirectory = Files.createTempDirectory("otel-extensions").toFile();
       tempDirectory.deleteOnExit();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InputStreamUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InputStreamUrlConnection.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.Permission;
+import javax.annotation.Nullable;
 
 public class InputStreamUrlConnection extends URLConnection {
   private final InputStream inputStream;
@@ -30,6 +31,7 @@ public class InputStreamUrlConnection extends URLConnection {
     return inputStream;
   }
 
+  @Nullable
   @Override
   public Permission getPermission() {
     // No permissions needed because all classes are in memory

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedConfigProvider;
@@ -16,6 +17,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
 import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 
 public final class OpenTelemetryInstaller {
@@ -36,15 +38,17 @@ public final class OpenTelemetryInstaller {
             .build();
     OpenTelemetrySdk sdk = autoConfiguredSdk.getOpenTelemetrySdk();
     ConfigProperties configProperties = AutoConfigureUtil.getConfig(autoConfiguredSdk);
-    boolean declarativeConfigUsed = configProperties == null;
 
-    if (!declarativeConfigUsed) {
+    if (configProperties != null) {
       // Provide a fake declarative configuration based on config properties
       // so that declarative configuration API can be used everywhere
       sdk =
           new ExtendedOpenTelemetrySdkWrapper(
               sdk, ConfigPropertiesBackedConfigProvider.create(configProperties));
       AgentDistributionConfig.set(AgentDistributionConfig.fromConfigProperties(configProperties));
+    } else {
+      // Declarative config path: no ConfigProperties available, use empty defaults
+      configProperties = DefaultConfigProperties.createFromMap(emptyMap());
     }
 
     setForceFlush(sdk);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -37,12 +37,12 @@ public final class OpenTelemetryInstaller {
             .build();
     OpenTelemetrySdk sdk = autoConfiguredSdk.getOpenTelemetrySdk();
     ConfigProperties configProperties = AutoConfigureUtil.getConfig(autoConfiguredSdk);
-    boolean declarativeConfigUsed = configProperties == null;
 
-    if (!declarativeConfigUsed) {
+    if (configProperties != null) {
       ConfigProperties nonNullConfigProperties = requireNonNull(configProperties);
       // Provide a fake declarative configuration based on config properties
-      // so that declarative configuration API can be used everywhere
+      // so that declarative configuration API can be used everywhere. In declarative-config mode
+      // there is no ConfigProperties instance to bridge here, so preserve the SDK as-is.
       sdk =
           new ExtendedOpenTelemetrySdkWrapper(
               sdk, ConfigPropertiesBackedConfigProvider.create(nonNullConfigProperties));

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -6,8 +6,7 @@
 package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
-
+import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedConfigProvider;
 import io.opentelemetry.javaagent.bootstrap.OpenTelemetrySdkAccess;
@@ -17,7 +16,6 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
 import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 
 public final class OpenTelemetryInstaller {
@@ -38,17 +36,17 @@ public final class OpenTelemetryInstaller {
             .build();
     OpenTelemetrySdk sdk = autoConfiguredSdk.getOpenTelemetrySdk();
     ConfigProperties configProperties = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    boolean declarativeConfigUsed = configProperties == null;
 
-    if (configProperties != null) {
+    if (!declarativeConfigUsed) {
+      ConfigProperties nonNullConfigProperties = requireNonNull(configProperties);
       // Provide a fake declarative configuration based on config properties
       // so that declarative configuration API can be used everywhere
       sdk =
           new ExtendedOpenTelemetrySdkWrapper(
-              sdk, ConfigPropertiesBackedConfigProvider.create(configProperties));
-      AgentDistributionConfig.set(AgentDistributionConfig.fromConfigProperties(configProperties));
-    } else {
-      // Declarative config path: no ConfigProperties available, use empty defaults
-      configProperties = DefaultConfigProperties.createFromMap(emptyMap());
+              sdk, ConfigPropertiesBackedConfigProvider.create(nonNullConfigProperties));
+      AgentDistributionConfig.set(
+          AgentDistributionConfig.fromConfigProperties(nonNullConfigProperties));
     }
 
     setForceFlush(sdk);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedConfigProvider;
 import io.opentelemetry.javaagent.bootstrap.OpenTelemetrySdkAccess;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Arrays.asList;
-import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedConfigProvider;
@@ -39,15 +38,13 @@ public final class OpenTelemetryInstaller {
     ConfigProperties configProperties = AutoConfigureUtil.getConfig(autoConfiguredSdk);
 
     if (configProperties != null) {
-      ConfigProperties nonNullConfigProperties = requireNonNull(configProperties);
       // Provide a fake declarative configuration based on config properties
       // so that declarative configuration API can be used everywhere. In declarative-config mode
       // there is no ConfigProperties instance to bridge here, so preserve the SDK as-is.
       sdk =
           new ExtendedOpenTelemetrySdkWrapper(
-              sdk, ConfigPropertiesBackedConfigProvider.create(nonNullConfigProperties));
-      AgentDistributionConfig.set(
-          AgentDistributionConfig.fromConfigProperties(nonNullConfigProperties));
+              sdk, ConfigPropertiesBackedConfigProvider.create(configProperties));
+      AgentDistributionConfig.set(AgentDistributionConfig.fromConfigProperties(configProperties));
     }
 
     setForceFlush(sdk);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
@@ -15,6 +15,7 @@ import java.net.URLConnection;
 import java.security.Permission;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.commons.ClassRemapper;
@@ -50,7 +51,7 @@ public class RemappingUrlConnection extends URLConnection {
   private final JarFile delegateJarFile;
   private final JarEntry entry;
 
-  private byte[] cacheClassBytes;
+  @Nullable private byte[] cacheClassBytes;
 
   public RemappingUrlConnection(URL url, JarFile delegateJarFile, JarEntry entry) {
     super(url);
@@ -89,6 +90,7 @@ public class RemappingUrlConnection extends URLConnection {
     return cw.toByteArray();
   }
 
+  @Nullable
   @Override
   public Permission getPermission() {
     // No permissions needed because all classes are in memory

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -35,11 +34,10 @@ public final class SafeServiceLoader {
   public static <T> List<T> load(Class<T> serviceClass, @Nullable ClassLoader classLoader) {
     List<T> result = new ArrayList<>();
     ServiceLoader<T> services = ServiceLoader.load(serviceClass, classLoader);
-    for (Iterator<T> iterator = new SafeIterator<>(services.iterator()); iterator.hasNext(); ) {
-      try {
-        result.add(iterator.next());
-      } catch (NoSuchElementException ignored) {
-        // UnsupportedClassVersionError was thrown and handled by SafeIterator
+    for (SafeIterator<T> iterator = new SafeIterator<>(services.iterator()); iterator.hasNext(); ) {
+      T service = iterator.nextOrNull();
+      if (service != null) {
+        result.add(service);
       }
     }
     return result;
@@ -58,7 +56,7 @@ public final class SafeServiceLoader {
 
   private SafeServiceLoader() {}
 
-  private static class SafeIterator<T> implements Iterator<T> {
+  private static class SafeIterator<T> {
     private final Iterator<T> delegate;
 
     SafeIterator(Iterator<T> iterator) {
@@ -73,8 +71,7 @@ public final class SafeServiceLoader {
           unsupportedClassVersionError.getMessage());
     }
 
-    @Override
-    public boolean hasNext() {
+    private boolean hasNext() {
       // jdk9 and newer throw UnsupportedClassVersionError in hasNext()
       while (true) {
         try {
@@ -85,14 +82,14 @@ public final class SafeServiceLoader {
       }
     }
 
-    @Override
-    public T next() {
+    @Nullable
+    private T nextOrNull() {
       // jdk8 throws UnsupportedClassVersionError in next()
       try {
         return delegate.next();
       } catch (UnsupportedClassVersionError unsupportedClassVersionError) {
         handleUnsupportedClassVersionError(unsupportedClassVersionError);
-        throw new NoSuchElementException(unsupportedClassVersionError.getMessage());
+        return null;
       }
     }
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
@@ -12,8 +12,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 public final class SafeServiceLoader {
 
@@ -30,13 +32,14 @@ public final class SafeServiceLoader {
    */
   // Because we want to catch exception per iteration
   @SuppressWarnings("ForEachIterable")
-  public static <T> List<T> load(Class<T> serviceClass, ClassLoader classLoader) {
+  public static <T> List<T> load(Class<T> serviceClass, @Nullable ClassLoader classLoader) {
     List<T> result = new ArrayList<>();
     ServiceLoader<T> services = ServiceLoader.load(serviceClass, classLoader);
     for (Iterator<T> iterator = new SafeIterator<>(services.iterator()); iterator.hasNext(); ) {
-      T service = iterator.next();
-      if (service != null) {
-        result.add(service);
+      try {
+        result.add(iterator.next());
+      } catch (NoSuchElementException ignored) {
+        // UnsupportedClassVersionError was thrown and handled by SafeIterator
       }
     }
     return result;
@@ -47,7 +50,7 @@ public final class SafeServiceLoader {
    * comparing their {@link Ordered#order()}.
    */
   public static <T extends Ordered> List<T> loadOrdered(
-      Class<T> serviceClass, ClassLoader classLoader) {
+      Class<T> serviceClass, @Nullable ClassLoader classLoader) {
     List<T> result = load(serviceClass, classLoader);
     result.sort(Comparator.comparingInt(Ordered::order));
     return result;
@@ -89,7 +92,7 @@ public final class SafeServiceLoader {
         return delegate.next();
       } catch (UnsupportedClassVersionError unsupportedClassVersionError) {
         handleUnsupportedClassVersionError(unsupportedClassVersionError);
-        return null;
+        throw new NoSuchElementException(unsupportedClassVersionError.getMessage());
       }
     }
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
@@ -11,6 +11,7 @@ import io.opentelemetry.javaagent.bootstrap.AgentClassLoader;
 import io.opentelemetry.javaagent.bootstrap.AgentClassLoader.BootstrapClassLoaderProxy;
 import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
 import java.security.PrivilegedAction;
+import javax.annotation.Nullable;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDefinition;
 
@@ -24,6 +25,7 @@ public class Utils {
     return AgentInstaller.class.getClassLoader();
   }
 
+  @Nullable
   public static ClassLoader getExtensionsClassLoader() {
     return AgentInitializer.getExtensionsClassLoader();
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFile.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFile.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 
 final class ConfigurationFile {
 
-  private static Map<String, String> configFileContents;
+  @Nullable private static Map<String, String> configFileContents;
 
   // this class is used early, and must not use logging in most of its methods
   // in case any file loading/parsing error occurs, we save the error message and log it later, when

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling.field;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldNames.getFieldAccessorInterfaceName;
+import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINEST;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -27,6 +28,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -78,8 +80,10 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
       Class<?> instrumenterClass, VirtualFieldMappings virtualFieldMappings) {
     this.instrumenterClass = instrumenterClass;
     this.virtualFieldMappings = virtualFieldMappings;
-    // This class is used only when running with javaagent, thus this calls is safe
-    this.instrumentation = InstrumentationHolder.getInstrumentation();
+    // This class is used only when running with javaagent, thus this call is safe
+    this.instrumentation =
+        requireNonNull(
+            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
 
     ByteBuddy byteBuddy = new ByteBuddy();
     fieldAccessorInterfaces =
@@ -146,6 +150,7 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
       final HelperInjector injector =
           HelperInjector.forDynamicTypes(getClass().getSimpleName(), helpers, instrumentation);
 
+      @Nullable
       @Override
       public DynamicType.Builder<?> transform(
           DynamicType.Builder<?> builder,

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
@@ -146,7 +146,6 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
       final HelperInjector injector =
           HelperInjector.forDynamicTypes(getClass().getSimpleName(), helpers, instrumentation);
 
-      @Nullable
       @Override
       public DynamicType.Builder<?> transform(
           DynamicType.Builder<?> builder,
@@ -154,13 +153,14 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
           ClassLoader classLoader,
           JavaModule javaModule,
           ProtectionDomain protectionDomain) {
-        return injector.transform(
+        injector.transform(
             builder,
             typeDescription,
             // virtual field implementation classes will always go to the bootstrap
             null,
             javaModule,
             protectionDomain);
+        return builder;
       }
     };
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.tooling.field;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldNames.getFieldAccessorInterfaceName;
-import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINEST;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -74,16 +73,13 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
   private final VirtualFieldImplementations virtualFieldImplementations;
   private final AgentBuilder.Transformer virtualFieldImplementationsInjector;
 
-  private final Instrumentation instrumentation;
+  @Nullable private final Instrumentation instrumentation;
 
   public FieldBackedImplementationInstaller(
       Class<?> instrumenterClass, VirtualFieldMappings virtualFieldMappings) {
     this.instrumenterClass = instrumenterClass;
     this.virtualFieldMappings = virtualFieldMappings;
-    // This class is used only when running with javaagent, thus this call is safe
-    this.instrumentation =
-        requireNonNull(
-            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
+    this.instrumentation = InstrumentationHolder.getInstrumentation();
 
     ByteBuddy byteBuddy = new ByteBuddy();
     fieldAccessorInterfaces =

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -17,6 +17,7 @@ import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -119,6 +120,7 @@ final class VirtualFieldImplementationsGenerator {
           private final boolean frames =
               implementationContext.getClassFileVersion().isAtLeast(ClassFileVersion.JAVA_V6);
 
+          @Nullable
           @Override
           public MethodVisitor visitMethod(
               int access, String name, String descriptor, String signature, String[] exceptions) {
@@ -275,25 +277,28 @@ final class VirtualFieldImplementationsGenerator {
       this.map = map;
     }
 
+    @Nullable
     @Override
     public Object get(Object object) {
       return realGet(object);
     }
 
     @Override
-    public void set(Object object, Object fieldValue) {
+    public void set(Object object, @Nullable Object fieldValue) {
       realPut(object, fieldValue);
     }
 
+    @Nullable
     private Object realGet(Object key) {
       // to be generated
       return null;
     }
 
-    private void realPut(Object key, Object value) {
+    private void realPut(Object key, @Nullable Object value) {
       // to be generated
     }
 
+    @Nullable
     private Object mapGet(Object key) {
       return map.get(key);
     }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -26,11 +26,8 @@ public class InstrumentationLoader implements AgentExtension {
 
   @Override
   public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
-    Instrumentation instrumentation =
-        requireNonNull(
-            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
     InstrumentationModuleInstaller instrumentationModuleInstaller =
-        new InstrumentationModuleInstaller(instrumentation);
+        new InstrumentationModuleInstaller(InstrumentationHolder.getInstrumentation());
     int numberOfLoadedModules = 0;
     ClassLoader extensionsClassLoader =
         requireNonNull(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
 import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.loadOrdered;
+import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 
@@ -15,6 +16,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
 import io.opentelemetry.javaagent.tooling.AgentExtension;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.lang.instrument.Instrumentation;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
@@ -22,14 +24,19 @@ import net.bytebuddy.agent.builder.AgentBuilder;
 public class InstrumentationLoader implements AgentExtension {
   private static final Logger logger = Logger.getLogger(InstrumentationLoader.class.getName());
 
-  private final InstrumentationModuleInstaller instrumentationModuleInstaller =
-      new InstrumentationModuleInstaller(InstrumentationHolder.getInstrumentation());
-
   @Override
   public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
+    Instrumentation instrumentation =
+        requireNonNull(
+            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
+    InstrumentationModuleInstaller instrumentationModuleInstaller =
+        new InstrumentationModuleInstaller(instrumentation);
     int numberOfLoadedModules = 0;
+    ClassLoader extensionsClassLoader =
+        requireNonNull(
+            Utils.getExtensionsClassLoader(), "Extensions class loader must not be null");
     for (InstrumentationModule instrumentationModule :
-        loadOrdered(InstrumentationModule.class, Utils.getExtensionsClassLoader())) {
+        loadOrdered(InstrumentationModule.class, extensionsClassLoader)) {
       if (logger.isLoggable(FINE)) {
         logger.log(
             FINE,

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -26,8 +26,11 @@ public class InstrumentationLoader implements AgentExtension {
 
   @Override
   public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
+    Instrumentation instrumentation =
+        requireNonNull(
+            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
     InstrumentationModuleInstaller instrumentationModuleInstaller =
-        new InstrumentationModuleInstaller(InstrumentationHolder.getInstrumentation());
+        new InstrumentationModuleInstaller(instrumentation);
     int numberOfLoadedModules = 0;
     ClassLoader extensionsClassLoader =
         requireNonNull(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -16,7 +16,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
 import io.opentelemetry.javaagent.tooling.AgentExtension;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import java.lang.instrument.Instrumentation;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
@@ -26,14 +25,14 @@ public class InstrumentationLoader implements AgentExtension {
 
   @Override
   public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
-    Instrumentation instrumentation =
-        requireNonNull(
-            InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
     ClassLoader extensionsClassLoader =
         requireNonNull(
             Utils.getExtensionsClassLoader(), "Extensions class loader must not be null");
     InstrumentationModuleInstaller instrumentationModuleInstaller =
-        new InstrumentationModuleInstaller(instrumentation, extensionsClassLoader);
+        new InstrumentationModuleInstaller(
+            requireNonNull(
+                InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null"),
+            extensionsClassLoader);
     int numberOfLoadedModules = 0;
     for (InstrumentationModule instrumentationModule :
         loadOrdered(InstrumentationModule.class, extensionsClassLoader)) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -29,12 +29,12 @@ public class InstrumentationLoader implements AgentExtension {
     Instrumentation instrumentation =
         requireNonNull(
             InstrumentationHolder.getInstrumentation(), "Instrumentation must not be null");
-    InstrumentationModuleInstaller instrumentationModuleInstaller =
-        new InstrumentationModuleInstaller(instrumentation);
-    int numberOfLoadedModules = 0;
     ClassLoader extensionsClassLoader =
         requireNonNull(
             Utils.getExtensionsClassLoader(), "Extensions class loader must not be null");
+    InstrumentationModuleInstaller instrumentationModuleInstaller =
+        new InstrumentationModuleInstaller(instrumentation, extensionsClassLoader);
+    int numberOfLoadedModules = 0;
     for (InstrumentationModule instrumentationModule :
         loadOrdered(InstrumentationModule.class, extensionsClassLoader)) {
       if (logger.isLoggable(FINE)) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
 import static java.util.Collections.emptyList;
-import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -70,7 +69,7 @@ public final class InstrumentationModuleInstaller {
               ClassFileLocator.ForClassLoader.of(Utils.getExtensionsClassLoader())));
 
   public InstrumentationModuleInstaller(Instrumentation instrumentation) {
-    this.instrumentation = requireNonNull(instrumentation, "Instrumentation must not be null");
+    this.instrumentation = instrumentation;
   }
 
   // Need to call deprecated API for backward compatibility with modules that haven't migrated

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -69,7 +70,7 @@ public final class InstrumentationModuleInstaller {
               ClassFileLocator.ForClassLoader.of(Utils.getExtensionsClassLoader())));
 
   public InstrumentationModuleInstaller(Instrumentation instrumentation) {
-    this.instrumentation = instrumentation;
+    this.instrumentation = requireNonNull(instrumentation, "Instrumentation must not be null");
   }
 
   // Need to call deprecated API for backward compatibility with modules that haven't migrated

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -60,16 +60,20 @@ public final class InstrumentationModuleInstaller {
       not(isAnnotatedWith(named("javax.decorator.Decorator")));
 
   private final Instrumentation instrumentation;
+  private final ClassLoader extensionsClassLoader;
   private final VirtualFieldImplementationInstallerFactory virtualFieldInstallerFactory =
       VirtualFieldImplementationInstallerFactory.getInstance();
-  private final AdviceInspector adviceInspector =
-      new AdviceInspector(
-          new ClassFileLocator.Compound(
-              ClassFileLocator.ForClassLoader.of(Utils.getAgentClassLoader()),
-              ClassFileLocator.ForClassLoader.of(Utils.getExtensionsClassLoader())));
+  private final AdviceInspector adviceInspector;
 
-  public InstrumentationModuleInstaller(Instrumentation instrumentation) {
+  public InstrumentationModuleInstaller(
+      Instrumentation instrumentation, ClassLoader extensionsClassLoader) {
     this.instrumentation = instrumentation;
+    this.extensionsClassLoader = extensionsClassLoader;
+    this.adviceInspector =
+        new AdviceInspector(
+            new ClassFileLocator.Compound(
+                ClassFileLocator.ForClassLoader.of(Utils.getAgentClassLoader()),
+                ClassFileLocator.ForClassLoader.of(extensionsClassLoader)));
   }
 
   // Need to call deprecated API for backward compatibility with modules that haven't migrated
@@ -245,7 +249,7 @@ public final class InstrumentationModuleInstaller {
             instrumentationModule.instrumentationName(),
             helperClassNames,
             helperResourceBuilder.getResources(),
-            Utils.getExtensionsClassLoader(),
+            extensionsClassLoader,
             instrumentation);
     VirtualFieldImplementationInstaller contextProvider =
         virtualFieldInstallerFactory.create(instrumentationModule);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
@@ -18,7 +19,7 @@ import io.opentelemetry.javaagent.tooling.muzzle.Mismatch;
 import io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher;
 import java.security.ProtectionDomain;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,9 +40,8 @@ class MuzzleMatcher implements AgentBuilder.RawMatcher {
   private final InstrumentationModule instrumentationModule;
   private final UnaryOperator<ClassLoader> classLoaderTransformer;
   private final Level muzzleLogLevel;
-  private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicReference<ReferenceMatcher> referenceMatcher = new AtomicReference<>();
   private final Cache<ClassLoader, Boolean> matchCache = Cache.weak();
-  private volatile ReferenceMatcher referenceMatcher;
 
   MuzzleMatcher(
       TransformSafeLogger instrumentationLogger,
@@ -106,9 +106,11 @@ class MuzzleMatcher implements AgentBuilder.RawMatcher {
   // ReferenceMatcher is lazily created to avoid unnecessarily loading the muzzle references from
   // the module during the agent setup
   private ReferenceMatcher getReferenceMatcher() {
-    if (initialized.compareAndSet(false, true)) {
-      referenceMatcher = ReferenceMatcher.of(instrumentationModule);
+    ReferenceMatcher result = referenceMatcher.get();
+    if (result == null) {
+      referenceMatcher.compareAndSet(null, ReferenceMatcher.of(instrumentationModule));
+      result = requireNonNull(referenceMatcher.get());
     }
-    return referenceMatcher;
+    return result;
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/http/RegexUrlTemplateCustomizerInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/http/RegexUrlTemplateCustomizerInitializer.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nullable;
 
 @AutoService(BeforeAgentListener.class)
 public final class RegexUrlTemplateCustomizerInitializer implements BeforeAgentListener {
@@ -48,6 +49,7 @@ public final class RegexUrlTemplateCustomizerInitializer implements BeforeAgentL
             });
   }
 
+  @Nullable
   private static Pattern toPattern(String patternString) {
     try {
       // ensure that pattern matches the whole url

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
@@ -121,6 +121,7 @@ public class IndyBootstrap {
         // a nested bootstrap call from lambda instrumentation which could lead to stack overflow
         new PrivilegedAction<CallSite>() {
           @Override
+          @Nullable
           public CallSite run() {
             return internalBootstrap(lookup, adviceMethodName, adviceMethodType, args);
           }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyBootstrap.java
@@ -127,6 +127,7 @@ public class IndyBootstrap {
         });
   }
 
+  @Nullable
   private static CallSite internalBootstrap(
       MethodHandles.Lookup lookup,
       String adviceMethodName,
@@ -198,7 +199,8 @@ public class IndyBootstrap {
         // Update the callsite of those to run the actual instrumentation
         logger.log(
             FINE,
-            "Fixing nested instrumentation invokedynamic instruction bootstrapping for instrumented class {0} and advice {1}.{2}, the instrumentation should be active now",
+            "Fixing nested instrumentation invokedynamic instruction bootstrapping for instrumented"
+                + " class {0} and advice {1}.{2}, the instrumentation should be active now",
             new Object[] {lookup.lookupClass().getName(), adviceClassName, adviceMethodName});
         nestedBootstrapCallSite.setTarget(methodHandle);
         MutableCallSite.syncAll(new MutableCallSite[] {nestedBootstrapCallSite});

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -171,7 +171,9 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
       ExperimentalInstrumentationModule experimentalModule =
           (ExperimentalInstrumentationModule) module;
       hiddenAgentPackages.addAll(experimentalModule.agentPackagesToHide());
-      if (!forMuzzleCheck && instrumentedCl != null && !experimentalModule.exposedClassNames().isEmpty()) {
+      if (!forMuzzleCheck
+          && instrumentedCl != null
+          && !experimentalModule.exposedClassNames().isEmpty()) {
         // Using a weak reference because HelperInjector.addExposedClass places the supplier into
         // a weak map where instrumentedCl is the key. We must ensure that the value of the map
         // does not strongly reference the key, otherwise we would leak class loaders.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -74,7 +74,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
 
   private final Map<String, BytecodeWithUrl> additionalInjectedClasses;
   private final ClassLoader agentOrExtensionCl;
-  private volatile MethodHandles.Lookup cachedLookup;
+  @Nullable private volatile MethodHandles.Lookup cachedLookup;
 
   @Nullable private final ClassLoader instrumentedCl;
 
@@ -289,6 +289,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
     return true;
   }
 
+  @Nullable
   private static Class<?> tryLoad(@Nullable ClassLoader cl, String name) {
     try {
       return Class.forName(name, false, cl);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -171,7 +171,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
       ExperimentalInstrumentationModule experimentalModule =
           (ExperimentalInstrumentationModule) module;
       hiddenAgentPackages.addAll(experimentalModule.agentPackagesToHide());
-      if (!forMuzzleCheck && !experimentalModule.exposedClassNames().isEmpty()) {
+      if (!forMuzzleCheck && instrumentedCl != null && !experimentalModule.exposedClassNames().isEmpty()) {
         // Using a weak reference because HelperInjector.addExposedClass places the supplier into
         // a weak map where instrumentedCl is the key. We must ensure that the value of the map
         // does not strongly reference the key, otherwise we would leak class loaders.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/VirtualFieldChecker.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/VirtualFieldChecker.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AsmApi;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.MethodVisitor;
@@ -67,6 +68,7 @@ class VirtualFieldChecker {
         });
   }
 
+  @Nullable
   private static AnnotationNode getAnnotationNode(MethodNode source, Type type) {
     if (source.visibleAnnotations != null) {
       for (AnnotationNode annotationNode : source.visibleAnnotations) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/ClassLoaderMap.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/ClassLoaderMap.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.modifier.Ownership;
 import net.bytebuddy.description.modifier.Visibility;
@@ -35,6 +36,7 @@ class ClassLoaderMap {
     return defaultInjector;
   }
 
+  @Nullable
   public static Object get(ClassLoader classLoader, Injector classInjector, Object key) {
     return getClassLoaderData(classLoader, classInjector, false).get(key);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/ClassLoaderValue.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/ClassLoaderValue.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling.util;
 
 import io.opentelemetry.javaagent.tooling.util.ClassLoaderMap.Injector;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Associate value with a class loader. Added value will behave as if it was stored in a field in
@@ -27,6 +28,7 @@ public final class ClassLoaderValue<T> {
     this.classInjector = classInjector;
   }
 
+  @Nullable
   @SuppressWarnings("unchecked") // we lose generic type when storing it in ClassLoaderMap
   public T get(ClassLoader classLoader) {
     return (T) ClassLoaderMap.get(classLoader, classInjector, this);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
@@ -22,16 +22,17 @@ public interface Trie<V> {
    * will return {@code 10}.
    */
   @Nullable
-  default V getOrNull(CharSequence str) {
-    return getOrDefault(str, null);
-  }
+  V getOrNull(CharSequence str);
 
   /**
    * Returns the value associated with the longest matched prefix, or the {@code defaultValue} if
    * there wasn't a match. For example: for a trie containing an {@code ("abc", 10)} entry {@code
    * trie.getOrDefault("abcd", -1)} will return {@code 10}.
    */
-  V getOrDefault(CharSequence str, V defaultValue);
+  default V getOrDefault(CharSequence str, V defaultValue) {
+    V result = getOrNull(str);
+    return result != null ? result : defaultValue;
+  }
 
   /** Returns {@code true} if this trie contains the prefix {@code str}. */
   default boolean contains(CharSequence str) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
@@ -22,17 +22,17 @@ public interface Trie<V> {
    * will return {@code 10}.
    */
   @Nullable
-  V getOrNull(CharSequence str);
+  @SuppressWarnings("NullAway") // intentional null sentinel for "no match"
+  default V getOrNull(CharSequence str) {
+    return getOrDefault(str, null);
+  }
 
   /**
    * Returns the value associated with the longest matched prefix, or the {@code defaultValue} if
    * there wasn't a match. For example: for a trie containing an {@code ("abc", 10)} entry {@code
    * trie.getOrDefault("abcd", -1)} will return {@code 10}.
    */
-  default V getOrDefault(CharSequence str, V defaultValue) {
-    V result = getOrNull(str);
-    return result != null ? result : defaultValue;
-  }
+  V getOrDefault(CharSequence str, V defaultValue);
 
   /** Returns {@code true} if this trie contains the prefix {@code str}. */
   default boolean contains(CharSequence str) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
@@ -20,10 +20,11 @@ final class TrieImpl<V> implements Trie<V> {
     this.root = root;
   }
 
+  @Nullable
   @Override
-  public V getOrDefault(CharSequence str, V defaultValue) {
+  public V getOrNull(CharSequence str) {
     Node<V> node = root;
-    V lastMatchedValue = defaultValue;
+    V lastMatchedValue = null;
 
     for (int i = 0; i < str.length(); ++i) {
       char c = str.charAt(i);
@@ -42,9 +43,9 @@ final class TrieImpl<V> implements Trie<V> {
   static final class Node<V> {
     final char[] chars;
     final Node<V>[] children;
-    final V value;
+    @Nullable final V value;
 
-    Node(char[] chars, Node<V>[] children, V value) {
+    Node(char[] chars, Node<V>[] children, @Nullable V value) {
       this.chars = chars;
       this.children = children;
       this.value = value;
@@ -89,7 +90,7 @@ final class TrieImpl<V> implements Trie<V> {
 
   static final class NodeBuilder<V> {
     final Map<Character, NodeBuilder<V>> children = new HashMap<>();
-    V value;
+    @Nullable V value;
 
     Node<V> build() {
       int size = children.size();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
@@ -20,11 +20,10 @@ final class TrieImpl<V> implements Trie<V> {
     this.root = root;
   }
 
-  @Nullable
   @Override
-  public V getOrNull(CharSequence str) {
+  public V getOrDefault(CharSequence str, V defaultValue) {
     Node<V> node = root;
-    V lastMatchedValue = null;
+    V lastMatchedValue = defaultValue;
 
     for (int i = 0; i < str.length(); ++i) {
       char c = str.charAt(i);

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   id("com.github.jk1.dependency-license-report")
 
   id("otel.java-conventions")
+  id("otel.nullaway-conventions")
   id("otel.publish-conventions")
   id("io.opentelemetry.instrumentation.javaagent-shadowing")
   id("org.spdx.sbom")

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -130,18 +130,22 @@ public class HelperInjector implements Transformer {
       @Nullable Instrumentation instrumentation) {
     this.requestingName = requestingName;
 
-    if (!helperClassNames.isEmpty()) {
-      requireNonNull(
-          helpersSource, "helpersSource must not be null when helperClassNames is non-empty");
+    List<HelperClassDefinition> helpers;
+    if (helperClassNames.isEmpty()) {
+      helpers = emptyList();
+    } else {
+      ClassLoader nonNullHelpersSource =
+          requireNonNull(
+              helpersSource, "helpersSource must not be null when helperClassNames is non-empty");
+      helpers =
+          helperClassNames.stream()
+              .distinct()
+              .map(
+                  className ->
+                      HelperClassDefinition.create(
+                          className, nonNullHelpersSource, InjectionMode.CLASS_ONLY))
+              .collect(toList());
     }
-    List<HelperClassDefinition> helpers =
-        helperClassNames.stream()
-            .distinct()
-            .map(
-                className ->
-                    HelperClassDefinition.create(
-                        className, helpersSource, InjectionMode.CLASS_ONLY))
-            .collect(toList());
 
     this.helperClassesGenerator = (cl) -> helpers;
     this.helperResources = helperResources;

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -130,17 +130,17 @@ public class HelperInjector implements Transformer {
       @Nullable Instrumentation instrumentation) {
     this.requestingName = requestingName;
 
+    if (!helperClassNames.isEmpty()) {
+      requireNonNull(
+          helpersSource, "helpersSource must not be null when helperClassNames is non-empty");
+    }
     List<HelperClassDefinition> helpers =
         helperClassNames.stream()
             .distinct()
             .map(
                 className ->
                     HelperClassDefinition.create(
-                        className,
-                        requireNonNull(
-                            helpersSource,
-                            "helpersSource must not be null when helperClassNames is non-empty"),
-                        InjectionMode.CLASS_ONLY))
+                        className, helpersSource, InjectionMode.CLASS_ONLY))
             .collect(toList());
 
     this.helperClassesGenerator = (cl) -> helpers;

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -136,7 +136,11 @@ public class HelperInjector implements Transformer {
             .map(
                 className ->
                     HelperClassDefinition.create(
-                        className, helpersSource, InjectionMode.CLASS_ONLY))
+                        className,
+                        requireNonNull(
+                            helpersSource,
+                            "helpersSource must not be null when helperClassNames is non-empty"),
+                        InjectionMode.CLASS_ONLY))
             .collect(toList());
 
     this.helperClassesGenerator = (cl) -> helpers;

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -126,7 +126,7 @@ public class HelperInjector implements Transformer {
       String requestingName,
       List<String> helperClassNames,
       List<HelperResource> helperResources,
-      ClassLoader helpersSource,
+      @Nullable ClassLoader helpersSource,
       @Nullable Instrumentation instrumentation) {
     this.requestingName = requestingName;
 

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -126,26 +126,18 @@ public class HelperInjector implements Transformer {
       String requestingName,
       List<String> helperClassNames,
       List<HelperResource> helperResources,
-      @Nullable ClassLoader helpersSource,
+      ClassLoader helpersSource,
       @Nullable Instrumentation instrumentation) {
     this.requestingName = requestingName;
 
-    List<HelperClassDefinition> helpers;
-    if (helperClassNames.isEmpty()) {
-      helpers = emptyList();
-    } else {
-      ClassLoader nonNullHelpersSource =
-          requireNonNull(
-              helpersSource, "helpersSource must not be null when helperClassNames is non-empty");
-      helpers =
-          helperClassNames.stream()
-              .distinct()
-              .map(
-                  className ->
-                      HelperClassDefinition.create(
-                          className, nonNullHelpersSource, InjectionMode.CLASS_ONLY))
-              .collect(toList());
-    }
+    List<HelperClassDefinition> helpers =
+        helperClassNames.stream()
+            .distinct()
+            .map(
+                className ->
+                    HelperClassDefinition.create(
+                        className, helpersSource, InjectionMode.CLASS_ONLY))
+            .collect(toList());
 
     this.helperClassesGenerator = (cl) -> helpers;
     this.helperResources = helperResources;


### PR DESCRIPTION
Blocked by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18090

Part of #15991

Enables NullAway for `javaagent-tooling`, `javaagent-tooling-java9`, and `javaagent` modules and adds required `@Nullable` annotations. This is the largest module in the set.

**Files changed:**
- `javaagent-tooling/build.gradle.kts`, `javaagent-tooling-java9/build.gradle.kts`, `javaagent/build.gradle.kts` — enable `otel.nullaway-conventions`
- `AgentInstaller.java` — use `requireNonNull` on `AutoConfigureUtil.getConfig()`; simplify config-null check
- `AgentStarterImpl.java` — `@Nullable` on `extensionClassLoader` field and `getExtensionClassLoader()` return
- `DefineClassHandler.java` — `@Nullable` annotations
- `ExtensionClassLoader.java` — `@Nullable` annotations
- `InputStreamUrlConnection.java` — `@Nullable` annotations
- `OpenTelemetryInstaller.java` — `@Nullable` annotations
- `RemappingUrlConnection.java` — `@Nullable` annotations
- `SafeServiceLoader.java` — `@Nullable` annotations
- `Utils.java` — `@Nullable` annotations
- `ConfigurationFile.java` — `@Nullable` annotations
- `JavaagentDistributionAccessCustomizerProvider.java` — `@Nullable` annotations
- `FieldBackedImplementationInstaller.java` — `@Nullable` annotations
- `VirtualFieldImplementationsGenerator.java` — `@Nullable` annotations
- `InstrumentationLoader.java` — `@Nullable` annotations
- `InstrumentationModuleInstaller.java` — `@Nullable` annotations
- `MuzzleMatcher.java` — `@Nullable` annotations
- `RegexUrlTemplateCustomizerInitializer.java` — `@Nullable` annotations
- `IndyBootstrap.java` — `@Nullable` annotations
- `InstrumentationModuleClassLoader.java` — `@Nullable` annotations
- `ClassLoaderMap.java`, `ClassLoaderValue.java`, `Trie.java`, `TrieImpl.java` — `@Nullable` annotations

Depends on: #17718 (nullaway-muzzle) should merge first so NullAway on tooling sees correct annotations on muzzle's public API