### PR TITLE
Add new declarative_name and example fields to metadata

### DIFF
--- a/instrumentation-docs/build.gradle.kts
+++ b/instrumentation-docs/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
   implementation("org.yaml:snakeyaml:2.6")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("io.opentelemetry:opentelemetry-sdk-common")
+
+  testImplementation(project(":declarative-config-bridge"))
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  testImplementation("io.opentelemetry:opentelemetry-api-incubator")
 }
 
 tasks {

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -169,7 +169,7 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
     about the scope.
 * configuration settings
   * List of settings that are available for the instrumentation module
-  * Each setting has a name, description, type, and default value
+  * Each setting has a name (flat property format), optional declarative_name (YAML path format), description, type, default value, and optional examples
 * metrics
   * List of metrics that the instrumentation module collects, including the metric name, description, type, and attributes.
   * Separate lists for the metrics emitted by default vs via configuration options.
@@ -200,9 +200,13 @@ classification: internal                          # instrumentation classificati
 library_link: https://...                         # URL to the library or framework's main website or documentation
 configurations:
   - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled    # Optional: YAML config path
     description: Enables query sanitization for database queries.
     type: boolean               # boolean | string | list | map
     default: true
+    examples:                   # Optional: Example values for this configuration
+      - "true"
+      - "false"
 override_telemetry: false                         # Set to true to ignore auto-generated .telemetry files
 additional_telemetry:                             # Manually document telemetry metadata
   - when: "default"

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -34,10 +34,6 @@ public record ConfigurationOption(
     }
   }
 
