### PR TITLE
Update servlet smoke test image version

### DIFF
--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/TestImageVersions.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/TestImageVersions.java
@@ -27,7 +27,7 @@ public class TestImageVersions {
   public static final String ZULU_OPENJDK_8U31_VERSION = "20251117.19421579350";
 
   // smoke-test-servlet-* (all servlet variants)
-  public static final String SERVLET_VERSION = "20260429.25096195273";
+  public static final String SERVLET_VERSION = "20260502.25257829980";
 
   private TestImageVersions() {}
 }


### PR DESCRIPTION
Updates `SERVLET_VERSION` to a freshly published servlet image batch.

The previous batch (`20260429.25096195273`) was incomplete: the Linux/WebSphere images existed, but the Windows Liberty publish job failed, so the Liberty Windows tags were missing.

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18506