### PR TITLE
Rerun flaky jobs for PR servlet image builds

### DIFF
--- a/.github/workflows/rerun-flaky-pr-jobs.yml
+++ b/.github/workflows/rerun-flaky-pr-jobs.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - "Build pull request"
+      - "PR build Servlet images for smoke tests"
     types:
       - completed
 

--- a/.github/workflows/rerun-flaky-pr-jobs.yml
+++ b/.github/workflows/rerun-flaky-pr-jobs.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - "Build pull request"
+      - "CodeQL"
       - "PR build Servlet images for smoke tests"
     types:
       - completed


### PR DESCRIPTION
The `Rerun flaky PR jobs` workflow only listened to the `Build pull request` workflow, so failures in `PR build Servlet images for smoke tests` (e.g. [run 25707666031](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/25707666031)) and `CodeQL` were never retried. Add those workflows to the `workflow_run` trigger list.