### PR TITLE
Switch off of deprecated elasticsearch-oss image

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -64,7 +64,7 @@ class ElasticsearchRest5Test {
               .withEnv("xpack.security.enabled", "false");
     } else {
       elasticsearch =
-          new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.16");
+          new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.8.16");
     }
     // limit memory usage
     elasticsearch.withEnv(

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -56,7 +56,8 @@ class ElasticsearchRest6Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.8.16");
+    elasticsearch =
+        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.8.16");
     // limit memory usage
     elasticsearch.withEnv(
         "ES_JAVA_OPTS",

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -56,8 +56,7 @@ class ElasticsearchRest6Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch =
-        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.16");
+    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.8.16");
     // limit memory usage
     elasticsearch.withEnv(
         "ES_JAVA_OPTS",

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -57,7 +57,8 @@ class ElasticsearchRest7Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
+    elasticsearch =
+        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
     cleanup.deferAfterAll(elasticsearch::stop);
     // limit memory usage
     elasticsearch.withEnv(

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -57,8 +57,7 @@ class ElasticsearchRest7Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch =
-        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2");
+    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
     cleanup.deferAfterAll(elasticsearch::stop);
     // limit memory usage
     elasticsearch.withEnv(

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -52,8 +52,7 @@ class ElasticsearchRest7Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch =
-        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2");
+    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
     cleanup.deferAfterAll(elasticsearch::stop);
     // limit memory usage
     elasticsearch.withEnv(

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -52,7 +52,8 @@ class ElasticsearchRest7Test {
 
   @BeforeAll
   static void setUp() {
-    elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
+    elasticsearch =
+        new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.10.2");
     cleanup.deferAfterAll(elasticsearch::stop);
     // limit memory usage
     elasticsearch.withEnv(


### PR DESCRIPTION
We're already using the `elasticsearch` image in a couple of places.

Probably won't help, but motivated by lots of download failures in CI for `docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.16` lately.