### PR TITLE
Fix ClassCastException when setting map-valued span attributes

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/ApplicationSpanBuilder.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/ApplicationSpanBuilder.java
@@ -11,6 +11,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.ValueBridging;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.context.AgentContextStorage;
 import java.util.concurrent.TimeUnit;
 
@@ -86,12 +87,17 @@ public class ApplicationSpanBuilder implements application.io.opentelemetry.api.
 
   @Override
   @CanIgnoreReturnValue
+  // unchecked: toAgent returns raw AttributeKey, VALUE bridging requires casting to Object key
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public <T> application.io.opentelemetry.api.trace.SpanBuilder setAttribute(
       application.io.opentelemetry.api.common.AttributeKey<T> applicationKey, T value) {
-    @SuppressWarnings("unchecked") // toAgent uses raw AttributeKey
     AttributeKey<T> agentKey = Bridging.toAgent(applicationKey);
     if (agentKey != null) {
-      agentBuilder.setAttribute(agentKey, value);
+      if (applicationKey.getType().name().equals("VALUE")) {
+        agentBuilder.setAttribute((AttributeKey) agentKey, ValueBridging.toAgent(value));
+      } else {
+        agentBuilder.setAttribute(agentKey, value);
+      }
     }
     return this;
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueAttributeTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.59/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_59/ValueAttributeTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.util.Arrays;
@@ -274,6 +276,22 @@ class ValueAttributeTest {
                 span ->
                     span.hasName("test-span")
                         .hasAttributesSatisfyingExactly(equalTo(valueKey("key"), value))));
+  }
+
+  @Test
+  void keyValueListViaSpanBuilderSetAllAttributes() {
+    Value<?> value = Value.of(KeyValue.of("bar", Value.of("baz")));
+    Attributes attributes = Attributes.builder().put(valueKey("foo"), value).build();
+    Tracer tracer = testing.getOpenTelemetry().getTracer("test");
+    Span testSpan = tracer.spanBuilder("test-span").setAllAttributes(attributes).startSpan();
+    testSpan.end();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("test-span")
+                        .hasAttributesSatisfyingExactly(equalTo(valueKey("foo"), value))));
   }
 
   @Test


### PR DESCRIPTION
Fixes #17851

Agent was throwing ClassCastException when span attributes had map values. Turns out VALUE type attributes need ValueBridging.toAgent() applied before passing to the agent builder. Added the type check and a test case.