### PR TITLE
Rename Sonatype Guide dependency audit workflow

### DIFF
--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -1,6 +1,6 @@
 # the benefit of this over renovate is that this also analyzes transitive dependencies
 # while renovate (at least currently) only analyzes top-level dependencies
-name: OSS Index dependency audit (daily)
+name: Sonatype Guide dependency audit (daily)
 
 on:
   schedule:
@@ -37,7 +37,7 @@ jobs:
       - name: Print vulnerability report
         if: steps.audit.outcome == 'failure'
         run: |
-          echo "=== OSS Index Vulnerability Report ==="
+          echo "=== Sonatype Guide Vulnerability Report ==="
           cat oss-index-cyclonedx-bom.json
           exit 1
 


### PR DESCRIPTION
Renames the daily dependency audit workflow file and displayed workflow name to match Sonatype Guide.

Follow-up to 

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18515