### PR TITLE
Rename grpc server network attribute getter

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcServerNetworkAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcServerNetworkAttributesGetter.java
@@ -12,7 +12,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class GrpcNetworkServerAttributesGetter
+final class GrpcServerNetworkAttributesGetter
     implements ServerAttributesGetter<GrpcRequest>, NetworkAttributesGetter<GrpcRequest, Status> {
 
   @Nullable

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -167,8 +167,8 @@ public final class GrpcTelemetryBuilder {
 
     GrpcClientNetworkAttributesGetter netClientAttributesGetter =
         new GrpcClientNetworkAttributesGetter();
-    GrpcNetworkServerAttributesGetter netServerAttributesGetter =
-        new GrpcNetworkServerAttributesGetter();
+    GrpcServerNetworkAttributesGetter netServerAttributesGetter =
+        new GrpcServerNetworkAttributesGetter();
     GrpcRpcAttributesGetter rpcAttributesGetter = new GrpcRpcAttributesGetter();
 
     clientInstrumenterBuilder


### PR DESCRIPTION
Rename class to align with `GrpcClientNetworkAttributesGetter`