### PR TITLE
Reduce flakiness in PlayServerTest.successfulGetRequest(int)

### DIFF
--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_4/server/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_4/server/PlayServerTest.java
@@ -47,7 +47,10 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
             .routeTo(
                 () ->
                     controller(
-                        SUCCESS, () -> Results.status(SUCCESS.getStatus(), SUCCESS.getBody())))
+                        SUCCESS,
+                        () ->
+                            closeConnection(
+                                Results.status(SUCCESS.getStatus(), SUCCESS.getBody()))))
             .GET(INDEXED_CHILD.getPath())
             .routeTo(
                 () ->
@@ -101,6 +104,17 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
                         }));
 
     return Server.forRouter(router.build(), port);
+  }
+
+  private static Results.Status closeConnection(Results.Status javaResult) {
+    Tuple2<String, String> header = new Tuple2<>("Connection", "close");
+    return new Results.Status(
+        javaResult
+            .toScala()
+            .withHeaders(
+                JavaConverters.asScalaIteratorConverter(singletonList(header).iterator())
+                    .asScala()
+                    .toSeq()));
   }
 
   @Override


### PR DESCRIPTION
Automated attempt at fixing flakiness in `io.opentelemetry.javaagent.instrumentation.playmvc.v2_4.server.PlayServerTest.successfulGetRequest(int)[3]`.

- Source: [`instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_4/server/PlayServerTest.java`](instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/play24Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_4/server/PlayServerTest.java)
- Exact test invocation: **100** flaky executions in last 7d
- Primary failed scan: https://develocity.opentelemetry.io/s/wnjscsdb3jmwa

### Recent failed/flaky scans

- [wnjscsdb3jmwa](https://develocity.opentelemetry.io/s/wnjscsdb3jmwa) (flaky, `:instrumentation:play:play-mvc:play-mvc-2.4:javaagent:play24Test`)
- [4dvi57eqzn422](https://develocity.opentelemetry.io/s/4dvi57eqzn422) (flaky, `:instrumentation:play:play-mvc:play-mvc-2.4:javaagent:play24Test`)
- [4n2udi4y3txfm](https://develocity.opentelemetry.io/s/4n2udi4y3txfm) (flaky, `:instrumentation:play:play-mvc:play-mvc-2.4:javaagent:play24Test`)
- [ej2n5jwep5vza](https://develocity.opentelemetry.io/s/ej2n5jwep5vza) (flaky, `:instrumentation:play:play-mvc:play-mvc-2.4:javaagent:play24Test`)
- [kjh4aiwqwe5vm](https://develocity.opentelemetry.io/s/kjh4aiwqwe5vm) (flaky, `:instrumentation:play:play-mvc:play-mvc-2.4:javaagent:play24Test`)

### Flake history (per UTC day)

| Day | flaky | failed | passed |
| --- | ---: | ---: | ---: |
| 2026-04-29 | 17 | 0 | 13 |
| 2026-04-30 | 23 | 0 | 33 |
| 2026-05-01 | 18 | 0 | 21 |
| 2026-05-02 | 23 | 0 | 37 |
| 2026-05-03 | 14 | 0 | 23 |
| 2026-05-04 | 5 | 0 | 1 |

### Sample failure (from Develocity)

```
java.lang.AssertionError: Error waiting for 50 traces
> java.util.concurrent.TimeoutException: Timeout waiting for 50 completed trace(s), found 49 completed trace(s) and 50 total trace(s): [[TestSpanData{name=GET, kind=SERVER, spanContext=ImmutableSpanContext{traceId=91489d3b1d0b82fe7a3b0c8e01b07317, spanId=c6b8ae7549d7967b, traceFlags=03, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=true}, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, status=ImmutableStatusData{statusCode=UNSET, description=}, startEpochNanos=1777860687692000000, attributes={client.address="1.1.1.1", http.request.method="GET", http.response.status_code=200, network.peer.address="127.0.0.1", network.peer.port=47130, network.protocol.version="1.1", server.address="localhost", server.port=11101, url.path="/success", url.scheme="http", user_agent.original=…
```

## Copilot diagnosis

## Root cause

The failed scans for `successfulGetRequest(int)[3]` consistently timed out while waiting for 50 completed traces, with 50 trace IDs present but only 49 containing a root span. The Play 2.4 test sends the 50 successful GET requests sequentially over a reusable HTTP/1.1 connection, and this old server stack can defer the final server-side completion/export path until the keep-alive connection is closed or reused again. That leaves the last request's child/controller telemetry visible while the trace is not considered complete by `TelemetryDataUtil.waitForTraces(...)`.

## Fix

- Added a Play 2.4-compatible helper that adds `Connection: close` to the `/success` response.
- Applied that helper only to the `SUCCESS` route used by `successfulGetRequest(int)`, preserving the same request count and trace/span assertions.

## Why this addresses the root cause

Forcing the `/success` response to close the HTTP/1.1 connection makes Play complete the per-request server lifecycle promptly instead of leaving the final keep-alive request dependent on later connection activity. The test still exercises 1, 4, and 50 successful GET requests and still waits for/asserts the same traces; it just removes the stale connection timing race that made one trace remain incomplete.

## Risks / follow-ups

- Maintainers should confirm the extra `Connection: close` response header is acceptable for this Play 2.4-only test path.
- If a future failure still reports incomplete traces, it would point to a deeper Play 2.4 server-span completion issue rather than keep-alive reuse.

---

Review the diagnosis and the diff carefully before merging - automated fixes can mask flakiness instead of addressing the root cause.
