### PR TITLE
Pin japicmp baseline in version.gradle.kts (atomic with apidiff snapshots)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,8 @@ jobs:
           PRIOR_VERSION: ${{ needs.release.outputs.prior-version }}
         run: |
           ./gradlew japicmp -PapiBaseVersion=$PRIOR_VERSION -PapiNewVersion=$VERSION
+          # Pin the apidiff baseline to the just-released version.
+          sed -i "s/^val apidiffBaselineVersion = .*/val apidiffBaselineVersion = \"$VERSION\"/" version.gradle.kts
           ./gradlew --refresh-dependencies japicmp
 
       - name: Use CLA approved bot
@@ -274,6 +276,7 @@ jobs:
           git checkout -b $branch
           git add CHANGELOG.md
           git add docs/apidiffs
+          git add version.gradle.kts
           git commit -m "$message"
           git push --set-upstream origin $branch
           gh pr create --title "$message" \

--- a/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -11,20 +11,12 @@ plugins {
 }
 
 /**
- * The latest *released* version of the project. Evaluated lazily so the work is only done if necessary.
+ * The baseline version japicmp compares against. Pinned in version.gradle.kts and bumped
+ * atomically with docs/apidiffs/current_vs_latest/ by the post-release PR opened from
+ * .github/workflows/release.yml.
  */
-val latestReleasedVersion: String by lazy {
-  // hack to find the current released version of the project
-  val temp: Configuration = configurations.create("tempConfig")
-  temp.resolutionStrategy.cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
-  // pick the bom, since we don't use dependency substitution on it.
-  dependencies.add(temp.name, "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:latest.release")
-  val moduleVersion = configurations["tempConfig"].resolvedConfiguration.firstLevelModuleDependencies.elementAt(0).moduleVersion
-
-  configurations.remove(temp)
-  logger.info("Discovered latest release version: $moduleVersion")
-  moduleVersion
-}
+val apidiffBaselineVersion: String =
+  rootProject.extra["apidiffBaselineVersion"] as String
 
 /**
  * Locate the project's artifact of a particular version.
@@ -68,7 +60,7 @@ if (project.findProperty("otel.stable") == "true" && project.path != ":javaagent
 
           // the japicmp "old" version is either the user-specified one, or the latest release.
           val apiBaseVersion: String? by project
-          val baselineVersion = apiBaseVersion ?: latestReleasedVersion
+          val baselineVersion = apiBaseVersion ?: apidiffBaselineVersion
           oldClasspath.from(
             try {
               files(findArtifact(baselineVersion))

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,10 +1,13 @@
 val stableVersion = "2.28.0-SNAPSHOT"
 val alphaVersion = "2.28.0-alpha-SNAPSHOT"
 
+val apidiffBaselineVersion = "2.27.0"
+
 allprojects {
   if (findProperty("otel.stable") != "true") {
     version = alphaVersion
   } else {
     version = stableVersion
   }
+  extra["apidiffBaselineVersion"] = apidiffBaselineVersion
 }


### PR DESCRIPTION
Replace the dynamic `latest.release` lookup in `otel.japicmp-conventions.gradle.kts` with a pinned property declared in `version.gradle.kts`. The post-release workflow now bumps that property in the same PR that regenerates `docs/apidiffs/current_vs_latest/*.txt`, so the baseline and the snapshot files always move together.

Without this change, the moment a release is published to Maven Central every PR against main starts failing the apidiff check until the post-release PR lands: the live `latest.release` resolution flips to the new version, but the apidiff snapshots committed to the repo are still against the previous one.

This also helps with #18298.