### PR TITLE
chore: upgrade flint to v0.22.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Linters
-"github:grafana/flint" = "0.21.0"
+"aqua:grafana/flint" = "0.22.2"
 lychee = "0.24.2"
 rumdl = "0.1.88"
 


### PR DESCRIPTION
## What changed
- upgraded the Flint runtime in `mise.toml` to `aqua:grafana/flint@0.22.2`

## Why
This rolls the repo forward to the Flint release that includes the aqua attestation fix, `renovate-deps` metadata fixups, and the `codespell` -> `typos` migration fixes used in other consumers.

## Notes
- this repo did not require any content changes or `typos` exceptions
- Renovate preset pins were intentionally left alone for Renovate to update separately

## Validation
- `mise run lint`
