### PR TITLE
Split copilot-instructions.md to fit code-review's 4,000-char per-file limit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,46 +14,11 @@ directly, so review comments on them are noise.
 
 Use category tags like `[Style]`, `[Naming]`, `[Testing]`, `[General]`.
 
-## [Style] Style Guide
+Java-specific style and test rules live in path-specific files (loaded in
+addition to this one when reviewing Java changes):
 
-Follow `docs/contributing/style-guide.md`.
-
-- **Visibility**: principle of least access. Use the most restrictive modifier
-  that still works. Static fields should be `private` unless they are
-  constant-like with a `SCREAMING_SNAKE_CASE` name.
-- **`final` on classes**: declare public API classes `final` where possible. Do
-  **not** add `final` in `javaagent/src/main/`, in `.internal` packages, or in
-  test code (paths under `src/test/` or modules whose name starts/ends with
-  `testing` or `tests`).
-- **`final` on parameters and local variables**: never declare them `final`.
-- **Null comparisons**: use `value == null` / `value != null`, not
-  `null == value` / `null != value`. Applies to Java, Kotlin, and Scala.
-- **`equals` operand order**: prefer `value.equals(CONSTANT)` over
-  `CONSTANT.equals(value)`. Do not flip operand order solely as a defensive
-  null-safety cleanup; only flip when `value` can actually be null.
-- **Class organization**: static fields → static initializer → instance fields
-  → constructors → methods → nested classes. Place calling methods above the
-  methods they call.
-- **Static factory entry points**: place them below fields and immediately
-  above constructors — treat factories and constructors as one construction
-  section.
-- **Static utility classes**: place the private no-arg constructor after all
-  methods.
-- **Uppercase field names**: use `SCREAMING_SNAKE_CASE` only for constant-like
-  values — literals, immutable value constants (e.g. `Duration` timeouts),
-  semantic keys/handles (`AttributeKey`, `ContextKey`, `VirtualField`,
-  `MethodHandle`, `Pattern`), and canonical singletons (`INSTANCE`, `EMPTY`,
-  `NOOP`). Use lower camel case for runtime collaborators (loggers,
-  instrumenters, helpers, caches), even when `static final`.
-- **Avoid throwaway forwarding locals** that mirror an existing constant,
-  argument, or SDK field into both an SDK call and span attributes; pass the
-  original value directly unless real derivation justifies a local.
-- **`Optional`**: do not use in public API signatures or on the hot path.
-- **Semconv constants**: in `library/src/main/`, copy incubating semconv
-  constants locally as `private static final` with a `// copied from <Class>`
-  comment; do not depend on the semconv incubating artifact. In
-  `javaagent/src/main/` and tests, use semconv constants directly.
-- **`@Nullable` in tests**: do not add it to test code.
+- `.github/instructions/java-style.instructions.md`
+- `.github/instructions/java-tests.instructions.md`
 
 ## [Style] `@SuppressWarnings` Scoping
 
@@ -92,64 +57,6 @@ attributes.put(SOME_KEY, getSomething());
 
 Do **not** flag when the guard protects a dereference or derived computation
 (e.g. `view.getClass().getName()`). When in doubt, stay silent.
