### PR TITLE
Reclassify reactor-3.4 instrumentation

### DIFF
--- a/instrumentation/reactor/reactor-3.4/metadata.yaml
+++ b/instrumentation/reactor/reactor-3.4/metadata.yaml
@@ -1,4 +1,7 @@
+display_name: Reactor
 description: >
-  This instrumentation provides a bridge between the agent's OpenTelemetry context and the
-  application's OpenTelemetry context when using Reactor 3.4+ with ContextView API.
-classification: internal
+  This instrumentation enables context propagation for Project Reactor reactive streams, it does
+  not emit any telemetry on its own.
+features:
+  - CONTEXT_PROPAGATION
+library_link: https://projectreactor.io/


### PR DESCRIPTION
This isn't `internal` instrumentation as [defined here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/documenting-instrumentation.md#classification-optional), so reclassifying as normal library instrumentation that handles context propagation