### PR TITLE
Add has_javaagent to metadata

### DIFF
--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -154,6 +154,10 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
     be Java 8
 * description
   * Short description of what the instrumentation does
+* has_standalone_library
+  * Whether the instrumentation module has a standalone library that can be used outside of the agent
+* has_javaagent
+  * Whether the instrumentation module has a javaagent component that can be used with the OpenTelemetry Java Agent
 * target_versions
   * List of supported versions by the module, broken down by `library` or `javaagent` support
 * scope (See [instrumentation-scope](https://opentelemetry.io/docs/specs/otel/common/instrumentation-scope/)

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -45,7 +45,7 @@ public class DocGeneratorApplication {
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      writer.write("file_format: 0.3\n\n");
+      writer.write("file_format: 0.4\n\n");
       YamlHelper.generateInstrumentationYaml(modules, writer);
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
@@ -32,6 +32,7 @@ public class InstrumentationModule {
   private Map<String, List<EmittedMetrics.Metric>> metrics;
   private Map<String, List<EmittedSpans.Span>> spans;
   private boolean hasStandaloneLibrary;
+  private boolean hasJavaAgent;
 
   @Nullable private Set<String> agentTargetVersions;
 
@@ -53,6 +54,7 @@ public class InstrumentationModule {
     this.metrics = requireNonNullElseGet(builder.metrics, HashMap::new);
     this.spans = requireNonNullElseGet(builder.spans, HashMap::new);
     this.hasStandaloneLibrary = builder.hasStandaloneLibrary;
+    this.hasJavaAgent = builder.hasJavaAgent;
     this.metadata = builder.metadata;
     this.agentTargetVersions = builder.agentTargetVersions;
     this.minJavaVersion = builder.minJavaVersion;
@@ -76,6 +78,10 @@ public class InstrumentationModule {
 
   public boolean hasStandaloneLibrary() {
     return hasStandaloneLibrary;
+  }
+
+  public boolean hasJavaAgent() {
+    return hasJavaAgent;
   }
 
   public String getGroup() {
@@ -128,6 +134,10 @@ public class InstrumentationModule {
     this.hasStandaloneLibrary = hasStandaloneLibrary;
   }
 
+  public void setHasJavaAgent(boolean hasJavaAgent) {
+    this.hasJavaAgent = hasJavaAgent;
+  }
+
   public void setMinJavaVersion(Integer minJavaVersion) {
     this.minJavaVersion = minJavaVersion;
   }
@@ -156,6 +166,7 @@ public class InstrumentationModule {
     @Nullable private Map<String, List<EmittedMetrics.Metric>> metrics;
     @Nullable private Map<String, List<EmittedSpans.Span>> spans;
     private boolean hasStandaloneLibrary;
+    private boolean hasJavaAgent;
 
     public Builder() {}
 
@@ -184,6 +195,12 @@ public class InstrumentationModule {
     @CanIgnoreReturnValue
     public Builder hasStandaloneLibrary(boolean hasStandaloneLibrary) {
       this.hasStandaloneLibrary = hasStandaloneLibrary;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder hasJavaAgent(boolean hasJavaAgent) {
+      this.hasJavaAgent = hasJavaAgent;
       return this;
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
@@ -205,6 +205,10 @@ public class GradleParser {
       return;
     }
 
+    if (type.get() == InstrumentationType.JAVAAGENT) {
+      module.setHasJavaAgent(true);
+    }
+
     DependencyInfo dependencyInfo = parseGradleFile(fileContents, type.get());
     versions.addAll(dependencyInfo.versions());
     if (dependencyInfo.minJavaVersionSupported() != null) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -145,6 +145,10 @@ public class YamlHelper {
       moduleMap.put("has_standalone_library", true);
     }
 
+    if (module.hasJavaAgent()) {
+      moduleMap.put("has_javaagent", true);
+    }
+
     if (module.getAgentTargetVersions() != null && !module.getAgentTargetVersions().isEmpty()) {
       moduleMap.put("javaagent_target_versions", new ArrayList<>(module.getAgentTargetVersions()));
     }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -667,6 +667,54 @@ class YamlHelperTest {
   }
 
   @Test
+  void testHasJavaAgentFlag() throws Exception {
+    List<InstrumentationModule> modules = new ArrayList<>();
+
+    modules.add(
+        new InstrumentationModule.Builder()
+            .srcPath("instrumentation/runtime-telemetry/runtime-telemetry-java8")
+            .instrumentationName("runtime-telemetry-java8")
+            .namespace("runtime-telemetry")
+            .group("runtime-telemetry")
+            .hasJavaAgent(true)
+            .build());
+
+    modules.add(
+        new InstrumentationModule.Builder()
+            .srcPath("instrumentation/library-only/library-only-1.0")
+            .instrumentationName("library-only-1.0")
+            .namespace("library-only")
+            .group("library-only")
+            .hasStandaloneLibrary(true)
+            .build());
+
+    StringWriter stringWriter = new StringWriter();
+    BufferedWriter writer = new BufferedWriter(stringWriter);
+
+    YamlHelper.generateInstrumentationYaml(modules, writer);
+    writer.flush();
+
+    String expectedYaml =
+        """
+        libraries:
+          library-only:
+          - name: library-only-1.0
+            source_path: instrumentation/library-only/library-only-1.0
+            scope:
+              name: io.opentelemetry.library-only-1.0
+            has_standalone_library: true
+          runtime-telemetry:
+          - name: runtime-telemetry-java8
+            source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
+            scope:
+              name: io.opentelemetry.runtime-telemetry-java8
+            has_javaagent: true
+        """;
+
+    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+  }
+
+  @Test
   void testInstrumentationsSortedBySemanticVersion() throws Exception {
     List<InstrumentationModule> modules = new ArrayList<>();
     InstrumentationMetadata metadata =


### PR DESCRIPTION
Right now we only indicate if an instrumentation has java agent support by listing `javaagent_target_versions`. For runtime-telemetry, there are no target versions, and therefore we have no indicator in the metadata that this has java agent support.

This change adds a new field `has_javaagent` for when an instrumentation has java agent support. 
