### PR TITLE
Lettuce 5.1: move per-class fixture state from static to instance fields

### DIFF
--- a/.github/agents/knowledge/README.md
+++ b/.github/agents/knowledge/README.md
@@ -18,7 +18,7 @@ Load only files relevant to the current scope to reduce noise and avoid over-con
 | `javaagent-singletons-patterns.md` | `*Singletons`, `*SpanNaming`, and similar holder classes; singleton accessors; callers of singleton accessors/fields |
 | `library-patterns.md` | Library instrumentation telemetry, builder, getter, or setter pattern changes |
 | `module-naming.md` | New or renamed modules or packages; settings includes |
-| `testing-general-patterns.md` | Test files in scope — assertion style, test method signatures and throws clauses, resource cleanup patterns, attribute assertion patterns, `satisfies()` lambda usage |
+| `testing-general-patterns.md` | Test files in scope — assertion style, test method signatures and throws clauses, resource cleanup patterns, abstract test base class state shape, attribute assertion patterns, `satisfies()` lambda usage |
 | `testing-experimental-flags.md` | `testExperimental` task or experimental span-attribute assertions |
 | `testing-semconv-stability.md` | Semconv opt-in modes, `emitOld*`/`emitStable*`, `maybeStable`, Semconv test tasks |
 

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -77,6 +77,34 @@
 - If the test intentionally closes the resource mid-test or asserts behavior around explicit
   close, keep the direct close or try-with-resources in the test body.
 
+## Abstract Test Base Classes — Per-Class State Goes On Instance Fields
+
+When an abstract test base is shared across multiple concrete subclasses run in the same
+JVM fork, treat per-class fixture state (containers, clients, connections, host/port, the
+`AutoCleanupExtension` itself, etc.) as **instance state on a `@TestInstance(PER_CLASS)`
+class**, not as `static` fields.
+
+- Annotate the base with `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`. JUnit then creates
+  one instance per concrete subclass and reuses it for every `@Test` in that class, so
+  instance fields give the same once-per-class lifecycle that `static` fields used to provide,
+  without leaking across subclasses.
+- Make `redisServer` / `kafkaContainer` / `client` / `host` / `port` / etc. instance fields
+  (`protected`, not `protected static`). Each concrete subclass then gets its own container
+  and client, freshly configured by its own `@BeforeAll`.
+- Make `@RegisterExtension AutoCleanupExtension cleanup` an **instance** field, not `static`.
+  A shared `static` `AutoCleanupExtension` only runs `deferAfterAll(...)` callbacks for the
+  first subclass JUnit invokes — its `rootContext` is set on first `beforeAll` and never
+  reset — so subsequent subclasses leak deferred resources (containers, clients, connections).
+- Helpers that read instance fields (e.g. `spanName(String)` reading `host`/`port`) must
+  also be instance methods, not `static`.
+- This is also the right shape when a subclass needs to mutate the container's builder
+  configuration (e.g. `withCommand("--requirepass password")`). With shared `static` state the
+  earlier subclass may have already started the container, so `withCommand` on the running
+  instance has no effect; with per-instance state each subclass mutates and starts its own
+  fresh container.
+- Reserve `static` for true JVM-wide constants (`DB_INDEX`, loggers, `*_HASH_MAP` literals,
+  pure helpers like `addExtraAttributes(...)` / `assertCommandEncodeEvents(...)`).
+
 ## Span Attribute Assertions
 
 - Use `span.hasAttributesSatisfyingExactly(...)` with `equalTo(...)`/`satisfies(...)` for

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -79,31 +79,33 @@
 
 ## Abstract Test Base Classes — Per-Class State Goes On Instance Fields
 
-When an abstract test base is shared across multiple concrete subclasses run in the same
-JVM fork, treat per-class fixture state (containers, clients, connections, host/port, the
-`AutoCleanupExtension` itself, etc.) as **instance state on a `@TestInstance(PER_CLASS)`
-class**, not as `static` fields.
+When an abstract test base is shared by multiple concrete subclasses run in the same JVM
+fork, `static` fixture fields become JVM-wide state the subclasses fight over. Annotate
+the base with `@TestInstance(Lifecycle.PER_CLASS)` and make per-class fixtures
+**instance** fields. JUnit creates one base instance per concrete subclass and reuses it
+for every `@Test`, giving the same once-per-class lifecycle as `static` without leaking
+across subclasses.
 
