### PR TITLE
Simplify @TestFactory tests to @ParameterizedTest

### DIFF
--- a/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesRequestUtilsTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesRequestUtilsTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient.v7_0;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -38,46 +39,27 @@ class KubernetesRequestUtilsTest {
         .isTrue();
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @MethodSource("parseCoreResourceArguments")
-  void parseCoreResource(
-      String urlPath,
-      String apiGroup,
-      String apiVersion,
-      String resource,
-      String subResource,
-      String namespace,
-      String name)
+  void parseCoreResource(String name, String urlPath, KubernetesResource expected)
       throws ParseKubernetesResourceException {
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getApiGroup()).isEqualTo(apiGroup);
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getApiVersion()).isEqualTo(apiVersion);
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getResource()).isEqualTo(resource);
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getSubResource())
-        .isEqualTo(subResource);
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getNamespace()).isEqualTo(namespace);
-    assertThat(KubernetesResource.parseCoreResource(urlPath).getName()).isEqualTo(name);
+    assertResourceEquals(KubernetesResource.parseCoreResource(urlPath), expected);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @MethodSource("parseRegularResourceArguments")
-  void parseRegularResource(
-      String urlPath,
-      String apiGroup,
-      String apiVersion,
-      String resource,
-      String subResource,
-      String namespace,
-      String name)
+  void parseRegularResource(String name, String urlPath, KubernetesResource expected)
       throws ParseKubernetesResourceException {
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getApiGroup()).isEqualTo(apiGroup);
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getApiVersion())
-        .isEqualTo(apiVersion);
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getResource()).isEqualTo(resource);
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getSubResource())
-        .isEqualTo(subResource);
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getNamespace())
-        .isEqualTo(namespace);
-    assertThat(KubernetesResource.parseRegularResource(urlPath).getName()).isEqualTo(name);
+    assertResourceEquals(KubernetesResource.parseRegularResource(urlPath), expected);
+  }
+
+  private static void assertResourceEquals(KubernetesResource actual, KubernetesResource expected) {
+    assertThat(actual.getApiGroup()).isEqualTo(expected.getApiGroup());
+    assertThat(actual.getApiVersion()).isEqualTo(expected.getApiVersion());
+    assertThat(actual.getResource()).isEqualTo(expected.getResource());
+    assertThat(actual.getSubResource()).isEqualTo(expected.getSubResource());
+    assertThat(actual.getNamespace()).isEqualTo(expected.getNamespace());
+    assertThat(actual.getName()).isEqualTo(expected.getName());
   }
 
   @ParameterizedTest
