### PR TITLE
Pin Docker images used in tests to specific versions

### DIFF
--- a/instrumentation/gwt-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtTest.java
+++ b/instrumentation/gwt-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtTest.java
@@ -80,7 +80,7 @@ class GwtTest {
     Testcontainers.exposeHostPorts(port);
 
     browser =
-        new BrowserWebDriverContainer("selenium/standalone-chrome")
+        new BrowserWebDriverContainer("selenium/standalone-chrome:4.43.0")
             .withLogConsumer(new Slf4jLogConsumer(logger));
     cleanup.deferAfterAll(browser::stop);
     browser.start();

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -64,7 +64,7 @@ abstract class AbstractJms1Test {
   @BeforeAll
   static void setUp() throws JMSException {
     broker =
-        new GenericContainer<>("rmohr/activemq:latest")
+        new GenericContainer<>("apache/activemq-classic:5.19.2")
             .withExposedPorts(61616, 8161)
             .withLogConsumer(new Slf4jLogConsumer(logger));
     broker.start();

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/AbstractRabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/AbstractRabbitMqTest.java
@@ -42,7 +42,7 @@ abstract class AbstractRabbitMqTest {
   @BeforeAll
   static void startRabbit() throws UnknownHostException {
     rabbitMqContainer =
-        new GenericContainer<>("rabbitmq:latest")
+        new GenericContainer<>("rabbitmq:4.2")
             .withExposedPorts(5672)
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/RabbitExtension.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/RabbitExtension.java
@@ -48,7 +48,7 @@ public class RabbitExtension implements BeforeEachCallback, AfterEachCallback {
   @Override
   public void beforeEach(ExtensionContext context) {
     rabbitMqContainer =
-        new GenericContainer<>("rabbitmq:latest")
+        new GenericContainer<>("rabbitmq:4.2")
             .withExposedPorts(5672)
             .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
             .withStartupTimeout(Duration.ofMinutes(2));

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -73,7 +73,7 @@ class SpringRabbitMqTest {
   @BeforeAll
   static void setUp() throws UnknownHostException {
     rabbitMqContainer =
-        new GenericContainer<>("rabbitmq:latest")
+        new GenericContainer<>("rabbitmq:4.2")
             .withExposedPorts(5672)
             .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
             .withStartupTimeout(Duration.ofMinutes(2));

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedTest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedTest.java
@@ -82,7 +82,7 @@ class SpymemcachedTest {
   @BeforeAll
   static void setUp() {
     memcachedContainer =
-        new GenericContainer<>("memcached:latest")
+        new GenericContainer<>("memcached:1.6.41")
             .withExposedPorts(11211)
             .withStartupTimeout(Duration.ofMinutes(2));
     memcachedContainer.start();

--- a/instrumentation/vaadin-14.2/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/v14_2/AbstractVaadinTest.java
+++ b/instrumentation/vaadin-14.2/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/v14_2/AbstractVaadinTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractVaadinTest
     Testcontainers.exposeHostPorts(port);
 
     browser =
-        new BrowserWebDriverContainer("selenium/standalone-chrome")
+        new BrowserWebDriverContainer("selenium/standalone-chrome:4.43.0")
             .withLogConsumer(new Slf4jLogConsumer(logger));
     browser.start();
 


### PR DESCRIPTION
Replaces :latest / unpinned tags with specific versions to prevent silent CI regressions from upstream image changes (e.g. RabbitMQ 4.3 broke Spring AnonymousQueue handling).