### PR TITLE
Remove nonexistent nats test suite from collection

### DIFF
--- a/.github/scripts/instrumentations.sh
+++ b/.github/scripts/instrumentations.sh
@@ -192,7 +192,6 @@ readonly INSTRUMENTATIONS=(
   "mongo:mongo-async-3.3:javaagent:testStableSemconv"
   "mybatis-3.2:javaagent:test"
   "nats:nats-2.17:javaagent:test"
-  "nats:nats-2.17:javaagent:testExperimental"
   "netty:netty-3.8:javaagent:test"
   "netty:netty-4.0:javaagent:test"
   "netty:netty-4.1:javaagent:test"


### PR DESCRIPTION
This suite was removed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18433