### PR TITLE
Fix muzzle match caching with indy instrumentation

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
@@ -63,7 +63,8 @@ class MuzzleMatcher implements AgentBuilder.RawMatcher {
     if (classLoader == BOOTSTRAP_LOADER) {
       classLoader = Utils.getBootstrapProxy();
     }
-    return matchCache.computeIfAbsent(classLoaderTransformer.apply(classLoader), this::doesMatch);
+    return matchCache.computeIfAbsent(
+        classLoader, cl -> doesMatch(classLoaderTransformer.apply(cl)));
   }
 
   private boolean doesMatch(ClassLoader classLoader) {


### PR DESCRIPTION
With indy instrumentation we create a new class loader that can load classes from both the application class loader and agent class loader. This class loader shouldn't be used as cache key as a new instance is created on each transformer function invocation.