### PR TITLE
Fix Renovate lookup warning

### DIFF
--- a/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
 configurations.configureEach {
   if (name.endsWith("testruntimeclasspath", ignoreCase = true)) {
     // Added by agent, don't let Gradle bring it in when running tests.
-    exclude(module = "javaagent-bootstrap")
+    exclude(group = "io.opentelemetry.javaagent", module = "javaagent-bootstrap")
   }
 }


### PR DESCRIPTION
Renovate has been emitting:

> Failed to look up maven package help:javaagent-bootstrap: no-result
>
> Files affected: version.gradle.kts
