### PR TITLE
Fix npe in context bridging

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
@@ -137,7 +137,7 @@ public class AgentContextStorage
 
   public static application.io.opentelemetry.context.Context toApplicationContext(
       Context agentContext) {
-    return new AgentContextWrapper(agentContext);
+    return AgentContextWrapper.getApplicationContext(agentContext);
   }
 
   public static application.io.opentelemetry.context.Context newContextWrapper(

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextWrapper.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextWrapper.java
@@ -46,10 +46,6 @@ final class AgentContextWrapper implements application.io.opentelemetry.context.
   final Context agentContext;
   final application.io.opentelemetry.context.Context applicationContext;
 
-  AgentContextWrapper(Context agentContext) {
-    this(agentContext, agentContext.get(AgentContextStorage.APPLICATION_CONTEXT));
-  }
-
   AgentContextWrapper(
       Context agentContext, application.io.opentelemetry.context.Context applicationContext) {
     if (applicationContext instanceof AgentContextWrapper) {
@@ -59,15 +55,31 @@ final class AgentContextWrapper implements application.io.opentelemetry.context.
     this.applicationContext = applicationContext;
   }
 
+  public static application.io.opentelemetry.context.Context getApplicationContext(
+      Context agentContext) {
+    application.io.opentelemetry.context.Context rootApplicationContext =
+        application.io.opentelemetry.context.Context.root();
+    if (agentContext == Context.root()) {
+      return rootApplicationContext;
+    }
+
+    application.io.opentelemetry.context.Context applicationContext =
+        agentContext.get(AgentContextStorage.APPLICATION_CONTEXT);
+    // application context can be null when the agent context is converted to application context
+    // from instrumented code e.g. instrumentation uses
+    // AgentContextStorage.toApplicationContext(agentContext) to get application context but agent
+    // context isn't really associated with application context
+    if (applicationContext == null) {
+      applicationContext = ((AgentContextWrapper) rootApplicationContext).applicationContext;
+    }
+    return new AgentContextWrapper(agentContext, applicationContext);
+  }
+
   Context toAgentContext() {
     if (agentContext.get(AgentContextStorage.APPLICATION_CONTEXT) == applicationContext) {
       return agentContext;
     }
     return agentContext.with(AgentContextStorage.APPLICATION_CONTEXT, applicationContext);
-  }
-
-  public Context getAgentContext() {
-    return agentContext;
   }
 
   @Override

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/extensionkotlin/v1_0/ContextExtensionInstrumentationTest.kt
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/extensionkotlin/v1_0/ContextExtensionInstrumentationTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -27,5 +28,13 @@ class ContextExtensionInstrumentationTest {
     // instrumentation does not preserve context identity due to conversion between application and
     // agent context
     assertThat(context1).isNotSameAs(context2)
+  }
+
+  @Test
+  fun `no context`() {
+    runBlocking {
+      assertThat(coroutineContext.getOpenTelemetryContext()).isEqualTo(Context.root())
+      assertThat(coroutineContext.getOpenTelemetryContext().get(animalKey)).isNull()
+    }
   }
 }


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16342

Ran into this while debugging a kotlin issue where the problematic call originated from https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/7e2f42a6b5f5d36afc30cb57bd9bd0cf47aaa646/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionkotlin/v1_0/ContextExtensionInstrumentation.java#L116-L117
How exactly it happens in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16342 is still a mystery.
