### PR TITLE
Auto-rerun failed daily workflow jobs

### DIFF
--- a/.github/scripts/rerun-failed-workflow-jobs.py
+++ b/.github/scripts/rerun-failed-workflow-jobs.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Rerun up to two failed jobs for the pull request CI run that triggered this workflow.
-
-Reads the triggering workflow run id from the WORKFLOW_RUN_ID environment variable,
-ignores the synthetic required-status-check job, and reruns eligible failed jobs
-up to two times.
-"""
+"""Rerun failed jobs for the workflow run that triggered this workflow."""
 
 from __future__ import annotations
 
@@ -13,8 +8,9 @@ import os
 import subprocess
 import urllib.parse
 
-MAX_FAILED_JOBS_PER_WORKFLOW_RUN = 5
-MAX_RERUN_ATTEMPTS = 2
+DEFAULT_IGNORED_JOB_SUFFIXES = ("required-status-check",)
+DEFAULT_MAX_FAILED_JOBS_PER_WORKFLOW_RUN = 5
+DEFAULT_MAX_RERUN_ATTEMPTS = 2
 
 
 def main() -> None:
@@ -22,34 +18,41 @@ def main() -> None:
     run_id = os.environ["WORKFLOW_RUN_ID"]
 
     run = gh_get(f"/repos/{owner}/{repo}/actions/runs/{run_id}")
-    pr_number = resolve_pr_number(owner, repo, run)
-    pr_label = f"PR #{pr_number}" if pr_number is not None else "PR unknown"
-    label = f"{pr_label}, run {run['id']}, attempt {run['run_attempt']}"
+    label = build_label(owner, repo, run)
 
     if run["status"] != "completed" or run.get("conclusion") != "failure":
         print(f"Skipped {label}: status={run['status']}, conclusion={run.get('conclusion')}.")
         return
 
+    max_rerun_attempts = int(os.getenv("MAX_RERUN_ATTEMPTS", DEFAULT_MAX_RERUN_ATTEMPTS))
     rerun_attempts = run["run_attempt"] - 1
-    if rerun_attempts >= MAX_RERUN_ATTEMPTS:
+    if rerun_attempts >= max_rerun_attempts:
         print(f"Skipped {label}: already rerun {rerun_attempts} times.")
         return
 
+    ignored_job_suffixes = tuple(
+        suffix.strip()
+        for suffix in os.getenv("IGNORED_JOB_SUFFIXES", ",".join(DEFAULT_IGNORED_JOB_SUFFIXES)).split(",")
+        if suffix.strip()
+    )
     failed_real_jobs = [
         job
         for job in list_jobs_for_run(owner, repo, run["id"])
         if job.get("conclusion") == "failure"
-        and not job["name"].endswith("required-status-check")
+        and not any(job["name"].endswith(suffix) for suffix in ignored_job_suffixes)
     ]
 
     if not failed_real_jobs:
-        print(f"Skipped {label}: only synthetic jobs failed.")
+        print(f"Skipped {label}: only ignored jobs failed.")
         return
 
-    if len(failed_real_jobs) > MAX_FAILED_JOBS_PER_WORKFLOW_RUN:
+    max_failed_jobs = int(
+        os.getenv("MAX_FAILED_JOBS_PER_WORKFLOW_RUN", DEFAULT_MAX_FAILED_JOBS_PER_WORKFLOW_RUN)
+    )
+    if len(failed_real_jobs) > max_failed_jobs:
         print(
             f"Skipped {label}: {len(failed_real_jobs)} failed jobs"
-            f" exceeded limit {MAX_FAILED_JOBS_PER_WORKFLOW_RUN}."
+            f" exceeded limit {max_failed_jobs}."
         )
         return
 
@@ -59,6 +62,12 @@ def main() -> None:
     )
     job_list = ", ".join(f"{j['name']} ({j['id']})" for j in failed_real_jobs)
     print(f"::notice::{label}: reran failed jobs {job_list}.")
+
+
+def build_label(owner: str, repo: str, run: dict) -> str:
+    pr_number = resolve_pr_number(owner, repo, run)
+    pr_label = f"PR #{pr_number}, " if pr_number is not None else ""
+    return f"{pr_label}{run['name']} #{run['run_number']}, run {run['id']}, attempt {run['run_attempt']}"
 
 
 def list_jobs_for_run(owner: str, repo: str, run_id: int) -> list[dict]:

--- a/.github/workflows/build-daily-no-build-cache.yml
+++ b/.github/workflows/build-daily-no-build-cache.yml
@@ -45,3 +45,4 @@ jobs:
           needs.common.result == 'success' &&
           needs.test-latest-deps.result == 'success'
         }}
+      failure-notification-after-attempts: 2

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -86,3 +86,4 @@ jobs:
           needs.lint.result == 'success' &&
           needs.publish-snapshots.result == 'success'
         }}
+      failure-notification-after-attempts: 2

--- a/.github/workflows/native-tests-daily.yml
+++ b/.github/workflows/native-tests-daily.yml
@@ -25,3 +25,4 @@ jobs:
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.graalvm-native-tests.result == 'success' }}
+      failure-notification-after-attempts: 2

--- a/.github/workflows/rerun-failed-daily-jobs.yml
+++ b/.github/workflows/rerun-failed-daily-jobs.yml
@@ -14,11 +14,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
   rerun-failed-jobs:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/rerun-failed-daily-jobs.yml
+++ b/.github/workflows/rerun-failed-daily-jobs.yml
@@ -1,14 +1,16 @@
-name: Rerun flaky PR jobs
+name: Rerun failed daily jobs
 
 on:
   workflow_run:
     workflows:
-      - "Build pull request"
+      - "Build (daily)"
+      - "Build (daily --no-build-cache)"
+      - "Daily GraalVM native tests"
     types:
       - completed
 
 concurrency:
-  group: rerun-flaky-pr-jobs
+  group: rerun-failed-daily-jobs
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -15,6 +15,11 @@ on:
         type: string
         required: false
         description: "Custom title for the issue (defaults to 'Workflow failed: $GITHUB_WORKFLOW')"
+      failure-notification-after-attempts:
+        type: number
+        required: false
+        default: 0
+        description: "Only notify on failure after this many workflow run attempts"
 
 permissions:
   contents: read
@@ -25,6 +30,7 @@ jobs:
       contents: read
       issues: write
     runs-on: ubuntu-latest
+    if: ${{ inputs.success || github.run_attempt > inputs.failure-notification-after-attempts }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
Addresses #18594.

This adds a workflow that automatically reruns failed jobs for the daily workflows, using GitHub's failed-job rerun endpoint so only the failed matrix jobs are retried.

Failure notification issues are delayed until the configured automatic reruns have been exhausted.