### PR TITLE
Fix pinned dependency alerts

### DIFF
--- a/.github/copilot-cli/package-lock.json
+++ b/.github/copilot-cli/package-lock.json
@@ -1,0 +1,125 @@
+{
+  "name": "copilot-cli",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@github/copilot": "1.0.40"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40.tgz",
+      "integrity": "sha512-s35c/9R5q8O2ZQi/rzU9TBpum/DU06dczDSfmepCTisRHVTTKWS703J7kZhZYqL6OIGqnhmLfx4A7afT8YVKKA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.40",
+        "@github/copilot-darwin-x64": "1.0.40",
+        "@github/copilot-linux-arm64": "1.0.40",
+        "@github/copilot-linux-x64": "1.0.40",
+        "@github/copilot-win32-arm64": "1.0.40",
+        "@github/copilot-win32-x64": "1.0.40"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40.tgz",
+      "integrity": "sha512-syHKff/G53VzosHRXG6pX+MEc00tMdly0SZS4jC0fFUSY2/6R7lgi4IEZt57Q6WKdjBiqn8EvEQ94efdRdPEzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40.tgz",
+      "integrity": "sha512-ai6PgHLx5SgC7Ht3Hy2tNepdnAnqcWaPPtYFaP2UGS69r1O87JBA/pB2QHVZP3vX34/4RyoOB/WQ1kiT5pvcpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40.tgz",
+      "integrity": "sha512-mAh8GmGmkkUiFFzBIvXYmReSIw5c3NWHme0iYT2v/72RWNAwRq4HLKP9NhHapZqUPyi7jQnRxllYPybZDFS6Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40.tgz",
+      "integrity": "sha512-gCo6RgpXwa39FZSdj5dMkN/z0xT/NS29MpkeYQ/S34SSoUsSbIKUWcuoMjRiXpaDWWuXQsFjXcqnwNs67JOejA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40.tgz",
+      "integrity": "sha512-59ANg2xfeeWwl8UNqVe4sk2OAizgMjKVRgTALYExHMc8p5HJyL8nrQ9np6pIkO/De0UpR8rUzk4D8oCqU7XLIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40.tgz",
+      "integrity": "sha512-dKS5L7SwzXZI/gaY9LIn8eoTGEPgczGLIgt1KwjfkHgk3achHwIuEjxSqPRVD1Z7q08uuOcuwVzOlwE8V38zNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    }
+  }
+}

--- a/.github/copilot-cli/package.json
+++ b/.github/copilot-cli/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@github/copilot": "1.0.40"
+  }
+}

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install Copilot CLI
         run: |
-          curl -fsSL https://gh.io/copilot-install | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          npm ci --prefix .github/copilot-cli
+          echo "$GITHUB_WORKSPACE/.github/copilot-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Use CLA approved bot
         run: .github/scripts/use-cla-approved-bot.sh

--- a/.github/workflows/gh-aw-lockfile-check.yml
+++ b/.github/workflows/gh-aw-lockfile-check.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -29,7 +29,9 @@ jobs:
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot@1.0.40
+        run: |
+          npm ci --prefix .github/copilot-cli
+          echo "$GITHUB_WORKSPACE/.github/copilot-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Generate dashboard
         env:


### PR DESCRIPTION
## Summary

- pin `actions/checkout` in the gh-aw lockfile check workflow to the full v5 commit SHA
- replace the draft-release-notes `curl | bash` Copilot CLI install with a lockfile-backed npm install
- replace the PR dashboard global npm install with the same lockfile-backed Copilot CLI install

## Code scanning alerts addressed

This targets the following open Security > Code scanning `PinnedDependenciesID` alerts:

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/security/code-scanning/260 (`draft-release-notes.yml`: `downloadThenRun` not pinned by hash)
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/security/code-scanning/263 (`pr-review-dashboard.yml`: `npmCommand` not pinned by hash)
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/security/code-scanning/293 (`gh-aw-lockfile-check.yml`: GitHub-owned action not pinned by hash)

## Testing

- `npm ci --prefix .github/copilot-cli`
- `.github/copilot-cli/node_modules/.bin/copilot --version`
- `git diff --check`