-
-## [Testing] General Patterns
-
-- Use AssertJ (`assertThat(...)`) for assertions in new test code. Do not
-  use JUnit `Assert.*` or Hamcrest `assertThat`.
-- Do not add AssertJ `.as(...)` descriptions or `.withFailMessage(...)` in
-  tests. Direct assertions whose failure output already shows the unexpected
-  values are preferred.
-- Test methods do not need `throws Exception` clauses unless actually required.
-- Prefer the nearest common parent in `catch` (including `Exception` /
-  `Throwable`) over multi-catch.
-- Use `e` / `f` / `t` / `ignored` per the naming rules above.
-
-## [Testing] AssertJ Idiomatic Simplifications
-
-Prefer built-in AssertJ collection/string/map assertions over manual extraction:
-
-| Anti-pattern | Idiomatic |
-| --- | --- |
-| `assertThat(list.size()).isEqualTo(N)` | `assertThat(list).hasSize(N)` |
-| `assertThat(list.isEmpty()).isTrue()` / `.hasSize(0)` | `assertThat(list).isEmpty()` |
-| `assertThat(list.contains(x)).isTrue()` | `assertThat(list).contains(x)` |
-| per-index `get(i)` checks of every element | `assertThat(list).containsExactly(a, b, ...)` |
-
-`containsExactly` already verifies size, so a separate `hasSize` is redundant.
-Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
-`assertThat(...).hasSize(N)`.
-
-## [Testing] Span Attribute Assertions
-
-- Prefer `hasAttributesSatisfyingExactly(...)` over `hasAttributesSatisfying(...)`
-  — the non-exact variant **silently ignores unexpected attributes**. Also
-  prefer it over `hasAttributes(...)` for consistency.
-- For zero-attribute span assertions, use `hasTotalAttributeCount(0)`.
-- `hasTotalAttributeCount(...)` paired with `hasAttributesSatisfyingExactly(...)`
-  is redundant — the exact variant already validates the count. Remove the
-  count call.
-- Metric points are different: there is no `hasTotalAttributeCount(...)` on
-  metric points, so use `point.hasAttributes(Attributes.empty())` for empty
-  metric-point checks.
-- Do not introduce redundant `(long)` casts in `equalTo(longKey(...), value)`
-  when `value` is already an `int` — the `equalTo(AttributeKey<Long>, int)`
-  overload exists.
-
-## [Testing] `satisfies()` Lambda Parameters
-
-Inside a `satisfies(AttributeKey, lambda)` attribute-assertion the lambda
-parameter is an `AbstractAssert` (e.g. `AbstractStringAssert<?>`), not the raw
-value. Fluent calls like `taskId.contains(jobName)` are already proper
-assertions — do **not** wrap them in `assertThat(value.contains(x)).isTrue()`,
-which degrades the failure message.
-
-Name the outer parameter `val` in Java (or `value` in Scala, where `val` is
-reserved). Use `v` only for a nested inner-lambda parameter.
-
-This guidance applies only to attribute-assertion `satisfies(...)`; for
-`span.satisfies(...)`, `point.satisfies(...)`, etc. use a descriptive name
-(`spanData`, `pointData`, `result`).
 
 ## [Javaagent] Singleton Accessor Naming
 

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -1,0 +1,44 @@
+---
+applyTo: "**/*.java"
+---
+
+# Java Style Rules (first-pass review)
+
+Follow `docs/contributing/style-guide.md`.
+
+- **Visibility**: principle of least access. Use the most restrictive modifier
+  that still works. Static fields should be `private` unless they are
+  constant-like with a `SCREAMING_SNAKE_CASE` name.
+- **`final` on classes**: declare public API classes `final` where possible. Do
+  **not** add `final` in `javaagent/src/main/`, in `.internal` packages, or in
+  test code (paths under `src/test/` or modules whose name starts/ends with
+  `testing` or `tests`).
+- **`final` on parameters and local variables**: never declare them `final`.
+- **Null comparisons**: use `value == null` / `value != null`, not
+  `null == value` / `null != value`. Applies to Java, Kotlin, and Scala.
+- **`equals` operand order**: prefer `value.equals(CONSTANT)` over
+  `CONSTANT.equals(value)`. Do not flip operand order solely as a defensive
+  null-safety cleanup; only flip when `value` can actually be null.
+- **Class organization**: static fields → static initializer → instance fields
+  → constructors → methods → nested classes. Place calling methods above the
+  methods they call.
+- **Static factory entry points**: place them below fields and immediately
+  above constructors — treat factories and constructors as one construction
+  section.
+- **Static utility classes**: place the private no-arg constructor after all
+  methods.
+- **Uppercase field names**: use `SCREAMING_SNAKE_CASE` only for constant-like
+  values — literals, immutable value constants (e.g. `Duration` timeouts),
+  semantic keys/handles (`AttributeKey`, `ContextKey`, `VirtualField`,
+  `MethodHandle`, `Pattern`), and canonical singletons (`INSTANCE`, `EMPTY`,
+  `NOOP`). Use lower camel case for runtime collaborators (loggers,
+  instrumenters, helpers, caches), even when `static final`.
+- **Avoid throwaway forwarding locals** that mirror an existing constant,
+  argument, or SDK field into both an SDK call and span attributes; pass the
+  original value directly unless real derivation justifies a local.
+- **`Optional`**: do not use in public API signatures or on the hot path.
+- **Semconv constants**: in `library/src/main/`, copy incubating semconv
+  constants locally as `private static final` with a `// copied from <Class>`
+  comment; do not depend on the semconv incubating artifact. In
+  `javaagent/src/main/` and tests, use semconv constants directly.
+- **`@Nullable` in tests**: do not add it to test code.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -4,7 +4,9 @@ applyTo: "**/*.java"
 
 # Java Test Rules (first-pass review)
 
