### PR TITLE
Simplify metric assertions, Part 2

### DIFF
--- a/instrumentation/avaje-jex-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/avaje/jex/v3_0/JexTest.java
+++ b/instrumentation/avaje-jex-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/avaje/jex/v3_0/JexTest.java
@@ -121,14 +121,12 @@ class JexTest {
     assertThat(response.status().code()).isEqualTo(200);
     testing.waitAndAssertMetrics(
         instrumentation,
-        "http.server.request.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasAttribute(HTTP_ROUTE, "/test/param/{id}")))));
+        metric ->
+            metric
+                .hasName("http.server.request.duration")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point -> point.hasAttribute(HTTP_ROUTE, "/test/param/{id}"))));
   }
 }

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/v4_0/DropwizardMetricsTest.java
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/v4_0/DropwizardMetricsTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.dropwizardmetrics.v4_0;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -42,13 +41,10 @@ class DropwizardMetricsTest {
     // then
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
-        "testgauge",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDoubleGaugeSatisfying(
-                            g -> g.hasPointsSatisfying(point -> point.hasValue(42)))));
+        metric ->
+            metric
+                .hasName("testgauge")
+                .hasDoubleGaugeSatisfying(g -> g.hasPointsSatisfying(point -> point.hasValue(42))));
 
     // when
     metricRegistry.remove("test'gauge");
@@ -75,15 +71,11 @@ class DropwizardMetricsTest {
     // then
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
-        "testcounter",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(point -> point.hasValue(7)))));
+        metric ->
+            metric
+                .hasName("testcounter")
+                .hasLongSumSatisfying(
+                    sum -> sum.isNotMonotonic().hasPointsSatisfying(point -> point.hasValue(7))));
     testing.clearData();
 
     // when
@@ -109,15 +101,13 @@ class DropwizardMetricsTest {
     // then
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
-        "testhistogram",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasHistogramSatisfying(
-                            histogramMetric ->
-                                histogramMetric.hasPointsSatisfying(
-                                    point -> point.hasSum(42).hasCount(2)))));
+        metric ->
+            metric
+                .hasName("testhistogram")
+                .hasHistogramSatisfying(
+                    histogramMetric ->
+                        histogramMetric.hasPointsSatisfying(
+                            point -> point.hasSum(42).hasCount(2))));
     testing.clearData();
 
     // when
@@ -143,15 +133,11 @@ class DropwizardMetricsTest {
     // then
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
-        "testmeter",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(point -> point.hasValue(12)))));
+        metric ->
+            metric
+                .hasName("testmeter")
+                .hasLongSumSatisfying(
+                    sum -> sum.isMonotonic().hasPointsSatisfying(point -> point.hasValue(12))));
     testing.clearData();
 
     // when
@@ -178,16 +164,13 @@ class DropwizardMetricsTest {
     // then
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
-        "testtimer",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasUnit("ms")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasSum(1.234).hasCount(2)))));
+        metric ->
+            metric
+                .hasName("testtimer")
+                .hasUnit("ms")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(point -> point.hasSum(1.234).hasCount(2))));
     testing.clearData();
 
     // when

--- a/instrumentation/javalin/testing/src/main/java/io/opentelemetry/instrumentation/javalin/AbstractJavalinTest.java
+++ b/instrumentation/javalin/testing/src/main/java/io/opentelemetry/instrumentation/javalin/AbstractJavalinTest.java
@@ -161,14 +161,12 @@ public abstract class AbstractJavalinTest {
     testing()
         .waitAndAssertMetrics(
             getJettyInstrumentation(),
-            "http.server.request.duration",
-            metrics ->
-                metrics.anySatisfy(
-                    metric ->
-                        assertThat(metric)
-                            .hasHistogramSatisfying(
-                                histogram ->
-                                    histogram.hasPointsSatisfying(
-                                        point -> point.hasAttribute(HTTP_ROUTE, "/param/{id}")))));
+            metric ->
+                metric
+                    .hasName("http.server.request.duration")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point -> point.hasAttribute(HTTP_ROUTE, "/param/{id}"))));
   }
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_10/metrics/CallbackGcCloseTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_10/metrics/CallbackGcCloseTest.java
@@ -83,13 +83,11 @@ class CallbackGcCloseTest {
     // 3. Verify the gauge is producing metrics.
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test.gc.close",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasLongGaugeSatisfying(
-                            gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(42)))));
+        metric ->
+            metric
+                .hasName("test.gc.close")
+                .hasLongGaugeSatisfying(
+                    gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(42))));
 
     // 4. Release the classloader — simulates app undeploy.
     WeakReference<ClassLoader> clRef = new WeakReference<>(childCl);
@@ -125,13 +123,11 @@ class CallbackGcCloseTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test.gc.alive",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasLongGaugeSatisfying(
-                            gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(99)))));
+        metric ->
+            metric
+                .hasName("test.gc.alive")
+                .hasLongGaugeSatisfying(
+                    gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(99))));
 
     // prevent callback from being collected during the test
     assertThat(callback).isNotNull();

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_10/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_10/metrics/MeterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_10.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 
 import io.opentelemetry.api.common.Attributes;
@@ -62,27 +61,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -96,27 +93,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     close(observableCounter);
 
@@ -138,27 +133,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -173,27 +166,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     close(observableCounter);
 
@@ -215,27 +206,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -249,27 +238,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     close(observableCounter);
 
@@ -291,27 +278,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -326,27 +311,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     close(observableCounter);
 
@@ -368,26 +351,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -400,26 +381,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
   }
 
   @Test
@@ -434,26 +413,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
 
     close(observableGauge);
 
