### PR TITLE
Fix remaining Renovate exclude parsing warnings

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
     // We exclude plexus-xml and plexus-utils here because our current usages of the shadow plugin
     // don't require it, the  failure happens in spdx-gradle-plugin that can continue using and
     // older version of plexus-xml and plexus-utils
-    exclude(group = "org.codehaus.plexus", module = "plexus-utils")
-    exclude(group = "org.codehaus.plexus", module = "plexus-xml")
+    exclude("org.codehaus.plexus", "plexus-utils")
+    exclude("org.codehaus.plexus", "plexus-xml")
   }
   implementation("org.apache.httpcomponents:httpclient:4.5.14")
   implementation("com.gradle.develocity:com.gradle.develocity.gradle.plugin:4.4.1")

--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
@@ -36,11 +36,11 @@ dependencies {
   // Apply common dependencies for instrumentation.
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api") {
     // OpenTelemetry SDK is not needed for compilation
-    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
+    exclude("io.opentelemetry", "opentelemetry-sdk")
   }
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
     // OpenTelemetry SDK is not needed for compilation
-    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
+    exclude("io.opentelemetry", "opentelemetry-sdk")
   }
 
   // Used by byte-buddy but not brought in as a transitive dependency

--- a/examples/distro/instrumentation/servlet-3/build.gradle.kts
+++ b/examples/distro/instrumentation/servlet-3/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   testInstrumentation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:$opentelemetryJavaagentAlphaVersion")
 
   testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common") {
-    exclude(group = "org.eclipse.jetty", module = "jetty-server")
+    exclude("org.eclipse.jetty", "jetty-server")
   }
 
   testImplementation("com.squareup.okhttp3:okhttp:5.3.2")

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation("com.google.guava:guava:33.6.0-jre")
   // we need to use byte buddy variant that does not shade asm
   implementation("net.bytebuddy:byte-buddy-gradle-plugin:${byteBuddyVersion}") {
-    exclude(group = "net.bytebuddy", module = "byte-buddy")
+    exclude("net.bytebuddy", "byte-buddy")
   }
   implementation("net.bytebuddy:byte-buddy-dep:${byteBuddyVersion}")
 
@@ -43,8 +43,8 @@ dependencies {
   implementation("com.gradleup.shadow:shadow-gradle-plugin:9.4.1") {
     // plexus-xml 4.1+ pulls in Maven 4 API which uses JPMS-only service registration,
     // causing "No XmlService implementation found" in Gradle's classloader
-    exclude(group = "org.codehaus.plexus", module = "plexus-utils")
-    exclude(group = "org.codehaus.plexus", module = "plexus-xml")
+    exclude("org.codehaus.plexus", "plexus-utils")
+    exclude("org.codehaus.plexus", "plexus-xml")
   }
 
   testImplementation("org.assertj:assertj-core:3.27.7")

--- a/javaagent-extension-api/build.gradle.kts
+++ b/javaagent-extension-api/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
 
 // Needed by mockito
 configurations.testRuntimeClasspath {
-  exclude(group = "net.bytebuddy", module = "byte-buddy-dep")
+  exclude("net.bytebuddy", "byte-buddy-dep")
 }


### PR DESCRIPTION
This extends the fix from #18653 since Renovate is now reporting another one:

```
Failed to look up maven package help:opentelemetry-sdk
Files affected: version.gradle.kts
```

This PR applies the same form to the remaining Renovate-visible `exclude(group = ..., module = ...)` calls outside `instrumentation/**`, so Renovate should no longer synthesize bogus Maven coordinates from these excludes. Hopefully this covers the rest of them.