### PR TITLE
Wire PR build Servlet images into required-status-check

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -64,10 +64,36 @@ jobs:
             echo "native=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # Build the Servlet smoke-test images only when the PR touches the
+  # servlet image sources or its workflow definition.
+  resolve-servlet-images:
+    runs-on: ubuntu-latest
+    outputs:
+      build-servlet-images: ${{ steps.filter.outputs.servlet }}
+    steps:
+      - name: Detect servlet-image-relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(
+            gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[].filename'
+          )
+          include='^smoke-tests/images/servlet/'
+          include+='|^\.github/workflows/reusable-build-servlet-images\.yml$'
+          if grep -Eq "$include" <<<"$files"; then
+            echo "servlet=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "servlet=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
-    needs: [resolve-native]
+    needs: [resolve-native, resolve-servlet-images]
     uses: ./.github/workflows/reusable-pr-build.yml
     with:
       skip-native-tests: ${{ !(needs.resolve-native.outputs.run-native-tests == 'true' || contains(github.event.pull_request.labels.*.name, 'test native')) }}
       skip-openj9-tests: ${{ !contains(github.event.pull_request.labels.*.name, 'test openj9') }}
       skip-windows-smoke-tests: ${{ !contains(github.event.pull_request.labels.*.name, 'test windows') }}
+      skip-servlet-images: ${{ needs.resolve-servlet-images.outputs.build-servlet-images != 'true' }}

--- a/.github/workflows/reusable-build-servlet-images.yml
+++ b/.github/workflows/reusable-build-servlet-images.yml
@@ -1,10 +1,7 @@
-name: PR build Servlet images for smoke tests
+name: Reusable - Build Servlet images for smoke tests
 
 on:
-  pull_request:
-    paths:
-      - "smoke-tests/images/servlet/**"
-      - ".github/workflows/pr-smoke-test-servlet-images.yml"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-native-tests.yml
+++ b/.github/workflows/reusable-native-tests.yml
@@ -3,9 +3,6 @@ name: Reusable - Native tests
 on:
   workflow_call:
     inputs:
-      skip-native-tests:
-        type: boolean
-        required: false
       test-latest-deps:
         type: boolean
         required: false
@@ -15,7 +12,6 @@ permissions:
 
 jobs:
   graalvm-native-tests:
-    if: "!inputs.skip-native-tests"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/reusable-pr-build.yml
+++ b/.github/workflows/reusable-pr-build.yml
@@ -14,6 +14,9 @@ on:
       skip-windows-smoke-tests:
         type: boolean
         default: false
+      skip-servlet-images:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -32,9 +35,8 @@ jobs:
       cache-read-only: true
 
   test-native:
+    if: "!inputs.skip-native-tests"
     uses: ./.github/workflows/reusable-native-tests.yml
-    with:
-      skip-native-tests: ${{ inputs.skip-native-tests }}
 
   muzzle:
     uses: ./.github/workflows/reusable-muzzle.yml
@@ -47,12 +49,18 @@ jobs:
     if: "!startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/')"
     uses: ./.github/workflows/reusable-lint-check.yml
 
+  build-servlet-images:
+    if: "!inputs.skip-servlet-images"
+    uses: ./.github/workflows/reusable-build-servlet-images.yml
+
   required-status-check:
     needs:
       - common
       - test-latest-deps
+      - test-native
       - muzzle
       - lint
+      - build-servlet-images
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -60,6 +68,14 @@ jobs:
           needs.common.result != 'success' ||
           needs.test-latest-deps.result != 'success' ||
           needs.muzzle.result != 'success' ||
+          (
+            needs.test-native.result != 'success' &&
+            needs.test-native.result != 'skipped'
+          ) ||
+          (
+            needs.build-servlet-images.result != 'success' &&
+            needs.build-servlet-images.result != 'skipped'
+          ) ||
           (
             !startsWith(github.base_ref, 'release/') &&
             needs.lint.result != 'success'


### PR DESCRIPTION
The `PR build Servlet images for smoke tests` workflow was running on PRs that touched `smoke-tests/images/servlet/**` but was not part of the PR `required-status-check`, so a failure there didn't actually block merges.

The same was true of `test-native`, so this PR adds both to `required-status-check`.