### PR TITLE
Fix race in ending spans in netty 3.8 and 4.0 instrumentation

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
@@ -39,22 +39,18 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
     HttpResponse response = (HttpResponse) msg.getMessage();
     customizeResponse(context, response);
 
+    requestAndContextField.set(ctx.getChannel(), null);
     try (Scope ignored = context.makeCurrent()) {
       super.writeRequested(ctx, msg);
     } catch (Throwable t) {
-      end(ctx.getChannel(), context, request, response, t);
+      end(context, request, response, t);
       throw t;
     }
-    end(ctx.getChannel(), context, request, response, null);
+    end(context, request, response, null);
   }
 
   private static void end(
-      Channel channel,
-      Context context,
-      NettyRequest request,
-      HttpResponse response,
-      @Nullable Throwable error) {
-    requestAndContextField.set(channel, null);
+      Context context, NettyRequest request, HttpResponse response, @Nullable Throwable error) {
     instrumenter().end(context, request, response, NettyErrorHolder.getOrDefault(context, error));
   }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_0.server;
 import static io.opentelemetry.javaagent.instrumentation.netty.v4_0.server.HttpServerRequestTracingHandler.HTTP_SERVER_REQUEST;
 import static io.opentelemetry.javaagent.instrumentation.netty.v4_0.server.NettyServerSingletons.instrumenter;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
@@ -33,19 +32,23 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
 
     customizeResponse(context, (HttpResponse) msg);
 
+    ctx.channel().attr(AttributeKeys.SERVER_CONTEXT).remove();
+    NettyCommonRequest request = ctx.channel().attr(HTTP_SERVER_REQUEST).getAndRemove();
     try (Scope ignored = context.makeCurrent()) {
       ctx.write(msg, prm);
     } catch (Throwable t) {
-      end(ctx.channel(), (HttpResponse) msg, t);
+      end(context, request, (HttpResponse) msg, t);
       throw t;
     }
-    end(ctx.channel(), (HttpResponse) msg, null);
+    end(context, request, (HttpResponse) msg, null);
   }
 
   // make sure to remove the server context on end() call
-  private static void end(Channel channel, HttpResponse response, @Nullable Throwable error) {
-    Context context = channel.attr(AttributeKeys.SERVER_CONTEXT).getAndRemove();
-    NettyCommonRequest request = channel.attr(HTTP_SERVER_REQUEST).getAndRemove();
+  private static void end(
+      Context context,
+      NettyCommonRequest request,
+      HttpResponse response,
+      @Nullable Throwable error) {
     error = NettyErrorHolder.getOrDefault(context, error);
     instrumenter().end(context, request, response, error);
   }


### PR DESCRIPTION
I was trying to reproduce the issue mentioned in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18546 For me it failed in `highConcurrency` not `successfulGetRequest`, but I believe it is the same issue. The problem seems to be that we cleared the virtual field from the channel after `super.writeRequested`, looks like by the time we cleared it the channel was already used for the next request. After this change I wasn't able to reproduce the issue with play24 (uses netty 3.8). Also made the same change for netty 4.0 in case it is also affected.