### PR TITLE
Run pr-review workflow in protected environment

### DIFF
--- a/.github/workflows/pr-review.lock.yml
+++ b/.github/workflows/pr-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4b7fb9157ec21afee2fa3b5d7e9d0102bbef1ac0e6cf4ce0809cf969905f7801","compiler_version":"v0.71.5","agent_id":"copilot","agent_model":"${{ needs.dispatch.outputs.model }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cf4056b23a3f641085863d70b872ab17129c40a1bcdee07e593dc04aedebff77","compiler_version":"v0.71.5","agent_id":"copilot","agent_model":"${{ needs.dispatch.outputs.model }}"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"93cb6efe18208431cddfb8368fd83d5badbf9bfd","version":"v5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"634f93cb2916e3fdff6788551b99b062d0335ce0","version":"v5"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"330a01c490aca151604b8cf639adc76d48f6c5d4","version":"330a01c490aca151604b8cf639adc76d48f6c5d4"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -96,7 +96,6 @@ jobs:
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
       text: ${{ steps.sanitized.outputs.text }}
@@ -139,11 +138,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -215,23 +209,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a5a3505cb78bf994_EOF'
+          cat << 'GH_AW_PROMPT_083de6375d632bd4_EOF'
           <system>
-          GH_AW_PROMPT_a5a3505cb78bf994_EOF
+          GH_AW_PROMPT_083de6375d632bd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a5a3505cb78bf994_EOF'
+          cat << 'GH_AW_PROMPT_083de6375d632bd4_EOF'
           <safe-output-tools>
           Tools: create_issue
-          GH_AW_PROMPT_a5a3505cb78bf994_EOF
+          GH_AW_PROMPT_083de6375d632bd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_a5a3505cb78bf994_EOF'
+          cat << 'GH_AW_PROMPT_083de6375d632bd4_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a5a3505cb78bf994_EOF
+          GH_AW_PROMPT_083de6375d632bd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a5a3505cb78bf994_EOF'
+          cat << 'GH_AW_PROMPT_083de6375d632bd4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -260,16 +254,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a5a3505cb78bf994_EOF
+          GH_AW_PROMPT_083de6375d632bd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_a5a3505cb78bf994_EOF'
+          cat << 'GH_AW_PROMPT_083de6375d632bd4_EOF'
           </system>
           {{#runtime-import .github/agents/pr-review.agent.md}}
           {{#runtime-import .github/workflows/pr-review.md}}
-          GH_AW_PROMPT_a5a3505cb78bf994_EOF
+          GH_AW_PROMPT_083de6375d632bd4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -351,6 +345,7 @@ jobs:
       - dispatch
     if: needs.dispatch.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    environment: protected
     permissions: read-all
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -481,9 +476,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e9cedee489eb11b8_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6aa7607fc163be36_EOF'
           {"create_issue":{"labels":["pr-review"],"max":1,"title_prefix":"[pr-review]"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e9cedee489eb11b8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6aa7607fc163be36_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -610,7 +605,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_994a7a8ede42f4f9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_081819dc2d8b7db1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -651,7 +646,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_994a7a8ede42f4f9_EOF
+          GH_AW_MCP_CONFIG_081819dc2d8b7db1_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -858,6 +853,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
+    environment: protected
     permissions:
       contents: read
       issues: write
@@ -902,7 +898,6 @@ jobs:
           GH_AW_WORKFLOW_ID: "pr-review"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_MCP_POLICY_ERROR: ${{ needs.agent.outputs.mcp_policy_error }}
@@ -1038,6 +1033,7 @@ jobs:
     if: >
       github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-slim
+    environment: protected
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
@@ -1072,6 +1068,7 @@ jobs:
       - agent
     if: (!cancelled()) && needs.agent.result != 'skipped'
     runs-on: ubuntu-slim
+    environment: protected
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-review.lock.yml
+++ b/.github/workflows/pr-review.lock.yml
@@ -390,6 +390,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Merge remote .github folder
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_AW_AGENT_FILE: ".github/agents/pr-review.agent.md"
+          GH_AW_AGENT_IMPORT_SPEC: ".github/agents/pr-review.agent.md"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/merge_remote_agent_github_folder.cjs');
+            await main();
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise

--- a/.github/workflows/pr-review.md
+++ b/.github/workflows/pr-review.md
@@ -32,6 +32,8 @@ concurrency:
 
 timeout-minutes: 30
 
+environment: protected
+
 strict: false
 
 engine:


### PR DESCRIPTION
The `COPILOT_GITHUB_TOKEN` secret is gated behind the `protected` environment. Without declaring `environment: protected` on the workflow, the `validate_multi_secret.sh` step in the agent job fails:

```
Error: None of the following secrets are set: COPILOT_GITHUB_TOKEN
```

This matches the pattern already used by [`module-cleanup.md`](.github/workflows/module-cleanup.md).