### PR TITLE
Avoid NumberFormatException when port is null

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -95,7 +95,11 @@ public final class UrlParsingUtils {
    * @param value the string value to parse
    * @return the parsed integer, or null if parsing fails
    */
-  public static Integer parsePort(String value) {
+  @Nullable
+  public static Integer parsePort(@Nullable String value) {
+    if (value == null) {
+      return null;
+    }
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {


### PR DESCRIPTION
The exceptions is caught. Noticed it being logged while running `vertx-rx-java-3.5` tests.