### PR TITLE
Simplify metric assertions, Part 3

### DIFF
--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
@@ -199,93 +199,83 @@ public abstract class AbstractDubboTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
-                                                  equalTo(RPC_METHOD, "hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
+                                          equalTo(RPC_METHOD, "hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "org.apache.dubbo.rpc.service.GenericService"),
-                                                  equalTo(RPC_METHOD, "$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  satisfies(
-                                                      NETWORK_TYPE,
-                                                      AbstractDubboTest::assertNetworkType))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "org.apache.dubbo.rpc.service.GenericService"),
+                                          equalTo(RPC_METHOD, "$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          satisfies(
+                                              NETWORK_TYPE,
+                                              AbstractDubboTest::assertNetworkType)))));
     }
 
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "org.apache.dubbo.rpc.service.GenericService/$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "org.apache.dubbo.rpc.service.GenericService/$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class))))));
     }
   }
 
@@ -405,93 +395,83 @@ public abstract class AbstractDubboTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
-                                                  equalTo(RPC_METHOD, "hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
+                                          equalTo(RPC_METHOD, "hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "org.apache.dubbo.rpc.service.GenericService"),
-                                                  equalTo(RPC_METHOD, "$invokeAsync"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  satisfies(
-                                                      NETWORK_TYPE,
-                                                      AbstractDubboTest::assertNetworkType))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "org.apache.dubbo.rpc.service.GenericService"),
+                                          equalTo(RPC_METHOD, "$invokeAsync"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          satisfies(
+                                              NETWORK_TYPE,
+                                              AbstractDubboTest::assertNetworkType)))));
     }
 
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "org.apache.dubbo.rpc.service.GenericService/$invokeAsync"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "org.apache.dubbo.rpc.service.GenericService/$invokeAsync"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class))))));
     }
   }
 

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
@@ -297,130 +297,117 @@ public abstract class AbstractDubboTraceChainTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
-                                                  equalTo(RPC_METHOD, "hello")),
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
-                                                  equalTo(RPC_METHOD, "hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"),
+                                          equalTo(RPC_METHOD, "hello")),
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
+                                          equalTo(RPC_METHOD, "hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "org.apache.dubbo.rpc.service.GenericService"),
-                                                  equalTo(RPC_METHOD, "$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  satisfies(
-                                                      NETWORK_TYPE,
-                                                      AbstractDubboTest::assertNetworkType)),
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "org.apache.dubbo.rpc.service.GenericService"),
-                                                  equalTo(RPC_METHOD, "$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  satisfies(
-                                                      NETWORK_TYPE,
-                                                      AbstractDubboTest::assertNetworkType))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "org.apache.dubbo.rpc.service.GenericService"),
+                                          equalTo(RPC_METHOD, "$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          satisfies(
+                                              NETWORK_TYPE, AbstractDubboTest::assertNetworkType)),
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "org.apache.dubbo.rpc.service.GenericService"),
+                                          equalTo(RPC_METHOD, "$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          satisfies(
+                                              NETWORK_TYPE,
+                                              AbstractDubboTest::assertNetworkType)))));
     }
 
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello")),
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService/hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello")),
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService/hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "org.apache.dubbo.rpc.service.GenericService/$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class))),
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "org.apache.dubbo.rpc.service.GenericService/$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "org.apache.dubbo.rpc.service.GenericService/$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class))),
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "org.apache.dubbo.rpc.service.GenericService/$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class))))));
     }
   }
 
