### PR TITLE
Fix deprecated name warning

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/DeprecatedInstrumentationNames.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/DeprecatedInstrumentationNames.java
@@ -72,7 +72,7 @@ public final class DeprecatedInstrumentationNames {
       expanded.add(deprecated);
       List<String> probe = singletonList(deprecated);
       if (config.isInstrumentationEnabled(probe, true)
-          != config.isInstrumentationEnabled(probe, false)) {
+          == config.isInstrumentationEnabled(probe, false)) {
         logger.log(
             WARNING,
             "otel.instrumentation.{0}.enabled is deprecated; "


### PR DESCRIPTION
Fixes the following warning displayed even when these flags aren't used
> [otel.javaagent 2026-05-06 16:59:35:528 +0300] [main] WARN io.opentelemetry.javaagent.extension.instrumentation.internal.DeprecatedInstrumentationNames - otel.instrumentation.jaxws-cxf-3.0.enabled is deprecated; use otel.instrumentation.jaxws-2.0-cxf-3.0.enabled instead.
[otel.javaagent 2026-05-06 16:59:35:528 +0300] [main] WARN io.opentelemetry.javaagent.extension.instrumentation.internal.DeprecatedInstrumentationNames - otel.instrumentation.jaxws-metro-2.2.enabled is deprecated; use otel.instrumentation.jaxws-2.0-metro-2.2.enabled instead.