@@ -104,73 +86,59 @@ class KubernetesRequestUtilsTest {
   }
 
   private static Stream<Arguments> parseRegularResourceArguments() {
+    KubernetesResource deploymentsList =
+        new KubernetesResource("apps", "v1", "deployments", null, null, null);
+    KubernetesResource namespacedDeployments =
+        new KubernetesResource("apps", "v1", "deployments", null, "default", null);
+    KubernetesResource namedDeployment =
+        new KubernetesResource("apps", "v1", "deployments", null, "default", "foo");
+    KubernetesResource namedDeploymentStatus =
+        new KubernetesResource("apps", "v1", "deployments", "status", "default", "foo");
+    KubernetesResource foosList =
+        new KubernetesResource("example.io", "v1alpha1", "foos", null, null, null);
+    KubernetesResource namespacedFoos =
+        new KubernetesResource("example.io", "v1alpha1", "foos", null, "default", null);
+    KubernetesResource namedFoo =
+        new KubernetesResource("example.io", "v1alpha1", "foos", null, "default", "foo");
+    KubernetesResource namedFooStatus =
+        new KubernetesResource("example.io", "v1alpha1", "foos", "status", "default", "foo");
     return Stream.of(
-        Arguments.of("/apis/apps/v1/deployments", "apps", "v1", "deployments", null, null, null),
-        Arguments.of(
-            "/apis/apps/v1/namespaces/default/deployments",
-            "apps",
-            "v1",
-            "deployments",
-            null,
-            "default",
-            null),
-        Arguments.of(
-            "/apis/apps/v1/namespaces/default/deployments/foo",
-            "apps",
-            "v1",
-            "deployments",
-            null,
-            "default",
-            "foo"),
-        Arguments.of(
+        arguments("cluster-scoped list", "/apis/apps/v1/deployments", deploymentsList),
+        arguments(
+            "namespaced list", "/apis/apps/v1/namespaces/default/deployments", namespacedDeployments),
+        arguments(
+            "namespaced named", "/apis/apps/v1/namespaces/default/deployments/foo", namedDeployment),
+        arguments(
+            "namespaced named subresource",
             "/apis/apps/v1/namespaces/default/deployments/foo/status",
-            "apps",
-            "v1",
-            "deployments",
-            "status",
-            "default",
-            "foo"),
-        Arguments.of(
-            "/apis/example.io/v1alpha1/foos", "example.io", "v1alpha1", "foos", null, null, null),
-        Arguments.of(
+            namedDeploymentStatus),
+        arguments("custom resource cluster-scoped list", "/apis/example.io/v1alpha1/foos", foosList),
+        arguments(
+            "custom resource namespaced list",
             "/apis/example.io/v1alpha1/namespaces/default/foos",
-            "example.io",
-            "v1alpha1",
-            "foos",
-            null,
-            "default",
-            null),
-        Arguments.of(
+            namespacedFoos),
+        arguments(
+            "custom resource namespaced named",
             "/apis/example.io/v1alpha1/namespaces/default/foos/foo",
-            "example.io",
-            "v1alpha1",
-            "foos",
-            null,
-            "default",
-            "foo"),
-        Arguments.of(
+            namedFoo),
+        arguments(
+            "custom resource namespaced named subresource",
             "/apis/example.io/v1alpha1/namespaces/default/foos/foo/status",
-            "example.io",
-            "v1alpha1",
-            "foos",
-            "status",
-            "default",
-            "foo"));
+            namedFooStatus));
   }
 
   private static Stream<Arguments> parseCoreResourceArguments() {
+    KubernetesResource podsList = new KubernetesResource("", "v1", "pods", null, null, null);
+    KubernetesResource namespacedPods =
+        new KubernetesResource("", "v1", "pods", null, "default", null);
+    KubernetesResource namedPod = new KubernetesResource("", "v1", "pods", null, "default", "foo");
+    KubernetesResource namedPodExec =
+        new KubernetesResource("", "v1", "pods", "exec", "default", "foo");
     return Stream.of(
-        Arguments.of("/api/v1/pods", "", "v1", "pods", null, null, null),
-        Arguments.of("/api/v1/namespaces/default/pods", "", "v1", "pods", null, "default", null),
-        Arguments.of(
-            "/api/v1/namespaces/default/pods/foo", "", "v1", "pods", null, "default", "foo"),
-        Arguments.of(
-            "/api/v1/namespaces/default/pods/foo/exec",
-            "",
-            "v1",
-            "pods",
-            "exec",
-            "default",
-            "foo"));
+        arguments("cluster-scoped list", "/api/v1/pods", podsList),
+        arguments("namespaced list", "/api/v1/namespaces/default/pods", namespacedPods),
+        arguments("namespaced named", "/api/v1/namespaces/default/pods/foo", namedPod),
+        arguments(
+            "namespaced named subresource", "/api/v1/namespaces/default/pods/foo/exec", namedPodExec));
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesRequestUtilsTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesRequestUtilsTest.java
@@ -105,14 +105,19 @@ class KubernetesRequestUtilsTest {
     return Stream.of(
         arguments("cluster-scoped list", "/apis/apps/v1/deployments", deploymentsList),
         arguments(
-            "namespaced list", "/apis/apps/v1/namespaces/default/deployments", namespacedDeployments),
+            "namespaced list",
+            "/apis/apps/v1/namespaces/default/deployments",
+            namespacedDeployments),
         arguments(
-            "namespaced named", "/apis/apps/v1/namespaces/default/deployments/foo", namedDeployment),
+            "namespaced named",
+            "/apis/apps/v1/namespaces/default/deployments/foo",
+            namedDeployment),
         arguments(
             "namespaced named subresource",
             "/apis/apps/v1/namespaces/default/deployments/foo/status",
             namedDeploymentStatus),
