### PR TITLE
Remove unnecessary class loader matchers

### DIFF
--- a/.github/agents/knowledge/javaagent-module-patterns.md
+++ b/.github/agents/knowledge/javaagent-module-patterns.md
@@ -39,25 +39,36 @@ public class MyLibrary10InstrumentationModule extends InstrumentationModule {
   `Arrays.asList(...)` for multiple items and `Collections.singletonList(...)` for a single
   item.
 
-### `classLoaderMatcher()` — Version-Boundary Detection
+### `classLoaderMatcher()` — Multi-Version Library Split
 
-Override `classLoaderMatcher()` only when the instrumentation targets a specific library
-version range and muzzle cannot distinguish that range on its own. Typical cases are classes
-that were added, removed, renamed, or introduced by a library's own native OpenTelemetry
-instrumentation, but are not referenced by the helper classes muzzle inspects.
+Override `classLoaderMatcher()` only when **multiple instrumentation versions exist for the
+same library** and the module still needs an extra class-presence check to keep one versioned
+module from applying where another versioned module should win. If `typeMatcher()` or
+`classLoaderOptimization()` already differentiates the versions, do not add
+`classLoaderMatcher()`.
+
+Do not add `classLoaderMatcher()` just because muzzle mismatches in cross tests, to avoid
+debug logging, or as a generic optimization. In the common case, the type instrumentation
+already short-circuits when the library is absent, and muzzle handles wrong-version rejection.
 
 **Execution order**: `classLoaderMatcher()` runs **first** and should be very cheap. It is
 followed by `typeMatcher()`, then muzzle. Use `classLoaderMatcher()` to reject obvious
-non-matches before the more expensive checks run.
+non-matches only when a versioned sibling module would otherwise overlap.
 
 **Override it when**:
 
-- A landmark class was **added** in the target version and excludes older versions.
-- A landmark class was **removed** in a newer version and excludes newer versions.
-- A newer version ships **native OpenTelemetry instrumentation** and the agent should back off.
+- There are **multiple instrumentation modules for one library** and a landmark class is needed
+  to separate their supported version ranges.
+- A landmark class was **added** in the target version and excludes older sibling modules.
+- A landmark class was **removed** in a newer version and excludes newer sibling modules.
+- A newer version ships **native OpenTelemetry instrumentation** and the older module should
+  back off.
 
 **Do not override it for**:
 
+- Single-version libraries with no competing instrumentation module.
+- Cross-test-driven preconditions whose only purpose is to avoid muzzle mismatches.
+- Library-absent fast paths that `typeMatcher()` or `classLoaderOptimization()` already cover.
 - Method signature changes.
 - Parameter type changes.
 - Field removals.
@@ -65,7 +76,8 @@ non-matches before the more expensive checks run.
 
 #### Pattern A: Single Landmark Class
 
-This is the most common case: one class cleanly identifies the lower bound.
+This is the most common valid case: one class cleanly identifies which sibling versioned
+module should handle the library.
 
 ```java
 @Override
@@ -176,8 +188,8 @@ the 3.7 module from activating on 4.0+ classloaders. That is why the comment mus
 
 #### Pattern C: Exclude Newer Versions with Native Instrumentation
 
-Use `.and(not(hasClassesNamed(...)))` when the newer library version ships its own
-OpenTelemetry instrumentation and the agent should opt out.
+Use `.and(not(hasClassesNamed(...)))` when a newer sibling version ships its own
+OpenTelemetry instrumentation and the older module should opt out.
 
 ```java
 @Override
@@ -204,13 +216,16 @@ public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
 
 #### Rules for `classLoaderMatcher()`
 
-- **Do NOT add `classLoaderMatcher()` for optimization.** The "skip when library is absent"
-  optimization belongs on `TypeInstrumentation.classLoaderOptimization()`, not here.
-  `classLoaderMatcher()` is only for **version-boundary detection**. Most modules do not need
-  it.
+- **Do NOT add `classLoaderMatcher()` for optimization or to silence muzzle mismatches.** The
+  "skip when library is absent" optimization belongs on
+  `TypeInstrumentation.classLoaderOptimization()`, not here. `classLoaderMatcher()` is only for
+  separating **multiple instrumentation versions of the same library** when the type
+  instrumentation does not already do that. Most modules do not need it.
 - **Do NOT flag modules that omit `classLoaderMatcher()`.** The default (`any()`) is correct
-  when muzzle can detect the version boundary on its own. Only flag a missing override when
-  the module truly depends on an added or removed landmark class that muzzle does not inspect.
+  when there is no competing sibling module, or when `typeMatcher()`,
+  `classLoaderOptimization()`, or muzzle already separates the versions. Only flag a missing
+  override when sibling versioned modules would otherwise overlap and the module truly depends
+  on an added or removed landmark class that the other checks do not inspect.
 - **Version comments are required on landmark classes.** For multi-class checks, or whenever
   the landmark version differs from the module's base version, every `hasClassesNamed()` call
   needs a role comment. When the entire return expression is a single `hasClassesNamed(...)`

--- a/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerInstrumentationModule.java
+++ b/instrumentation/activej-http-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/activejhttp/ActivejHttpServerInstrumentationModule.java
@@ -5,14 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.activejhttp;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class ActivejHttpServerInstrumentationModule extends InstrumentationModule {
@@ -24,11 +22,5 @@ public class ActivejHttpServerInstrumentationModule extends InstrumentationModul
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new ActivejAsyncServletInstrumentation());
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 6.0
-    return hasClassesNamed("io.activej.http.HttpServer");
   }
 }