-  /**
-   * Convenience constructor for configurations without a declarative name or examples (backwards
-   * compatibility).
-   */
   public ConfigurationOption(
       String name, String description, String defaultValue, ConfigurationType type) {
     this(name, null, description, defaultValue, type, null);

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.docs.internal;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Represents a configuration option available for an instrumentation. This class is internal and is
@@ -15,9 +17,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record ConfigurationOption(
     String name,
+    @JsonProperty("declarative_name") @Nullable String declarativeName,
     String description,
     @JsonProperty("default") String defaultValue,
-    ConfigurationType type) {
+    ConfigurationType type,
+    @Nullable List<String> examples) {
 
   public ConfigurationOption {
     requireNonNull(name, "name");
@@ -28,5 +32,14 @@ public record ConfigurationOption(
     if (name.isBlank() || description.isBlank()) {
       throw new IllegalArgumentException("ConfigurationOption name/description cannot be blank");
     }
+  }
+
+  /**
+   * Convenience constructor for configurations without a declarative name or examples (backwards
+   * compatibility).
+   */
+  public ConfigurationOption(
+      String name, String description, String defaultValue, ConfigurationType type) {
+    this(name, null, description, defaultValue, type, null);
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -250,6 +250,9 @@ public class YamlHelper {
   private static Map<String, Object> configurationToMap(ConfigurationOption configuration) {
     Map<String, Object> conf = new LinkedHashMap<>();
     conf.put("name", configuration.name());
+    if (configuration.declarativeName() != null) {
+      conf.put("declarative_name", configuration.declarativeName());
+    }
     conf.put("description", configuration.description());
     conf.put("type", configuration.type().toString());
     if (configuration.type().equals(ConfigurationType.BOOLEAN)) {
@@ -258,6 +261,9 @@ public class YamlHelper {
       conf.put("default", Integer.parseInt(configuration.defaultValue()));
     } else {
       conf.put("default", configuration.defaultValue());
+    }
+    if (configuration.examples() != null && !configuration.examples().isEmpty()) {
+      conf.put("examples", configuration.examples());
     }
     return conf;
   }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ConfigurationExamplesTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ConfigurationExamplesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
+import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
+import org.junit.jupiter.api.Test;
+
+/** Tests that the examples field in configuration options is properly parsed and serialized. */
+@SuppressWarnings("NullAway")
+class ConfigurationExamplesTest {
+
+  @Test
+  void testParseConfigurationWithExamples() throws Exception {
+    String yaml =
+        """
+        description: Test instrumentation
+        configurations:
+          - name: otel.instrumentation.test.example-config
+            declarative_name: java.test.example_config
+            description: Test configuration
+            type: string
+            default: "default-value"
+            examples:
+              - "example1"
+              - "example2"
+              - "example3"
+        """;
+
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(yaml);
+
+    assertThat(metadata.getConfigurations()).hasSize(1);
+    assertThat(metadata.getConfigurations().get(0).name())
+        .isEqualTo("otel.instrumentation.test.example-config");
+    assertThat(metadata.getConfigurations().get(0).declarativeName())
+        .isEqualTo("java.test.example_config");
+    assertThat(metadata.getConfigurations().get(0).examples())
+        .containsExactly("example1", "example2", "example3");
+  }
+
+  @Test
+  void testParseConfigurationWithoutExamples() throws Exception {
+    String yaml =
+        """
+        description: Test instrumentation
+        configurations:
+          - name: otel.instrumentation.test.example-config
+            description: Test configuration
+            type: string
+            default: "default-value"
+        """;
+
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(yaml);
+
+    assertThat(metadata.getConfigurations()).hasSize(1);
+    assertThat(metadata.getConfigurations().get(0).examples()).isNull();
+  }
+}

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ConfigurationExamplesTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ConfigurationExamplesTest.java
@@ -11,8 +11,6 @@ import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import org.junit.jupiter.api.Test;
 
-/** Tests that the examples field in configuration options is properly parsed and serialized. */
-@SuppressWarnings("NullAway")
 class ConfigurationExamplesTest {
 
   @Test

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedDeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
+import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that declarative_name values in metadata.yaml files correctly map to their
+ * corresponding flat property names using the actual
+ * ConfigPropertiesBackedDeclarativeConfigProperties bridge.
+ *
+ * <p>For each configuration with a declarative_name, this test: 1. Creates a ConfigProperties with
+ * the flat property (name) set to a test value 2. Navigates to the declarative path
+ * (declarative_name) using the bridge 3. Verifies that the value can be retrieved at that path
+ */
+@SuppressWarnings("NullAway")
+class DeclarativeConfigValidationTest {
+
+  private static final String TEST_VALUE = "test-validation-value";
+  private static final Path INSTRUMENTATION_DIR = Paths.get("../instrumentation");
+
+  @Test
+  void validateDeclarativeNames() throws IOException {
+    List<ValidationResult> results = new ArrayList<>();
+    List<String> errors = new ArrayList<>();
+
+    // Find all metadata.yaml files
+    try (Stream<Path> paths = Files.walk(INSTRUMENTATION_DIR)) {
+      List<Path> metadataFiles =
+          paths.filter(p -> p.getFileName().toString().equals("metadata.yaml")).toList();
+
+      for (Path metadataFile : metadataFiles) {
+        String content = Files.readString(metadataFile);
+        try {
+          InstrumentationMetadata metadata = YamlHelper.metaDataParser(content);
+
+          for (ConfigurationOption config : metadata.getConfigurations()) {
+            if (config.declarativeName() != null && !config.declarativeName().isBlank()) {
+              ValidationResult result = validateConfig(metadataFile, config);
+              results.add(result);
+              if (!result.valid) {
+                errors.add(result.toString());
+              }
+            }
+          }
+        } catch (Exception e) {
+          errors.add(String.format("Failed to parse %s: %s", metadataFile, e.getMessage()));
+        }
+      }
+    }
+
+    long validCount = results.stream().filter(r -> r.valid).count();
+    System.out.printf(
+        "Validated %d declarative names: %d valid, %d invalid%n",
+        results.size(), validCount, results.size() - validCount);
+
+    if (!errors.isEmpty()) {
+      fail(
+          String.format(
+              Locale.ROOT,
+              "Found %d invalid declarative_name mappings:%n%s",
+              errors.size(),
+              String.join("\n", errors)));
+    }
+  }
+
+  private static ValidationResult validateConfig(Path metadataFile, ConfigurationOption config) {
+    String flatProperty = config.name();
+    String declarativePath = config.declarativeName();
+
+    // Create a ConfigProperties with the flat property set
+    Map<String, String> properties = new HashMap<>();
+    properties.put(flatProperty, TEST_VALUE);
+    DefaultConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
+
+    // Create the bridge
+    DeclarativeConfigProperties declarativeConfig =
+        ConfigPropertiesBackedDeclarativeConfigProperties.createInstrumentationConfig(
+            configProperties);
+
+    // Navigate to the declarative path and try to get the value
+    String retrievedValue = navigateAndGetValue(declarativeConfig, declarativePath);
+
+    boolean valid = TEST_VALUE.equals(retrievedValue);
+
+    return new ValidationResult(
+        metadataFile.toString(), flatProperty, declarativePath, valid, retrievedValue);
+  }
+
+  /**
+   * Navigates through the declarative config using the path segments and retrieves the value.
+   *
+   * <p>The path format is like "java.grpc.emit_message_events" or
+   * "java.logback_appender.capture_code_attributes/development".
+   */
+  private static String navigateAndGetValue(DeclarativeConfigProperties config, String path) {
+    String[] segments = path.split("\\.");
+
+    DeclarativeConfigProperties current = config;
+
+    // Navigate through all segments except the last one
+    for (int i = 0; i < segments.length - 1; i++) {
+      current = current.getStructured(segments[i]);
+      if (current == null) {
+        return null;
+      }
+    }
+
+    // Get the value from the last segment
+    String lastSegment = segments[segments.length - 1];
+    return current.getString(lastSegment);
+  }
+
+  private record ValidationResult(
+      String metadataFile,
+      String flatProperty,
+      String declarativePath,
+      boolean valid,
+      String retrievedValue) {
+
+    @Override
+    public String toString() {
+      if (valid) {
+        return String.format("  OK: %s -> %s", flatProperty, declarativePath);
+      } else {
+        return String.format(
+            "  FAIL in %s:%n"
+                + "    flat property: %s%n"
+                + "    declarative_name: %s%n"
+                + "    expected: %s%n"
+                + "    got: %s",
+            metadataFile, flatProperty, declarativePath, TEST_VALUE, retrievedValue);
+      }
+    }
+  }
+}

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.fail;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedDeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
+import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
@@ -22,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -29,15 +32,12 @@ import org.junit.jupiter.api.Test;
  * Validates that declarative_name values in metadata.yaml files correctly map to their
  * corresponding flat property names using the actual
  * ConfigPropertiesBackedDeclarativeConfigProperties bridge.
- *
- * <p>For each configuration with a declarative_name, this test: 1. Creates a ConfigProperties with
- * the flat property (name) set to a test value 2. Navigates to the declarative path
- * (declarative_name) using the bridge 3. Verifies that the value can be retrieved at that path
  */
-@SuppressWarnings("NullAway")
 class DeclarativeConfigValidationTest {
 
-  private static final String TEST_VALUE = "test-validation-value";
+  private static final Logger logger =
+      Logger.getLogger(DeclarativeConfigValidationTest.class.getName());
+
   private static final Path INSTRUMENTATION_DIR = Paths.get("../instrumentation");
 
   @Test
@@ -45,7 +45,6 @@ class DeclarativeConfigValidationTest {
     List<ValidationResult> results = new ArrayList<>();
     List<String> errors = new ArrayList<>();
 
-    // Find all metadata.yaml files
     try (Stream<Path> paths = Files.walk(INSTRUMENTATION_DIR)) {
       List<Path> metadataFiles =
           paths.filter(p -> p.getFileName().toString().equals("metadata.yaml")).toList();
@@ -71,9 +70,13 @@ class DeclarativeConfigValidationTest {
     }
 
     long validCount = results.stream().filter(r -> r.valid).count();
-    System.out.printf(
-        "Validated %d declarative names: %d valid, %d invalid%n",
-        results.size(), validCount, results.size() - validCount);
+    logger.info(
+        String.format(
+            Locale.ROOT,
+            "Validated %d declarative names: %d valid, %d invalid",
+            results.size(),
+            validCount,
+            results.size() - validCount));
 
     if (!errors.isEmpty()) {
       fail(
@@ -88,25 +91,44 @@ class DeclarativeConfigValidationTest {
   private static ValidationResult validateConfig(Path metadataFile, ConfigurationOption config) {
     String flatProperty = config.name();
     String declarativePath = config.declarativeName();
+    ConfigurationType type = config.type();
 
-    // Create a ConfigProperties with the flat property set
+    // Create test value appropriate for the type
+    TestValue testValue = createTestValue(type);
+
     Map<String, String> properties = new HashMap<>();
-    properties.put(flatProperty, TEST_VALUE);
+    properties.put(flatProperty, testValue.propertyValue);
     DefaultConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
-    // Create the bridge
     DeclarativeConfigProperties declarativeConfig =
         ConfigPropertiesBackedDeclarativeConfigProperties.createInstrumentationConfig(
             configProperties);
 
-    // Navigate to the declarative path and try to get the value
-    String retrievedValue = navigateAndGetValue(declarativeConfig, declarativePath);
+    Object retrievedValue = navigateAndGetValue(declarativeConfig, declarativePath, type);
 
-    boolean valid = TEST_VALUE.equals(retrievedValue);
+    boolean valid = Objects.equals(testValue.expectedValue, retrievedValue);
 
     return new ValidationResult(
-        metadataFile.toString(), flatProperty, declarativePath, valid, retrievedValue);
+        metadataFile.toString(),
+        flatProperty,
+        declarativePath,
+        type,
+        valid,
+        testValue.expectedValue,
+        retrievedValue);
   }
+
+  private static TestValue createTestValue(ConfigurationType type) {
+    return switch (type) {
+      case BOOLEAN -> new TestValue("true", true);
+      case STRING -> new TestValue("test-validation-value", "test-validation-value");
+      case INT -> new TestValue("42", 42);
+      case LIST -> new TestValue("item1,item2,item3", List.of("item1", "item2", "item3"));
+      case MAP -> new TestValue("key1=value1,key2=value2", "key1=value1,key2=value2");
+    };
+  }
+
+  private record TestValue(String propertyValue, Object expectedValue) {}
 
   /**
    * Navigates through the declarative config using the path segments and retrieves the value.
@@ -114,7 +136,8 @@ class DeclarativeConfigValidationTest {
    * <p>The path format is like "java.grpc.emit_message_events" or
    * "java.logback_appender.capture_code_attributes/development".
    */
-  private static String navigateAndGetValue(DeclarativeConfigProperties config, String path) {
+  private static Object navigateAndGetValue(
+      DeclarativeConfigProperties config, String path, ConfigurationType type) {
     String[] segments = path.split("\\.");
 
     DeclarativeConfigProperties current = config;
@@ -127,30 +150,38 @@ class DeclarativeConfigValidationTest {
       }
     }
 
-    // Get the value from the last segment
     String lastSegment = segments[segments.length - 1];
-    return current.getString(lastSegment);
+    return switch (type) {
+      case BOOLEAN -> current.getBoolean(lastSegment);
+      case STRING -> current.getString(lastSegment);
+      case INT -> current.getInt(lastSegment);
+      case LIST -> current.getScalarList(lastSegment, String.class);
+      case MAP -> current.getString(lastSegment);
+    };
   }
 
   private record ValidationResult(
       String metadataFile,
       String flatProperty,
       String declarativePath,
+      ConfigurationType type,
       boolean valid,
-      String retrievedValue) {
+      Object expectedValue,
+      Object retrievedValue) {
 
     @Override
     public String toString() {
       if (valid) {
-        return String.format("  OK: %s -> %s", flatProperty, declarativePath);
+        return String.format("  OK: %s -> %s (%s)", flatProperty, declarativePath, type);
       } else {
         return String.format(
             "  FAIL in %s:%n"
                 + "    flat property: %s%n"
                 + "    declarative_name: %s%n"
+                + "    type: %s%n"
                 + "    expected: %s%n"
                 + "    got: %s",
-            metadataFile, flatProperty, declarativePath, TEST_VALUE, retrievedValue);
+            metadataFile, flatProperty, declarativePath, type, expectedValue, retrievedValue);
       }
     }
   }

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -6,20 +6,24 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 configurations:
   - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
     description: >
       Configures the instrumentation to recognize an alternative set of HTTP request methods. All
       other methods will be treated as `_OTHER`.
     type: list
     default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
   - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
     description: List of HTTP response headers to capture in HTTP server telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
     description: >
       Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
       and `http.response.body.size` attributes to spans, and records `http.server.request.size` and

--- a/instrumentation/grpc-1.6/metadata.yaml
+++ b/instrumentation/grpc-1.6/metadata.yaml
@@ -8,22 +8,29 @@ semantic_conventions:
 library_link: https://github.com/grpc/grpc-java
 configurations:
   - name: otel.instrumentation.grpc.emit-message-events
+    declarative_name: java.grpc.emit_message_events
     type: boolean
     description: Determines whether to emit a span event for each individual message received and sent.
     default: true
   - name: otel.instrumentation.grpc.experimental-span-attributes
+    declarative_name: java.grpc.experimental_span_attributes/development
     type: boolean
     description: >
       Enable the capture of experimental span attributes `grpc.received.message_count`,
       `grpc.sent.message_count` and `grpc.canceled`.
     default: false
   - name: otel.instrumentation.grpc.capture-metadata.client.request
+    declarative_name: java.grpc.capture_metadata.client.request
     type: list
     description: >
       A comma-separated list of request metadata keys. gRPC client instrumentation will capture
       metadata values corresponding to configured keys as span attributes.
     default: ''
+    examples:
+      - "custom-request-header"
+      - "my-metadata-key,another-metadata-key"
   - name: otel.instrumentation.grpc.capture-metadata.server.request
+    declarative_name: java.grpc.capture_metadata.server.request
     type: list
     description: >
       A comma-separated list of request metadata keys. gRPC server instrumentation will capture

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
@@ -5,18 +5,22 @@ semantic_conventions:
   - MESSAGING_SPANS
 configurations:
   - name: otel.instrumentation.kafka.producer-propagation.enabled
+    declarative_name: java.kafka.producer_propagation.enabled
     description: Enable context propagation for Kafka message producers.
     type: boolean
     default: true
   - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
     description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
     type: boolean
     default: false
   - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
     description: A comma-separated list of header names to capture as span attributes.
     type: list
     default: ''
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
     description: >
       Enables experimental receive telemetry, which will cause consumers to start a new trace, with
       only a span link connecting it to the producer trace.

--- a/instrumentation/logback/logback-appender-1.0/metadata.yaml
+++ b/instrumentation/logback/logback-appender-1.0/metadata.yaml
@@ -6,58 +6,69 @@ features:
   - LOGGING_BRIDGE
 configurations:
   - name: otel.instrumentation.logback-appender.experimental-log-attributes
+    declarative_name: java.logback_appender.experimental_log_attributes/development
     description: >
       Enables the capture of experimental log attributes, including thread name and thread ID.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-code-attributes
+    declarative_name: java.logback_appender.capture_code_attributes/development
     description: >
       Enables the capture of code location attributes, including file path, class name, method
       name, and line number.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
+    declarative_name: java.logback_appender.capture_marker_attribute/development
     description: >
       Enables the capture of the Logback marker attribute.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
+    declarative_name: java.logback_appender.capture_key_value_pair_attributes/development
     description: >
       Enables the capture of attributes from Logback key-value pairs.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
+    declarative_name: java.logback_appender.capture_logger_context_attributes/development
     description: >
       Enables the capture of attributes from the Logback logger context.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-template
+    declarative_name: java.logback_appender.capture_template/development
     description: >
       Enables the capture of the log message template before parameter substitution.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-arguments
+    declarative_name: java.logback_appender.capture_arguments/development
     description: >
       Enables the capture of log message arguments as separate attributes.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
+    declarative_name: java.logback_appender.capture_logstash_marker_attributes/development
     description: >
       Enables the capture of attributes from Logstash markers.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
+    declarative_name: java.logback_appender.capture_logstash_structured_arguments/development
     description: >
       Enables the capture of attributes from Logstash structured arguments.
     type: boolean
     default: false
   - name: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
+    declarative_name: java.logback_appender.capture_mdc_attributes/development
     description: >
       Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a
       comma-separated list of specific keys.
     type: list
     default: ''
   - name: otel.instrumentation.logback-appender.experimental.capture-event-name
+    declarative_name: java.logback_appender.capture_event_name/development
     description: >
       Enables the capture of the event name from the MDC attribute "event.name" and sets it as the
       log record's event name.


### PR DESCRIPTION
As discussed in todays SIG call, I've added two new fields to the configuration metadata: `declarative_name` for the declarative configuration representation, and `examples`.

I've also added a test that will validate all the metadata files and if there is a `declarative_name`, it will use the Declarative config bridge and API to validate that it matches the system property `name`.

My plan is to follow this up with a knowledge base entry for the copilot review task, so that it can work through all the modules and add the `declarative_name` and `examples` (where applicable). Having the integration test will give us one more guardrail to help with reviewing all those PRs.

For example, if I had put: `grpc.capture_metadata.client.request` (missing the leading `java.` and `java.grpc.experimental_span_attributes` (missing the `/development`), the test fails:

```
Found 1 invalid declarative_name mappings:
  FAIL in ../instrumentation/grpc-1.6/metadata.yaml:
    flat property: otel.instrumentation.grpc.capture-metadata.client.request
    declarative_name: grpc.capture_metadata.client.request
    type: list
    expected: [item1, item2, item3]
    got: null
java.lang.AssertionError: Found 1 invalid declarative_name mappings:
  FAIL in ../instrumentation/grpc-1.6/metadata.yaml:
    flat property: otel.instrumentation.grpc.capture-metadata.client.request
    declarative_name: grpc.capture_metadata.client.request
    type: list
    expected: [item1, item2, item3]
    got: null
```