@@ -535,93 +522,83 @@ public abstract class AbstractDubboTraceChainTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
-                                                  equalTo(RPC_METHOD, "hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService"),
+                                          equalTo(RPC_METHOD, "hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM, "apache_dubbo"),
-                                                  equalTo(
-                                                      RPC_SERVICE,
-                                                      "org.apache.dubbo.rpc.service.GenericService"),
-                                                  equalTo(RPC_METHOD, "$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  satisfies(
-                                                      NETWORK_TYPE,
-                                                      AbstractDubboTest::assertNetworkType))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM, "apache_dubbo"),
+                                          equalTo(
+                                              RPC_SERVICE,
+                                              "org.apache.dubbo.rpc.service.GenericService"),
+                                          equalTo(RPC_METHOD, "$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          satisfies(
+                                              NETWORK_TYPE,
+                                              AbstractDubboTest::assertNetworkType)))));
     }
 
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService/hello"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.MiddleService/hello")))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.apache-dubbo-2.7",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "dubbo"),
-                                                  equalTo(
-                                                      RPC_METHOD,
-                                                      "org.apache.dubbo.rpc.service.GenericService/$invoke"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "dubbo"),
+                                          equalTo(
+                                              RPC_METHOD,
+                                              "org.apache.dubbo.rpc.service.GenericService/$invoke"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class))))));
     }
   }
 }

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
@@ -296,98 +296,86 @@ public abstract class AbstractGrpcStreamingTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(RPC_METHOD, "Conversation"),
-                                                  equalTo(RPC_SERVICE, "example.Greeter"),
-                                                  equalTo(RPC_SYSTEM, "grpc"),
-                                                  equalTo(NETWORK_TYPE, "ipv4"),
-                                                  equalTo(
-                                                      RPC_GRPC_STATUS_CODE,
-                                                      (long) Status.Code.OK.value()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "Conversation"),
+                                          equalTo(RPC_SERVICE, "example.Greeter"),
+                                          equalTo(RPC_SYSTEM, "grpc"),
+                                          equalTo(NETWORK_TYPE, "ipv4"),
+                                          equalTo(
+                                              RPC_GRPC_STATUS_CODE,
+                                              (long) Status.Code.OK.value())))));
     }
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "grpc"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(
-                                                      RPC_METHOD, "example.Greeter/Conversation"),
-                                                  equalTo(
-                                                      RPC_RESPONSE_STATUS_CODE,
-                                                      Status.Code.OK.name()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "grpc"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "example.Greeter/Conversation"),
+                                          equalTo(
+                                              RPC_RESPONSE_STATUS_CODE, Status.Code.OK.name())))));
     }
     if (emitOldRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(RPC_METHOD, "Conversation"),
-                                                  equalTo(RPC_SERVICE, "example.Greeter"),
-                                                  equalTo(RPC_SYSTEM, "grpc"),
-                                                  equalTo(
-                                                      RPC_GRPC_STATUS_CODE,
-                                                      (long) Status.Code.OK.value()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "Conversation"),
+                                          equalTo(RPC_SERVICE, "example.Greeter"),
+                                          equalTo(RPC_SYSTEM, "grpc"),
+                                          equalTo(
+                                              RPC_GRPC_STATUS_CODE,
+                                              (long) Status.Code.OK.value())))));
     }
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(RPC_SYSTEM_NAME, "grpc"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(
-                                                      RPC_METHOD, "example.Greeter/Conversation"),
-                                                  equalTo(
-                                                      RPC_RESPONSE_STATUS_CODE,
-                                                      Status.Code.OK.name()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(RPC_SYSTEM_NAME, "grpc"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "example.Greeter/Conversation"),
+                                          equalTo(
+                                              RPC_RESPONSE_STATUS_CODE, Status.Code.OK.name())))));
     }
   }
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -1725,197 +1725,167 @@ public abstract class AbstractGrpcTest {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.server.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  equalTo(RPC_METHOD, "SayHello"),
-                                                  equalTo(RPC_SERVICE, "example.Greeter"),
-                                                  equalTo(RPC_SYSTEM, "grpc"),
-                                                  equalTo(
-                                                      RPC_GRPC_STATUS_CODE,
-                                                      (long) statusCode.value()),
-                                                  equalTo(NETWORK_TYPE, "ipv4"))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          equalTo(RPC_METHOD, "SayHello"),
+                                          equalTo(RPC_SERVICE, "example.Greeter"),
+                                          equalTo(RPC_SYSTEM, "grpc"),
+                                          equalTo(RPC_GRPC_STATUS_CODE, (long) statusCode.value()),
+                                          equalTo(NETWORK_TYPE, "ipv4")))));
 
       if (hasSizeMetric) {
         testing()
             .waitAndAssertMetrics(
                 "io.opentelemetry.grpc-1.6",
-                "rpc.server.request.size",
-                metrics ->
-                    metrics.anySatisfy(
-                        metric ->
-                            assertThat(metric)
-                                .hasUnit("By")
-                                .hasHistogramSatisfying(
-                                    histogram ->
-                                        histogram.hasPointsSatisfying(
-                                            point ->
-                                                point.hasAttributesSatisfyingExactly(
-                                                    equalTo(SERVER_ADDRESS, "localhost"),
-                                                    satisfies(
-                                                        SERVER_PORT,
-                                                        val -> val.isInstanceOf(Long.class)),
-                                                    equalTo(RPC_METHOD, "SayHello"),
-                                                    equalTo(RPC_SERVICE, "example.Greeter"),
-                                                    equalTo(RPC_SYSTEM, "grpc"),
-                                                    equalTo(
-                                                        RPC_GRPC_STATUS_CODE,
-                                                        (long) statusCode.value()),
-                                                    equalTo(NETWORK_TYPE, "ipv4"))))));
+                metric ->
+                    metric
+                        .hasName("rpc.server.request.size")
+                        .hasUnit("By")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point.hasAttributesSatisfyingExactly(
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            satisfies(
+                                                SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                            equalTo(RPC_METHOD, "SayHello"),
+                                            equalTo(RPC_SERVICE, "example.Greeter"),
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(
+                                                RPC_GRPC_STATUS_CODE, (long) statusCode.value()),
+                                            equalTo(NETWORK_TYPE, "ipv4")))));
         testing()
             .waitAndAssertMetrics(
                 "io.opentelemetry.grpc-1.6",
-                "rpc.server.response.size",
-                metrics ->
-                    metrics.anySatisfy(
-                        metric ->
-                            assertThat(metric)
-                                .hasUnit("By")
-                                .hasHistogramSatisfying(
-                                    histogram ->
-                                        histogram.hasPointsSatisfying(
-                                            point ->
-                                                point.hasAttributesSatisfyingExactly(
-                                                    equalTo(SERVER_ADDRESS, "localhost"),
-                                                    satisfies(
-                                                        SERVER_PORT,
-                                                        val -> val.isInstanceOf(Long.class)),
-                                                    equalTo(RPC_METHOD, "SayHello"),
-                                                    equalTo(RPC_SERVICE, "example.Greeter"),
-                                                    equalTo(RPC_SYSTEM, "grpc"),
-                                                    equalTo(
-                                                        RPC_GRPC_STATUS_CODE,
-                                                        (long) statusCode.value()),
-                                                    equalTo(NETWORK_TYPE, "ipv4"))))));
+                metric ->
+                    metric
+                        .hasName("rpc.server.response.size")
+                        .hasUnit("By")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point.hasAttributesSatisfyingExactly(
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            satisfies(
+                                                SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                            equalTo(RPC_METHOD, "SayHello"),
+                                            equalTo(RPC_SERVICE, "example.Greeter"),
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(
+                                                RPC_GRPC_STATUS_CODE, (long) statusCode.value()),
+                                            equalTo(NETWORK_TYPE, "ipv4")))));
       }
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.client.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("ms")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(RPC_METHOD, "SayHello"),
-                                                  equalTo(RPC_SERVICE, "example.Greeter"),
-                                                  equalTo(RPC_SYSTEM, "grpc"),
-                                                  equalTo(
-                                                      RPC_GRPC_STATUS_CODE,
-                                                      (long) statusCode.value()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.duration")
+                      .hasUnit("ms")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "SayHello"),
+                                          equalTo(RPC_SERVICE, "example.Greeter"),
+                                          equalTo(RPC_SYSTEM, "grpc"),
+                                          equalTo(
+                                              RPC_GRPC_STATUS_CODE, (long) statusCode.value())))));
 
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.client.request.size",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("By")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(RPC_METHOD, "SayHello"),
-                                                  equalTo(RPC_SERVICE, "example.Greeter"),
-                                                  equalTo(RPC_SYSTEM, "grpc"),
-                                                  equalTo(
-                                                      RPC_GRPC_STATUS_CODE,
-                                                      (long) statusCode.value()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.request.size")
+                      .hasUnit("By")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "SayHello"),
+                                          equalTo(RPC_SERVICE, "example.Greeter"),
+                                          equalTo(RPC_SYSTEM, "grpc"),
+                                          equalTo(
+                                              RPC_GRPC_STATUS_CODE, (long) statusCode.value())))));
       if (hasSizeMetric) {
         testing()
             .waitAndAssertMetrics(
                 "io.opentelemetry.grpc-1.6",
-                "rpc.client.response.size",
-                metrics ->
-                    metrics.anySatisfy(
-                        metric ->
-                            assertThat(metric)
-                                .hasUnit("By")
-                                .hasHistogramSatisfying(
-                                    histogram ->
-                                        histogram.hasPointsSatisfying(
-                                            point ->
-                                                point.hasAttributesSatisfying(
-                                                    equalTo(SERVER_ADDRESS, "localhost"),
-                                                    equalTo(SERVER_PORT, server.getPort()),
-                                                    equalTo(RPC_METHOD, "SayHello"),
-                                                    equalTo(RPC_SERVICE, "example.Greeter"),
-                                                    equalTo(RPC_SYSTEM, "grpc"),
-                                                    equalTo(
-                                                        RPC_GRPC_STATUS_CODE,
-                                                        (long) statusCode.value()))))));
+                metric ->
+                    metric
+                        .hasName("rpc.client.response.size")
+                        .hasUnit("By")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point.hasAttributesSatisfying(
+                                            equalTo(SERVER_ADDRESS, "localhost"),
+                                            equalTo(SERVER_PORT, server.getPort()),
+                                            equalTo(RPC_METHOD, "SayHello"),
+                                            equalTo(RPC_SERVICE, "example.Greeter"),
+                                            equalTo(RPC_SYSTEM, "grpc"),
+                                            equalTo(
+                                                RPC_GRPC_STATUS_CODE,
+                                                (long) statusCode.value())))));
       }
     }
     if (emitStableRpcSemconv()) {
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.server.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfyingExactly(
-                                                  equalTo(RPC_SYSTEM_NAME, "grpc"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  satisfies(
-                                                      SERVER_PORT,
-                                                      val -> val.isInstanceOf(Long.class)),
-                                                  equalTo(RPC_METHOD, "example.Greeter/SayHello"),
-                                                  equalTo(
-                                                      RPC_RESPONSE_STATUS_CODE,
-                                                      statusCode.name()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.server.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfyingExactly(
+                                          equalTo(RPC_SYSTEM_NAME, "grpc"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          satisfies(
+                                              SERVER_PORT, val -> val.isInstanceOf(Long.class)),
+                                          equalTo(RPC_METHOD, "example.Greeter/SayHello"),
+                                          equalTo(RPC_RESPONSE_STATUS_CODE, statusCode.name())))));
       testing()
           .waitAndAssertMetrics(
               "io.opentelemetry.grpc-1.6",
-              "rpc.client.call.duration",
-              metrics ->
-                  metrics.anySatisfy(
-                      metric ->
-                          assertThat(metric)
-                              .hasUnit("s")
-                              .hasHistogramSatisfying(
-                                  histogram ->
-                                      histogram.hasPointsSatisfying(
-                                          point ->
-                                              point.hasAttributesSatisfying(
-                                                  equalTo(RPC_SYSTEM_NAME, "grpc"),
-                                                  equalTo(SERVER_ADDRESS, "localhost"),
-                                                  equalTo(SERVER_PORT, server.getPort()),
-                                                  equalTo(RPC_METHOD, "example.Greeter/SayHello"),
-                                                  equalTo(
-                                                      RPC_RESPONSE_STATUS_CODE,
-                                                      statusCode.name()))))));
+              metric ->
+                  metric
+                      .hasName("rpc.client.call.duration")
+                      .hasUnit("s")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point.hasAttributesSatisfying(
+                                          equalTo(RPC_SYSTEM_NAME, "grpc"),
+                                          equalTo(SERVER_ADDRESS, "localhost"),
+                                          equalTo(SERVER_PORT, server.getPort()),
+                                          equalTo(RPC_METHOD, "example.Greeter/SayHello"),
+                                          equalTo(RPC_RESPONSE_STATUS_CODE, statusCode.name())))));
     }
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientTest.java
@@ -106,17 +106,14 @@ class KubernetesClientTest {
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.kubernetes-client-7.0",
-        "http.client.request.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("Duration of HTTP client requests.")
-                        .hasUnit("s")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasSumGreaterThan(0.0)))));
+        metric ->
+            metric
+                .hasName("http.client.request.duration")
+                .hasDescription("Duration of HTTP client requests.")
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(point -> point.hasSumGreaterThan(0.0))));
   }
 
   @Test

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientVer20Test.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientVer20Test.java
@@ -110,17 +110,14 @@ class KubernetesClientVer20Test {
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.kubernetes-client-7.0",
-        "http.client.request.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metric ->
-                    assertThat(metric)
-                        .hasDescription("Duration of HTTP client requests.")
-                        .hasUnit("s")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point -> point.hasSumGreaterThan(0.0)))));
+        metric ->
+            metric
+                .hasName("http.client.request.duration")
+                .hasDescription("Duration of HTTP client requests.")
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(point -> point.hasSumGreaterThan(0.0))));
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/BufferPoolsTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/BufferPoolsTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -55,58 +54,49 @@ class BufferPoolsTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.buffer.memory.used",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of memory used by buffers.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(10)
-                                            .hasAttribute(
-                                                stringKey("jvm.buffer.pool.name"),
-                                                "buffer_pool_1")))));
+        metric ->
+            metric
+                .hasName("jvm.buffer.memory.used")
+                .hasDescription("Measure of memory used by buffers.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(10)
+                                    .hasAttribute(
+                                        stringKey("jvm.buffer.pool.name"), "buffer_pool_1"))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.buffer.memory.limit",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of total memory capacity of buffers.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(11)
-                                            .hasAttribute(
-                                                stringKey("jvm.buffer.pool.name"),
-                                                "buffer_pool_1")))));
+        metric ->
+            metric
+                .hasName("jvm.buffer.memory.limit")
+                .hasDescription("Measure of total memory capacity of buffers.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(11)
+                                    .hasAttribute(
+                                        stringKey("jvm.buffer.pool.name"), "buffer_pool_1"))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.buffer.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of buffers in the pool.")
-                        .hasUnit("{buffer}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(12)
-                                            .hasAttribute(
-                                                stringKey("jvm.buffer.pool.name"),
-                                                "buffer_pool_1")))));
+        metric ->
+            metric
+                .hasName("jvm.buffer.count")
+                .hasDescription("Number of buffers in the pool.")
+                .hasUnit("{buffer}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(12)
+                                    .hasAttribute(
+                                        stringKey("jvm.buffer.pool.name"), "buffer_pool_1"))));
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/ClassesTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/ClassesTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.Attributes;
@@ -36,48 +35,39 @@ class ClassesTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.class.loaded",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of classes loaded since JVM start.")
-                        .hasUnit("{class}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point.hasValue(3).hasAttributes(Attributes.empty())))));
+        metric ->
+            metric
+                .hasName("jvm.class.loaded")
+                .hasDescription("Number of classes loaded since JVM start.")
+                .hasUnit("{class}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point -> point.hasValue(3).hasAttributes(Attributes.empty()))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.class.unloaded",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of classes unloaded since JVM start.")
-                        .hasUnit("{class}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point.hasValue(2).hasAttributes(Attributes.empty())))));
+        metric ->
+            metric
+                .hasName("jvm.class.unloaded")
+                .hasDescription("Number of classes unloaded since JVM start.")
+                .hasUnit("{class}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isMonotonic()
+                            .hasPointsSatisfying(
+                                point -> point.hasValue(2).hasAttributes(Attributes.empty()))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.class.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of classes currently loaded.")
-                        .hasUnit("{class}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point.hasValue(1).hasAttributes(Attributes.empty())))));
+        metric ->
+            metric
+                .hasName("jvm.class.count")
+                .hasDescription("Number of classes currently loaded.")
+                .hasUnit("{class}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point -> point.hasValue(1).hasAttributes(Attributes.empty()))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/CpuCountTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/CpuCountTest.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import java.util.function.IntSupplier;
@@ -27,18 +25,13 @@ class CpuCountTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.cpu.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Number of processors available to the Java virtual machine.")
-                        .hasUnit("{cpu}")
-                        .hasLongSumSatisfying(
-                            count ->
-                                count
-                                    .isNotMonotonic()
-                                    .hasPointsSatisfying(point -> point.hasValue(8)))));
+        metric ->
+            metric
+                .hasName("jvm.cpu.count")
+                .hasDescription("Number of processors available to the Java virtual machine.")
+                .hasUnit("{cpu}")
+                .hasLongSumSatisfying(
+                    count ->
+                        count.isNotMonotonic().hasPointsSatisfying(point -> point.hasValue(8))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/CpuTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/CpuTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -29,29 +28,21 @@ class CpuTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.cpu.time",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("CPU time used by the process as reported by the JVM.")
-                        .hasUnit("s")
-                        .hasDoubleSumSatisfying(
-                            count ->
-                                count
-                                    .isMonotonic()
-                                    .hasPointsSatisfying(point -> point.hasValue(42)))));
+        metric ->
+            metric
+                .hasName("jvm.cpu.time")
+                .hasDescription("CPU time used by the process as reported by the JVM.")
+                .hasUnit("s")
+                .hasDoubleSumSatisfying(
+                    count -> count.isMonotonic().hasPointsSatisfying(point -> point.hasValue(42))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.cpu.recent_utilization",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Recent CPU utilization for the process as reported by the JVM.")
-                        .hasUnit("1")
-                        .hasDoubleGaugeSatisfying(
-                            gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(0.05)))));
+        metric ->
+            metric
+                .hasName("jvm.cpu.recent_utilization")
+                .hasDescription("Recent CPU utilization for the process as reported by the JVM.")
+                .hasUnit("1")
+                .hasDoubleGaugeSatisfying(
+                    gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(0.05))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/FileDescriptorTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/FileDescriptorTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
 
