### PR TITLE
Reduce JMX metric test flakiness

### DIFF
--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
@@ -262,20 +262,24 @@ class TargetSystemTest {
               List<ExportMetricsServiceRequest> receivedMetrics = otlpServer.getMetrics();
               assertThat(receivedMetrics).isNotEmpty();
 
-              List<Metric> metrics =
-                  receivedMetrics.stream()
-                      .map(ExportMetricsServiceRequest::getResourceMetricsList)
-                      .flatMap(rm -> rm.stream().map(ResourceMetrics::getScopeMetricsList))
-                      .flatMap(Collection::stream)
-                      .filter(
-                          // TODO: disabling batch span exporter might help remove unwanted metrics
-                          sm -> sm.getScope().getName().equals("io.opentelemetry.jmx"))
-                      .flatMap(sm -> sm.getMetricsList().stream())
-                      .collect(toList());
+              assertThat(receivedMetrics)
+                  .anySatisfy(
+                      request -> {
+                        List<Metric> metrics =
+                            request.getResourceMetricsList().stream()
+                                .map(ResourceMetrics::getScopeMetricsList)
+                                .flatMap(Collection::stream)
+                                .filter(
+                                    // TODO: disabling batch span exporter might help remove
+                                    // unwanted metrics
+                                    sm -> sm.getScope().getName().equals("io.opentelemetry.jmx"))
+                                .flatMap(sm -> sm.getMetricsList().stream())
+                                .collect(toList());
 
-              assertThat(metrics).isNotEmpty();
+                        assertThat(metrics).isNotEmpty();
 
-              metricsVerifier.verify(metrics);
+                        metricsVerifier.verify(metrics);
+                      });
             });
   }
 


### PR DESCRIPTION
Alternative to

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18491
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18502
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18512

This is a proposed fix for flaky JMX metric target-system tests.

`TargetSystemTest.verifyMetrics()` currently verifies all OTLP metric exports received since test start together. As a result, an incomplete startup export can keep failing the Awaitility assertion even after a later export contains the expected metrics.

This changes the verifier to pass when any received JMX metric export satisfies the existing strict assertions. That better matches the usual metric assertion pattern elsewhere in the repository: wait until the expected metric data is observed, without requiring every intermediate startup export to already have the final steady-state shape.