--- a/instrumentation/armeria/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaInstrumentationModule.java
+++ b/instrumentation/armeria/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaInstrumentationModule.java
@@ -5,25 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class ArmeriaInstrumentationModule extends InstrumentationModule {
   public ArmeriaInstrumentationModule() {
     super("armeria", "armeria-1.3");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // Unrelated class which was added in Armeria 1.3.0, the minimum version we support.
-    return hasClassesNamed("com.linecorp.armeria.server.metric.PrometheusExpositionServiceBuilder");
   }
 
   @Override

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
@@ -13,7 +12,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class ClickHouseClientV1InstrumentationModule extends InstrumentationModule
@@ -26,12 +24,6 @@ public class ClickHouseClientV1InstrumentationModule extends InstrumentationModu
   @Override
   public boolean isHelperClass(String className) {
     return "com.clickhouse.client.ClickHouseRequestAccess".equals(className);
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // Unrelated class which was added in 0.5.0, the minimum version where tests pass
-    return hasClassesNamed("com.clickhouse.client.config.ClickHouseProxyType");
   }
 
   @Override

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/DropwizardMetricsInstrumentationModule.java
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/DropwizardMetricsInstrumentationModule.java
@@ -5,27 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.dropwizardmetrics;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class DropwizardMetricsInstrumentationModule extends InstrumentationModule {
 
   public DropwizardMetricsInstrumentationModule() {
     super("dropwizard-metrics", "dropwizard-metrics-4.0");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // removed in 4.0
-    return not(hasClassesNamed("com.codahale.metrics.LongAdder"));
   }
 
   @Override

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyInstrumentationModule.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyInstrumentationModule.java
@@ -5,25 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.grizzly;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class GrizzlyInstrumentationModule extends InstrumentationModule {
   public GrizzlyInstrumentationModule() {
     super("grizzly", "grizzly-2.3");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // class added in 2.3
-    return hasClassesNamed("org.glassfish.grizzly.InputSource");
   }
 
   @Override

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtInstrumentationModule.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.gwt;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class GwtInstrumentationModule extends InstrumentationModule {
 
   public GwtInstrumentationModule() {
     super("gwt", "gwt-2.0");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 2.0
-    return hasClassesNamed("com.google.gwt.uibinder.client.UiBinder");
   }
 
   @Override

--- a/instrumentation/jfinal-3.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jfinal/v3_2/JFinalInstrumentationModule.java
+++ b/instrumentation/jfinal-3.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jfinal/v3_2/JFinalInstrumentationModule.java
@@ -5,28 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.jfinal.v3_2;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class JFinalInstrumentationModule extends InstrumentationModule {
 
   public JFinalInstrumentationModule() {
     super("jfinal", "jfinal-3.2");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // In version 3.2, TypeConverter is moved from com.jfinal.core
-    // to com.jfinal.core.converter
-    return not(hasClassesNamed("com.jfinal.core.TypeConverter"));
   }
 
   @Override

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectInstrumentationModule.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectInstrumentationModule.java
@@ -5,14 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class KafkaConnectInstrumentationModule extends InstrumentationModule {
@@ -24,11 +22,5 @@ public class KafkaConnectInstrumentationModule extends InstrumentationModule {
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new SinkTaskInstrumentation(), new WorkerSinkTaskInstrumentation());
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // class added in 2.6.0
-    return hasClassesNamed("org.apache.kafka.connect.sink.SinkConnectorContext");
   }
 }

--- a/instrumentation/log4j/log4j-mdc-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/mdc/v1_2/Log4j1InstrumentationModule.java
+++ b/instrumentation/log4j/log4j-mdc-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/mdc/v1_2/Log4j1InstrumentationModule.java
@@ -5,25 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.log4j.mdc.v1_2;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class Log4j1InstrumentationModule extends InstrumentationModule {
   public Log4j1InstrumentationModule() {
     super("log4j-mdc", "log4j-mdc-1.2");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 1.2
-    return hasClassesNamed("org.apache.log4j.MDC");
   }
 
   @Override

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiInstrumentationModule.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/OpenAiInstrumentationModule.java
@@ -5,24 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class OpenAiInstrumentationModule extends InstrumentationModule {
   public OpenAiInstrumentationModule() {
     super("openai-java", "openai-java-1.1", "openai");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.openai.client.OpenAIClient");
   }
 
   @Override

--- a/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/PayaraInstrumentationModule.java
+++ b/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/PayaraInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.payara;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class PayaraInstrumentationModule extends InstrumentationModule {
 
   public PayaraInstrumentationModule() {
     super("payara");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 5.182
-    return hasClassesNamed("fish.payara.opentracing.OpenTracingService");
   }
 
   @Override

--- a/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestryInstrumentationModule.java
+++ b/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestryInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.tapestry;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class TapestryInstrumentationModule extends InstrumentationModule {
 
   public TapestryInstrumentationModule() {
     super("tapestry", "tapestry-5.4");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // class added in tapestry 5.4.0
-    return hasClassesNamed("org.apache.tapestry5.Binding2");
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowInstrumentationModule.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class UndertowInstrumentationModule extends InstrumentationModule {
 
   public UndertowInstrumentationModule() {
     super("undertow", "undertow-1.4");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 1.4.0.Final
-    return hasClassesNamed("io.undertow.Undertow$ListenerInfo");
   }
 
   @Override

--- a/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinInstrumentationModule.java
+++ b/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.vaadin;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class VaadinInstrumentationModule extends InstrumentationModule {
 
   public VaadinInstrumentationModule() {
     super("vaadin", "vaadin-14.2");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 14.2
-    return hasClassesNamed("com.vaadin.flow.server.frontend.installer.NodeInstaller");
   }
 
   @Override

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpInstrumentationModule.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpInstrumentationModule.java
@@ -5,28 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class ViburDbcpInstrumentationModule extends InstrumentationModule {
   public ViburDbcpInstrumentationModule() {
     super("vibur-dbcp", "vibur-dbcp-11.0");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // in 11.0, the ViburDBCPDataSource#getPool() method signature was changed - this is detected by
-    // muzzle
-    return hasClassesNamed(
-        // added in 10.0
-        "org.vibur.dbcp.ViburConfig");
   }
 
   @Override

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/WicketInstrumentationModule.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/WicketInstrumentationModule.java
@@ -5,26 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.wicket;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class WicketInstrumentationModule extends InstrumentationModule {
 
   public WicketInstrumentationModule() {
     super("wicket", "wicket-8.0");
-  }
-
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // added in 8.0
-    return hasClassesNamed("org.apache.wicket.request.RequestHandlerExecutor");
   }
 
   @Override


### PR DESCRIPTION
Remove class loader matchers from instrumentations that only have a single version module.

Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/17544