### PR TITLE
Avoid Spotless-covered Copilot review comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,12 @@ separately later in the PR lifecycle. **Prefer silence over uncertainty.** Only
 flag substantive issues on changed lines. Skip stylistic preferences not listed
 below. Do not nitpick.
 
-Do not comment on Spotless-covered formatting: indentation, wrapping, alignment,
-brace placement, imports, or whitespace. Do not ask authors to run the
-formatter. Only flag formatting that causes or hides a real correctness problem.
+Do not flag anything CI will catch. This includes compilation errors (missing
+imports, unbalanced braces, type errors, unresolved symbols), Spotless-covered
+formatting (indentation, wrapping, alignment, brace placement, import
+ordering/grouping, whitespace), Checkstyle/ErrorProne/NullAway findings, and
+test failures. Do not ask authors to run the formatter. CI surfaces these
+directly, so review comments on them are noise.
 
 Use category tags like `[Style]`, `[Naming]`, `[Testing]`, `[General]`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,10 @@ separately later in the PR lifecycle. **Prefer silence over uncertainty.** Only
 flag substantive issues on changed lines. Skip stylistic preferences not listed
 below. Do not nitpick.
 
+Do not comment on Spotless-covered formatting: indentation, wrapping, alignment,
+brace placement, imports, or whitespace. Do not ask authors to run the
+formatter. Only flag formatting that causes or hides a real correctness problem.
+
 Use category tags like `[Style]`, `[Naming]`, `[Testing]`, `[General]`.
 
 ## [Style] Style Guide


### PR DESCRIPTION
Updates the Copilot review instructions to avoid comments about formatting that Spotless CI already enforces, such as indentation, wrapping, alignment, imports, and whitespace.

This was prompted by a Copilot review on #16259 that left several indentation/formatting comments.