### PR TITLE
Add gh-aw lockfile CI check

### DIFF
--- a/.github/workflows/gh-aw-lockfile-check.yml
+++ b/.github/workflows/gh-aw-lockfile-check.yml
@@ -1,0 +1,111 @@
+name: Check gh-aw lockfiles
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*.md"
+      - ".github/workflows/*.lock.yml"
+      - ".github/agents/**"
+      - ".github/aw/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install gh-aw
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin v0.71.5
+
+      - name: Determine workflows to compile
+        id: workflows
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            mapfile -t changed_files < <(
+              git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD -- \
+                ".github/workflows/*.md" \
+                ".github/workflows/*.lock.yml" \
+                ".github/agents/**" \
+                ".github/aw/**"
+            )
+          else
+            mapfile -t changed_files < <(find .github/workflows -maxdepth 1 -name "*.md" | sort)
+          fi
+
+          declare -A workflow_ids=()
+          compile_all=false
+
+          for changed_file in "${changed_files[@]}"; do
+            case "$changed_file" in
+              .github/workflows/*.md)
+                workflow_file="${changed_file##*/}"
+                workflow_ids["${workflow_file%.md}"]=1
+                ;;
+              .github/workflows/*.lock.yml)
+                workflow_file="${changed_file##*/}"
+                workflow_ids["${workflow_file%.lock.yml}"]=1
+                ;;
+              .github/agents/*|.github/aw/*)
+                compile_all=true
+                ;;
+            esac
+          done
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            compile_all=true
+          fi
+
+          if [[ "$compile_all" == "true" ]]; then
+            while IFS= read -r lock_file; do
+              workflow_file="${lock_file##*/}"
+              workflow_ids["${workflow_file%.lock.yml}"]=1
+            done < <(find .github/workflows -maxdepth 1 -name "*.lock.yml" | sort)
+          fi
+
+          if [[ ${#workflow_ids[@]} -eq 0 ]]; then
+            echo "No gh-aw workflow sources or lockfiles changed."
+            echo "workflows=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s\n' "${!workflow_ids[@]}" | sort > /tmp/gh-aw-workflows.txt
+          echo "Workflows to compile:"
+          cat /tmp/gh-aw-workflows.txt
+
+          {
+            echo "workflows<<EOF"
+            tr '\n' ' ' < /tmp/gh-aw-workflows.txt
+            echo
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate gh-aw workflows
+        if: steps.workflows.outputs.workflows != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh aw validate ${{ steps.workflows.outputs.workflows }} --no-check-update
+
+      - name: Compile gh-aw workflows
+        if: steps.workflows.outputs.workflows != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh aw compile ${{ steps.workflows.outputs.workflows }} --no-check-update
+
+      - name: Check generated files are committed
+        if: steps.workflows.outputs.workflows != ''
+        run: |
+          git diff --exit-code -- \
+            .github/workflows \
+            .github/aw/actions-lock.json


### PR DESCRIPTION
Add a CI workflow that recompiles affected gh-aw workflows and fails when generated files are stale
