### PR TITLE
Reduce flakiness in CouchbaseClient26Test.upsertAndGet(BucketSettings)

### DIFF
--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTest.java
@@ -27,7 +27,7 @@ class CouchbaseClientTest extends AbstractCouchbaseClientTest {
 
   @Test
   void hasDurationMetric() {
-    CouchbaseCluster cluster = prepareCluster(bucketCouchbase);
+    CouchbaseCluster cluster = getCluster(bucketCouchbase);
     ClusterManager manager = cluster.clusterManager(USERNAME, PASSWORD);
 
     testing.waitForTraces(1);

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java
@@ -34,7 +34,7 @@ class CouchbaseClient26Test extends AbstractCouchbaseClientTest {
 
   @Test
   void hasDurationMetric() {
-    CouchbaseCluster cluster = prepareCluster(bucketCouchbase);
+    CouchbaseCluster cluster = getCluster(bucketCouchbase);
     ClusterManager manager = cluster.clusterManager(USERNAME, PASSWORD);
 
     testing.waitForTraces(1);

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -38,6 +38,7 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,27 +53,43 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
 
   @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
+  private CouchbaseEnvironment environmentCouchbase;
+  private CouchbaseEnvironment environmentMemcache;
+  private CouchbaseCluster clusterCouchbase;
+  private CouchbaseCluster clusterMemcache;
+
   private static Stream<Arguments> bucketSettings() {
     return Stream.of(
         Arguments.of(named(bucketCouchbase.type().name(), bucketCouchbase)),
         Arguments.of(named(bucketMemcache.type().name(), bucketMemcache)));
   }
 
-  protected CouchbaseCluster prepareCluster(BucketSettings bucketSettings) {
-    CouchbaseEnvironment environment = envBuilder(bucketSettings).build();
-    CouchbaseCluster cluster = CouchbaseCluster.create(environment, singletonList("127.0.0.1"));
-    // AutoCleanupExtension runs in LIFO order; clear spans emitted while closing the client.
-    cleanup.deferCleanup(testing::clearData);
-    cleanup.deferCleanup(environment::shutdown);
-    cleanup.deferCleanup(cluster::disconnect);
+  @BeforeAll
+  void setUpClusters() {
+    environmentCouchbase = envBuilder(bucketCouchbase).build();
+    clusterCouchbase = CouchbaseCluster.create(environmentCouchbase, singletonList("127.0.0.1"));
+    cleanup.deferAfterAll(environmentCouchbase::shutdown);
+    cleanup.deferAfterAll(clusterCouchbase::disconnect);
 
-    return cluster;
+    environmentMemcache = envBuilder(bucketMemcache).build();
+    clusterMemcache = CouchbaseCluster.create(environmentMemcache, singletonList("127.0.0.1"));
+    cleanup.deferAfterAll(environmentMemcache::shutdown);
+    cleanup.deferAfterAll(clusterMemcache::disconnect);
+  }
+
+  protected CouchbaseCluster getCluster(BucketSettings bucketSettings) {
+    if (bucketSettings == bucketCouchbase) {
+      return clusterCouchbase;
+    } else if (bucketSettings == bucketMemcache) {
+      return clusterMemcache;
+    }
+    throw new IllegalArgumentException("unknown setting " + bucketSettings.name());
   }
 
   @ParameterizedTest
   @MethodSource("bucketSettings")
   void hasBucket(BucketSettings bucketSettings) {
-    CouchbaseCluster cluster = prepareCluster(bucketSettings);
+    CouchbaseCluster cluster = getCluster(bucketSettings);
     ClusterManager manager = cluster.clusterManager(USERNAME, PASSWORD);
 
     testing.waitForTraces(1);
@@ -101,10 +118,11 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
   @ParameterizedTest
   @MethodSource("bucketSettings")
   void upsertAndGet(BucketSettings bucketSettings) {
-    CouchbaseCluster cluster = prepareCluster(bucketSettings);
+    CouchbaseCluster cluster = getCluster(bucketSettings);
 
     // Connect to the bucket and open it
     Bucket bucket = cluster.openBucket(bucketSettings.name(), bucketSettings.password());
+    cleanup.deferCleanup(bucket::close);
 
     // Create a JSON document and store it with the ID "helloworld"
     JsonObject content = JsonObject.create().put("hello", "world");
@@ -170,8 +188,9 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
   @Test
   void query() {
     // Only couchbase buckets support queries.
-    CouchbaseCluster cluster = prepareCluster(bucketCouchbase);
+    CouchbaseCluster cluster = getCluster(bucketCouchbase);
     Bucket bucket = cluster.openBucket(bucketCouchbase.name(), bucketCouchbase.password());
+    cleanup.deferCleanup(bucket::close);
 
     // Mock expects this specific query.
     // See com.couchbase.mock.http.query.QueryServer.handleString.

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -53,8 +53,6 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
 
   @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  private CouchbaseEnvironment environmentCouchbase;
-  private CouchbaseEnvironment environmentMemcache;
   private CouchbaseCluster clusterCouchbase;
   private CouchbaseCluster clusterMemcache;
 
@@ -66,12 +64,12 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
 
   @BeforeAll
   void setUpClusters() {
-    environmentCouchbase = envBuilder(bucketCouchbase).build();
+    CouchbaseEnvironment environmentCouchbase = envBuilder(bucketCouchbase).build();
     clusterCouchbase = CouchbaseCluster.create(environmentCouchbase, singletonList("127.0.0.1"));
     cleanup.deferAfterAll(environmentCouchbase::shutdown);
     cleanup.deferAfterAll(clusterCouchbase::disconnect);
 
-    environmentMemcache = envBuilder(bucketMemcache).build();
+    CouchbaseEnvironment environmentMemcache = envBuilder(bucketMemcache).build();
     clusterMemcache = CouchbaseCluster.create(environmentMemcache, singletonList("127.0.0.1"));
     cleanup.deferAfterAll(environmentMemcache::shutdown);
     cleanup.deferAfterAll(clusterMemcache::disconnect);

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -61,6 +61,8 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
   protected CouchbaseCluster prepareCluster(BucketSettings bucketSettings) {
     CouchbaseEnvironment environment = envBuilder(bucketSettings).build();
     CouchbaseCluster cluster = CouchbaseCluster.create(environment, singletonList("127.0.0.1"));
+    // AutoCleanupExtension runs in LIFO order; clear spans emitted while closing the client.
+    cleanup.deferCleanup(testing::clearData);
     cleanup.deferCleanup(environment::shutdown);
     cleanup.deferCleanup(cluster::disconnect);
 


### PR DESCRIPTION
Automated attempt at fixing flakiness in `io.opentelemetry.javaagent.instrumentation.couchbase.v2_6.CouchbaseClient26Test.upsertAndGet(BucketSettings)[2]`.

- Source: [`instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java`](instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java)
- Exact test invocation: **19** flaky executions in last 7d
- Primary failed scan: https://develocity.opentelemetry.io/s/4biifabqiahsc

### Recent failed/flaky scans

- [4biifabqiahsc](https://develocity.opentelemetry.io/s/4biifabqiahsc) (`:instrumentation:couchbase:couchbase-2.6:javaagent:testStableSemconv`)
- [nwrghgyjjs2ry](https://develocity.opentelemetry.io/s/nwrghgyjjs2ry) (`:instrumentation:couchbase:couchbase-2.6:javaagent:test`)
- [bqgyiqt3fjdts](https://develocity.opentelemetry.io/s/bqgyiqt3fjdts) (`:instrumentation:couchbase:couchbase-2.6:javaagent:testExperimental`)
- [u63tmkdmqbzca](https://develocity.opentelemetry.io/s/u63tmkdmqbzca) (`:instrumentation:couchbase:couchbase-2.6:javaagent:test`)
- [j7e72ydibaivg](https://develocity.opentelemetry.io/s/j7e72ydibaivg) (`:instrumentation:couchbase:couchbase-2.6:javaagent:testExperimental`)

### Flake history (per UTC day)

| Day | flaky | failed | passed |
| --- | ---: | ---: | ---: |
| 2026-04-26 | 0 | 0 | 25 |
| 2026-04-27 | 2 | 0 | 184 |
| 2026-04-28 | 4 | 0 | 225 |
| 2026-04-29 | 2 | 0 | 236 |
| 2026-04-30 | 6 | 0 | 352 |
| 2026-05-01 | 0 | 0 | 116 |
| 2026-05-02 | 4 | 0 | 271 |
| 2026-05-03 | 1 | 0 | 119 |

### Sample failure (from Develocity)

```
(no failure message captured)
```

## Copilot diagnosis

## Root cause

`CouchbaseClient26Test.upsertAndGet(BucketSettings)[2]` uses the shared synchronous Couchbase client helper, which was creating a new Couchbase environment and cluster for each parameterized invocation. Each invocation also disconnected the cluster and shut down the environment during per-test cleanup. Those setup and teardown operations can produce Couchbase telemetry around the same time the next invocation starts, so trace assertions that expect only the operation under test can intermittently observe extra traces.

## Fix

- Create the Couchbase and memcache environments/clusters once in `AbstractCouchbaseClientTest` during `@BeforeAll`.
- Reuse those clusters through `getCluster(BucketSettings)` instead of creating and disconnecting a cluster in each test invocation.
- Defer cluster disconnect and environment shutdown until after all tests in the class have completed.
- Close buckets opened by individual tests with per-test cleanup.
- Update the Couchbase 2.0 and 2.6 duration metric tests to use the same shared cluster lifecycle.

## Why this addresses the root cause

Keeping the Couchbase clusters alive for the whole test class removes per-invocation disconnect/shutdown telemetry from the boundary between parameterized test cases. The tests still clear telemetry between invocations and still assert the `openBucket`, `upsert`, `get`, `query`, and metric behavior they covered before, but cluster lifecycle telemetry is no longer mixed into each test's operation window.

## Risks / follow-ups

- The shared clusters make these tests depend on per-test cleanup of opened buckets and exported telemetry, so related Couchbase sync tests should continue to be watched for state or telemetry leakage.
- If Couchbase emits delayed telemetry from bucket close operations, additional cleanup or waiting may still be needed.

---

Review the diagnosis and the diff carefully before merging - automated fixes can mask flakiness instead of addressing the root cause.