### PR TITLE
Move starting weak map cleaner earlier

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -99,8 +99,8 @@ public class AgentStarterImpl implements AgentStarter {
       loggingCustomizer.init();
       EarlyInitAgentConfig.get().logEarlyConfigErrorsIfAny();
 
-      AgentInstaller.installBytebuddyAgent(instrumentation, extensionClassLoader);
       WeakConcurrentMapCleaner.start();
+      AgentInstaller.installBytebuddyAgent(instrumentation, extensionClassLoader);
 
       // LazyStorage reads system properties. Initialize it here where we have permissions to avoid
       // failing permission checks when it is initialized from user code.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -99,6 +99,7 @@ public class AgentStarterImpl implements AgentStarter {
       loggingCustomizer.init();
       EarlyInitAgentConfig.get().logEarlyConfigErrorsIfAny();
 
+      // start cleaner first so weak refs created during bytebuddy install get cleaned up
       WeakConcurrentMapCleaner.start();
       AgentInstaller.installBytebuddyAgent(instrumentation, extensionClassLoader);
 


### PR DESCRIPTION
Weak caches are used during `installBytebuddyAgent` starting cleaner earlier should allow for cleaning these caches.