### PR TITLE
Disable inline expunge when in computeIfAbsent

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/weaklockfree/AbstractWeakConcurrentMap.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/weaklockfree/AbstractWeakConcurrentMap.java
@@ -184,7 +184,15 @@ abstract class AbstractWeakConcurrentMap<K, V, L> implements Iterable<Map.Entry<
     }
     return previous == null
         ? target.computeIfAbsent(
-            new WeakKey<>(key, weakTarget), ignored -> mappingFunction.apply(key))
+            new WeakKey<>(key, weakTarget),
+            ignored -> {
+              enterComputeIfAbsent();
+              try {
+                return mappingFunction.apply(key);
+              } finally {
+                exitComputeIfAbsent();
+              }
+            })
         : previous;
   }
 
@@ -236,6 +244,13 @@ abstract class AbstractWeakConcurrentMap<K, V, L> implements Iterable<Map.Entry<
 
   /** Cleans all unused references. */
   public static void expungeStaleEntries() {
+    // Skip expunging stale entries if we are inside computeIfAbsent. This check prevents a deadlock
+    // when there are 2 threads calling computeIfAbsent, that locks the map, and both threads try
+    // to remove entry from the map locked by the other thread.
+    // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18232
+    if (isInComputeIfAbsent()) {
+      return;
+    }
     // Skip expunging stale entries if we are running on a virtual thread.
     // See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/17847
     // Stale entries are also expunged from the background thread, see the runCleanup method below.
@@ -247,6 +262,36 @@ abstract class AbstractWeakConcurrentMap<K, V, L> implements Iterable<Map.Entry<
     while ((reference = REFERENCE_QUEUE.poll()) != null) {
       removeWeakKey((WeakKey<?>) reference);
     }
+  }
+
+  private static final ThreadLocal<Counter> COMPUTE_COUNTER = new ThreadLocal<>();
+
+  private static void enterComputeIfAbsent() {
+    Counter counter = COMPUTE_COUNTER.get();
+    if (counter == null) {
+      counter = new Counter();
+      COMPUTE_COUNTER.set(counter);
+    }
+    counter.count++;
+  }
+
+  private static void exitComputeIfAbsent() {
+    Counter counter = COMPUTE_COUNTER.get();
+    if (counter != null) {
+      counter.count--;
+      if (counter.count == 0) {
+        COMPUTE_COUNTER.remove();
+      }
+    }
+  }
+
+  private static boolean isInComputeIfAbsent() {
+    Counter counter = COMPUTE_COUNTER.get();
+    return counter != null && counter.count > 0;
+  }
+
+  private static final class Counter {
+    int count;
   }
 
   private static void removeWeakKey(WeakKey<?> weakKey) {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/cache/CacheTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/cache/CacheTest.java
@@ -5,13 +5,25 @@
 
 package io.opentelemetry.instrumentation.api.internal.cache;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.opentelemetry.instrumentation.test.utils.GcUtils;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class CacheTest {
+  @RegisterExtension
+  private static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   @Nested
   @SuppressWarnings("ClassCanBeStatic")
@@ -73,6 +85,98 @@ class CacheTest {
       System.gc();
       // Wait for GC to be reflected.
       await().untilAsserted(() -> assertThat(weakLockFreeCache.size()).isEqualTo(0));
+    }
+
+    // regression test for
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18232
+    @Test
+    void computeIfAbsentDeadlock() throws InterruptedException {
+      Cache<Object, String> cache1 = Cache.weak();
+      Cache<String, String> cache2 = Cache.weak();
+
+      class State {
+        Object key = new Object();
+        final WeakReference<Object> keyRef = new WeakReference<>(key);
+      }
+      // add a bunch of entries to cache1, later we'll let GC clear them so that there would be
+      // stale elements to expunge from the cache
+      List<State> state = new ArrayList<>();
+      for (int i = 0; i < 1000000; i++) {
+        State s = new State();
+        state.add(s);
+        cache1.put(s.key, "value");
+      }
+
+      // To truly tigger a deadlock we'd need to call computeIfAbsent on both caches and inside
+      // computeIfAbsent call some other operation on the cache to trigger inline eviction so that
+      // it removes elements from the other cache.
+      // Since that is too complicated we use a latch to simulate a long-running computation that
+      // locks the map (or a part of it) and see if we can get another thread to block on it.
+      CountDownLatch wait = new CountDownLatch(1);
+      CountDownLatch started = new CountDownLatch(1);
+      CountDownLatch completed = new CountDownLatch(1);
+      Thread t1 =
+          new Thread(
+              () ->
+                  cache1.computeIfAbsent(
+                      "test",
+                      unused -> {
+                        started.countDown();
+                        try {
+                          if (!wait.await(20, SECONDS)) {
+                            throw new IllegalStateException("wait timed out");
+                          }
+                          return "value";
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new IllegalStateException(e);
+                        }
+                      }));
+      cleanup.deferCleanup(t1::interrupt);
+      t1.start();
+
+      if (!started.await(10, SECONDS)) {
+        throw new IllegalStateException("wait timed out");
+      }
+      Thread t2 =
+          new Thread(
+              () ->
+                  cache2.computeIfAbsent(
+                      "key",
+                      unused -> {
+                        // first clean keys so they could ge GCd
+                        for (State s : state) {
+                          s.key = null;
+                        }
+                        // trigger GC and wait for the key to be cleared
+                        for (State s : state) {
+                          try {
+                            GcUtils.awaitGc(s.keyRef, Duration.ofSeconds(10));
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                          } catch (TimeoutException e) {
+                            throw new IllegalStateException(e);
+                          }
+                        }
+                        // now trigger inline eviction of the cleared keys in cache1
+                        // note that currently inline eviction is disabled when inside
+                        // computeIfAbsent call to
+                        // trigger the deadlock modify AbstractWeakConcurrentMap.expungeStaleEntries
+                        // method
+                        cache2.get("test");
+                        completed.countDown();
+                        return "value";
+                      }));
+      cleanup.deferCleanup(t2::interrupt);
+      t2.start();
+      // this wait will time out when t2 is blocked by t1
+      if (!completed.await(10, SECONDS)) {
+        throw new IllegalStateException("wait timed out");
+      }
+
+      wait.countDown();
+      t1.join(Duration.ofSeconds(10).toMillis());
     }
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/cache/CacheTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/cache/CacheTest.java
@@ -98,6 +98,7 @@ class CacheTest {
         Object key = new Object();
         final WeakReference<Object> keyRef = new WeakReference<>(key);
       }
+
       // add a bunch of entries to cache1, later we'll let GC clear them so that there would be
       // stale elements to expunge from the cache
       List<State> state = new ArrayList<>();


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18232
An alternative for https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18629
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18629 explores removing the inline expunge which is a bit complicated because library instrumentations don't currently use the background thread.