### PR TITLE
Fix auto rerunning failed workflows

### DIFF
--- a/.github/scripts/rerun-failed-workflow-jobs.py
+++ b/.github/scripts/rerun-failed-workflow-jobs.py
@@ -76,10 +76,10 @@ def list_jobs_for_run(owner: str, repo: str, run_id: int) -> list[dict]:
     while True:
         response = gh_get(
             f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-            {"filter": "latest", "per_page": "100", "page": str(page)},
+            {"filter": "latest", "per_page": "30", "page": str(page)},
         )
         jobs.extend(response["jobs"])
-        if len(response["jobs"]) < 100:
+        if len(response["jobs"]) < 30:
             return jobs
         page += 1
 


### PR DESCRIPTION
The `/repos/{owner}/{repo}/actions/runs/{id}/jobs` endpoint returns `HTTP 502 Server Error` with `per_page=100` for recent PR runs (~88 jobs). This causes the `Rerun flaky PR jobs` workflow to error out in `list_jobs_for_run` before it can issue the rerun.

Reproduced manually: the same URL with `per_page=100` returns 502 consistently, while `per_page=30` succeeds.