@@ -48,27 +47,21 @@ class FileDescriptorTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.file_descriptor.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of open file descriptors as reported by the JVM.")
-                        .hasUnit("{file_descriptor}")
-                        .hasLongSumSatisfying(
-                            sum -> sum.hasPointsSatisfying(point -> point.hasValue(42)))));
+        metric ->
+            metric
+                .hasName("jvm.file_descriptor.count")
+                .hasDescription("Number of open file descriptors as reported by the JVM.")
+                .hasUnit("{file_descriptor}")
+                .hasLongSumSatisfying(sum -> sum.hasPointsSatisfying(point -> point.hasValue(42))));
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.file_descriptor.limit",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Measure of max open file descriptors as reported by the JVM.")
-                        .hasUnit("{file_descriptor}")
-                        .hasLongSumSatisfying(
-                            sum -> sum.hasPointsSatisfying(point -> point.hasValue(100)))));
+        metric ->
+            metric
+                .hasName("jvm.file_descriptor.limit")
+                .hasDescription("Measure of max open file descriptors as reported by the JVM.")
+                .hasUnit("{file_descriptor}")
+                .hasLongSumSatisfying(
+                    sum -> sum.hasPointsSatisfying(point -> point.hasValue(100))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/GarbageCollectorTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/GarbageCollectorTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.JvmAttributes.JVM_GC_ACTION;
 import static io.opentelemetry.semconv.JvmAttributes.JVM_GC_NAME;
@@ -75,38 +74,36 @@ class GarbageCollectorTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.gc.duration",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Duration of JVM garbage collection actions.")
-                        .hasUnit("s")
-                        .hasHistogramSatisfying(
-                            histogram ->
-                                histogram.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasCount(2)
-                                            .hasSum(0.022)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(JVM_GC_NAME, "G1 Young Generation"),
-                                                equalTo(JVM_GC_ACTION, "end of minor GC"),
-                                                equalTo(
-                                                    stringKey("jvm.gc.cause"),
-                                                    captureGcCause ? "Allocation Failure" : null))
-                                            .hasBucketBoundaries(GC_DURATION_BUCKETS),
-                                    point ->
-                                        point
-                                            .hasCount(1)
-                                            .hasSum(0.011)
-                                            .hasAttributesSatisfyingExactly(
-                                                equalTo(JVM_GC_NAME, "G1 Old Generation"),
-                                                equalTo(JVM_GC_ACTION, "end of major GC"),
-                                                equalTo(
-                                                    stringKey("jvm.gc.cause"),
-                                                    captureGcCause ? "System.gc()" : null))
-                                            .hasBucketBoundaries(GC_DURATION_BUCKETS)))));
+        metric ->
+            metric
+                .hasName("jvm.gc.duration")
+                .hasDescription("Duration of JVM garbage collection actions.")
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasCount(2)
+                                    .hasSum(0.022)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(JVM_GC_NAME, "G1 Young Generation"),
+                                        equalTo(JVM_GC_ACTION, "end of minor GC"),
+                                        equalTo(
+                                            stringKey("jvm.gc.cause"),
+                                            captureGcCause ? "Allocation Failure" : null))
+                                    .hasBucketBoundaries(GC_DURATION_BUCKETS),
+                            point ->
+                                point
+                                    .hasCount(1)
+                                    .hasSum(0.011)
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(JVM_GC_NAME, "G1 Old Generation"),
+                                        equalTo(JVM_GC_ACTION, "end of major GC"),
+                                        equalTo(
+                                            stringKey("jvm.gc.cause"),
+                                            captureGcCause ? "System.gc()" : null))
+                                    .hasBucketBoundaries(GC_DURATION_BUCKETS))));
   }
 
   private static Notification createTestNotification(

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/MemoryInitTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/MemoryInitTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.mockito.Mockito.when;
 
@@ -59,28 +58,24 @@ class MemoryInitTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.memory.init",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of initial memory requested.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(11)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "heap_pool")
-                                            .hasAttribute(stringKey("jvm.memory.type"), "heap"),
-                                    point ->
-                                        point
-                                            .hasValue(15)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "non_heap_pool")
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.type"), "non_heap")))));
+        metric ->
+            metric
+                .hasName("jvm.memory.init")
+                .hasDescription("Measure of initial memory requested.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(11)
+                                    .hasAttribute(stringKey("jvm.memory.pool.name"), "heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "heap"),
+                            point ->
+                                point
+                                    .hasValue(15)
+                                    .hasAttribute(
+                                        stringKey("jvm.memory.pool.name"), "non_heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "non_heap"))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/MemoryPoolsTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/MemoryPoolsTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
@@ -81,105 +80,89 @@ class MemoryPoolsTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.memory.used",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of memory used.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(11)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "heap_pool")
-                                            .hasAttribute(stringKey("jvm.memory.type"), "heap"),
-                                    point ->
-                                        point
-                                            .hasValue(15)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "non_heap_pool")
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.type"), "non_heap")))));
+        metric ->
+            metric
+                .hasName("jvm.memory.used")
+                .hasDescription("Measure of memory used.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(11)
+                                    .hasAttribute(stringKey("jvm.memory.pool.name"), "heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "heap"),
+                            point ->
+                                point
+                                    .hasValue(15)
+                                    .hasAttribute(
+                                        stringKey("jvm.memory.pool.name"), "non_heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "non_heap"))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.memory.committed",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of memory committed.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(12)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "heap_pool")
-                                            .hasAttribute(stringKey("jvm.memory.type"), "heap"),
-                                    point ->
-                                        point
-                                            .hasValue(16)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "non_heap_pool")
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.type"), "non_heap")))));
+        metric ->
+            metric
+                .hasName("jvm.memory.committed")
+                .hasDescription("Measure of memory committed.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(12)
+                                    .hasAttribute(stringKey("jvm.memory.pool.name"), "heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "heap"),
+                            point ->
+                                point
+                                    .hasValue(16)
+                                    .hasAttribute(
+                                        stringKey("jvm.memory.pool.name"), "non_heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "non_heap"))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.memory.limit",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Measure of max obtainable memory.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(13)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "heap_pool")
-                                            .hasAttribute(stringKey("jvm.memory.type"), "heap"),
-                                    point ->
-                                        point
-                                            .hasValue(17)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "non_heap_pool")
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.type"), "non_heap")))));
+        metric ->
+            metric
+                .hasName("jvm.memory.limit")
+                .hasDescription("Measure of max obtainable memory.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(13)
+                                    .hasAttribute(stringKey("jvm.memory.pool.name"), "heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "heap"),
+                            point ->
+                                point
+                                    .hasValue(17)
+                                    .hasAttribute(
+                                        stringKey("jvm.memory.pool.name"), "non_heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "non_heap"))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.memory.used_after_last_gc",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Measure of memory used, as measured after the most recent garbage collection event on this pool.")
-                        .hasUnit("By")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.hasPointsSatisfying(
-                                    point ->
-                                        point
-                                            .hasValue(18)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "heap_pool")
-                                            .hasAttribute(stringKey("jvm.memory.type"), "heap"),
-                                    point ->
-                                        point
-                                            .hasValue(19)
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.pool.name"), "non_heap_pool")
-                                            .hasAttribute(
-                                                stringKey("jvm.memory.type"), "non_heap")))));
+        metric ->
+            metric
+                .hasName("jvm.memory.used_after_last_gc")
+                .hasDescription(
+                    "Measure of memory used, as measured after the most recent garbage collection event on this pool.")
+                .hasUnit("By")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasValue(18)
+                                    .hasAttribute(stringKey("jvm.memory.pool.name"), "heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "heap"),
+                            point ->
+                                point
+                                    .hasValue(19)
+                                    .hasAttribute(
+                                        stringKey("jvm.memory.pool.name"), "non_heap_pool")
+                                    .hasAttribute(stringKey("jvm.memory.type"), "non_heap"))));
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/SystemCpuTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/SystemCpuTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry.internal;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -36,27 +35,23 @@ class SystemCpuTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.system.cpu.load_1m",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Average CPU load of the whole system for the last minute as reported by the JVM.")
-                        .hasUnit("{run_queue_item}")
-                        .hasDoubleGaugeSatisfying(
-                            gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(2.2)))));
+        metric ->
+            metric
+                .hasName("jvm.system.cpu.load_1m")
+                .hasDescription(
+                    "Average CPU load of the whole system for the last minute as reported by the JVM.")
+                .hasUnit("{run_queue_item}")
+                .hasDoubleGaugeSatisfying(
+                    gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(2.2))));
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.system.cpu.utilization",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription(
-                            "Recent CPU utilization for the whole system as reported by the JVM.")
-                        .hasUnit("1")
-                        .hasDoubleGaugeSatisfying(
-                            gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(0.11)))));
+        metric ->
+            metric
+                .hasName("jvm.system.cpu.utilization")
+                .hasDescription(
+                    "Recent CPU utilization for the whole system as reported by the JVM.")
+                .hasUnit("1")
+                .hasDoubleGaugeSatisfying(
+                    gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(0.11))));
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/ThreadsTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/ThreadsTest.java
@@ -53,27 +53,25 @@ class ThreadsTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.thread.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of executing platform threads.")
-                        .hasUnit("{thread}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(2)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, true)),
-                                        point ->
-                                            point
-                                                .hasValue(5)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, false))))));
+        metric ->
+            metric
+                .hasName("jvm.thread.count")
+                .hasDescription("Number of executing platform threads.")
+                .hasUnit("{thread}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(2)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, true)),
+                                point ->
+                                    point
+                                        .hasValue(5)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, false)))));
   }
 
   @Test