-        arguments("custom resource cluster-scoped list", "/apis/example.io/v1alpha1/foos", foosList),
+        arguments(
+            "custom resource cluster-scoped list", "/apis/example.io/v1alpha1/foos", foosList),
         arguments(
             "custom resource namespaced list",
             "/apis/example.io/v1alpha1/namespaces/default/foos",
@@ -139,6 +144,8 @@ class KubernetesRequestUtilsTest {
         arguments("namespaced list", "/api/v1/namespaces/default/pods", namespacedPods),
         arguments("namespaced named", "/api/v1/namespaces/default/pods/foo", namedPod),
         arguments(
-            "namespaced named subresource", "/api/v1/namespaces/default/pods/foo/exec", namedPodExec));
+            "namespaced named subresource",
+            "/api/v1/namespaces/default/pods/foo/exec",
+            namedPodExec));
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/HostIdResourceTest.java
@@ -11,93 +11,63 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.assertj.core.api.MapAssert;
-import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class HostIdResourceTest {
 
-  private static class LinuxTestCase {
-    private final String name;
-    private final String expectedValue;
-    private final Function<Path, List<String>> pathReader;
-
-    private LinuxTestCase(
-        String name, String expectedValue, Function<Path, List<String>> pathReader) {
-      this.name = name;
-      this.expectedValue = expectedValue;
-      this.pathReader = pathReader;
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("createResourceLinuxCases")
+  void createResourceLinux(
+      String name, String expectedValue, Function<Path, List<String>> pathReader) {
+    HostIdResource hostIdResource = new HostIdResource(() -> "linux", pathReader, null);
+    assertHostId(expectedValue, hostIdResource);
   }
 
-  private static class WindowsTestCase {
-    private final String name;
-    private final String expectedValue;
-    private final Supplier<List<String>> queryWindowsRegistry;
-
-    private WindowsTestCase(
-        String name, String expectedValue, Supplier<List<String>> queryWindowsRegistry) {
-      this.name = name;
-      this.expectedValue = expectedValue;
-      this.queryWindowsRegistry = queryWindowsRegistry;
-    }
-  }
-
-  @TestFactory
-  Collection<DynamicTest> createResourceLinux() {
+  private static Stream<Arguments> createResourceLinuxCases() {
     return Stream.of(
-            new LinuxTestCase("default", "test", path -> singletonList("test")),
-            new LinuxTestCase("empty file or error reading", null, path -> emptyList()))
-        .map(
-            testCase ->
-                DynamicTest.dynamicTest(
-                    testCase.name,
-                    () -> {
-                      HostIdResource hostIdResource =
-                          new HostIdResource(() -> "linux", testCase.pathReader, null);
-
-                      assertHostId(testCase.expectedValue, hostIdResource);
-                    }))
-        .collect(toList());
+        arguments("default", "test", (Function<Path, List<String>>) path -> singletonList("test")),
+        arguments(
+            "empty file or error reading",
+            null,
+            (Function<Path, List<String>>) path -> emptyList()));
   }
 
-  @TestFactory
-  Collection<DynamicTest> createResourceWindows() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("createResourceWindowsCases")
+  void createResourceWindows(
+      String name, String expectedValue, Supplier<List<String>> queryWindowsRegistry) {
+    HostIdResource hostIdResource =
+        new HostIdResource(() -> "Windows 95", null, queryWindowsRegistry);
+    assertHostId(expectedValue, hostIdResource);
+  }
+
+  private static Stream<Arguments> createResourceWindowsCases() {
     return Stream.of(
-            new WindowsTestCase(
-                "default",
-                "test",
+        arguments(
+            "default",
+            "test",
+            (Supplier<List<String>>)
                 () ->
                     asList(
                         "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography",
                         "    MachineGuid    REG_SZ    test")),
-            new WindowsTestCase("short output", null, Collections::emptyList))
-        .map(
-            testCase ->
-                DynamicTest.dynamicTest(
-                    testCase.name,
-                    () -> {
-                      HostIdResource hostIdResource =
-                          new HostIdResource(
-                              () -> "Windows 95", null, testCase.queryWindowsRegistry);
-
-                      assertHostId(testCase.expectedValue, hostIdResource);
-                    }))
-        .collect(toList());
+        arguments("short output", null, (Supplier<List<String>>) Collections::emptyList));
   }
 
   private static void assertHostId(String expectedValue, HostIdResource hostIdResource) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
@@ -25,11 +25,7 @@ class ManifestResourceProviderTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("createResourceCases")
   void createResource(
-      String name,
-      String expectedName,
-      String expectedVersion,
-      Resource input,
-      Resource existing) {
+      String name, String expectedName, String expectedVersion, Resource input, Resource existing) {
     ConfigProperties config = DefaultConfigProperties.createFromMap(emptyMap());
 
     ManifestResourceProvider provider = new ManifestResourceProvider(() -> input);

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ManifestResourceProviderTest.java
@@ -8,76 +8,45 @@ package io.opentelemetry.instrumentation.resources;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.Collection;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ManifestResourceProviderTest {
 
-  private static class TestCase {
-    private final String name;
-    private final String expectedName;
-    private final String expectedVersion;
-    private final Resource input;
-    private final Resource existing;
-
-    TestCase(
-        String name,
-        String expectedName,
-        String expectedVersion,
-        Resource input,
-        Resource existing) {
-      this.name = name;
-      this.expectedName = expectedName;
-      this.expectedVersion = expectedVersion;
-      this.input = input;
-      this.existing = existing;
-    }
-  }
-
-  @TestFactory
-  Collection<DynamicTest> createResource() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("createResourceCases")
+  void createResource(
+      String name,
+      String expectedName,
+      String expectedVersion,
+      Resource input,
+      Resource existing) {
     ConfigProperties config = DefaultConfigProperties.createFromMap(emptyMap());
 
-    return Stream.of(
-            new TestCase(
-                "name ok",
-                "demo",
-                "0.0.1-SNAPSHOT",
-                Resource.create(
-                    Attributes.of(SERVICE_NAME, "demo", SERVICE_VERSION, "0.0.1-SNAPSHOT")),
-                Resource.getDefault()),
-            new TestCase(
-                "name - empty resource", null, null, Resource.empty(), Resource.getDefault()),
-            new TestCase(
-                "name already detected",
-                null,
-                "0.0.1-SNAPSHOT",
-                Resource.create(
-                    Attributes.of(SERVICE_NAME, "demo", SERVICE_VERSION, "0.0.1-SNAPSHOT")),
-                Resource.create(Attributes.of(SERVICE_NAME, "old"))))
-        .map(
-            t ->
-                DynamicTest.dynamicTest(
-                    t.name,
-                    () -> {
-                      ManifestResourceProvider provider =
-                          new ManifestResourceProvider(() -> t.input);
-                      provider.shouldApply(config, t.existing);
+    ManifestResourceProvider provider = new ManifestResourceProvider(() -> input);
+    provider.shouldApply(config, existing);
 
-                      Resource resource = provider.createResource(config);
-                      assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(t.expectedName);
-                      assertThat(resource.getAttribute(SERVICE_VERSION))
-                          .isEqualTo(t.expectedVersion);
-                    }))
-        .collect(toList());
+    Resource resource = provider.createResource(config);
+    assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(expectedName);
+    assertThat(resource.getAttribute(SERVICE_VERSION)).isEqualTo(expectedVersion);
+  }
+
+  private static Stream<Arguments> createResourceCases() {
+    Resource manifest =
+        Resource.create(Attributes.of(SERVICE_NAME, "demo", SERVICE_VERSION, "0.0.1-SNAPSHOT"));
+    Resource existingWithName = Resource.create(Attributes.of(SERVICE_NAME, "old"));
+    return Stream.of(
+        arguments("name ok", "demo", "0.0.1-SNAPSHOT", manifest, Resource.getDefault()),
+        arguments("name - empty resource", null, null, Resource.empty(), Resource.getDefault()),
+        arguments("name already detected", null, "0.0.1-SNAPSHOT", manifest, existingWithName));
   }
 }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
@@ -53,8 +53,7 @@ class ManifestResourceExtractorTest {
     return Stream.of(
         arguments("name ok", "demo", "0.0.1-SNAPSHOT", openClasspathResource("MANIFEST.MF")),
         arguments("name - no resource", null, null, null),
-        arguments(
-            "name - empty resource", null, null, openClasspathResource("empty-MANIFEST.MF")));
+        arguments("name - empty resource", null, null, openClasspathResource("empty-MANIFEST.MF")));
   }
 
   private static InputStream openClasspathResource(String resource) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
@@ -7,71 +7,54 @@ package io.opentelemetry.instrumentation.resources.internal;
 
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ManifestResourceExtractorTest {
 
-  private static class TestCase {
-    private final String name;
-    private final String expectedName;
-    private final String expectedVersion;
-    private final InputStream input;
-
-    TestCase(String name, String expectedName, String expectedVersion, InputStream input) {
-      this.name = name;
-      this.expectedName = expectedName;
-      this.expectedVersion = expectedVersion;
-      this.input = input;
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("extractResourceCases")
+  void extractResource(
+      String name, String expectedName, String expectedVersion, InputStream input) {
+    Resource resource =
+        new ManifestResourceExtractor(
+                new MainJarPathFinder(
+                    () -> JarServiceNameResourceExtractorTest.getArgs("app.jar"),
+                    prop -> null,
+                    JarServiceNameResourceExtractorTest::failPath),
+                p -> {
+                  if (input == null) {
+                    return Optional.empty();
+                  }
+                  try {
+                    Manifest manifest = new Manifest();
+                    manifest.read(input);
+                    return Optional.of(manifest);
+                  } catch (IOException ignored) {
+                    return Optional.empty();
+                  }
+                })
+            .extract();
+    assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(expectedName);
+    assertThat(resource.getAttribute(SERVICE_VERSION)).isEqualTo(expectedVersion);
   }
 
-  @TestFactory
-  Collection<DynamicTest> extractResource() {
+  private static Stream<Arguments> extractResourceCases() {
     return Stream.of(
-            new TestCase("name ok", "demo", "0.0.1-SNAPSHOT", openClasspathResource("MANIFEST.MF")),
-            new TestCase("name - no resource", null, null, null),
-            new TestCase(
-                "name - empty resource", null, null, openClasspathResource("empty-MANIFEST.MF")))
-        .map(
-            t ->
-                DynamicTest.dynamicTest(
-                    t.name,
-                    () -> {
-                      Resource resource =
-                          new ManifestResourceExtractor(
-                                  new MainJarPathFinder(
-                                      () -> JarServiceNameResourceExtractorTest.getArgs("app.jar"),
-                                      prop -> null,
-                                      JarServiceNameResourceExtractorTest::failPath),
-                                  p -> {
-                                    if (t.input == null) {
-                                      return Optional.empty();
-                                    }
-                                    try {
-                                      Manifest manifest = new Manifest();
-                                      manifest.read(t.input);
-                                      return Optional.of(manifest);
-                                    } catch (IOException ignored) {
-                                      return Optional.empty();
-                                    }
-                                  })
-                              .extract();
-                      assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(t.expectedName);
-                      assertThat(resource.getAttribute(SERVICE_VERSION))
-                          .isEqualTo(t.expectedVersion);
-                    }))
-        .collect(toList());
+        arguments("name ok", "demo", "0.0.1-SNAPSHOT", openClasspathResource("MANIFEST.MF")),
+        arguments("name - no resource", null, null, null),
+        arguments(
+            "name - empty resource", null, null, openClasspathResource("empty-MANIFEST.MF")));
   }
 
   private static InputStream openClasspathResource(String resource) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/internal/ManifestResourceExtractorTest.java
@@ -25,38 +25,44 @@ class ManifestResourceExtractorTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("extractResourceCases")
   void extractResource(
-      String name, String expectedName, String expectedVersion, InputStream input) {
-    Resource resource =
-        new ManifestResourceExtractor(
-                new MainJarPathFinder(
-                    () -> JarServiceNameResourceExtractorTest.getArgs("app.jar"),
-                    prop -> null,
-                    JarServiceNameResourceExtractorTest::failPath),
-                p -> {
-                  if (input == null) {
-                    return Optional.empty();
-                  }
-                  try {
-                    Manifest manifest = new Manifest();
-                    manifest.read(input);
-                    return Optional.of(manifest);
-                  } catch (IOException ignored) {
-                    return Optional.empty();
-                  }
-                })
-            .extract();
-    assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(expectedName);
-    assertThat(resource.getAttribute(SERVICE_VERSION)).isEqualTo(expectedVersion);
+      String name, String expectedName, String expectedVersion, String resourceName)
+      throws IOException {
+    try (InputStream input = openClasspathResource(resourceName)) {
+      Resource resource =
+          new ManifestResourceExtractor(
+                  new MainJarPathFinder(
+                      () -> JarServiceNameResourceExtractorTest.getArgs("app.jar"),
+                      prop -> null,
+                      JarServiceNameResourceExtractorTest::failPath),
+                  p -> {
+                    if (input == null) {
+                      return Optional.empty();
+                    }
+                    try {
+                      Manifest manifest = new Manifest();
+                      manifest.read(input);
+                      return Optional.of(manifest);
+                    } catch (IOException ignored) {
+                      return Optional.empty();
+                    }
+                  })
+              .extract();
+      assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo(expectedName);
+      assertThat(resource.getAttribute(SERVICE_VERSION)).isEqualTo(expectedVersion);
+    }
   }
 
   private static Stream<Arguments> extractResourceCases() {
     return Stream.of(
-        arguments("name ok", "demo", "0.0.1-SNAPSHOT", openClasspathResource("MANIFEST.MF")),
+        arguments("name ok", "demo", "0.0.1-SNAPSHOT", "MANIFEST.MF"),
         arguments("name - no resource", null, null, null),
-        arguments("name - empty resource", null, null, openClasspathResource("empty-MANIFEST.MF")));
+        arguments("name - empty resource", null, null, "empty-MANIFEST.MF"));
   }
 
   private static InputStream openClasspathResource(String resource) {
+    if (resource == null) {
+      return null;
+    }
     return ManifestResourceExtractorTest.class.getClassLoader().getResourceAsStream(resource);
   }
 }

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
@@ -29,8 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceProviderPropertiesCustomizerTest {
 
-  private static final String PROVIDER_CLASS_NAME =
-      "io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizerTest$Provider";
+  private static final String PROVIDER_CLASS_NAME = Provider.class.getName();
 
   public static class Provider implements ResourceProvider {
     @Override

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
@@ -50,8 +50,7 @@ class ResourceProviderPropertiesCustomizerTest {
       @Nullable Boolean explicitEnabled) {
     Map<String, String> props = new HashMap<>();
     props.put(
-        ResourceProviderPropertiesCustomizer.ENABLED_KEY,
-        Strings.join(enabledProviders).with(","));
+        ResourceProviderPropertiesCustomizer.ENABLED_KEY, Strings.join(enabledProviders).with(","));
     props.put(
         ResourceProviderPropertiesCustomizer.DISABLED_KEY,
         Strings.join(disabledProviders).with(","));
@@ -66,9 +65,7 @@ class ResourceProviderPropertiesCustomizerTest {
 
     Attributes attributes =
         SdkAutoconfigureAccess.getResourceAttributes(
-            AutoConfiguredOpenTelemetrySdk.builder()
-                .addPropertiesSupplier(() -> props)
-                .build());
+            AutoConfiguredOpenTelemetrySdk.builder().addPropertiesSupplier(() -> props).build());
 
     if (expectedEnabled) {
       assertThat(attributes.get(stringKey("key"))).isEqualTo("value");

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -22,10 +23,14 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.assertj.core.util.Strings;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceProviderPropertiesCustomizerTest {
+
+  private static final String PROVIDER_CLASS_NAME =
+      "io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizerTest$Provider";
 
   public static class Provider implements ResourceProvider {
     @Override
@@ -34,87 +39,57 @@ class ResourceProviderPropertiesCustomizerTest {
     }
   }
 
-  private static class EnabledTestCase {
-    private final String name;
-    private final boolean result;
-    private final Set<String> enabledProviders;
-    private final Set<String> disabledProviders;
-    private final Boolean explicitEnabled;
+  @SuppressWarnings("BooleanParameter")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("enabledTestCases")
+  void enabled(
+      String name,
+      boolean expectedEnabled,
+      Set<String> enabledProviders,
+      Set<String> disabledProviders,
+      @Nullable Boolean explicitEnabled) {
+    Map<String, String> props = new HashMap<>();
+    props.put(
+        ResourceProviderPropertiesCustomizer.ENABLED_KEY,
+        Strings.join(enabledProviders).with(","));
+    props.put(
+        ResourceProviderPropertiesCustomizer.DISABLED_KEY,
+        Strings.join(disabledProviders).with(","));
 
-    private EnabledTestCase(
-        String name,
-        boolean result,
-        Set<String> enabledProviders,
-        Set<String> disabledProviders,
-        @Nullable Boolean explicitEnabled) {
-      this.name = name;
-      this.result = result;
-      this.enabledProviders = enabledProviders;
-      this.disabledProviders = disabledProviders;
-      this.explicitEnabled = explicitEnabled;
+    if (explicitEnabled != null) {
+      props.put("otel.resource.providers.test.enabled", Boolean.toString(explicitEnabled));
+    }
+
+    props.put("otel.traces.exporter", "none");
+    props.put("otel.metrics.exporter", "none");
+    props.put("otel.logs.exporter", "none");
+
+    Attributes attributes =
+        SdkAutoconfigureAccess.getResourceAttributes(
+            AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesSupplier(() -> props)
+                .build());
+
+    if (expectedEnabled) {
+      assertThat(attributes.get(stringKey("key"))).isEqualTo("value");
+    } else {
+      assertThat(attributes.get(stringKey("key"))).isNull();
     }
   }
 
-  @SuppressWarnings("BooleanParameter")
-  @TestFactory
-  Stream<DynamicTest> enabledTestCases() {
-    String className =
-        "io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizerTest$Provider";
+  private static Stream<Arguments> enabledTestCases() {
     return Stream.of(
-            new EnabledTestCase("explicitEnabled", true, emptySet(), emptySet(), true),
-            new EnabledTestCase("explicitEnabledFalse", false, emptySet(), emptySet(), false),
-            new EnabledTestCase("enabledProvidersEmpty", false, emptySet(), emptySet(), null),
-            new EnabledTestCase(
-                "enabledProvidersContains", true, singleton(className), emptySet(), null),
-            new EnabledTestCase(
-                "enabledProvidersNotContains",
-                false,
-                singleton("otherClassName"),
-                emptySet(),
-                null),
-            new EnabledTestCase(
-                "disabledProvidersContains", false, emptySet(), singleton(className), null),
-            new EnabledTestCase(
-                "disabledProvidersNotContains",
-                false,
-                emptySet(),
-                singleton("otherClassName"),
-                null),
-            new EnabledTestCase("defaultEnabledFalse", false, emptySet(), emptySet(), null))
-        .map(
-            tc ->
-                DynamicTest.dynamicTest(
-                    tc.name,
-                    () -> {
-                      Map<String, String> props = new HashMap<>();
-                      props.put(
-                          ResourceProviderPropertiesCustomizer.ENABLED_KEY,
-                          Strings.join(tc.enabledProviders).with(","));
-                      props.put(
-                          ResourceProviderPropertiesCustomizer.DISABLED_KEY,
-                          Strings.join(tc.disabledProviders).with(","));
-
-                      if (tc.explicitEnabled != null) {
-                        props.put(
-                            "otel.resource.providers.test.enabled",
-                            Boolean.toString(tc.explicitEnabled));
-                      }
-
-                      props.put("otel.traces.exporter", "none");
-                      props.put("otel.metrics.exporter", "none");
-                      props.put("otel.logs.exporter", "none");
-
-                      Attributes attributes =
-                          SdkAutoconfigureAccess.getResourceAttributes(
-                              AutoConfiguredOpenTelemetrySdk.builder()
-                                  .addPropertiesSupplier(() -> props)
-                                  .build());
-
-                      if (tc.result) {
-                        assertThat(attributes.get(stringKey("key"))).isEqualTo("value");
-                      } else {
-                        assertThat(attributes.get(stringKey("key"))).isNull();
-                      }
-                    }));
+        arguments("explicitEnabled", true, emptySet(), emptySet(), true),
+        arguments("explicitEnabledFalse", false, emptySet(), emptySet(), false),
+        arguments("enabledProvidersEmpty", false, emptySet(), emptySet(), null),
+        arguments(
+            "enabledProvidersContains", true, singleton(PROVIDER_CLASS_NAME), emptySet(), null),
+        arguments(
+            "enabledProvidersNotContains", false, singleton("otherClassName"), emptySet(), null),
+        arguments(
+            "disabledProvidersContains", false, emptySet(), singleton(PROVIDER_CLASS_NAME), null),
+        arguments(
+            "disabledProvidersNotContains", false, emptySet(), singleton("otherClassName"), null),
+        arguments("defaultEnabledFalse", false, emptySet(), emptySet(), null));
   }
 }


### PR DESCRIPTION
Convert four tests that used `@TestFactory` + `DynamicTest` + a nested `TestCase` value class into standard `@ParameterizedTest` + `@MethodSource`. In each case all test rows were known at compile time, every row ran the same body, and there was no per-test lifecycle state — so none of `@TestFactory`'s capabilities (runtime enumeration, heterogeneous executables, instance-state access, nested grouping) were being used.

Also reshape the `parseCoreResource` / `parseRegularResource` rows in `KubernetesRequestUtilsTest` to declare named `KubernetesResource` expected values as locals inside the `Stream<Arguments>` provider, rather than packing 7 positional arguments per row. The test bodies collapse to a single `assertResourceEquals(actual, expected)` call.