### PR TITLE
Module cleanup agent: forbid hoisting non-capturing lambdas into static fields

### DIFF
--- a/.github/agents/module-cleanup.agent.md
+++ b/.github/agents/module-cleanup.agent.md
@@ -290,9 +290,13 @@ Auto-fix boundaries:
 - Never change:
   - literal type suffixes (e.g., `200` → `200L` or vice-versa) — Java widens
     automatically; both forms compile identically and the change is noise
-  - non-capturing lambdas or method references as allocation issues; do not flag,
-    fix, or justify changes to these as per-call allocations. On HotSpot /
-    OpenJDK 8+, these are cached at the call site.
+  - non-capturing lambdas or method references: never hoist an inline
+    non-capturing lambda or method reference into a `private static final` field,
+    regardless of justification (allocation, "pattern consistency", matching a
+    singletons style, or otherwise). On HotSpot / OpenJDK 8+, these are cached
+    at the `invokedynamic` call site, so the hoist is pure noise. The singleton
+    accessor pattern applies to stored singleton fields (e.g. `Instrumenter`),
+    not to arbitrary lambda expressions.
 
 Output content rules:
 


### PR DESCRIPTION
Tighten the module-cleanup agent's lambda rule so it cannot rationalize hoisting an inline non-capturing lambda into a `private static final` field.

### Context

PR #18674 (module-cleanup batch) included this change to `ApacheShenYuSingletons.java`:

```diff
+  private static final HttpServerRouteGetter<MetaData> httpRouteGetter =
+      (context, metaData) -> metaData.getPath();
+
   private ApacheShenYuSingletons() {}

   public static HttpServerRouteGetter<MetaData> httpRouteGetter() {
-    return (context, metaData) -> metaData.getPath();
+    return httpRouteGetter;
   }
```

justified as "matching the singletons pattern".