@@ -89,29 +87,27 @@ class ThreadsTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.thread.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of executing platform threads.")
-                        .hasUnit("{thread}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, false),
-                                                    equalTo(JVM_THREAD_STATE, "runnable")),
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, true),
-                                                    equalTo(JVM_THREAD_STATE, "waiting"))))));
+        metric ->
+            metric
+                .hasName("jvm.thread.count")
+                .hasDescription("Number of executing platform threads.")
+                .hasUnit("{thread}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, false),
+                                            equalTo(JVM_THREAD_STATE, "runnable")),
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, true),
+                                            equalTo(JVM_THREAD_STATE, "waiting")))));
   }
 
   @Test
@@ -133,29 +129,27 @@ class ThreadsTest {
 
     testing.waitAndAssertMetrics(
         "test",
-        "jvm.thread.count",
-        metrics ->
-            metrics.anySatisfy(
-                metricData ->
-                    assertThat(metricData)
-                        .hasDescription("Number of executing platform threads.")
-                        .hasUnit("{thread}")
-                        .hasLongSumSatisfying(
-                            sum ->
-                                sum.isNotMonotonic()
-                                    .hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, false),
-                                                    equalTo(JVM_THREAD_STATE, "runnable")),
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(JVM_THREAD_DAEMON, true),
-                                                    equalTo(JVM_THREAD_STATE, "waiting"))))));
+        metric ->
+            metric
+                .hasName("jvm.thread.count")
+                .hasDescription("Number of executing platform threads.")
+                .hasUnit("{thread}")
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.isNotMonotonic()
+                            .hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, false),
+                                            equalTo(JVM_THREAD_STATE, "runnable")),
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(JVM_THREAD_DAEMON, true),
+                                            equalTo(JVM_THREAD_STATE, "waiting")))));
   }
 
   @Test


### PR DESCRIPTION
> [!TIP]
> Hide whitespace when reviewing

Mechanical conversion: wherever the body matched

```java
metrics -> metrics.anySatisfy(metric -> assertThat(metric).X)
```

it becomes

```java
metric -> metric.hasName(NAME).X
```
