### PR TITLE
Pin Copilot CLI install in flaky-test-remediation workflow

### DIFF
--- a/.github/workflows/flaky-test-remediation.yml
+++ b/.github/workflows/flaky-test-remediation.yml
@@ -95,8 +95,8 @@ jobs:
 
       - name: Install Copilot CLI
         run: |
-          curl -fsSL https://gh.io/copilot-install | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          npm ci --prefix .github/scripts/copilot-cli
+          echo "$GITHUB_WORKSPACE/.github/scripts/copilot-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Use CLA approved bot
         run: .github/scripts/use-cla-approved-bot.sh


### PR DESCRIPTION
Switches the flaky-test-remediation workflow's Copilot CLI install from `curl -fsSL https://gh.io/copilot-install | bash` to the same pinned `npm ci` pattern already used by [draft-release-notes.yml](.github/workflows/draft-release-notes.yml) and [pr-review-dashboard.yml](.github/workflows/pr-review-dashboard.yml), via [.github/scripts/copilot-cli/package.json](.github/scripts/copilot-cli/package.json) + `package-lock.json`.

Addresses Scorecard code-scanning alert [#294](https://github.com/open-telemetry/opentelemetry-java-instrumentation/security/code-scanning/294) (Pinned-Dependencies: `downloadThenRun not pinned by hash`).