### PR TITLE
Deduplicate PR build runs when a test label is auto-added

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,11 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # fixed group name (not github.workflow) so that runs triggered by pull_request
+  # and runs triggered via workflow_call from rebuild-pull-request-on-label.yml
+  # share the group, otherwise the PR build would run twice in parallel whenever
+  # a "test *" label is added
+  group: build-pull-request-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
`build-pull-request.yml` is invoked two ways:

1. Directly by `pull_request` (`opened` / `synchronize` / `reopened`).
2. Via `workflow_call` from `rebuild-pull-request-on-label.yml` when a
   `test openj9` / `test windows` / `test native` label is added.

Its concurrency group was keyed on `${{ github.workflow }}`, which resolves
to the caller workflow's name — so the two invocations landed in different
groups and both ran in full. Since the auto Labeler applies `test native`
on any PR touching common build files, a large fraction of PRs paid the
full CI cost twice (see #18229).

Use a fixed group name so the label-triggered run cancels the initial
`opened` run (which couldn't have seen the label anyway).