### PR TITLE
PR dashboard: fix missing workflow failure tracking issues section

### DIFF
--- a/.github/scripts/pull-request-dashboard.py
+++ b/.github/scripts/pull-request-dashboard.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -98,14 +99,16 @@ Where:
 # ---------------------------------------------------------------- gh helpers
 
 
-def gh_api(path: str, paginate: bool = False) -> Any:
+def gh_api(path: str, paginate: bool = False, token: str | None = None) -> Any:
     cmd = ["gh", "api", "-H", "Accept: application/vnd.github+json"]
     if paginate:
         cmd += ["--paginate", "--slurp"]
     cmd.append(path)
+    env = {**os.environ, "GH_TOKEN": token} if token else None
     proc = subprocess.run(
         cmd, capture_output=True, text=True, check=False,
         encoding="utf-8", errors="replace",
+        env=env,
     )
     if proc.returncode != 0:
         raise RuntimeError(f"gh api {path} failed: {proc.stderr.strip()}")
@@ -219,14 +222,22 @@ def detect_repo() -> str:
 
 
 def load_reviewer_set(org: str) -> set[str]:
+    # Reading org team membership requires a token with org:read scope.
+    # The default Actions GITHUB_TOKEN can't do this, so use OTELBOT_TOKEN
+    # (a GitHub App installation token) when present; fall back to the
+    # default GH_TOKEN otherwise (useful for local runs with a user token).
+    token = os.environ.get("OTELBOT_TOKEN") or None
     reviewers: set[str] = set()
     for slug in APPROVER_TEAM_SLUGS:
-        members = gh_api(f"/orgs/{org}/teams/{slug}/members?per_page=100", paginate=True)
+        members = gh_api(
+            f"/orgs/{org}/teams/{slug}/members?per_page=100",
+            paginate=True, token=token,
+        )
         reviewers.update(m["login"] for m in members)
     if not reviewers:
         raise RuntimeError(
             f"no reviewers found in teams {APPROVER_TEAM_SLUGS}; "
-            f"the GH_TOKEN must have org:read permission"
+            f"the token must have org:read permission"
         )
     return {r.lower() for r in reviewers}
 

--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -32,10 +32,9 @@ jobs:
 
       - name: Generate dashboard
         env:
-          # Use the otelbot app token so the script can read approver/maintainer
-          # team membership via /orgs/.../teams/.../members (the default
-          # GITHUB_TOKEN cannot read org team membership).
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # needed for reading approver team membership (org:read)
+          OTELBOT_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: |
           python3 .github/scripts/pull-request-dashboard.py \


### PR DESCRIPTION
The auto-generated dashboard was silently dropping the workflow failure tracking issues section because `gh issue list --search` returns empty results when run under the otelbot GitHub App installation token used by the workflow.
