### PR TITLE
Pin copilot version

### DIFF
--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot
+        run: npm install -g @github/copilot@1.0.40
 
       - name: Generate dashboard
         env:


### PR DESCRIPTION
There's other usages of copilot in `draft-release-notes.yml` and `code-review-sweep.yml`, but they use `curl -fsSL https://gh.io/copilot-install | bash` install path which is harder to pin.