### PR TITLE
Change play-mvc test config for telemetry collection

### DIFF
--- a/.github/scripts/instrumentations.sh
+++ b/.github/scripts/instrumentations.sh
@@ -212,7 +212,7 @@ readonly INSTRUMENTATIONS=(
   "oshi:javaagent:testExperimental"
   "pekko:pekko-http-1.0:javaagent:test"
   "play:play-mvc:play-mvc-2.4:javaagent:test"
-  "play:play-mvc:play-mvc-2.6:javaagent:test"
+  "play:play-mvc:play-mvc-2.6:javaagent:check"
   "play:play-ws:play-ws-1.0:javaagent:test"
   "play:play-ws:play-ws-2.0:javaagent:test"
   "play:play-ws:play-ws-2.1:javaagent:test"


### PR DESCRIPTION
Related to [this removal](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18671/files#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1L11779)

the standard `test` task is configured to only run on java 8 now
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/build.gradle.kts#L89-L96
