### PR TITLE
Fix PR review finalize: findings path inside agent artifact

### DIFF
--- a/.github/workflows/pr-review.lock.yml
+++ b/.github/workflows/pr-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c41e7ad6421af1b44c31d9774686d688204ba689c1f56bdf19887d2862f8731e","compiler_version":"v0.74.0","agent_id":"copilot","agent_model":"${{ needs.dispatch.outputs.model }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4c736d401af94e33322fa432365448da81e57d81da32f52aaa73d0022174fada","compiler_version":"v0.74.0","agent_id":"copilot","agent_model":"${{ needs.dispatch.outputs.model }}"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"330a01c490aca151604b8cf639adc76d48f6c5d4","version":"330a01c490aca151604b8cf639adc76d48f6c5d4"},{"repo":"github/gh-aw-actions/setup","sha":"28ffccfcaa92868c8160807f95519789a590defc","version":"v0.74.0"}],"containers":[{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -210,20 +210,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_95b69f6134f29d9a_EOF'
+          cat << 'GH_AW_PROMPT_9f47aab4f64bcfff_EOF'
           <system>
-          GH_AW_PROMPT_95b69f6134f29d9a_EOF
+          GH_AW_PROMPT_9f47aab4f64bcfff_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_95b69f6134f29d9a_EOF'
+          cat << 'GH_AW_PROMPT_9f47aab4f64bcfff_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, suppress_default_create_issue
           </safe-output-tools>
-          GH_AW_PROMPT_95b69f6134f29d9a_EOF
+          GH_AW_PROMPT_9f47aab4f64bcfff_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_95b69f6134f29d9a_EOF'
+          cat << 'GH_AW_PROMPT_9f47aab4f64bcfff_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -252,16 +252,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_95b69f6134f29d9a_EOF
+          GH_AW_PROMPT_9f47aab4f64bcfff_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_95b69f6134f29d9a_EOF'
+          cat << 'GH_AW_PROMPT_9f47aab4f64bcfff_EOF'
           </system>
           {{#runtime-import .github/agents/pr-review.agent.md}}
           {{#runtime-import .github/workflows/pr-review.md}}
-          GH_AW_PROMPT_95b69f6134f29d9a_EOF
+          GH_AW_PROMPT_9f47aab4f64bcfff_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -497,9 +497,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_51d8bc5d7b7e8f0c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4f8d30dfac41ff14_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"suppress_default_create_issue":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_51d8bc5d7b7e8f0c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4f8d30dfac41ff14_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -674,7 +674,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d21086e8bdec76a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_93c98b9d8d18d3c5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -715,7 +715,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d21086e8bdec76a0_EOF
+          GH_AW_MCP_CONFIG_93c98b9d8d18d3c5_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1136,7 +1136,7 @@ jobs:
           python .github/scripts/pr-review/post.py \
             "$PR_NUMBER" \
             --bundle-dir ./review-bundle \
-            --findings ./agent-artifact/findings.json \
+            --findings ./agent-artifact/agent/findings.json \
             --event COMMENT \
             --triggered-by "$TRIGGERED_BY" \
             --model "$MODEL" \

--- a/.github/workflows/pr-review.md
+++ b/.github/workflows/pr-review.md
@@ -161,7 +161,7 @@ jobs:
           python .github/scripts/pr-review/post.py \
             "$PR_NUMBER" \
             --bundle-dir ./review-bundle \
-            --findings ./agent-artifact/findings.json \
+            --findings ./agent-artifact/agent/findings.json \
             --event COMMENT \
             --triggered-by "$TRIGGERED_BY" \
             --model "$MODEL" \


### PR DESCRIPTION
The `agent` artifact is uploaded with `/tmp/gh-aw` as the archive root (least common ancestor of the upload paths), so the findings file lands at `agent/findings.json` inside the artifact. The finalize job was looking at `./agent-artifact/findings.json` and failing with:

```
ERROR: missing findings.json: agent-artifact/findings.json
```

See finalize job in run [25823942783](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/25823942783/job/75873206796).

Fix the `--findings` path to `./agent-artifact/agent/findings.json` and regenerate the lockfile.