### PR TITLE
Use TestInstance.Lifecycle.PER_CLASS in subclasses too

### DIFF
--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -99,6 +99,17 @@ private static Stream<Arguments> testCases() {
   closeable fields are assigned — JUnit still runs the teardown in that case,
   and an unguarded close on a null field NPEs and skips cleanup of resources
   initialized earlier (e.g. a still-running test container).
+- In abstract test bases that are inherited by multiple concrete test classes,
+  use `@TestInstance(Lifecycle.PER_CLASS)`, instance fixture fields, and an
+  instance `@RegisterExtension AutoCleanupExtension cleanup`. Register
+  `deferAfterAll(...)` callbacks in each `@BeforeAll` immediately after the
+  resource is created. When subclasses also declare instance fields or instance
+  `@BeforeAll` methods, repeat `@TestInstance(Lifecycle.PER_CLASS)` on those
+  subclasses so the lifecycle is visible where the non-static setup appears. Do
+  not use a `static AutoCleanupExtension` inherited from an abstract test base:
+  the shared extension instance records the first concrete class's root context,
+  so `deferAfterAll(...)` callbacks registered by later concrete subclasses can
+  be skipped.
 - Reuse an existing `cleanup` extension when one is already in scope.
   Otherwise, add a `@RegisterExtension` field when the deferred-cleanup pattern improves
   clarity or avoids wrapping most of the test body.

--- a/.github/agents/module-cleanup.agent.md
+++ b/.github/agents/module-cleanup.agent.md
@@ -207,6 +207,16 @@ Auto-fix boundaries:
     `AutoCleanupExtension` with `deferAfterAll(...)` over nested `@AfterAll` cleanup
     chains. Do not introduce or keep `AutoCleanupExtension` solely for a single
     `deferAfterAll(...)` call — use a plain `@AfterAll` instead.
+    When the resources live in an abstract test base that is inherited by multiple
+    concrete test classes, convert the base to `@TestInstance(Lifecycle.PER_CLASS)`,
+    make per-class fixtures instance fields, and use an instance
+    `@RegisterExtension AutoCleanupExtension cleanup` shared by inherited setup
+    methods. Repeat `@TestInstance(Lifecycle.PER_CLASS)` on subclasses that also
+    declare instance fields or instance `@BeforeAll` methods, so the lifecycle is
+    visible where non-static setup appears. Keep `InstrumentationExtension` static.
+    Do not use a shared `static AutoCleanupExtension` inherited from an abstract
+    test base because it can skip `deferAfterAll(...)` cleanup for later concrete
+    subclasses.
   - `hasAttributesSatisfying(...)` calls in test assertions — replace with
     `hasAttributesSatisfyingExactly(...)` because it is more precise (the non-exact
     variant silently ignores unexpected attributes)

--- a/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayJavaStreamedWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayJavaStreamedWsClientBaseTest.java
@@ -11,18 +11,20 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import play.libs.ws.StandaloneWSClient;
 import play.libs.ws.StandaloneWSRequest;
 import play.libs.ws.StandaloneWSResponse;
 import play.libs.ws.ahc.StandaloneAhcWSClient;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PlayJavaStreamedWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWSRequest> {
 
-  private static StandaloneWSClient wsClient;
-  private static StandaloneWSClient wsClientWithReadTimeout;
+  private StandaloneWSClient wsClient;
+  private StandaloneWSClient wsClientWithReadTimeout;
 
   @BeforeAll
-  static void setup() {
+  void setup() {
     wsClient = new StandaloneAhcWSClient(asyncHttpClient, materializer);
     cleanup.deferAfterAll(wsClient);
     wsClientWithReadTimeout =
@@ -64,8 +66,7 @@ public class PlayJavaStreamedWsClientBaseTest extends PlayWsClientBaseTest<Stand
             });
   }
 
-  private static CompletionStage<StandaloneWSResponse> internalSendRequest(
-      StandaloneWSRequest request) {
+  private CompletionStage<StandaloneWSResponse> internalSendRequest(StandaloneWSRequest request) {
     CompletionStage<? extends StandaloneWSResponse> stream = request.stream();
     // The status can be ready before the body, so explicitly wait for the body to be ready.
     return stream
@@ -74,7 +75,7 @@ public class PlayJavaStreamedWsClientBaseTest extends PlayWsClientBaseTest<Stand
         .thenCombine(stream, (body, response) -> response);
   }
 
-  private static StandaloneWSClient getClient(URI uri) {
+  private StandaloneWSClient getClient(URI uri) {
     if (uri.toString().contains("/read-timeout")) {
       return wsClientWithReadTimeout;
     }

--- a/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayJavaWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayJavaWsClientBaseTest.java
@@ -10,17 +10,19 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import play.libs.ws.StandaloneWSClient;
 import play.libs.ws.StandaloneWSRequest;
 import play.libs.ws.ahc.StandaloneAhcWSClient;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PlayJavaWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWSRequest> {
 
-  private static StandaloneWSClient wsClient;
-  private static StandaloneWSClient wsClientWithReadTimeout;
+  private StandaloneWSClient wsClient;
+  private StandaloneWSClient wsClientWithReadTimeout;
 
   @BeforeAll
-  static void setup() {
+  void setup() {
     wsClient = new StandaloneAhcWSClient(asyncHttpClient, materializer);
     cleanup.deferAfterAll(wsClient);
     wsClientWithReadTimeout =
@@ -61,7 +63,7 @@ public class PlayJavaWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWSR
             });
   }
 
-  private static StandaloneWSClient getClient(URI uri) {
+  private StandaloneWSClient getClient(URI uri) {
     if (uri.toString().contains("/read-timeout")) {
       return wsClientWithReadTimeout;
     }

--- a/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayScalaStreamedWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayScalaStreamedWsClientBaseTest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
 import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import play.api.libs.ws.StandaloneWSClient;
 import play.api.libs.ws.StandaloneWSRequest;
 import play.api.libs.ws.StandaloneWSResponse;
@@ -23,13 +24,14 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.Duration;
 import scala.util.Try;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PlayScalaStreamedWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWSRequest> {
 
-  private static StandaloneWSClient wsClient;
-  private static StandaloneWSClient wsClientWithReadTimeout;
+  private StandaloneWSClient wsClient;
+  private StandaloneWSClient wsClientWithReadTimeout;
 
   @BeforeAll
-  static void setup() {
+  void setup() {
     wsClient = new StandaloneAhcWSClient(asyncHttpClient, materializer);
     cleanup.deferAfterAll(wsClient);
     wsClientWithReadTimeout =
@@ -77,7 +79,7 @@ public class PlayScalaStreamedWsClientBaseTest extends PlayWsClientBaseTest<Stan
             ExecutionContext.global());
   }
 
-  private static Future<StandaloneWSResponse> internalSendRequest(StandaloneWSRequest request) {
+  private Future<StandaloneWSResponse> internalSendRequest(StandaloneWSRequest request) {
     Future<StandaloneWSResponse> futureResponse = request.stream();
     // The status can be ready before the body, so explicitly wait for the body to be ready.
     Future<String> bodyResponse =
@@ -99,7 +101,7 @@ public class PlayScalaStreamedWsClientBaseTest extends PlayWsClientBaseTest<Stan
         ExecutionContext.global());
   }
 
-  private static StandaloneWSClient getClient(URI uri) {
+  private StandaloneWSClient getClient(URI uri) {
     if (uri.toString().contains("/read-timeout")) {
       return wsClientWithReadTimeout;
     }

--- a/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayScalaWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayScalaWsClientBaseTest.java
@@ -12,6 +12,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import play.api.libs.ws.StandaloneWSClient;
 import play.api.libs.ws.StandaloneWSRequest;
 import play.api.libs.ws.StandaloneWSResponse;
@@ -23,13 +24,14 @@ import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;
 import scala.util.Try;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PlayScalaWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWSRequest> {
 
-  private static StandaloneWSClient wsClient;
-  private static StandaloneWSClient wsClientWithReadTimeout;
+  private StandaloneWSClient wsClient;
+  private StandaloneWSClient wsClientWithReadTimeout;
 
   @BeforeAll
-  static void setup() {
+  void setup() {
     wsClient = new StandaloneAhcWSClient(asyncHttpClient, materializer);
     cleanup.deferAfterAll(wsClient);
     wsClientWithReadTimeout =
@@ -78,7 +80,7 @@ public class PlayScalaWsClientBaseTest extends PlayWsClientBaseTest<StandaloneWS
             ExecutionContext.global());
   }
 
-  private static StandaloneWSClient getClient(URI uri) {
+  private StandaloneWSClient getClient(URI uri) {
     if (uri.toString().contains("/read-timeout")) {
       return wsClientWithReadTimeout;
     }

--- a/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayWsClientBaseTest.java
+++ b/instrumentation/play/play-ws/play-ws-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/common/v1_0/PlayWsClientBaseTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import play.shaded.ahc.io.netty.resolver.InetNameResolver;
 import play.shaded.ahc.io.netty.util.concurrent.EventExecutor;
@@ -36,20 +37,21 @@ import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClient;
 import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import play.shaded.ahc.org.asynchttpclient.RequestBuilderBase;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class PlayWsClientBaseTest<REQUEST> extends AbstractHttpClientTest<REQUEST> {
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forAgent();
 
-  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
-  private static ActorSystem system;
-  static AsyncHttpClient asyncHttpClient;
-  static AsyncHttpClient asyncHttpClientWithReadTimeout;
-  static ActorMaterializer materializer;
+  private ActorSystem system;
+  AsyncHttpClient asyncHttpClient;
+  AsyncHttpClient asyncHttpClientWithReadTimeout;
+  ActorMaterializer materializer;
 
   @BeforeAll
-  static void setupHttpClient() {
+  void setupHttpClient() {
     String name = "play-ws";
     system = ActorSystem.create(name);
     cleanup.deferAfterAll(() -> system.terminate());


### PR DESCRIPTION
Subclasses already inherit `TestInstance.Lifecycle.PER_CLASS` from their parent, but (a) this is easy to miss since you have to look at the parent to know this, and (b) we are still using `static` state in many of them.

This PR establishes the coding guidelines / pattern.

Will follow-up afterwards to apply to remaining locations.

Extracted from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18741

