### PR TITLE
Reduce max automated code review PRs from 10 to 5

### DIFF
--- a/.github/scripts/code-review/build-review-matrix.py
+++ b/.github/scripts/code-review/build-review-matrix.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 SETTINGS_FILE = "settings.gradle.kts"
 # Skip the run entirely if at least this many automated review PRs are already open.
-MAX_OPEN_PRS = 10
+MAX_OPEN_PRS = 5
 # Upper bound on modules the review job will walk through in a single run,
 # even if the file-count threshold is never reached. Keeps one run bounded.
 MODULE_LIMIT_PER_RUN = 50


### PR DESCRIPTION
I'd like to take another spin through the modules. I think the min 10 modified files is working well to reduce PR spam. But reducing the max open PRs from 10 down to 5 should also help.