### PR TITLE
Prefer OpenTelemetryAssertions.assertThat over dual static imports

### DIFF
--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -203,6 +203,10 @@ affect end users.
 Prefer AssertJ assertions over JUnit assertions (assertEquals, assertTrue, etc.) for better
 error messages.
 
+In test files that use `io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat`,
+do not also statically import `org.assertj.core.api.Assertions.assertThat` — `OpenTelemetryAssertions`
+extends `Assertions`, so all AssertJ `assertThat` overloads are already in scope via inheritance.
+
 ### JUnit
 
 Test classes and test methods should generally be package-protected (no explicit visibility

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientTest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientTest.java
@@ -17,7 +17,6 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientVer20Test.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/version20Test/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/v7_0/KubernetesClientVer20Test.java
@@ -17,7 +17,6 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -42,7 +42,6 @@ import static io.opentelemetry.semconv.UserAgentAttributes.USER_AGENT_ORIGINAL;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 


### PR DESCRIPTION
`OpenTelemetryAssertions` extends `org.assertj.core.api.Assertions`, so all AssertJ `assertThat` overloads are already in scope via inheritance when `OpenTelemetryAssertions.assertThat` is statically imported. Importing both makes call sites harder to read and can become ambiguous if overloads overlap.

This PR:

- Adds a short style-guide note under **Tooling conventions → AssertJ**.
- Removes the redundant `org.assertj.core.api.Assertions.assertThat` static import from the three files currently doing both:
  - `testing-common/.../AbstractHttpServerTest.java`
  - `instrumentation/kubernetes-client-7.0/javaagent/.../KubernetesClientTest.java`
  - `instrumentation/kubernetes-client-7.0/javaagent/.../KubernetesClientVer20Test.java`