### PR TITLE
Disable byte-buddy No types were transformed warning

### DIFF
--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
@@ -66,6 +66,7 @@ fun createLanguageTask(
     group = "Byte Buddy"
     outputs.cacheIf { true }
     classFileVersion = ClassFileVersion.JAVA_V8
+    isWarnOnEmptyTypeSet = false
     val compileTask = compileTaskProvider.get()
     // this does not work for kotlin as compile task does not extend AbstractCompile
     if (compileTask is AbstractCompile) {


### PR DESCRIPTION
```
> Task :instrumentation:quarkus-resteasy-reactive:quarkus-3.0-testing:byteBuddyJava
No types were transformed during plugin execution
```