### PR TITLE
Flatten metadata and remove internal modules

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -45,7 +45,7 @@ public class DocGeneratorApplication {
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      writer.write("file_format: 0.4\n\n");
+      writer.write("file_format: 0.5\n\n");
       YamlHelper.generateInstrumentationYaml(modules, writer);
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -6,8 +6,6 @@
 package io.opentelemetry.instrumentation.docs.utils;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -49,27 +47,20 @@ public class YamlHelper {
 
     Yaml yaml = new Yaml(options);
 
-    // Add library modules
     Map<String, Object> libraries = getLibraryInstrumentations(list);
     if (!libraries.isEmpty()) {
-      yaml.dump(getLibraryInstrumentations(list), writer);
-    }
-
-    // Add internal modules
-    Map<String, Object> internal = generateBaseYaml(list, InstrumentationClassification.INTERNAL);
-    if (!internal.isEmpty()) {
-      yaml.dump(internal, writer);
+      yaml.dump(libraries, writer);
     }
 
     // add custom instrumentation modules
-    Map<String, Object> custom = generateBaseYaml(list, InstrumentationClassification.CUSTOM);
+    Map<String, Object> custom = getCustomInstrumentations(list);
     if (!custom.isEmpty()) {
       yaml.dump(custom, writer);
     }
   }
 
   private static Map<String, Object> getLibraryInstrumentations(List<InstrumentationModule> list) {
-    Map<String, List<InstrumentationModule>> libraryInstrumentations =
+    List<InstrumentationModule> libraryInstrumentations =
         list.stream()
             .filter(
                 module ->
@@ -77,40 +68,32 @@ public class YamlHelper {
                         .getMetadata()
                         .getClassification()
                         .equals(InstrumentationClassification.LIBRARY))
-            .collect(
-                groupingBy(
-                    InstrumentationModule::getGroup,
-                    TreeMap::new,
-                    collectingAndThen(
-                        toList(),
-                        modules ->
-                            modules.stream()
-                                .sorted(InstrumentationNameComparator.BY_NAME_AND_VERSION)
-                                .collect(toList()))));
+            .sorted(InstrumentationNameComparator.BY_NAME_AND_VERSION)
+            .toList();
+
+    if (libraryInstrumentations.isEmpty()) {
+      return new TreeMap<>();
+    }
+
+    List<Map<String, Object>> instrumentations = new ArrayList<>();
+    for (InstrumentationModule module : libraryInstrumentations) {
+      instrumentations.add(baseProperties(module));
+    }
 
     Map<String, Object> output = new TreeMap<>();
-    libraryInstrumentations.forEach(
-        (group, modules) -> {
-          List<Map<String, Object>> instrumentations = new ArrayList<>();
-          for (InstrumentationModule module : modules) {
-            instrumentations.add(baseProperties(module));
-          }
-          output.put(group, instrumentations);
-        });
-
-    Map<String, Object> newOutput = new TreeMap<>();
-    if (output.isEmpty()) {
-      return newOutput;
-    }
-    newOutput.put("libraries", output);
-    return newOutput;
+    output.put("libraries", instrumentations);
+    return output;
   }
 
-  private static Map<String, Object> generateBaseYaml(
-      List<InstrumentationModule> list, InstrumentationClassification classification) {
+  private static Map<String, Object> getCustomInstrumentations(List<InstrumentationModule> list) {
     List<InstrumentationModule> filtered =
         list.stream()
-            .filter(module -> module.getMetadata().getClassification().equals(classification))
+            .filter(
+                module ->
+                    module
+                        .getMetadata()
+                        .getClassification()
+                        .equals(InstrumentationClassification.CUSTOM))
             .sorted(InstrumentationNameComparator.BY_NAME_AND_VERSION)
             .toList();
 
@@ -123,7 +106,7 @@ public class YamlHelper {
     if (instrumentations.isEmpty()) {
       return newOutput;
     }
-    newOutput.put(classification.toString(), instrumentations);
+    newOutput.put(InstrumentationClassification.CUSTOM.toString(), instrumentations);
     return newOutput;
   }
 

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -84,34 +84,32 @@ class YamlHelperTest {
 
     String expectedYaml =
         """
-            libraries:
-              spring:
-              - name: spring-web-6.0
-                display_name: Spring Web
-                description: Spring Web 6.0 instrumentation
-                semantic_conventions:
-                - DATABASE_CLIENT_METRICS
-                - DATABASE_CLIENT_SPANS
-                disabled_by_default: true
-                source_path: instrumentation/spring/spring-web/spring-web-6.0
-                minimum_java_version: 11
-                scope:
-                  name: io.opentelemetry.spring-web-6.0
-                  schema_url: http:://www.schema.org
-                  attributes:
-                    instrumentation.type: library
-                    version.major: 6
-                javaagent_target_versions:
-                - org.springframework:spring-web:[6.0.0,)
-              struts:
-              - name: struts-2.3
-                source_path: instrumentation/struts/struts-2.3
-                scope:
-                  name: io.opentelemetry.struts-2.3
-                has_standalone_library: true
-                javaagent_target_versions:
-                - org.apache.struts:struts2-core:2.1.0
-            """;
+        libraries:
+        - name: spring-web-6.0
+          display_name: Spring Web
+          description: Spring Web 6.0 instrumentation
+          semantic_conventions:
+          - DATABASE_CLIENT_METRICS
+          - DATABASE_CLIENT_SPANS
+          disabled_by_default: true
+          source_path: instrumentation/spring/spring-web/spring-web-6.0
+          minimum_java_version: 11
+          scope:
+            name: io.opentelemetry.spring-web-6.0
+            schema_url: http:://www.schema.org
+            attributes:
+              instrumentation.type: library
+              version.major: 6
+          javaagent_target_versions:
+          - org.springframework:spring-web:[6.0.0,)
+        - name: struts-2.3
+          source_path: instrumentation/struts/struts-2.3
+          scope:
+            name: io.opentelemetry.struts-2.3
+          has_standalone_library: true
+          javaagent_target_versions:
+          - org.apache.struts:struts2-core:2.1.0
+        """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
   }
@@ -154,6 +152,7 @@ class YamlHelperTest {
             .classification(InstrumentationClassification.INTERNAL.name())
             .build();
 
+    // we don't include internal
     modules.add(
         new InstrumentationModule.Builder()
             .srcPath("instrumentation/internal/internal-application-logger")
@@ -185,31 +184,25 @@ class YamlHelperTest {
     String expectedYaml =
         """
             libraries:
-              spring:
-              - name: spring-web-6.0
-                description: Spring Web 6.0 instrumentation
-                semantic_conventions:
-                - DATABASE_CLIENT_METRICS
-                - DATABASE_CLIENT_SPANS
-                features:
-                - HTTP_ROUTE
-                - CONTEXT_PROPAGATION
-                source_path: instrumentation/spring/spring-web/spring-web-6.0
-                minimum_java_version: 11
-                scope:
-                  name: io.opentelemetry.spring-web-6.0
-                javaagent_target_versions:
-                - org.springframework:spring-web:[6.0.0,)
-                configurations:
-                - name: otel.instrumentation.spring-web-6.0.enabled
-                  description: Enables or disables Spring Web 6.0 instrumentation.
-                  type: boolean
-                  default: true
-            internal:
-            - name: internal-application-logger
-              source_path: instrumentation/internal/internal-application-logger
+            - name: spring-web-6.0
+              description: Spring Web 6.0 instrumentation
+              semantic_conventions:
+              - DATABASE_CLIENT_METRICS
+              - DATABASE_CLIENT_SPANS
+              features:
+              - HTTP_ROUTE
+              - CONTEXT_PROPAGATION
+              source_path: instrumentation/spring/spring-web/spring-web-6.0
+              minimum_java_version: 11
               scope:
-                name: io.opentelemetry.internal-application-logger
+                name: io.opentelemetry.spring-web-6.0
+              javaagent_target_versions:
+              - org.springframework:spring-web:[6.0.0,)
+              configurations:
+              - name: otel.instrumentation.spring-web-6.0.enabled
+                description: Enables or disables Spring Web 6.0 instrumentation.
+                type: boolean
+                default: true
             custom:
             - name: opentelemetry-external-annotations
               source_path: instrumentation/opentelemetry-external-annotations-1.0
@@ -374,32 +367,31 @@ class YamlHelperTest {
     String expectedYaml =
         """
         libraries:
-          mylib:
-          - name: mylib-2.3
-            source_path: instrumentation/mylib/mylib-core-2.3
-            scope:
-              name: io.opentelemetry.mylib-2.3
-            javaagent_target_versions:
-            - org.apache.mylib:mylib-core:2.3.0
-            telemetry:
-            - when: default
-              metrics:
-              - name: db.client.operation.duration
-                description: Duration of database client operations.
-                instrument: histogram
-                data_type: HISTOGRAM
-                unit: s
-                attributes:
-                - name: db.namespace
-                  type: STRING
-                - name: db.operation.name
-                  type: STRING
-                - name: db.system.name
-                  type: STRING
-                - name: server.address
-                  type: STRING
-                - name: server.port
-                  type: LONG
+        - name: mylib-2.3
+          source_path: instrumentation/mylib/mylib-core-2.3
+          scope:
+            name: io.opentelemetry.mylib-2.3
+          javaagent_target_versions:
+          - org.apache.mylib:mylib-core:2.3.0
+          telemetry:
+          - when: default
+            metrics:
+            - name: db.client.operation.duration
+              description: Duration of database client operations.
+              instrument: histogram
+              data_type: HISTOGRAM
+              unit: s
+              attributes:
+              - name: db.namespace
+                type: STRING
+              - name: db.operation.name
+                type: STRING
+              - name: db.system.name
+                type: STRING
+              - name: server.address
+                type: STRING
+              - name: server.port
+                type: LONG
         """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -435,38 +427,37 @@ class YamlHelperTest {
     String expectedYaml =
         """
         libraries:
-          test:
-          - name: test-1.0
-            source_path: instrumentation/test/test-1.0
-            scope:
-              name: io.opentelemetry.test-1.0
-            telemetry:
-            - when: default
-              metrics:
-              - name: test.counter
-                description: desc
-                instrument: counter
-                data_type: LONG_SUM
-                unit: '1'
-                attributes: []
-              - name: test.gauge
-                description: desc
-                instrument: gauge
-                data_type: DOUBLE_GAUGE
-                unit: '{test}'
-                attributes: []
-              - name: test.histogram
-                description: desc
-                instrument: histogram
-                data_type: HISTOGRAM
-                unit: s
-                attributes: []
-              - name: test.updowncounter
-                description: desc
-                instrument: updowncounter
-                data_type: LONG_SUM
-                unit: '1'
-                attributes: []
+        - name: test-1.0
+          source_path: instrumentation/test/test-1.0
+          scope:
+            name: io.opentelemetry.test-1.0
+          telemetry:
+          - when: default
+            metrics:
+            - name: test.counter
+              description: desc
+              instrument: counter
+              data_type: LONG_SUM
+              unit: '1'
+              attributes: []
+            - name: test.gauge
+              description: desc
+              instrument: gauge
+              data_type: DOUBLE_GAUGE
+              unit: '{test}'
+              attributes: []
+            - name: test.histogram
+              description: desc
+              instrument: histogram
+              data_type: HISTOGRAM
+              unit: s
+              attributes: []
+            - name: test.updowncounter
+              description: desc
+              instrument: updowncounter
+              data_type: LONG_SUM
+              unit: '1'
+              attributes: []
         """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -505,27 +496,26 @@ class YamlHelperTest {
     String expectedYaml =
         """
         libraries:
-          mylib:
-          - name: mylib-2.3
-            source_path: instrumentation/mylib/mylib-core-2.3
-            scope:
-              name: io.opentelemetry.mylib-2.3
-            has_standalone_library: true
-            telemetry:
-            - when: default
-              spans:
-              - span_kind: CLIENT
-                attributes:
-                - name: db.namespace
-                  type: STRING
-                - name: db.operation.name
-                  type: STRING
-                - name: db.system.name
-                  type: STRING
-                - name: server.address
-                  type: STRING
-                - name: server.port
-                  type: LONG
+        - name: mylib-2.3
+          source_path: instrumentation/mylib/mylib-core-2.3
+          scope:
+            name: io.opentelemetry.mylib-2.3
+          has_standalone_library: true
+          telemetry:
+          - when: default
+            spans:
+            - span_kind: CLIENT
+              attributes:
+              - name: db.namespace
+                type: STRING
+              - name: db.operation.name
+                type: STRING
+              - name: db.system.name
+                type: STRING
+              - name: server.address
+                type: STRING
+              - name: server.port
+                type: LONG
         """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -644,23 +634,21 @@ class YamlHelperTest {
     String expectedYaml =
         """
             libraries:
-              other-lib:
-              - name: other-lib-1.0
-                description: Test library instrumentation without link
-                source_path: instrumentation/other-lib/other-lib-1.0
-                scope:
-                  name: io.opentelemetry.other-lib-1.0
-                javaagent_target_versions:
-                - com.example:test-library:[1.0.0,)
-              test-lib:
-              - name: test-lib-1.0
-                description: Test library instrumentation with link
-                library_link: https://example.com/test-library-docs
-                source_path: instrumentation/test-lib/test-lib-1.0
-                scope:
-                  name: io.opentelemetry.test-lib-1.0
-                javaagent_target_versions:
-                - com.example:test-library:[1.0.0,)
+            - name: other-lib-1.0
+              description: Test library instrumentation without link
+              source_path: instrumentation/other-lib/other-lib-1.0
+              scope:
+                name: io.opentelemetry.other-lib-1.0
+              javaagent_target_versions:
+              - com.example:test-library:[1.0.0,)
+            - name: test-lib-1.0
+              description: Test library instrumentation with link
+              library_link: https://example.com/test-library-docs
+              source_path: instrumentation/test-lib/test-lib-1.0
+              scope:
+                name: io.opentelemetry.test-lib-1.0
+              javaagent_target_versions:
+              - com.example:test-library:[1.0.0,)
             """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -697,18 +685,16 @@ class YamlHelperTest {
     String expectedYaml =
         """
         libraries:
-          library-only:
-          - name: library-only-1.0
-            source_path: instrumentation/library-only/library-only-1.0
-            scope:
-              name: io.opentelemetry.library-only-1.0
-            has_standalone_library: true
-          runtime-telemetry:
-          - name: runtime-telemetry-java8
-            source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
-            scope:
-              name: io.opentelemetry.runtime-telemetry-java8
-            has_javaagent: true
+        - name: library-only-1.0
+          source_path: instrumentation/library-only/library-only-1.0
+          scope:
+            name: io.opentelemetry.library-only-1.0
+          has_standalone_library: true
+        - name: runtime-telemetry-java8
+          source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
+          scope:
+            name: io.opentelemetry.runtime-telemetry-java8
+          has_javaagent: true
         """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());
@@ -766,27 +752,26 @@ class YamlHelperTest {
     String expectedYaml =
         """
             libraries:
-              opentelemetry-api:
-              - name: opentelemetry-api-1.9
-                source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.9
-                scope:
-                  name: io.opentelemetry.opentelemetry-api-1.9
-              - name: opentelemetry-api-1.10
-                source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.10
-                scope:
-                  name: io.opentelemetry.opentelemetry-api-1.10
-              - name: opentelemetry-api-1.56
-                source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.56
-                scope:
-                  name: io.opentelemetry.opentelemetry-api-1.56
-              - name: opentelemetry-api-1.57
-                source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.57
-                scope:
-                  name: io.opentelemetry.opentelemetry-api-1.57
-              - name: opentelemetry-api-2.0
-                source_path: instrumentation/opentelemetry-api/opentelemetry-api-2.0
-                scope:
-                  name: io.opentelemetry.opentelemetry-api-2.0
+            - name: opentelemetry-api-1.9
+              source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.9
+              scope:
+                name: io.opentelemetry.opentelemetry-api-1.9
+            - name: opentelemetry-api-1.10
+              source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.10
+              scope:
+                name: io.opentelemetry.opentelemetry-api-1.10
+            - name: opentelemetry-api-1.56
+              source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.56
+              scope:
+                name: io.opentelemetry.opentelemetry-api-1.56
+            - name: opentelemetry-api-1.57
+              source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.57
+              scope:
+                name: io.opentelemetry.opentelemetry-api-1.57
+            - name: opentelemetry-api-2.0
+              source_path: instrumentation/opentelemetry-api/opentelemetry-api-2.0
+              scope:
+                name: io.opentelemetry.opentelemetry-api-2.0
             """;
 
     assertThat(expectedYaml).isEqualTo(stringWriter.toString());


### PR DESCRIPTION
At one point I thought it might be useful to group instrumentations under groups/namespaces, but I haven't found a good use case for it, and we can always re-construct that information using the `source_path` if someone consuming the data wants to rebuild those associations.

So I removed all the nesting and now we will just have a flat list of libraries. I also removed the `internal` modules because there's little value in publishing those too.