-- Annotate the base with `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`. JUnit then creates
-  one instance per concrete subclass and reuses it for every `@Test` in that class, so
-  instance fields give the same once-per-class lifecycle that `static` fields used to provide,
-  without leaking across subclasses.
-- Make `redisServer` / `kafkaContainer` / `client` / `host` / `port` / etc. instance fields
-  (`protected`, not `protected static`). Each concrete subclass then gets its own container
-  and client, freshly configured by its own `@BeforeAll`.
-- Make `@RegisterExtension AutoCleanupExtension cleanup` an **instance** field, not `static`.
-  A shared `static` `AutoCleanupExtension` only runs `deferAfterAll(...)` callbacks for the
-  first subclass JUnit invokes — its `rootContext` is set on first `beforeAll` and never
-  reset — so subsequent subclasses leak deferred resources (containers, clients, connections).
-- Helpers that read instance fields (e.g. `spanName(String)` reading `host`/`port`) must
-  also be instance methods, not `static`.
-- This is also the right shape when a subclass needs to mutate the container's builder
-  configuration (e.g. `withCommand("--requirepass password")`). With shared `static` state the
-  earlier subclass may have already started the container, so `withCommand` on the running
-  instance has no effect; with per-instance state each subclass mutates and starts its own
-  fresh container.
-- Reserve `static` for true JVM-wide constants (`DB_INDEX`, loggers, `*_HASH_MAP` literals,
-  pure helpers like `addExtraAttributes(...)` / `assertCommandEncodeEvents(...)`).
+What goes where:
+
+- **Instance** (`protected`, not `protected static`): containers, clients, connections,
+  `host` / `port` / URI fields, and any helper method that reads them (e.g.
+  `spanName(String)` reading `host`/`port`).
+- **Instance** `@RegisterExtension AutoCleanupExtension cleanup`: a shared `static`
+  `AutoCleanupExtension` latches `rootContext` on the first subclass's `beforeAll` and
+  never resets it, so `deferAfterAll(...)` callbacks registered by later subclasses
+  silently leak.
+- **`static`** for true JVM-wide constants only: `DB_INDEX`, loggers, `*_HASH_MAP`
+  literals, pure helpers (`addExtraAttributes(...)`, `assertCommandEncodeEvents(...)`),
+  and `@RegisterExtension InstrumentationExtension testing` — the agent/SDK extension
+  must be `static final` because JUnit only invokes `BeforeAllCallback` /
+  `AfterAllCallback` for class-level (static) `@RegisterExtension` fields.
+
+This shape is also required when a subclass needs to mutate the container's builder
+(e.g. `withCommand("--requirepass password")`): with shared `static` state an earlier
+subclass may have already started the container, so `withCommand` on the running
+instance is a no-op; with per-instance state each subclass mutates and starts its own
+fresh container.
 
 ## Span Attribute Assertions
 

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testCompatibility/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceCompatibilityTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testCompatibility/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceCompatibilityTest.java
@@ -34,7 +34,7 @@ class LettuceCompatibilityTest extends AbstractLettuceClientTest {
     return RedisClient.create(uri);
   }
 
