### PR TITLE
Flakiness: fix duplicate Pulsar multi-topic receive spans

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/ConsumerImplInstrumentation.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/ConsumerImplInstrumentation.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry.P
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -34,9 +33,7 @@ class ConsumerImplInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return namedOneOf(
-        "org.apache.pulsar.client.impl.ConsumerImpl",
-        "org.apache.pulsar.client.impl.MultiTopicsConsumerImpl");
+    return named("org.apache.pulsar.client.impl.ConsumerImpl");
   }
 
   @Override


### PR DESCRIPTION
I've been seeing this issue causing tests to fail completely (even on retry) from time to time, e.g. https://scans.gradle.com/s/rg3ci7zt2glcm

## Problem

`PulsarClientTest.testConsumeMultiTopics()` has been flaky in Develocity. In the last seven days, Develocity reported this method as the top flaky method in `PulsarClientTest`, with failures split between:

- extra receive traces, for example `Expected size: 4 but was: 5/6`
- missing message id assertions, for example `[STRING attribute 'messaging.message.id'] expected: \"32:0:-1\" but was: null`

The multi-topic Pulsar client path is a little unusual: `MultiTopicsConsumerImpl` is a wrapper consumer. It starts real per-topic `ConsumerImpl` sub-consumers, receives messages from those sub-consumers with `receiveAsync()`, wraps the received message in `TopicMessageImpl`, and then dispatches the wrapped message to the listener.

Before this change, the javaagent receive instrumentation matched both `ConsumerImpl` and `MultiTopicsConsumerImpl`. That means one logical multi-topic message could be observed at both levels: once when the sub-consumer actually receives the message, and again when the wrapper drains/dispatches the already-received message. This explains the extra receive spans seen in the flaky failures. Those extra receive traces can also make the sorted trace assertions line up against the wrong receive trace, which surfaces as the missing `messaging.message.id` assertion.

## Fix

Only apply `ConsumerImplInstrumentation` to `org.apache.pulsar.client.impl.ConsumerImpl`.

For multi-topic consumers, this keeps instrumentation at the real receive point: the underlying per-topic `ConsumerImpl` sub-consumer. The receive context is still injected into the Pulsar message and recovered by the listener wrapper, so the expected receive/process relationship is preserved without creating a duplicate wrapper-level receive span.
