### PR TITLE
Dashboard: add Copilot review column

### DIFF
--- a/.github/scripts/pull-request-dashboard.py
+++ b/.github/scripts/pull-request-dashboard.py
@@ -556,6 +556,23 @@ def ts_text(ts: datetime | None) -> str:
     return ts.isoformat() if ts else ""
 
 
+def is_copilot_review(review: dict[str, Any]) -> bool:
+    login = actor_login(review.get("user") or {}).lower()
+    if not login:
+        return False
+    return "copilot" in login and (login.endswith("[bot]") or "pull-request-reviewer" in login)
+
+
+def latest_copilot_review_clean(reviews: list[dict[str, Any]], review_comments: list[dict[str, Any]]) -> tuple[bool, bool]:
+    candidates = [r for r in reviews if is_copilot_review(r) and r.get("submitted_at")]
+    if not candidates:
+        return False, False
+    latest = max(candidates, key=lambda r: r.get("submitted_at") or "")
+    review_id = latest.get("id")
+    has_comments = any(c.get("pull_request_review_id") == review_id for c in review_comments)
+    return True, not has_comments
+
+
 def compute_facts(raw: dict[str, Any], author: str, events: list[dict[str, Any]]) -> dict[str, Any]:
     pr = raw["pr"]
     checks = raw["checks"]
@@ -567,6 +584,9 @@ def compute_facts(raw: dict[str, Any], author: str, events: list[dict[str, Any]]
     approver_activity_ts = latest_substantive_activity(events, {"approver"})
     external_activity_ts = latest_substantive_activity(events, {"outsider"})
     api_author = actor_login(pr.get("author") or {})
+    copilot_reviewed, copilot_review_clean = latest_copilot_review_clean(
+        raw["reviews"], raw["review_comments"]
+    )
     return {
         "author": author,
         "is_otelbot_author": api_author.lower() == "app/otelbot",
@@ -575,6 +595,8 @@ def compute_facts(raw: dict[str, Any], author: str, events: list[dict[str, Any]]
         "ci_failing_count": len(failing),
         "ci_pending_count": len(pending),
         "conflicts": compute_conflicts(pr),
+        "copilot_reviewed": copilot_reviewed,
+        "copilot_review_clean": copilot_review_clean,
         "created_at": ts_text(created_ts),
         "last_activity_at": ts_text(last_activity_ts),
         "last_author_activity_at": ts_text(author_activity_ts),
@@ -1044,6 +1066,12 @@ def approved_cell(facts: dict[str, Any]) -> str:
     return "✅" if facts.get("approved") else " "
 
 
+def copilot_cell(facts: dict[str, Any]) -> str:
+    if facts.get("copilot_reviewed") and facts.get("copilot_review_clean"):
+        return "✅"
+    return " "
+
+
 def age_seconds(facts: dict[str, Any]) -> int | None:
     value = facts.get("seconds_since_waiting")
     if isinstance(value, int):
@@ -1124,8 +1152,8 @@ def render_markdown_compact(
         rows.sort(key=row_sort_key, reverse=True)
         out.append(f"## {SIDE_LABELS.get(side, side)}")
         out.append("")
-        out.append("| PR | Author | CI | Conflicts | Age |")
-        out.append("|---|---|:---:|:---:|:---:|")
+        out.append("| PR | Author | CI | Conflicts | Copilot | Age |")
+        out.append("|---|---|:---:|:---:|:---:|:---:|")
         for pr in rows:
             number = pr["number"]
             title = _md_escape(pr.get("title", ""))
@@ -1139,7 +1167,7 @@ def render_markdown_compact(
                 pr_cell += " ✅"
             out.append(
                 f"| {pr_cell} | {author} | {ci_cell(facts)} | "
-                f"{conflicts_cell(facts)} | {activity_cell} |"
+                f"{conflicts_cell(facts)} | {copilot_cell(facts)} | {activity_cell} |"
             )
         out.append("")
 

--- a/.github/scripts/pull-request-dashboard.py
+++ b/.github/scripts/pull-request-dashboard.py
@@ -558,9 +558,7 @@ def ts_text(ts: datetime | None) -> str:
 
 def is_copilot_review(review: dict[str, Any]) -> bool:
     login = actor_login(review.get("user") or {}).lower()
-    if not login:
-        return False
-    return "copilot" in login and (login.endswith("[bot]") or "pull-request-reviewer" in login)
+    return login == "copilot-pull-request-reviewer[bot]"
 
 
 def latest_copilot_review_clean(reviews: list[dict[str, Any]], review_comments: list[dict[str, Any]]) -> tuple[bool, bool]:


### PR DESCRIPTION
Adds an informational `Copilot` column to each per-side PR table in the dashboard issue.

The column shows ✅ when the most recent review by `copilot-pull-request-reviewer[bot]` has no inline review comments (i.e. Copilot found nothing to flag). Otherwise the cell is blank.

This column is purely informational — it is not used in PR routing.