### PR TITLE
Reduce flakiness in LettuceSyncClientAuthTest.testAuthCommand()

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/testing/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/testing/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   // 6.0+ added protocolVersion access which allows forcing RESP2 for consistency in tests
   compileOnly("io.lettuce:lettuce-core:6.0.0.RELEASE")
 
-  implementation("org.testcontainers:testcontainers")
+  api("org.testcontainers:testcontainers")
   implementation("com.google.guava:guava")
 
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -35,8 +35,6 @@ import io.lettuce.core.codec.StringCodec;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -63,20 +61,9 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
   private static RedisAsyncCommands<String, String> asyncCommands;
 
   @BeforeAll
-  void setUp() throws UnknownHostException {
-    redisServer.start();
-    cleanup.deferAfterAll(redisServer::stop);
-    host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
-    port = redisServer.getMappedPort(6379);
-    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
-
+  void setUp() {
     incorrectPort = PortUtils.findOpenPort();
     dbUriNonExistent = "redis://" + host + ":" + incorrectPort + "/" + DB_INDEX;
-
-    redisClient = createClient(embeddedDbUri);
-    cleanup.deferAfterAll(redisClient::shutdown);
-    redisClient.setOptions(LettuceTestUtil.CLIENT_OPTIONS);
 
     connection = redisClient.connect();
     cleanup.deferAfterAll(connection);

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
@@ -32,11 +32,7 @@ public abstract class AbstractLettuceClientTest {
 
   protected static final int DB_INDEX = 0;
 
-  protected static GenericContainer<?> redisServer =
-      new GenericContainer<>("redis:6.2.3-alpine")
-          .withExposedPorts(6379)
-          .withLogConsumer(new Slf4jLogConsumer(logger))
-          .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
+  protected static GenericContainer<?> redisServer = newRedisServer();
 
   protected static RedisClient redisClient;
   protected static StatefulRedisConnection<String, String> connection;
@@ -49,12 +45,15 @@ public abstract class AbstractLettuceClientTest {
 
   protected abstract InstrumentationExtension testing();
 
+  protected static GenericContainer<?> newRedisServer() {
+    return new GenericContainer<>("redis:6.2.3-alpine")
+        .withExposedPorts(6379)
+        .withLogConsumer(new Slf4jLogConsumer(logger))
+        .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
+  }
+
   protected ContainerConnection newContainerConnection() {
-    GenericContainer<?> server =
-        new GenericContainer<>("redis:6.2.3-alpine")
-            .withExposedPorts(6379)
-            .withLogConsumer(new Slf4jLogConsumer(logger))
-            .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
+    GenericContainer<?> server = newRedisServer();
     server.start();
     cleanup.deferCleanup(server::stop);
 

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
@@ -15,7 +15,10 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -32,7 +35,7 @@ public abstract class AbstractLettuceClientTest {
 
   protected static final int DB_INDEX = 0;
 
-  protected static GenericContainer<?> redisServer = newRedisServer();
+  protected static GenericContainer<?> redisServer;
 
   protected static RedisClient redisClient;
   protected static StatefulRedisConnection<String, String> connection;
@@ -44,6 +47,26 @@ public abstract class AbstractLettuceClientTest {
   protected abstract RedisClient createClient(String uri);
 
   protected abstract InstrumentationExtension testing();
+
+  @BeforeAll
+  void setUpRedis() throws UnknownHostException {
+    redisServer = createRedisServer();
+    redisServer.start();
+    cleanup.deferAfterAll(redisServer::stop);
+
+    host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
+    port = redisServer.getMappedPort(6379);
+    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
+
+    redisClient = createClient(embeddedDbUri);
+    cleanup.deferAfterAll(redisClient::shutdown);
+    redisClient.setOptions(LettuceTestUtil.CLIENT_OPTIONS);
+  }
+
+  protected GenericContainer<?> createRedisServer() {
+    return newRedisServer();
+  }
 
   protected static GenericContainer<?> newRedisServer() {
     return new GenericContainer<>("redis:6.2.3-alpine")

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
@@ -25,8 +25,6 @@ import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.trace.SpanKind;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
@@ -38,18 +36,7 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
   protected static RedisReactiveCommands<String, String> reactiveCommands;
 
   @BeforeAll
-  void setUp() throws UnknownHostException {
-    redisServer.start();
-    cleanup.deferAfterAll(redisServer::stop);
-
-    host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
-    port = redisServer.getMappedPort(6379);
-    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
-    redisClient = createClient(embeddedDbUri);
-    cleanup.deferAfterAll(redisClient::shutdown);
-    redisClient.setOptions(LettuceTestUtil.CLIENT_OPTIONS);
-
+  void setUp() {
     connection = redisClient.connect();
     cleanup.deferAfterAll(connection);
     reactiveCommands = connection.reactive();

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
@@ -38,11 +38,10 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
 
   @BeforeAll
   void setUp() throws UnknownHostException {
-    redisServer = redisServer.withCommand("redis-server", "--requirepass password");
+    redisServer = newRedisServer().withCommand("redis-server", "--requirepass", "password");
     redisServer.start();
     // Set back so other tests don't fail due to NOAUTH error.
-    cleanup.deferAfterAll(
-        () -> redisServer = redisServer.withCommand("redis-server", "--requirepass \"\""));
+    cleanup.deferAfterAll(() -> redisServer = newRedisServer());
     cleanup.deferAfterAll(redisServer::stop);
 
     host = redisServer.getHost();

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
@@ -28,30 +28,15 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.trace.SpanKind;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceClientTest {
 
-  @BeforeAll
-  void setUp() throws UnknownHostException {
-    redisServer = newRedisServer().withCommand("redis-server", "--requirepass", "password");
-    redisServer.start();
-    // Set back so other tests don't fail due to NOAUTH error.
-    cleanup.deferAfterAll(() -> redisServer = newRedisServer());
-    cleanup.deferAfterAll(redisServer::stop);
-
-    host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
-    port = redisServer.getMappedPort(6379);
-    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
-
-    redisClient = createClient(embeddedDbUri);
-    cleanup.deferAfterAll(redisClient::shutdown);
-    redisClient.setOptions(LettuceTestUtil.CLIENT_OPTIONS);
+  @Override
+  protected GenericContainer<?> createRedisServer() {
+    return newRedisServer().withCommand("redis-server", "--requirepass", "password");
   }
 
   @Test

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -41,8 +41,6 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -64,21 +62,9 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
   private static RedisCommands<String, String> syncCommands;
 
   @BeforeAll
-  void setUp() throws UnknownHostException {
-    redisServer.start();
-    cleanup.deferAfterAll(redisServer::stop);
-
-    host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
-    port = redisServer.getMappedPort(6379);
-    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
-
+  void setUp() {
     int incorrectPort = PortUtils.findOpenPort();
     dbUriNonExistent = "redis://" + host + ":" + incorrectPort + "/" + DB_INDEX;
-
-    redisClient = createClient(embeddedDbUri);
-    cleanup.deferAfterAll(redisClient::shutdown);
-    redisClient.setOptions(LettuceTestUtil.CLIENT_OPTIONS);
 
     connection = redisClient.connect();
     cleanup.deferAfterAll(connection);


### PR DESCRIPTION
Automated attempt at fixing flakiness in `io.opentelemetry.javaagent.instrumentation.lettuce.v5_1.LettuceSyncClientAuthTest.testAuthCommand()`.

- Source: [`instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.java`](instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.java)
- Flaky executions in last 7d (this test): **200**
- Flaky executions in last 7d (test container): **200**
- Primary failed scan: https://develocity.opentelemetry.io/s/45f772z365f7i

### Recent failed/flaky scans

- [45f772z365f7i](https://develocity.opentelemetry.io/s/45f772z365f7i) (flaky, `:instrumentation:lettuce:lettuce-5.1:javaagent:test`)
- [ixxu3l6mnfw4m](https://develocity.opentelemetry.io/s/ixxu3l6mnfw4m) (flaky, `:instrumentation:lettuce:lettuce-5.1:javaagent:test`)
- [hlknni5wuin5u](https://develocity.opentelemetry.io/s/hlknni5wuin5u) (flaky, `:instrumentation:lettuce:lettuce-5.1:javaagent:test`)
- [svctl4rcxgxoi](https://develocity.opentelemetry.io/s/svctl4rcxgxoi) (flaky, `:instrumentation:lettuce:lettuce-5.1:javaagent:test`)
- [jkxrp4ylohito](https://develocity.opentelemetry.io/s/jkxrp4ylohito) (flaky, `:instrumentation:lettuce:lettuce-5.1:javaagent:test`)

### Flake history (per UTC day)

| Day | flaky | failed | passed |
| --- | ---: | ---: | ---: |
| 2026-05-01 | 106 | 0 | 0 |

### Sample failure (from Develocity)

```
io.lettuce.core.RedisCommandExecutionException: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
> io.lettuce.core.RedisCommandExecutionException: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
```

## Copilot diagnosis

## Root cause

`testAuthCommand()` expects to authenticate against a Redis server that was started with a password. The sample failures show Redis rejecting `AUTH <password>` because the default user had no password configured, which means the test sometimes talked to a Redis process that was not started with the auth configuration the test requires.

## Fix

`AbstractLettuceClientTest` now owns the shared Redis server and `RedisClient` lifecycle. Its `@BeforeAll` setup creates the Redis container, starts it, records the connection metadata, creates the Lettuce client, and registers cleanup.

The Redis container is created through a `createRedisServer()` template method. Default Lettuce tests use the standard Redis container, while `AbstractLettuceSyncClientAuthTest` overrides that method to return a Redis container configured with `--requirepass password` before the container starts.

## Why this addresses the root cause

The auth test's password requirement is now part of Redis container construction, and Redis startup is centralized in the superclass. As a result, `testAuthCommand()` always runs against a Redis server that was started with the expected password configuration, while the non-auth Lettuce tests continue to use the default Redis server configuration.

## Verification

- `./gradlew :instrumentation:lettuce:lettuce-5.1:javaagent:test --tests io.opentelemetry.javaagent.instrumentation.lettuce.v5_1.LettuceSyncClientAuthTest`
- `./gradlew :instrumentation:lettuce:lettuce-5.1:javaagent:test --tests io.opentelemetry.javaagent.instrumentation.lettuce.v5_1.LettuceSyncClientTest`

## Risks / follow-ups

- Maintainers should validate the full Lettuce 5.1 javaagent test task in CI.

---

Review the diagnosis and the diff carefully before merging - automated fixes can mask flakiness instead of addressing the root cause.