### PR TITLE
Update renovate config to use semantic commits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     'config:best-practices',
     'helpers:pinGitHubActionDigestsToSemver',
+    ':semanticCommits',
   ],
   ignorePaths: [
     'instrumentation/**',


### PR DESCRIPTION
Some of the renovate PR titles have changed to no longer include the `fix(deps)` or `chore(deps)` prefixes.

From the [docs](https://docs.renovatebot.com/semantic-commits/#semantic-commit-messages):

> Renovate looks at the last 20 commit messages in the base branch to decide if the repository uses semantic commits. If there are Semantic Commits, Renovate uses an algorithm inspired by the [conventional-commits-detector](https://github.com/conventional-changelog/conventional-commits-detector) package to decide what convention the commit messages follow.

Adding ":semanticCommits" ([ref](https://docs.renovatebot.com/semantic-commits/#manually-enabling-or-disabling-semantic-commits)) tells it to always use this convention