### PR TITLE
Pair OpenTelemetryAppender install/reset symmetrically in logging appender tests

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.FormattedMessage;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -42,12 +41,6 @@ abstract class AbstractOpenTelemetryAppenderTest {
 
   static void generalBeforeEachSetup() {
     ThreadContext.clearAll();
-  }
-
-  @AfterAll
-  static void cleanupAll() {
-    // This is to make sure that other test classes don't have issues with the logger provider set
-    OpenTelemetryAppender.resetForTest();
   }
 
   protected abstract InstrumentationExtension getTesting();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/Log4j2Test.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -26,8 +26,8 @@ class Log4j2Test extends AbstractLog4j2Test {
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
   }
 
-  @AfterAll
-  static void cleanup() {
+  @AfterEach
+  void cleanup() {
     OpenTelemetryAppender.resetForTest();
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
@@ -10,13 +10,13 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.List;
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,14 +28,11 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
   private static final LibraryInstrumentationExtension testing =
       LibraryInstrumentationExtension.create();
 
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
   @BeforeEach
   void setup() {
     generalBeforeEachSetup();
-  }
-
-  @AfterEach
-  void resetOpenTelemetry() {
-    OpenTelemetryAppender.resetForTest();
   }
 
   @Override
@@ -46,6 +43,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
   @Override
   void executeAfterLogsExecution() {
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
   }
 
   private static boolean isAsyncLogger() {
@@ -63,6 +61,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
         "log message 2"); // Won't be instrumented because cache size is 1 (see log4j2.xml file)
 
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
 
     testing.waitAndAssertLogRecords(
         logRecord ->
@@ -91,6 +90,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     logger.info(message2); // Won't be instrumented because cache size is 1 (see log4j2.xml file)
 
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
 
     testing.waitAndAssertLogRecords(
         logRecord ->
@@ -124,6 +124,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     logger.info(message2); // Won't be instrumented because cache size is 1 (see log4j2.xml file)
 
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
 
     testing.waitAndAssertLogRecords(
         logRecord ->

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -20,6 +21,11 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   void setup() {
     generalBeforeEachSetup();
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+  }
+
+  @AfterEach
+  void cleanup() {
+    OpenTelemetryAppender.resetForTest();
   }
 
   @Override

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogReplayOpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogReplayOpenTelemetryAppenderTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeSta
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.spi.ContextAware;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import java.net.URL;
@@ -23,6 +24,8 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
   @RegisterExtension
   private static final LibraryInstrumentationExtension testing =
       LibraryInstrumentationExtension.create();
+
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   @BeforeEach
   void setup() throws Exception {
@@ -59,6 +62,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
   @Override
   void executeAfterLogsExecution() {
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
   }
 
   @Test
@@ -69,6 +73,7 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     // file)
 
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+    cleanup.deferCleanup(OpenTelemetryAppender::resetForTest);
 
     testing.waitAndAssertLogRecords(
         logRecord ->

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderTest.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,6 +23,11 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   @BeforeEach
   void setup() {
     OpenTelemetryAppender.install(testing.getOpenTelemetry());
+  }
+
+  @AfterEach
+  void cleanup() {
+    OpenTelemetryAppender.resetForTest();
   }
 
   @Override


### PR DESCRIPTION
Pairing them, either
- BeforeEach / AfterEach, or
- during a test, via deferCleanup