### PR TITLE
Fix ktor empty interceptor workaround

### DIFF
--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -105,15 +105,11 @@ object KtorServerTelemetryUtil {
   private class EmptyInterceptor(val dispatcher: CoroutineDispatcher) : ContinuationInterceptor {
     override val key: CoroutineContext.Key<*> = ContinuationInterceptor
 
-    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
-      val c = dispatcher.interceptContinuation(continuation)
+override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
+  dispatcher.interceptContinuation(continuation)
 
-      return object : Continuation<T> {
-        override val context = c.context
-        override fun resumeWith(result: Result<T>) {
-          c.resumeWith(result)
-        }
-      }
-    }
+override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
+  dispatcher.releaseInterceptedContinuation(continuation)
+}
   }
 }

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -105,11 +105,10 @@ object KtorServerTelemetryUtil {
   private class EmptyInterceptor(val dispatcher: CoroutineDispatcher) : ContinuationInterceptor {
     override val key: CoroutineContext.Key<*> = ContinuationInterceptor
 
-override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
-  dispatcher.interceptContinuation(continuation)
+    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = dispatcher.interceptContinuation(continuation)
 
-override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
-  dispatcher.releaseInterceptedContinuation(continuation)
-}
+    override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
+      dispatcher.releaseInterceptedContinuation(continuation)
+    }
   }
 }

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorServerTelemetryUtil.kt
@@ -17,34 +17,18 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil
 import io.opentelemetry.instrumentation.ktor.common.v2_0.AbstractKtorServerTelemetryBuilder
 import io.opentelemetry.instrumentation.ktor.common.v2_0.ApplicationRequestGetter
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 object KtorServerTelemetryUtil {
-  // A no-op ContinuationInterceptor. There seems to be a bug in Ktor where when propagate otel
-  // context by using withContext(context.asContextElement()) updateThreadContext, that activates
-  // the otel scope, gets called in
-  // https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/kotlin/src/main/java/io/opentelemetry/extension/kotlin/KotlinContextElement.java
-  // but the restoreThreadContext is not always called, which causes the otel context to leak across
-  // requests. This issue can be worked around by adding -Dio.ktor.internal.disable.sfg=true to jvm
-  // arguments. Adding this no-op interceptor seems to also work around the issue.
-  // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
-  private val emptyInterceptor = object : ContinuationInterceptor {
-    override val key = ContinuationInterceptor
-
-    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = object : Continuation<T> {
-      override val context = continuation.context
-
-      override fun resumeWith(result: Result<T>) {
-        continuation.resumeWith(result)
-      }
-    }
-  }
 
   fun configureTelemetry(builder: AbstractKtorServerTelemetryBuilder, application: Application) {
     val contextKey = AttributeKey<Context>("OpenTelemetry")
@@ -61,10 +45,10 @@ object KtorServerTelemetryUtil {
 
       if (context != null) {
         call.attributes.put(contextKey, context)
-        withContext(emptyInterceptor) {
-          withContext(context.asContextElement()) {
-            proceed()
-          }
+        val dispatcher = coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+        val extra = if (dispatcher != null) EmptyInterceptor(dispatcher) else EmptyCoroutineContext
+        withContext(context.asContextElement() + extra) {
+          proceed()
         }
       } else {
         proceed()
@@ -109,4 +93,27 @@ object KtorServerTelemetryUtil {
     ApplicationRequestGetter,
     builder.spanKindExtractor(SpanKindExtractor.alwaysServer())
   )
+
+  // A no-op ContinuationInterceptor. There seems to be a bug in Ktor where when propagate otel
+  // context by using withContext(context.asContextElement()) updateThreadContext, that activates
+  // the otel scope, gets called in
+  // https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/kotlin/src/main/java/io/opentelemetry/extension/kotlin/KotlinContextElement.java
+  // but the restoreThreadContext is not always called, which causes the otel context to leak across
+  // requests. This issue can be worked around by adding -Dio.ktor.internal.disable.sfg=true to jvm
+  // arguments. Adding this no-op interceptor seems to also work around the issue.
+  // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16430
+  private class EmptyInterceptor(val dispatcher: CoroutineDispatcher) : ContinuationInterceptor {
+    override val key: CoroutineContext.Key<*> = ContinuationInterceptor
+
+    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
+      val c = dispatcher.interceptContinuation(continuation)
+
+      return object : Continuation<T> {
+        override val context = c.context
+        override fun resumeWith(result: Result<T>) {
+          c.resumeWith(result)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18373
Apparently current version of the empty interceptor causes the `updateThreadContext`/`restoreThreadContext` to be skipped sometimes. With the updated interceptor the test that was added along with the interceptor still passes.