### PR TITLE
Move instrumenation extension to instance field

### DIFF
--- a/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/v2_3/GrizzlyTest.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/grizzly/v2_3/GrizzlyTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 abstract class GrizzlyTest extends AbstractHttpServerTest<HttpServer> {
 
   @RegisterExtension
-  static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forAgent();
+  final InstrumentationExtension testing = HttpServerInstrumentationExtension.forAgent();
 
   @Override
   protected HttpServer setupServer() throws Exception {


### PR DESCRIPTION
While looking at https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18524 noticed that since the instrumentation extension is shared the tests reuse the server port.