@@ -476,26 +453,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
 
     close(observableGauge);
 

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.15/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_15/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.15/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_15/metrics/MeterTest.java
@@ -60,27 +60,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     callback.close();
 
@@ -106,27 +104,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     callback.close();
 
@@ -152,27 +148,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     callback.close();
 
@@ -203,27 +197,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("q"), "r")))));
 
     callback.close();
 
@@ -249,26 +241,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
 
     callback.close();
 
@@ -294,26 +284,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("q"), "r"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("q"), "r")))));
 
     callback.close();
 

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.31/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_31/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.31/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_31/metrics/MeterTest.java
@@ -81,27 +81,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -119,27 +117,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -157,27 +153,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -196,27 +190,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -235,27 +227,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -274,27 +264,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -312,26 +300,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -357,27 +343,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -401,26 +385,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -445,27 +427,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.32/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_32/incubator/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.32/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_32/incubator/metrics/MeterTest.java
@@ -81,27 +81,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -119,27 +117,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -157,27 +153,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -196,27 +190,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -235,27 +227,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -274,27 +264,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -312,26 +300,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -357,27 +343,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -401,26 +385,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -445,27 +427,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.32/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_32/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.32/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_32/metrics/MeterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_32.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -67,27 +66,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -103,26 +100,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/incubator/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/incubator/metrics/MeterTest.java
@@ -81,27 +81,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -119,27 +117,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -157,27 +153,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -196,27 +190,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -235,27 +227,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -274,27 +264,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -312,26 +300,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -357,27 +343,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -401,26 +385,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -445,27 +427,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/oldAndNewIncubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/incubator/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/oldAndNewIncubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/incubator/metrics/MeterTest.java
@@ -81,27 +81,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -119,27 +117,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -157,27 +153,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(11)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(11)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -196,27 +190,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(12.1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(12.1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -235,27 +227,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -274,27 +264,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -312,26 +300,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -357,27 +343,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -401,26 +385,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     observableGauge.close();
 
@@ -445,27 +427,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.37/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_37/metrics/MeterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_37.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,27 +64,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(11.0)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(11.0)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 
   @Test
@@ -101,26 +98,24 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasSum(12.1)
-                                            .hasBucketBoundaries(10.0)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(12.1)
+                                    .hasBucketBoundaries(10.0)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
   }
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.38/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_38/incubator/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.38/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_38/incubator/metrics/MeterTest.java
@@ -61,27 +61,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -104,27 +102,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.38/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_38/metrics/MeterTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.38/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_38/metrics/MeterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_38.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -63,27 +62,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasLongGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(321).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(123)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasLongGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(321).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(123)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);
@@ -103,27 +100,25 @@ class MeterTest {
 
     testing.waitAndAssertMetrics(
         instrumentationName,
-        "test",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("d")
-                        .hasUnit("u")
-                        .hasInstrumentationScope(
-                            InstrumentationScopeInfo.builder(instrumentationName)
-                                .setVersion("1.2.3")
-                                .setSchemaUrl("http://schema.org")
-                                .build())
-                        .hasDoubleGaugeSatisfying(
-                            gauge ->
-                                gauge.hasPointsSatisfying(
-                                    point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
-                                    point ->
-                                        point
-                                            .hasValue(1.23)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(stringKey("test"), "test"))))));
+        metric ->
+            metric
+                .hasName("test")
+                .hasDescription("d")
+                .hasUnit("u")
+                .hasInstrumentationScope(
+                    InstrumentationScopeInfo.builder(instrumentationName)
+                        .setVersion("1.2.3")
+                        .setSchemaUrl("http://schema.org")
+                        .build())
+                .hasDoubleGaugeSatisfying(
+                    gauge ->
+                        gauge.hasPointsSatisfying(
+                            point -> point.hasValue(3.21).hasAttributes(Attributes.empty()),
+                            point ->
+                                point
+                                    .hasValue(1.23)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(stringKey("test"), "test")))));
 
     // sleep exporter interval
     Thread.sleep(100);

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/ActuatorTest.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/actuator/v2_0/ActuatorTest.java
@@ -40,21 +40,19 @@ class ActuatorTest {
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.micrometer-1.5",
-        "test-counter",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasUnit("thingies")
-                        .hasDoubleSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(stringKey("tag"), "value"))))));
+        metric ->
+            metric
+                .hasName("test-counter")
+                .hasUnit("thingies")
+                .hasDoubleSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(stringKey("tag"), "value")))));
 
     MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
     assertThat(meterRegistry).isInstanceOf(CompositeMeterRegistry.class);

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -756,17 +756,14 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     testing.waitAndAssertMetrics(
         instrumentationName.get(),
-        "http.client.request.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("Duration of HTTP client requests.")
-                        .hasUnit("s")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasSumGreaterThan(0.0)))));
+        metric ->
+            metric
+                .hasName("http.client.request.duration")
+                .hasDescription("Duration of HTTP client requests.")
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(point -> point.hasSumGreaterThan(0.0))));
   }
 
   /**

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -417,17 +417,14 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
 
     testing.waitAndAssertMetrics(
         instrumentationName.get(),
-        "http.server.request.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("Duration of HTTP server requests.")
-                        .hasUnit("s")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasSumGreaterThan(0.0)))));
+        metric ->
+            metric
+                .hasName("http.server.request.duration")
+                .hasDescription("Duration of HTTP server requests.")
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(point -> point.hasSumGreaterThan(0.0))));
   }
 
   /**


### PR DESCRIPTION
> [!TIP]
> Hide whitespace when reviewing

Mechanical conversion: wherever the body matched

```java
metrics -> metrics.anySatisfy(metric -> assertThat(metric).X)
```

it becomes

```java
metric -> metric.hasName(NAME).X
```
