### PR TITLE
Improve draft-release-notes classification

### DIFF
--- a/.github/scripts/draft-release-notes/classify.py
+++ b/.github/scripts/draft-release-notes/classify.py
@@ -128,6 +128,17 @@ def iter_bundles() -> list[PrBundle]:
 
 def preclassify(bundle: PrBundle) -> dict | None:
     """Return a decision dict if we can decide without the LLM, else None."""
+    labels = bundle.meta.get("labels") or []
+    if "automated code review" in labels:
+        return {
+            "decision": "omit",
+            "section": None,
+            "surface": "automated code review sweep",
+            "user_visible_effect": "none",
+            "bullet": None,
+            "evidence": "PR labeled 'automated code review'",
+            "source": "preclassify",
+        }
     if not bundle.meta.get("touches_src_main"):
         files = [f["path"] for f in bundle.meta.get("files", [])]
         return {

--- a/.github/scripts/draft-release-notes/rules.md
+++ b/.github/scripts/draft-release-notes/rules.md
@@ -92,6 +92,13 @@ behavior is a bug fix, not an enhancement — diffs that remove an
 over-restrictive condition, add a fallback branch, or invert an `&&`
 usually belong here. Describe the user-visible symptom.
 
+## metadata.yaml is documentation, not evidence
+
+`metadata.yaml` files are static documentation; they don't change
+runtime behavior. Treat any change to `metadata.yaml` as describing
+existing functionality. Don't emit an Enhancements bullet for a config
+property whose only diff evidence is a metadata.yaml entry.
+
 ## When to omit
 
 Omit only when the PR's `src/main` runtime changes are entirely limited
@@ -101,7 +108,8 @@ to one or more of:
 - test-only changes, cross-testing, moving tests out of default packages,
 - CI/build-tooling with no runtime effect,
 - renames of internal (not extension-API) fields, packages, or helpers,
-- new package-private, `internal`-package, or test-only methods.
+- new package-private, `internal`-package, or test-only methods,
+- `metadata.yaml` documentation (see section above).
 
 Trivial omits (renovate bumps, all-test/docs/build paths, post-release
 version bumps) are handled by `classify.py --preclassify-only`.

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -61,9 +61,7 @@ jobs:
           body=$(cat <<EOF
           Automated draft of the \`## Unreleased\` section of \`CHANGELOG.md\`.
 
-          The entire \`## Unreleased\` block was regenerated from per-PR
-          classifications. Review the diff to recover any hand-written
-          content that should be retained.
+          The entire \`## Unreleased\` block was regenerated from per-PR classifications. Review the diff to recover any hand-written content that should be retained.
 
           [Download draft diagnostics]($ARTIFACT_URL)
           EOF


### PR DESCRIPTION
Refinements based on initial run at https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18387

- Skip PRs labeled 'automated code review' in preclassify
- Treat metadata.yaml changes as documentation only
- Workflow tweaks