### PR TITLE
Move per-class fixture state from static to instance fields in remaining abstract test bases

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractBaseAwsClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractBaseAwsClientTest.java
@@ -38,20 +38,22 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractBaseAwsClientTest {
   protected static final AWSStaticCredentialsProvider credentialsProvider =
       new AWSStaticCredentialsProvider(new AnonymousAWSCredentials());
-  protected static final MockWebServerExtension server = new MockWebServerExtension();
-  protected static AwsClientBuilder.EndpointConfiguration endpoint;
+  protected final MockWebServerExtension server = new MockWebServerExtension();
+  protected AwsClientBuilder.EndpointConfiguration endpoint;
 
   protected abstract InstrumentationExtension testing();
 
   protected abstract boolean hasRequestId();
 
   @BeforeAll
-  static void setUp() {
+  void setUp() {
     System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key");
     System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key");
     server.start();
@@ -64,7 +66,7 @@ public abstract class AbstractBaseAwsClientTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     System.clearProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY);
     System.clearProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY);
     server.stop();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
@@ -119,7 +119,6 @@ public abstract class AbstractAws2SqsBaseTest {
   }
 
   @BeforeAll
-  @SuppressWarnings("unchecked")
   void setUp() {
     sqs = SQSRestServerBuilder.withPort(0).withInterface("localhost").start();
     Http.ServerBinding server = sqs.waitUntilStarted();
@@ -138,7 +137,8 @@ public abstract class AbstractAws2SqsBaseTest {
             .queueUrl(queueUrl)
             .messageBody("{\"type\": \"hello\"}")
             .build();
-    sendMessageBatchRequest =
+    @SuppressWarnings("unchecked")
+    SendMessageBatchRequest batch =
         SendMessageBatchRequest.builder()
             .queueUrl(queueUrl)
             .entries(
@@ -148,6 +148,7 @@ public abstract class AbstractAws2SqsBaseTest {
                 // 10 attributes, injection with custom propagator never possible
                 e -> e.messageBody("e3").id("i3").messageAttributes(dummyMessageAttributes(10)))
             .build();
+    sendMessageBatchRequest = batch;
   }
 
   @AfterAll

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
@@ -38,6 +38,7 @@ import org.elasticmq.rest.sqs.SQSRestServerBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -54,42 +55,25 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractAws2SqsBaseTest {
   protected static final StaticCredentialsProvider CREDENTIALS_PROVIDER =
       StaticCredentialsProvider.create(
           AwsBasicCredentials.create("my-access-key", "my-secret-key"));
-  protected static int sqsPort;
-  protected static SQSRestServer sqs;
-  protected final String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+  protected int sqsPort;
+  protected SQSRestServer sqs;
+  protected String queueUrl;
 
-  protected ReceiveMessageRequest receiveMessageRequest =
-      ReceiveMessageRequest.builder().queueUrl(queueUrl).build();
+  protected ReceiveMessageRequest receiveMessageRequest;
 
-  protected ReceiveMessageRequest receiveMessageBatchRequest =
-      ReceiveMessageRequest.builder()
-          .queueUrl(queueUrl)
-          .maxNumberOfMessages(3)
-          .messageAttributeNames("All")
-          .waitTimeSeconds(5)
-          .build();
+  protected ReceiveMessageRequest receiveMessageBatchRequest;
 
   protected CreateQueueRequest createQueueRequest =
       CreateQueueRequest.builder().queueName("testSdkSqs").build();
 
-  protected SendMessageRequest sendMessageRequest =
-      SendMessageRequest.builder().queueUrl(queueUrl).messageBody("{\"type\": \"hello\"}").build();
+  protected SendMessageRequest sendMessageRequest;
 
-  @SuppressWarnings("unchecked")
-  protected SendMessageBatchRequest sendMessageBatchRequest =
-      SendMessageBatchRequest.builder()
-          .queueUrl(queueUrl)
-          .entries(
-              e -> e.messageBody("e1").id("i1"),
-              // 8 attributes, injection always possible
-              e -> e.messageBody("e2").id("i2").messageAttributes(dummyMessageAttributes(8)),
-              // 10 attributes, injection with custom propagator never possible
-              e -> e.messageBody("e3").id("i3").messageAttributes(dummyMessageAttributes(10)))
-          .build();
+  protected SendMessageBatchRequest sendMessageBatchRequest;
 
   protected abstract InstrumentationExtension getTesting();
 
@@ -135,14 +119,39 @@ public abstract class AbstractAws2SqsBaseTest {
   }
 
   @BeforeAll
-  static void setUp() {
+  @SuppressWarnings("unchecked")
+  void setUp() {
     sqs = SQSRestServerBuilder.withPort(0).withInterface("localhost").start();
     Http.ServerBinding server = sqs.waitUntilStarted();
     sqsPort = server.localAddress().getPort();
+    queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+    receiveMessageRequest = ReceiveMessageRequest.builder().queueUrl(queueUrl).build();
+    receiveMessageBatchRequest =
+        ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(3)
+            .messageAttributeNames("All")
+            .waitTimeSeconds(5)
+            .build();
+    sendMessageRequest =
+        SendMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .messageBody("{\"type\": \"hello\"}")
+            .build();
+    sendMessageBatchRequest =
+        SendMessageBatchRequest.builder()
+            .queueUrl(queueUrl)
+            .entries(
+                e -> e.messageBody("e1").id("i1"),
+                // 8 attributes, injection always possible
+                e -> e.messageBody("e2").id("i2").messageAttributes(dummyMessageAttributes(8)),
+                // 10 attributes, injection with custom propagator never possible
+                e -> e.messageBody("e3").id("i3").messageAttributes(dummyMessageAttributes(10)))
+            .build();
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     if (sqs != null) {
       sqs.stopAndWait();
     }
@@ -200,7 +209,7 @@ public abstract class AbstractAws2SqsBaseTest {
     assertSqsTraces(false, false);
   }
 
-  static SpanDataAssert createQueueSpan(SpanDataAssert span) {
+  SpanDataAssert createQueueSpan(SpanDataAssert span) {
     return span.hasName("Sqs.CreateQueue")
         .hasKind(SpanKind.CLIENT)
         .hasNoParent()
@@ -221,7 +230,7 @@ public abstract class AbstractAws2SqsBaseTest {
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  static SpanDataAssert processSpan(SpanDataAssert span, SpanData parent) {
+  SpanDataAssert processSpan(SpanDataAssert span, SpanData parent) {
     return span.hasName("testSdkSqs process")
         .hasKind(SpanKind.CONSUMER)
         .hasParent(parent)
@@ -243,7 +252,7 @@ public abstract class AbstractAws2SqsBaseTest {
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  static SpanDataAssert publishSpan(SpanDataAssert span, String queueUrl, String rcpMethod) {
+  SpanDataAssert publishSpan(SpanDataAssert span, String queueUrl, String rcpMethod) {
     return span.hasName("testSdkSqs publish")
         .hasKind(SpanKind.PRODUCER)
         .hasNoParent()

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
@@ -252,7 +252,7 @@ public abstract class AbstractAws2SqsBaseTest {
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  SpanDataAssert publishSpan(SpanDataAssert span, String queueUrl, String rcpMethod) {
+  SpanDataAssert publishSpan(SpanDataAssert span, String queueUrl, String rpcMethod) {
     return span.hasName("testSdkSqs publish")
         .hasKind(SpanKind.PRODUCER)
         .hasNoParent()
@@ -264,7 +264,7 @@ public abstract class AbstractAws2SqsBaseTest {
                 val -> val.matches("\\s*00000000-0000-0000-0000-000000000000\\s*|UNKNOWN")),
             equalTo(RPC_SYSTEM, "aws-api"),
             equalTo(RPC_SERVICE, "Sqs"),
-            equalTo(RPC_METHOD, rcpMethod),
+            equalTo(RPC_METHOD, rpcMethod),
             equalTo(HTTP_REQUEST_METHOD, "POST"),
             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
             satisfies(URL_FULL, val -> val.startsWith("http://localhost:" + sqsPort)),

--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -32,17 +32,13 @@ import static org.junit.jupiter.api.Named.named;
 import com.datastax.oss.driver.api.core.CqlSession;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.cassandra.common.v4_0.AbstractCassandraTest;
-import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 
 public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
-
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -57,17 +58,18 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractCassandraTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractCassandraTest.class);
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension protected final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  private static GenericContainer<?> cassandra;
+  private GenericContainer<?> cassandra;
 
-  protected static String cassandraHost;
-  protected static String cassandraIp;
-  protected static int cassandraPort;
+  protected String cassandraHost;
+  protected String cassandraIp;
+  protected int cassandraPort;
 
   protected abstract InstrumentationExtension testing();
 
@@ -78,7 +80,7 @@ public abstract class AbstractCassandraTest {
   }
 
   @BeforeAll
-  static void beforeAll() throws UnknownHostException {
+  void beforeAll() throws UnknownHostException {
     cassandra =
         new GenericContainer<>("cassandra:4.0")
             .withEnv("JVM_OPTS", "-Xmx128m -Xms128m")

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/AbstractHibernateTest.java
@@ -37,17 +37,19 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AnnotationConfiguration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractHibernateTest {
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  protected static SessionFactory sessionFactory;
-  protected static List<Value> prepopulated;
+  protected SessionFactory sessionFactory;
+  protected List<Value> prepopulated;
 
   @BeforeAll
-  static void setUp() {
+  void setUp() {
     sessionFactory = new AnnotationConfiguration().configure().buildSessionFactory();
 
     // Pre-populate the DB, so delete/update can be tested.
@@ -63,7 +65,7 @@ abstract class AbstractHibernateTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     if (sessionFactory != null) {
       sessionFactory.close();
     }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/AbstractHibernateTest.java
@@ -14,19 +14,21 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractHibernateTest {
 
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  protected static SessionFactory sessionFactory;
-  protected static List<Value> prepopulated;
+  protected SessionFactory sessionFactory;
+  protected List<Value> prepopulated;
 
   @BeforeAll
   @SuppressWarnings("deprecation") // buildSessionFactory
-  static void setUp() {
+  void setUp() {
     sessionFactory = new Configuration().configure().buildSessionFactory();
 
     // Pre-populate the DB, so delete/update can be tested.
@@ -45,7 +47,7 @@ abstract class AbstractHibernateTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     if (sessionFactory != null) {
       sessionFactory.close();
     }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionTest.java
@@ -246,7 +246,7 @@ class SessionTest extends AbstractHibernateTest {
                                     trace.getSpan(1).getAttributes().get(HIBERNATE_SESSION_ID))))));
   }
 
-  private static Stream<Arguments> provideArgumentsHibernateActionStateless() {
+  private Stream<Arguments> provideArgumentsHibernateActionStateless() {
     return Stream.of(
         Arguments.of(named("refresh", new Parameter("refresh", null, StatelessSession::refresh))),
         Arguments.of(
@@ -586,7 +586,7 @@ class SessionTest extends AbstractHibernateTest {
                                 emitStableDatabaseSemconv() ? null : "Value"))));
   }
 
-  private static Stream<Arguments> provideArgumentsHibernateCommitAction() {
+  private Stream<Arguments> provideArgumentsHibernateCommitAction() {
     return Stream.of(
         Arguments.of(
             named(

--- a/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/AbstractHibernateTest.java
+++ b/instrumentation/hibernate/hibernate-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/v6_0/AbstractHibernateTest.java
@@ -14,17 +14,19 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractHibernateTest {
-  protected static SessionFactory sessionFactory;
-  protected static List<Value> prepopulated;
+  protected SessionFactory sessionFactory;
+  protected List<Value> prepopulated;
 
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   @BeforeAll
-  protected static void setup() {
+  protected void setup() {
     sessionFactory = new Configuration().configure().buildSessionFactory();
     // Pre-populate the DB, so delete/update can be tested.
     try (Session writer = sessionFactory.openSession()) {
@@ -39,7 +41,7 @@ abstract class AbstractHibernateTest {
   }
 
   @AfterAll
-  protected static void cleanup() {
+  protected void cleanup() {
     if (sessionFactory != null) {
       sessionFactory.close();
     }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -38,6 +38,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -48,18 +49,19 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractJms1Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms1Test.class);
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  static Session session;
+  Session session;
 
   @BeforeAll
-  static void setUp() throws JMSException {
+  void setUp() throws JMSException {
     GenericContainer<?> broker =
         new GenericContainer<>("apache/activemq-classic:5.19.2")
             .withExposedPorts(61616, 8161)

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -39,6 +39,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -50,21 +51,22 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractJms3Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms3Test.class);
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  static GenericContainer<?> broker;
-  static ActiveMQConnectionFactory connectionFactory;
-  static Connection connection;
-  static Session session;
+  GenericContainer<?> broker;
+  ActiveMQConnectionFactory connectionFactory;
+  Connection connection;
+  Session session;
 
   @BeforeAll
-  static void setUp() throws JMSException {
+  void setUp() throws JMSException {
     broker =
         new GenericContainer<>("quay.io/artemiscloud/activemq-artemis-broker:artemis.2.27.0")
             .withEnv("AMQ_USER", "test")

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/AbstractLettuceClientTest.java
@@ -13,6 +13,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLettuceClientTest {
 
   protected static final Logger logger = LoggerFactory.getLogger(AbstractLettuceClientTest.class);
@@ -28,7 +30,7 @@ abstract class AbstractLettuceClientTest {
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected static final int DB_INDEX = 0;
 
@@ -38,25 +40,25 @@ abstract class AbstractLettuceClientTest {
 
   static final DockerImageName CONTAINER_IMAGE = DockerImageName.parse("redis:6.2.3-alpine");
 
-  protected static final GenericContainer<?> redisServer =
+  protected final GenericContainer<?> redisServer =
       new GenericContainer<>(CONTAINER_IMAGE)
           .withExposedPorts(6379)
           .withLogConsumer(new Slf4jLogConsumer(logger))
           .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
-  protected static RedisClient redisClient;
+  protected RedisClient redisClient;
 
-  protected static StatefulRedisConnection<String, String> connection;
+  protected StatefulRedisConnection<String, String> connection;
 
-  protected static String ip;
+  protected String ip;
 
-  protected static String host;
+  protected String host;
 
-  protected static int port;
+  protected int port;
 
-  protected static String embeddedDbUri;
+  protected String embeddedDbUri;
 
-  protected static StatefulRedisConnection<String, String> newContainerConnection() {
+  protected StatefulRedisConnection<String, String> newContainerConnection() {
     GenericContainer<?> server =
         new GenericContainer<>(CONTAINER_IMAGE)
             .withExposedPorts(6379)

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -61,8 +61,8 @@ import org.junit.jupiter.api.condition.OS;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class LettuceAsyncClientTest extends AbstractLettuceClientTest {
-  private static int incorrectPort;
-  private static String dbUriNonExistent;
+  private int incorrectPort;
+  private String dbUriNonExistent;
 
   private static final ImmutableMap<String, String> testHashMap =
       ImmutableMap.of(
@@ -70,10 +70,10 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
           "lastname", "Doe",
           "age", "53");
 
-  private static RedisAsyncCommands<String, String> asyncCommands;
+  private RedisAsyncCommands<String, String> asyncCommands;
 
   @BeforeAll
-  static void setUp() throws UnknownHostException {
+  void setUp() throws UnknownHostException {
     redisServer.start();
 
     host = redisServer.getHost();
@@ -99,7 +99,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     connection.close();
     shutdown(redisClient);
     redisServer.stop();

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
@@ -37,10 +37,10 @@ import reactor.core.scheduler.Schedulers;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class LettuceReactiveClientTest extends AbstractLettuceClientTest {
-  private static RedisReactiveCommands<String, String> reactiveCommands;
+  private RedisReactiveCommands<String, String> reactiveCommands;
 
   @BeforeAll
-  static void setUp() throws UnknownHostException {
+  void setUp() throws UnknownHostException {
     redisServer.start();
 
     host = redisServer.getHost();
@@ -63,7 +63,7 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     connection.close();
     shutdown(redisClient);
     redisServer.stop();

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -40,8 +40,8 @@ import org.junit.jupiter.api.condition.OS;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class LettuceSyncClientTest extends AbstractLettuceClientTest {
-  private static int incorrectPort;
-  private static String dbUriNonExistent;
+  private int incorrectPort;
+  private String dbUriNonExistent;
 
   private static final ImmutableMap<String, String> testHashMap =
       ImmutableMap.of(
@@ -49,10 +49,10 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
           "lastname", "Doe",
           "age", "53");
 
-  private static RedisCommands<String, String> syncCommands;
+  private RedisCommands<String, String> syncCommands;
 
   @BeforeAll
-  static void setUp() throws UnknownHostException {
+  void setUp() throws UnknownHostException {
     redisServer.start();
     host = redisServer.getHost();
     ip = InetAddress.getByName(host).getHostAddress();
@@ -77,7 +77,7 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
   }
 
   @AfterAll
-  static void cleanUp() {
+  void cleanUp() {
     connection.close();
     shutdown(redisClient);
     redisServer.stop();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/AbstractOpenTelemetryAppenderTest.java
@@ -21,23 +21,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.FormattedMessage;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 abstract class AbstractOpenTelemetryAppenderTest {
 
   static final Logger logger = LogManager.getLogger("TestLogger");
 
-  static Resource resource;
-  static InstrumentationScopeInfo instrumentationScopeInfo;
+  static final Resource RESOURCE = Resource.getDefault();
+  static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
+      InstrumentationScopeInfo.create("TestLogger");
 
   void executeAfterLogsExecution() {}
-
-  @BeforeAll
-  static void setupAll() {
-    resource = Resource.getDefault();
-    instrumentationScopeInfo = InstrumentationScopeInfo.create("TestLogger");
-  }
 
   static void generalBeforeEachSetup() {
     ThreadContext.clearAll();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/LogReplayOpenTelemetryAppenderTest.java
@@ -66,8 +66,8 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     testing.waitAndAssertLogRecords(
         logRecord ->
             logRecord
-                .hasResource(resource)
-                .hasInstrumentationScope(instrumentationScopeInfo)
+                .hasResource(RESOURCE)
+                .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
                 .hasBody("log message 1"));
   }
 
@@ -95,8 +95,8 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     testing.waitAndAssertLogRecords(
         logRecord ->
             logRecord
-                .hasResource(resource)
-                .hasInstrumentationScope(instrumentationScopeInfo)
+                .hasResource(RESOURCE)
+                .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
                 .hasAttributesSatisfyingExactly(
                     addLocationAttributes(
                         "twoLogsStringMapMessage",
@@ -129,8 +129,8 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     testing.waitAndAssertLogRecords(
         logRecord ->
             logRecord
-                .hasResource(resource)
-                .hasInstrumentationScope(instrumentationScopeInfo)
+                .hasResource(RESOURCE)
+                .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
                 .hasBody("a message")
                 .hasAttributesSatisfyingExactly(
                     addLocationAttributes(

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/AbstractOpenTelemetryAppenderTest.java
@@ -26,15 +26,14 @@ abstract class AbstractOpenTelemetryAppenderTest {
 
   static final Logger logger = LoggerFactory.getLogger("TestLogger");
 
-  static Resource resource;
-  static InstrumentationScopeInfo instrumentationScopeInfo;
+  static final Resource RESOURCE = Resource.getDefault();
+  static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
+      InstrumentationScopeInfo.create("TestLogger");
 
   void executeAfterLogsExecution() {}
 
   @BeforeAll
   static void setupAll() {
-    resource = Resource.getDefault();
-    instrumentationScopeInfo = InstrumentationScopeInfo.create("TestLogger");
     // by default LoggerContext contains HOSTNAME property we clear it to start with empty context
     Helper.resetLoggerContext();
   }
@@ -64,8 +63,8 @@ abstract class AbstractOpenTelemetryAppenderTest {
         .waitAndAssertLogRecords(
             logRecord ->
                 logRecord
-                    .hasResource(resource)
-                    .hasInstrumentationScope(instrumentationScopeInfo)
+                    .hasResource(RESOURCE)
+                    .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
                     .hasBody("log message 1")
                     .hasAttributesSatisfyingExactly(assertions));
   }

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogReplayOpenTelemetryAppenderTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/LogReplayOpenTelemetryAppenderTest.java
@@ -88,8 +88,8 @@ class LogReplayOpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTe
     testing.waitAndAssertLogRecords(
         logRecord ->
             logRecord
-                .hasResource(resource)
-                .hasInstrumentationScope(instrumentationScopeInfo)
+                .hasResource(RESOURCE)
+                .hasInstrumentationScope(INSTRUMENTATION_SCOPE_INFO)
                 .hasBody("log message 1")
                 .hasAttributesSatisfyingExactly(assertions));
   }

--- a/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsDispatcherTest.java
@@ -23,7 +23,7 @@ class NatsDispatcherTest extends AbstractNatsDispatcherTest {
   }
 
   @BeforeAll
-  static void beforeAll() {
+  void wrapConnection() {
     connection =
         NatsTelemetry.builder(testing.getOpenTelemetry())
             .setCapturedHeaders(singletonList("Test-Message-Header"))

--- a/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsPublishTest.java
+++ b/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsPublishTest.java
@@ -21,7 +21,7 @@ class NatsPublishTest extends AbstractNatsPublishTest {
   }
 
   @BeforeAll
-  static void beforeAll() {
+  void wrapConnection() {
     connection = NatsTelemetry.create(testing.getOpenTelemetry()).wrap(connection);
   }
 }

--- a/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsRequestTest.java
+++ b/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsRequestTest.java
@@ -24,7 +24,7 @@ class NatsRequestTest extends AbstractNatsRequestTest {
   }
 
   @BeforeAll
-  static void beforeAll() throws IOException, InterruptedException {
+  void wrapConnection() throws IOException, InterruptedException {
     NatsTelemetry telemetry = NatsTelemetry.create(testing.getOpenTelemetry());
     connection =
         telemetry.createConnection(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsTest.java
@@ -12,21 +12,23 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.io.IOException;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractNatsTest {
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  private static GenericContainer<?> natsContainer;
-  static Connection connection;
+  private GenericContainer<?> natsContainer;
+  Connection connection;
 
   protected abstract InstrumentationExtension testing();
 
   @BeforeAll
-  static void beforeAll() throws IOException, InterruptedException {
+  void beforeAll() throws IOException, InterruptedException {
     DockerImageName natsImage = DockerImageName.parse("nats:2.11.2-alpine3.21");
 
     natsContainer = new GenericContainer<>(natsImage).withExposedPorts(4222);


### PR DESCRIPTION
Follows up on #18667, which converted the lettuce-5.1 abstract test base
from `static` to instance per-class fixture state and codified the pattern
in `.github/agents/knowledge/testing-general-patterns.md` (section
"Abstract Test Base Classes — Per-Class State Goes On Instance Fields").

This PR applies the same pattern to the remaining abstract test base classes.