### PR TITLE
Reduce flakiness in io.opentelemetry.instrumentation.jmx.rules.WildflyTest.testWildflyMetrics(String)[1]

### DIFF
--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
@@ -279,6 +279,10 @@ class TargetSystemTest {
             });
   }
 
+  protected void resetMetrics() {
+    otlpServer.reset();
+  }
+
   /** Minimal OTLP gRPC backend to capture metrics */
   private static class OtlpGrpcServer extends ServerExtension {
 

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java
@@ -65,14 +65,15 @@ class WildflyTest extends TargetSystemTest {
     verifyMetrics(createMetricsVerifier());
   }
 
-  private static void exerciseTestApp(GenericContainer<?> target, String dockerImage) throws IOException {
+  private static void exerciseTestApp(GenericContainer<?> target, String dockerImage)
+      throws IOException {
     URL url =
         URI.create(
-            "http://"
-                + target.getHost()
-                + ":"
-                + target.getMappedPort(WILDFLY_SERVICE_PORT)
-                + testAppPath(dockerImage))
+                "http://"
+                    + target.getHost()
+                    + ":"
+                    + target.getMappedPort(WILDFLY_SERVICE_PORT)
+                    + testAppPath(dockerImage))
             .toURL();
 
     await()

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java
@@ -9,9 +9,15 @@ import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAtt
 import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAttributes.attributeGroup;
 import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAttributes.attributeWithAnyValue;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.opentelemetry.instrumentation.jmx.rules.assertions.AttributeMatcher;
 import io.opentelemetry.instrumentation.jmx.rules.assertions.AttributeMatcherGroup;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +38,7 @@ class WildflyTest extends TargetSystemTest {
         // recent/latest to be maintained as newer versions are released
         "quay.io/wildfly/wildfly:36.0.1.Final-jdk21"
       })
-  void testWildflyMetrics(String dockerImage) {
+  void testWildflyMetrics(String dockerImage) throws IOException {
     List<String> yamlFiles = singletonList("wildfly.yaml");
 
     yamlFiles.forEach(this::validateYamlSyntax);
@@ -53,8 +59,42 @@ class WildflyTest extends TargetSystemTest {
     copyTestWebAppToTarget(target, "/opt/jboss/wildfly/standalone/deployments/testapp.war");
 
     startTarget(target);
+    exerciseTestApp(target, dockerImage);
+    resetMetrics();
 
     verifyMetrics(createMetricsVerifier());
+  }
+
+  private static void exerciseTestApp(GenericContainer<?> target, String dockerImage) throws IOException {
+    URL url =
+        URI.create(
+            "http://"
+                + target.getHost()
+                + ":"
+                + target.getMappedPort(WILDFLY_SERVICE_PORT)
+                + testAppPath(dockerImage))
+            .toURL();
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreException(IOException.class)
+        .untilAsserted(() -> assertThat(getStatusCode(url)).isEqualTo(200));
+  }
+
+  private static int getStatusCode(URL url) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setConnectTimeout(1_000);
+    connection.setReadTimeout(5_000);
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private static String testAppPath(String dockerImage) {
+    return dockerImage.startsWith("jboss/wildfly:") ? "/testapp/javax/" : "/testapp/jakarta/";
   }
 
   private static MetricsVerifier createMetricsVerifier() {


### PR DESCRIPTION
Automated attempt at fixing flakiness in `io.opentelemetry.instrumentation.jmx.rules.WildflyTest.testWildflyMetrics(String)[1]`.

- Source: [`instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java`](instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WildflyTest.java)
- Flaky executions in last 7d (this test): **57**
- Flaky executions in last 7d (test container): **68**
- Primary failed scan: https://develocity.opentelemetry.io/s/y6yh2s5b3je5o

### Recent failed/flaky scans

- [y6yh2s5b3je5o](https://develocity.opentelemetry.io/s/y6yh2s5b3je5o) (flaky, `:instrumentation:jmx-metrics:library:test`)

### Flake history (per UTC day)

| Day | flaky | failed | passed |
| --- | ---: | ---: | ---: |
| 2026-04-25 | 3 | 0 | 426 |
| 2026-04-26 | 5 | 0 | 529 |
| 2026-04-27 | 6 | 0 | 500 |
| 2026-04-28 | 8 | 0 | 689 |
| 2026-04-29 | 15 | 0 | 691 |
| 2026-04-30 | 11 | 0 | 718 |
| 2026-05-01 | 9 | 0 | 411 |

### Sample failure (from Develocity)

```
org.opentest4j.AssertionFailedError: [no data point matched attribute set '[{wildfly.server=default-server}, {wildfly.listener=default}, {network.io.direction=receive}]' for metric 'wildfly.network.io'] 
expected: true
 but was: false
```

## Copilot diagnosis

## Root cause

`WildflyTest` started WildFly and immediately verified all captured OTLP metric exports without ever sending a real HTTP request to the deployed test application. The sample failure consistently showed `wildfly.network.io` missing the `network.io.direction=receive` datapoint for the default listener, which can happen when Undertow listener metrics are scraped before the listener has received request bytes. Because `TargetSystemTest.verifyMetrics()` verifies every export accumulated since test start, an early incomplete export stayed in the queue and could keep the Awaitility assertion failing even if later exports became complete.

## Fix

- Added a small WildFly test warm-up request to the deployed servlet after the container starts, using the `javax` servlet path for the old WildFly image and the `jakarta` path for the newer image.
- Poll the warm-up request with Awaitility until it returns HTTP 200, retrying transient `IOException`s while the deployment finishes.
- Added a protected `resetMetrics()` helper and clear pre-warmup OTLP exports before running the existing metric verifier.

## Why this addresses the root cause

The real servlet request initializes the Undertow listener request and network counters, including both receive and transmit directions, before the assertions inspect exported metrics. Clearing captured exports after the warm-up prevents a pre-request scrape with incomplete network datapoints from being rechecked on every Awaitility poll.

## Risks / follow-ups

- If a WildFly image changes the deployed context path or servlet API support, the warm-up request could expose that as a deterministic HTTP readiness failure.
- Maintainers may want to consider whether `TargetSystemTest.verifyMetrics()` should ignore older failed snapshots once newer exports satisfy assertions, but this change keeps the fix scoped to the flaky WildFly test.

---

Review the diagnosis and the diff carefully before merging - automated fixes can mask flakiness instead of addressing the root cause.
