### PR TITLE
Fix duplicate examples key in log4j-appender-2.17 metadata.yaml

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/metadata.yaml
+++ b/instrumentation/log4j/log4j-appender-2.17/metadata.yaml
@@ -40,9 +40,6 @@ configurations:
       - "*"
       - "key1,key2"
     default: ''
-    examples:
-      - "custom-mdc-key"
-      - "key1,key2,key3"
   - name: otel.instrumentation.log4j-appender.experimental.capture-event-name
     declarative_name: java.log4j_appender.capture_event_name/development
     description: >


### PR DESCRIPTION
The `capture-mdc-attributes` configuration in `instrumentation/log4j/log4j-appender-2.17/metadata.yaml` had two `examples:` blocks (one before `default:` and one after), introduced in #18191. Jackson's YAML parser rejects duplicate keys against the `ConfigurationOption` record, causing `DeclarativeConfigValidationTest.validateDeclarativeNames` to fail with:

```
Should never call set() on setterless property ('examples')
```

This wasn't caught on main because the Gradle build cache served a stale pass for `:instrumentation-docs:test` (see `> Task :instrumentation-docs:test FROM-CACHE` in the post-merge CI run). PRs whose merge commit invalidates that cache hit the real parse error — e.g. #16344.

Fix: drop the second (duplicate) `examples:` block; keep the first one.

Note: the gradle build caching bug is fixed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18225