-  private static RedisCommands<String, String> syncCommands;
+  private RedisCommands<String, String> syncCommands;
 
   @BeforeAll
   void setUp() throws UnknownHostException {
@@ -54,7 +54,7 @@ class LettuceCompatibilityTest extends AbstractLettuceClientTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     connection.close();
     redisClient.shutdown();
     redisServer.stop();

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -51,8 +51,8 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"InterruptedExceptionSwallowed", "deprecation"}) // using deprecated semconv
 public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClientTest {
-  private static String dbUriNonExistent;
-  private static int incorrectPort;
+  private String dbUriNonExistent;
+  private int incorrectPort;
 
   private static final ImmutableMap<String, String> TEST_HASH_MAP =
       ImmutableMap.of(
@@ -60,7 +60,7 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
           "lastname", "Doe",
           "age", "53");
 
-  private static RedisAsyncCommands<String, String> asyncCommands;
+  private RedisAsyncCommands<String, String> asyncCommands;
 
   @BeforeAll
   void setUp() throws UnknownHostException {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceClientTest.java
@@ -28,22 +28,22 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public abstract class AbstractLettuceClientTest {
   private static final Logger logger = LoggerFactory.getLogger(AbstractLettuceClientTest.class);
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected static final int DB_INDEX = 0;
 
-  protected static GenericContainer<?> redisServer =
+  protected GenericContainer<?> redisServer =
       new GenericContainer<>("redis:6.2.3-alpine")
           .withExposedPorts(6379)
           .withLogConsumer(new Slf4jLogConsumer(logger))
           .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
-  protected static RedisClient redisClient;
-  protected static StatefulRedisConnection<String, String> connection;
-  protected static String host;
-  protected static String ip;
-  protected static int port;
-  protected static String embeddedDbUri;
+  protected RedisClient redisClient;
+  protected StatefulRedisConnection<String, String> connection;
+  protected String host;
+  protected String ip;
+  protected int port;
+  protected String embeddedDbUri;
 
   protected abstract RedisClient createClient(String uri);
 
@@ -91,7 +91,7 @@ public abstract class AbstractLettuceClientTest {
             event -> event.hasName("redis.encode.end"));
   }
 
-  protected static String spanName(String operation) {
+  protected String spanName(String operation) {
     return spanName(operation, host, port);
   }
 

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings({"InterruptedExceptionSwallowed", "deprecation"}) // using deprecated semconv
 public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceClientTest {
 
-  protected static RedisReactiveCommands<String, String> reactiveCommands;
+  protected RedisReactiveCommands<String, String> reactiveCommands;
 
   @BeforeAll
   void setUp() throws UnknownHostException {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.java
@@ -40,9 +40,6 @@ public abstract class AbstractLettuceSyncClientAuthTest extends AbstractLettuceC
   void setUp() throws UnknownHostException {
     redisServer = redisServer.withCommand("redis-server", "--requirepass password");
     redisServer.start();
-    // Set back so other tests don't fail due to NOAUTH error.
-    cleanup.deferAfterAll(
-        () -> redisServer = redisServer.withCommand("redis-server", "--requirepass \"\""));
     cleanup.deferAfterAll(redisServer::stop);
 
     host = redisServer.getHost();

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClientTest {
 
-  private static String dbUriNonExistent;
+  private String dbUriNonExistent;
 
   private static final ImmutableMap<String, String> TEST_HASH_MAP =
       ImmutableMap.of(
@@ -61,7 +61,7 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
           "lastname", "Doe",
           "age", "53");
 
-  private static RedisCommands<String, String> syncCommands;
+  private RedisCommands<String, String> syncCommands;
 
   @BeforeAll
   void setUp() throws UnknownHostException {


### PR DESCRIPTION
Move per-class fixture state from static to instance fields on lettuce-5.1 abstract test bases, and codify the underlying pattern in the agent knowledge base.

## Why

When an abstract test base is shared across multiple concrete subclasses run in the same JVM fork, `static` fixture fields (containers, clients, host/port, the `AutoCleanupExtension` itself, etc.) become JVM-wide state that the subclasses fight over.

In the lettuce-5.1 case this manifested as two distinct failure modes:

1. **`AutoCleanupExtension` rootContext leak.** A shared `static AutoCleanupExtension cleanup` latches `rootContext` on the first subclass`s `@BeforeAll` and never resets it. `afterAll` then early-returns for every subsequent subclass, so any `deferAfterAll(...)` callbacks registered by those subclasses (e.g. closing `connection`) never fire and the resources leak.

2. **`testAuthCommand` flakiness.** `AbstractLettuceSyncClientAuthTest.setUp` did:

   ```java
   redisServer = redisServer.withCommand("redis-server", "--requirepass password");
   redisServer.start();
   ```

   With `redisServer` shared across subclasses, when `LettuceSyncClientTest` ran first in the JVM fork it had already started the same container with no auth. `withCommand(...)` mutates builder configuration but does not affect an already-running container, and `start()` on an already-started container is a no-op, so the auth test ended up talking to the non-auth Redis from the previous class — yielding `ERR AUTH <password> called without any password configured`. Test ordering wasn`t deterministic, hence flaky rather than always-failing.

Both bugs collapse to: the abstract base was using `static` fields where it should have been using instance fields on a `@TestInstance(PER_CLASS)` class.

This is an alternative (more minimal) fix to #18492, which solved the same root cause via a `createRedisServer()` template method.
