### PR TITLE
Avoid misleading module cleanup example

### DIFF
--- a/.github/agents/module-cleanup.agent.md
+++ b/.github/agents/module-cleanup.agent.md
@@ -473,7 +473,7 @@ Do not begin Phase 5 until Phase 4 is fully closed out.
    ```
    Cleanup for alibaba-druid-1.0 javaagent
 
-   - Move collectMetadata system property to withType<Test>().configureEach
+   - Narrow test method throws clause to IOException
    ```
 
    Create exactly one commit for all fixes — do not commit incrementally.


### PR DESCRIPTION
This replaces the module-cleanup agent commit-message example that mentioned moving collectMetadata to withType<Test>().configureEach.

The detailed Gradle guidance already covers when withType<Test>().configureEach is appropriate; using an unrelated cleanup example avoids nudging the agent toward that specific rewrite in single-test-task modules.