### PR TITLE
Use Sonatype Guide PAT for OSS Index audit

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -17,9 +17,8 @@ Secrets:
 - `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
 - `GRADLE_PUBLISH_KEY` - owned by [@trask](https://github.com/trask)
 - `GRADLE_PUBLISH_SECRET` - owned by [@trask](https://github.com/trask)
+- `SONATYPE_GUIDE_PAT` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_KEY` - owned by [@trask](https://github.com/trask)
-- `SONATYPE_OSS_INDEX_PASSWORD` - owned by [@trask](https://github.com/trask)
-- `SONATYPE_OSS_INDEX_USER` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_USER` - owned by [@trask](https://github.com/trask)
 
 ## Secrets and variables > Actions

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -32,8 +32,7 @@ jobs:
         id: audit
         continue-on-error: true
         env:
-          SONATYPE_OSS_INDEX_USER: ${{ secrets.SONATYPE_OSS_INDEX_USER }}
-          SONATYPE_OSS_INDEX_PASSWORD: ${{ secrets.SONATYPE_OSS_INDEX_PASSWORD }}
+          SONATYPE_GUIDE_PAT: ${{ secrets.SONATYPE_GUIDE_PAT }}
 
       - name: Print vulnerability report
         if: steps.audit.outcome == 'failure'

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -428,8 +428,9 @@ tasks.withType<Checkstyle> {
 }
 
 ossIndexAudit {
-  username = System.getenv("SONATYPE_OSS_INDEX_USER") ?: ""
-  password = System.getenv("SONATYPE_OSS_INDEX_PASSWORD") ?: ""
+  // Guide PAT authentication ignores this, but the scan plugin requires it.
+  username = "unused"
+  password = System.getenv("SONATYPE_GUIDE_PAT") ?: ""
   outputFormat = org.sonatype.gradle.plugins.scan.ossindex.OutputFormat.JSON_CYCLONE_DX_1_4
 }
 


### PR DESCRIPTION
Updates the OSS Index audit workflow for the Sonatype Guide migration by using a Guide PAT secret and dropping the unused OSS Index user secret.

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18395

I've added the `SONATYPE_GUIDE_PAT` secret and deleted `SONATYPE_OSS_INDEX_USER` / `SONATYPE_OSS_INDEX_PASSWORD` (which weren't working anymore anyways).