### PR TITLE
Simplify PR triage script output

### DIFF
--- a/.github/scripts/pr-triage/common.py
+++ b/.github/scripts/pr-triage/common.py
@@ -32,6 +32,8 @@ class WorkflowError(RuntimeError):
 @dataclass
 class Summary:
     pr: int
+    pr_url: str | None = None
+    review_url: str | None = None
     original_branch: str = ""
     pr_branch: str = ""
     restored_branch: str | None = None
@@ -76,6 +78,12 @@ class Summary:
             print("Notes:")
             for note in self.notes:
                 print(f"- {note}")
+        if self.pr_url or self.review_url:
+            print("Links:")
+            if self.pr_url:
+                print(f"- PR: {self.pr_url}")
+            if self.review_url:
+                print(f"- Review: {self.review_url}")
 
 
 def format_cmd(cmd: list[str]) -> str:
@@ -190,8 +198,14 @@ def detect_repo(summary: Summary | None = None) -> str:
 
 
 def pr_view(pr: int, summary: Summary) -> dict[str, Any]:
-    fields = "headRepositoryOwner,headRepository,headRefName,isCrossRepository,maintainerCanModify"
+    fields = "headRepositoryOwner,headRepository,headRefName,isCrossRepository,maintainerCanModify,url"
     return gh_json(["pr", "view", str(pr), "--json", fields], summary)
+
+
+def remember_pr_url(metadata: dict[str, Any], summary: Summary) -> None:
+    url = metadata.get("url")
+    if isinstance(url, str) and url:
+        summary.pr_url = url
 
 
 def authed_login(summary: Summary) -> str:
@@ -214,13 +228,16 @@ def checkout_pr(pr: int, summary: Summary) -> dict[str, Any]:
     progress(f"Checking out PR #{pr}")
     gh(["pr", "checkout", str(pr)], summary)
     summary.pr_branch = current_branch(summary)
-    return ensure_pr_push_allowed(pr, summary)
+    metadata = ensure_pr_push_allowed(pr, summary)
+    remember_pr_url(metadata, summary)
+    return metadata
 
 
 def checkout_pr_no_push_check(pr: int, summary: Summary) -> None:
     progress(f"Checking out PR #{pr}")
     gh(["pr", "checkout", str(pr)], summary)
     summary.pr_branch = current_branch(summary)
+    remember_pr_url(pr_view(pr, summary), summary)
 
 
 def run_pr_workflow(pr: int, body: Callable[[Summary], int], *, push_required: bool = True) -> int:

--- a/.github/scripts/pr-triage/fix_ci.py
+++ b/.github/scripts/pr-triage/fix_ci.py
@@ -35,9 +35,8 @@ AGGREGATE_CHECK_SUFFIX = "required-status-check"
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int, help="pull request number")
-    parser.add_argument("--no-push", action="store_true", help="commit but do not push")
+    parser.add_argument("--no-push", action="store_true", help="commit locally but do not push to the PR")
     parser.add_argument("--keep-temp", action="store_true", help="reuse and retain the temp bundle directory")
-    parser.add_argument("--skip-copilot", action="store_true", help="download logs and stop before invoking Copilot")
     return parser.parse_args()
 
 
@@ -181,10 +180,6 @@ def main() -> int:
         bundle_dir = make_temp_dir("otel-ci-fix", args.pr, args.keep_temp)
         bundle_checks = write_ci_bundle(args.pr, checks, bundle_dir, summary)
 
-        if args.skip_copilot:
-            summary.outcome = "downloaded CI logs; skipped Copilot handoff"
-            return 0
-
         commit_message_path = bundle_dir / "commit-message.txt"
         prompt_improvement_path = bundle_dir / "prompt-improvement.md"
         response = invoke_copilot(copilot_prompt(args.pr, bundle_checks, commit_message_path, prompt_improvement_path), summary)
@@ -208,7 +203,7 @@ def main() -> int:
         summary.outcome = "CI fix committed"
         return 0
 
-    return run_pr_workflow(args.pr, body)
+    return run_pr_workflow(args.pr, body, push_required=not args.no_push)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr-triage/resolve_conflicts.py
+++ b/.github/scripts/pr-triage/resolve_conflicts.py
@@ -25,9 +25,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int, help="pull request number")
     parser.add_argument("--upstream", default="upstream", help="upstream remote name")
-    parser.add_argument("--no-push", action="store_true", help="commit but do not push")
+    parser.add_argument("--no-push", action="store_true", help="commit locally but do not push to the PR")
     parser.add_argument("--keep-temp", action="store_true", help="reuse and retain the temp bundle directory")
-    parser.add_argument("--skip-copilot", action="store_true", help="stop after collecting conflict context")
     return parser.parse_args()
 
 
@@ -100,9 +99,6 @@ def main() -> int:
         summary.changed_files = conflicts
         bundle_dir = make_temp_dir("otel-conflicts", args.pr, args.keep_temp)
         plan_path = write_conflict_bundle(bundle_dir, summary)
-        if args.skip_copilot:
-            summary.outcome = "collected conflict context; skipped Copilot handoff"
-            return 1
 
         response = invoke_copilot(copilot_prompt(plan_path), summary)
         (bundle_dir / "copilot-response.txt").write_text(response + "\n", encoding="utf-8")
@@ -121,7 +117,7 @@ def main() -> int:
         summary.outcome = "resolved conflicts and merged upstream/main"
         return 0
 
-    return run_pr_workflow(args.pr, workflow)
+    return run_pr_workflow(args.pr, workflow, push_required=not args.no_push)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr-triage/review.py
+++ b/.github/scripts/pr-triage/review.py
@@ -251,7 +251,7 @@ def validate_comments(findings: dict[str, Any], diff_scope: dict[str, dict[str, 
 
 
 def post_review(repo: str, pr: int, payload_path: Path, summary: Summary) -> str:
-    result = gh(
+    review = gh_json(
         [
             "api",
             f"repos/{repo}/pulls/{pr}/reviews",
@@ -259,12 +259,16 @@ def post_review(repo: str, pr: int, payload_path: Path, summary: Summary) -> str
             "POST",
             "--input",
             str(payload_path),
-            "--jq",
-            ".id",
         ],
         summary,
     )
-    return result.stdout.strip()
+    review_id = str(review.get("id") or "")
+    review_url = review.get("html_url")
+    if isinstance(review_url, str) and review_url:
+        summary.review_url = review_url
+    elif review_id and summary.pr_url:
+        summary.review_url = f"{summary.pr_url}#pullrequestreview-{review_id}"
+    return review_id
 
 
 def main() -> int:
@@ -272,6 +276,7 @@ def main() -> int:
 
     def workflow(summary: Summary) -> int:
         metadata = pr_metadata(args.pr, summary)
+        summary.pr_url = metadata.get("url")
         progress("Collecting PR diff")
         diff_names = gh(["pr", "diff", str(args.pr), "--name-only"], summary).stdout.splitlines()
         diff_text = gh(["pr", "diff", str(args.pr), "--color", "never"], summary).stdout


### PR DESCRIPTION
Keep the PR triage scripts focused on the next useful link at the end of a run.

- add final PR/review links to the shared summary
- remove skip-copilot from fix_ci and resolve_conflicts
- make --no-push skip the push-permission check