-Apply only to changes in test code.
+This file is loaded for all Java changes, but the rules below apply only when
+reviewing test code (e.g. `src/test/**`, `src/*Test/**`, and `testing/`
+modules). Skip them on production sources.
 
 ## [Testing] General Patterns
 

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "**/*.java"
+---
+
+# Java Test Rules (first-pass review)
+
+Apply only to changes in test code.
+
+## [Testing] General Patterns
+
+- Use AssertJ (`assertThat(...)`) for assertions in new test code. Do not
+  use JUnit `Assert.*` or Hamcrest `assertThat`.
+- Do not add AssertJ `.as(...)` descriptions or `.withFailMessage(...)` in
+  tests. Direct assertions whose failure output already shows the unexpected
+  values are preferred.
+- Test methods do not need `throws Exception` clauses unless actually required.
+- Prefer the nearest common parent in `catch` (including `Exception` /
+  `Throwable`) over multi-catch.
+- Use `e` / `f` / `t` / `ignored` for catch variables (per the catch-variable
+  naming rule in `.github/copilot-instructions.md`).
+
+## [Testing] AssertJ Idiomatic Simplifications
+
+Prefer built-in AssertJ collection/string/map assertions over manual extraction:
+
+| Anti-pattern | Idiomatic |
+| --- | --- |
+| `assertThat(list.size()).isEqualTo(N)` | `assertThat(list).hasSize(N)` |
+| `assertThat(list.isEmpty()).isTrue()` / `.hasSize(0)` | `assertThat(list).isEmpty()` |
+| `assertThat(list.contains(x)).isTrue()` | `assertThat(list).contains(x)` |
+| per-index `get(i)` checks of every element | `assertThat(list).containsExactly(a, b, ...)` |
+
+`containsExactly` already verifies size, so a separate `hasSize` is redundant.
+Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
+`assertThat(...).hasSize(N)`.
+
+## [Testing] Span Attribute Assertions
+
+- Prefer `hasAttributesSatisfyingExactly(...)` over `hasAttributesSatisfying(...)`
+  — the non-exact variant **silently ignores unexpected attributes**. Also
+  prefer it over `hasAttributes(...)` for consistency.
+- For zero-attribute span assertions, use `hasTotalAttributeCount(0)`.
+- `hasTotalAttributeCount(...)` paired with `hasAttributesSatisfyingExactly(...)`
+  is redundant — the exact variant already validates the count. Remove the
+  count call.
+- Metric points are different: there is no `hasTotalAttributeCount(...)` on
+  metric points, so use `point.hasAttributes(Attributes.empty())` for empty
+  metric-point checks.
+- Do not introduce redundant `(long)` casts in `equalTo(longKey(...), value)`
+  when `value` is already an `int` — the `equalTo(AttributeKey<Long>, int)`
+  overload exists.
+
+## [Testing] `satisfies()` Lambda Parameters
+
+Inside a `satisfies(AttributeKey, lambda)` attribute-assertion the lambda
+parameter is an `AbstractAssert` (e.g. `AbstractStringAssert<?>`), not the raw
+value. Fluent calls like `taskId.contains(jobName)` are already proper
+assertions — do **not** wrap them in `assertThat(value.contains(x)).isTrue()`,
+which degrades the failure message.
+
+Name the outer parameter `val` in Java (or `value` in Scala, where `val` is
+reserved). Use `v` only for a nested inner-lambda parameter.
+
+This guidance applies only to attribute-assertion `satisfies(...)`; for
+`span.satisfies(...)`, `point.satisfies(...)`, etc. use a descriptive name
+(`spanData`, `pointData`, `result`).


### PR DESCRIPTION
GitHub Copilot code review reads **only the first 4,000 characters** of any
custom instruction file ([docs][1]). The current `.github/copilot-instructions.md`
is 8,375 chars, so rules in the second half — including all of the `[Testing]`
section — never reach the PR reviewer. This explains a recent case where
the reviewer suggested adding `.as(...)` to a test assertion despite the file
explicitly forbidding it.

This PR splits Java-specific rules into path-specific
`.github/instructions/*.instructions.md` files. Each file gets its own
4,000-char budget, and (per [the support matrix][2]) Copilot code review
loads `**/*.instructions.md` files whose `applyTo` glob matches a changed file
**in addition to** the repo-wide file.

I empirically verified the "in addition to" behavior on a throwaway repo: a
PR touching one Java file with three `*.instructions.md` files all
matching `**/*.java` produced review comments tagged from each of the three
files (results in https://github.com/trask/copilot-instructions-test/pull/1).

### File sizes after the split

| File | Chars |
| --- | --: |
| `.github/copilot-instructions.md` | 3,343 |
| `.github/instructions/java-style.instructions.md` | 2,550 |
| `.github/instructions/java-tests.instructions.md` | 3,076 |

### Content moved

- `[Style] Style Guide` → `java-style.instructions.md`
- `[Testing] General Patterns` → `java-tests.instructions.md`
- `[Testing] AssertJ Idiomatic Simplifications` → `java-tests.instructions.md`
- `[Testing] Span Attribute Assertions` → `java-tests.instructions.md`
- `[Testing] satisfies() Lambda Parameters` → `java-tests.instructions.md`

The remaining sections in `copilot-instructions.md` (intro, `@SuppressWarnings`
scoping, catch-variable naming, public-API getters, no-redundant-null-guards,
singleton accessor naming, engineering correctness) apply to all languages
or are short enough that splitting them out is unnecessary.

`AGENTS.md` and the `.github/agents/knowledge/*.md` deep-review knowledge
files are unchanged — those surfaces (custom `pr-review` workflow, IDE agents)
have no equivalent 4,000-char cap.

[1]: https://docs.github.com/en/copilot/concepts/prompting/response-customization
[2]: https://docs.github.com/en/copilot/reference/custom-instructions-support