### PR TITLE
Redact sensitive SQL password phrases

### DIFF
--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -524,11 +524,13 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "PASSWORD" {
+          boolean passwordTokenIsIdentifier = false;
           if (!insideComment && !extractionDone) {
-            extractionDone = operation.handleIdentifier();
+            passwordTokenIsIdentifier = operation.handleIdentifier();
+            extractionDone = passwordTokenIsIdentifier;
           }
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterPassword()) {
+          if (!passwordTokenIsIdentifier && !insideComment && shouldSanitizeRemainderAfterPassword()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -127,6 +127,16 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
+  private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    return !insideComment
+        && !(operation instanceof Select)
+        && !(operation instanceof Insert)
+        && !(operation instanceof Delete)
+        && !(operation instanceof Update)
+        && !(operation instanceof Merge)
+        && !(operation instanceof Call);
+  }
+
   private static abstract class Operation {
     String mainIdentifier = null;
 
@@ -493,13 +503,23 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "USER" {
+          if (!insideComment && !extractionDone && operation.expectingOperationTarget()) {
+            extractionDone = operation.handleOperationTarget(yytext());
+          }
           appendCurrentFragment();
-          if (!insideComment && (operation instanceof Create || operation instanceof Alter)) {
-            // CREATE USER and ALTER USER statements could contain an unquoted password. We are not
-            // going to try figuring out whether that is the case or not, just sanitize the whole
-            // statement.
-            // https://docs.oracle.com/cd/B13789_01/server.101/b10759/statements_8003.htm
-            // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
+          if (isOverLimit()) return YYEOF;
+      }
+  "PASSWORD" {
+          appendCurrentFragment();
+          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+            builder.append(" ?");
+            return YYEOF;
+          }
+          if (isOverLimit()) return YYEOF;
+      }
+  "IDENTIFIED" {WHITESPACE}+ "BY" {
+          appendCurrentFragment();
+          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -549,6 +549,13 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
+  ";" {
+          if (!insideComment) {
+            sensitivePhraseSanitizationAllowed = false;
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
   {IDENTIFIER} {
           if (!insideComment && !extractionDone) {
             extractionDone = operation.handleIdentifier();

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -120,7 +120,8 @@ WHITESPACE           = [ \t\r\n]+
   private Operation operation = NoOp.INSTANCE;
   private boolean extractionDone = false;
   private boolean doubleQuotesAreIdentifiers;
-  private boolean sensitivePhraseSanitizationAllowed = false;
+  private boolean passwordSanitizationEnabled = false;
+  private boolean identifiedBySanitizationEnabled = false;
 
   private void setOperation(Operation operation) {
     if (this.operation == NoOp.INSTANCE) {
@@ -128,10 +129,16 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+  private boolean shouldSanitizeRemainderAfterPassword() {
     return !insideComment
-        && (sensitivePhraseSanitizationAllowed
-            || operation.shouldSanitizeRemainderAfterSensitivePhrase());
+      && (passwordSanitizationEnabled
+        || operation.shouldSanitizeRemainderAfterPassword());
+  }
+
+  private boolean shouldSanitizeRemainderAfterIdentifiedBy() {
+    return !insideComment
+      && (identifiedBySanitizationEnabled
+        || operation.shouldSanitizeRemainderAfterPassword());
   }
 
   private static abstract class Operation {
@@ -176,7 +183,7 @@ WHITESPACE           = [ \t\r\n]+
       return false;
     }
 
-    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    boolean shouldSanitizeRemainderAfterPassword() {
       return false;
     }
 
@@ -212,7 +219,7 @@ WHITESPACE           = [ \t\r\n]+
           || "VIEW".equals(operationTarget);
     }
 
-    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    boolean shouldSanitizeRemainderAfterPassword() {
       return !hasSafeDdlTarget();
     }
 
@@ -453,9 +460,17 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "CONNECT" | "GRANT" | "VALIDATE" | "CHECK" | "EXPORT" | "IMPORT" | "RECOVER" {
+  "GRANT" {
           if (!insideComment && operation == NoOp.INSTANCE) {
-            sensitivePhraseSanitizationAllowed = true;
+            identifiedBySanitizationEnabled = true;
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "CONNECT" | "VALIDATE" | "CHECK" | "EXPORT" | "IMPORT" | "RECOVER" {
+          if (!insideComment && operation == NoOp.INSTANCE) {
+            passwordSanitizationEnabled = true;
+            identifiedBySanitizationEnabled = true;
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
@@ -513,7 +528,7 @@ WHITESPACE           = [ \t\r\n]+
             extractionDone = operation.handleIdentifier();
           }
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterPassword()) {
             builder.append(" ?");
             return YYEOF;
           }
@@ -521,7 +536,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "IDENTIFIED" {WHITESPACE}+ "BY" {
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterIdentifiedBy()) {
             builder.append(" ?");
             return YYEOF;
           }
@@ -537,7 +552,8 @@ WHITESPACE           = [ \t\r\n]+
       }
   ";" {
           if (!insideComment) {
-            sensitivePhraseSanitizationAllowed = false;
+            passwordSanitizationEnabled = false;
+            identifiedBySanitizationEnabled = false;
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -120,6 +120,7 @@ WHITESPACE           = [ \t\r\n]+
   private Operation operation = NoOp.INSTANCE;
   private boolean extractionDone = false;
   private boolean doubleQuotesAreIdentifiers;
+  private boolean statementStart = true;
   private boolean passwordSanitizationEnabled = false;
   private boolean identifiedBySanitizationEnabled = false;
 
@@ -127,6 +128,10 @@ WHITESPACE           = [ \t\r\n]+
     if (this.operation == NoOp.INSTANCE) {
       this.operation = operation;
     }
+  }
+
+  private void markStatementStarted() {
+    statementStart = false;
   }
 
   private boolean shouldSanitizeRemainderAfterPassword() {
@@ -399,6 +404,7 @@ WHITESPACE           = [ \t\r\n]+
 
   "SELECT" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Select());
           }
           appendCurrentFragment();
@@ -406,6 +412,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "INSERT" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Insert());
           }
           appendCurrentFragment();
@@ -413,6 +420,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "DELETE" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Delete());
           }
           appendCurrentFragment();
@@ -420,6 +428,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "UPDATE" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Update());
           }
           appendCurrentFragment();
@@ -427,6 +436,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "CALL" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Call());
           }
           appendCurrentFragment();
@@ -434,6 +444,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "MERGE" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Merge());
           }
           appendCurrentFragment();
@@ -441,6 +452,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "CREATE" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Create());
           }
           appendCurrentFragment();
@@ -448,6 +460,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "DROP" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Drop());
           }
           appendCurrentFragment();
@@ -455,28 +468,36 @@ WHITESPACE           = [ \t\r\n]+
       }
   "ALTER" {
           if (!insideComment) {
+            markStatementStarted();
             setOperation(new Alter());
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
   "GRANT" {
-          if (!insideComment && operation == NoOp.INSTANCE) {
-            identifiedBySanitizationEnabled = true;
+          if (!insideComment) {
+            if (statementStart) {
+              identifiedBySanitizationEnabled = true;
+            }
+            markStatementStarted();
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
   "CONNECT" | "VALIDATE" | "CHECK" | "EXPORT" | "IMPORT" | "RECOVER" {
-          if (!insideComment && operation == NoOp.INSTANCE) {
-            passwordSanitizationEnabled = true;
-            identifiedBySanitizationEnabled = true;
+          if (!insideComment) {
+            if (statementStart) {
+              passwordSanitizationEnabled = true;
+              identifiedBySanitizationEnabled = true;
+            }
+            markStatementStarted();
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
   "FROM" {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             if (operation == NoOp.INSTANCE) {
               // hql/jpql queries may skip SELECT and start with FROM clause
               // treat such queries as SELECT queries
@@ -489,6 +510,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "INTO" {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             extractionDone = operation.handleInto();
           }
           appendCurrentFragment();
@@ -496,6 +518,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "JOIN" {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             extractionDone = operation.handleJoin();
           }
           appendCurrentFragment();
@@ -503,6 +526,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "NEXT" {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             extractionDone = operation.handleNext();
           }
           appendCurrentFragment();
@@ -514,6 +538,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" | "USER" {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             if (operation.expectingOperationTarget()) {
               extractionDone = operation.handleOperationTarget(yytext());
             } else {
@@ -526,6 +551,7 @@ WHITESPACE           = [ \t\r\n]+
   "PASSWORD" {
           boolean passwordTokenIsIdentifier = false;
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             passwordTokenIsIdentifier = operation.handleIdentifier();
             extractionDone = passwordTokenIsIdentifier;
           }
@@ -537,6 +563,9 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "IDENTIFIED" {WHITESPACE}+ "BY" {
+          if (!insideComment) {
+            markStatementStarted();
+          }
           appendCurrentFragment();
           if (!insideComment && shouldSanitizeRemainderAfterIdentifiedBy()) {
             builder.append(" ?");
@@ -547,6 +576,7 @@ WHITESPACE           = [ \t\r\n]+
 
   {COMMA} {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             extractionDone = operation.handleComma();
           }
           appendCurrentFragment();
@@ -554,6 +584,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   ";" {
           if (!insideComment) {
+            statementStart = true;
             passwordSanitizationEnabled = false;
             identifiedBySanitizationEnabled = false;
           }
@@ -562,6 +593,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   {IDENTIFIER} {
           if (!insideComment && !extractionDone) {
+            markStatementStarted();
             extractionDone = operation.handleIdentifier();
           }
           appendCurrentFragment();
@@ -570,6 +602,7 @@ WHITESPACE           = [ \t\r\n]+
 
   {OPEN_PAREN}  {
           if (!insideComment) {
+            markStatementStarted();
             parenLevel += 1;
           }
           appendCurrentFragment();
@@ -577,6 +610,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   {CLOSE_PAREN} {
           if (!insideComment) {
+            markStatementStarted();
             parenLevel -= 1;
           }
           appendCurrentFragment();

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -129,12 +129,13 @@ WHITESPACE           = [ \t\r\n]+
 
   private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
     return !insideComment
-        && !(operation instanceof Select)
-        && !(operation instanceof Insert)
-        && !(operation instanceof Delete)
-        && !(operation instanceof Update)
-        && !(operation instanceof Merge)
-        && !(operation instanceof Call);
+        && !(operation instanceof DmlOperation)
+        && !isSafeDdlOperation();
+  }
+
+  private boolean isSafeDdlOperation() {
+    return operation instanceof DdlOperation
+        && ((DdlOperation) operation).hasSafeDdlTarget();
   }
 
   private static abstract class Operation {
@@ -203,6 +204,14 @@ WHITESPACE           = [ \t\r\n]+
       return "TABLE".equals(operationTarget);
     }
 
+    /** Returns true for DDL targets where PASSWORD is treated as an identifier, not a secret clause. */
+    boolean hasSafeDdlTarget() {
+      return "TABLE".equals(operationTarget)
+          || "INDEX".equals(operationTarget)
+          || "PROCEDURE".equals(operationTarget)
+          || "VIEW".equals(operationTarget);
+    }
+
     boolean handleIdentifier() {
       if (shouldHandleIdentifier()) {
         mainIdentifier = readIdentifierName();
@@ -226,7 +235,9 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Select extends Operation {
+  private abstract class DmlOperation extends Operation {}
+
+  private class Select extends DmlOperation {
     // you can reference a table in the FROM clause in one of the following ways:
     //   table
     //   table t
@@ -300,7 +311,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Insert extends Operation {
+  private class Insert extends DmlOperation {
     boolean expectingTableName = false;
 
     boolean handleInto() {
@@ -318,7 +329,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Delete extends Operation {
+  private class Delete extends DmlOperation {
     boolean expectingTableName = false;
 
     boolean handleFrom() {
@@ -337,7 +348,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** Operation that extracts the first identifier as the main identifier. */
-  private class SimpleOperation extends Operation {
+  private class SimpleOperation extends DmlOperation {
     boolean handleIdentifier() {
       mainIdentifier = readIdentifierName();
       return true;
@@ -491,7 +502,7 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" {
+  "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" | "USER" {
           if (!insideComment && !extractionDone) {
             if (operation.expectingOperationTarget()) {
               extractionDone = operation.handleOperationTarget(yytext());
@@ -502,14 +513,10 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "USER" {
-          if (!insideComment && !extractionDone && operation.expectingOperationTarget()) {
-            extractionDone = operation.handleOperationTarget(yytext());
-          }
-          appendCurrentFragment();
-          if (isOverLimit()) return YYEOF;
-      }
   "PASSWORD" {
+          if (!insideComment && !extractionDone) {
+            extractionDone = operation.handleIdentifier();
+          }
           appendCurrentFragment();
           if (shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -513,7 +513,7 @@ WHITESPACE           = [ \t\r\n]+
             extractionDone = operation.handleIdentifier();
           }
           appendCurrentFragment();
-          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }
@@ -521,7 +521,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "IDENTIFIED" {WHITESPACE}+ "BY" {
           appendCurrentFragment();
-          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -143,7 +143,7 @@ WHITESPACE           = [ \t\r\n]+
   private boolean shouldSanitizeRemainderAfterIdentifiedBy() {
     return !insideComment
       && (identifiedBySanitizationEnabled
-        || operation.shouldSanitizeRemainderAfterPassword());
+        || operation.shouldSanitizeRemainderAfterIdentifiedBy());
   }
 
   private static abstract class Operation {
@@ -192,6 +192,10 @@ WHITESPACE           = [ \t\r\n]+
       return false;
     }
 
+    boolean shouldSanitizeRemainderAfterIdentifiedBy() {
+      return false;
+    }
+
     SqlQuery getResult(String fullStatement) {
       return SqlQuery.create(fullStatement, getClass().getSimpleName().toUpperCase(java.util.Locale.ROOT), mainIdentifier);
     }
@@ -225,6 +229,10 @@ WHITESPACE           = [ \t\r\n]+
     }
 
     boolean shouldSanitizeRemainderAfterPassword() {
+      return !hasSafeDdlTarget();
+    }
+
+    boolean shouldSanitizeRemainderAfterIdentifiedBy() {
       return !hasSafeDdlTarget();
     }
 

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -120,6 +120,7 @@ WHITESPACE           = [ \t\r\n]+
   private Operation operation = NoOp.INSTANCE;
   private boolean extractionDone = false;
   private boolean doubleQuotesAreIdentifiers;
+  private boolean sensitivePhraseSanitizationAllowed = false;
 
   private void setOperation(Operation operation) {
     if (this.operation == NoOp.INSTANCE) {
@@ -129,13 +130,8 @@ WHITESPACE           = [ \t\r\n]+
 
   private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
     return !insideComment
-        && !(operation instanceof DmlOperation)
-        && !isSafeDdlOperation();
-  }
-
-  private boolean isSafeDdlOperation() {
-    return operation instanceof DdlOperation
-        && ((DdlOperation) operation).hasSafeDdlTarget();
+        && (sensitivePhraseSanitizationAllowed
+            || operation.shouldSanitizeRemainderAfterSensitivePhrase());
   }
 
   private static abstract class Operation {
@@ -180,6 +176,10 @@ WHITESPACE           = [ \t\r\n]+
       return false;
     }
 
+    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+      return false;
+    }
+
     SqlQuery getResult(String fullStatement) {
       return SqlQuery.create(fullStatement, getClass().getSimpleName().toUpperCase(java.util.Locale.ROOT), mainIdentifier);
     }
@@ -210,6 +210,10 @@ WHITESPACE           = [ \t\r\n]+
           || "INDEX".equals(operationTarget)
           || "PROCEDURE".equals(operationTarget)
           || "VIEW".equals(operationTarget);
+    }
+
+    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+      return !hasSafeDdlTarget();
     }
 
     boolean handleIdentifier() {
@@ -447,6 +451,13 @@ WHITESPACE           = [ \t\r\n]+
   "ALTER" {
           if (!insideComment) {
             setOperation(new Alter());
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "GRANT" | "VALIDATE" | "CHECK" | "EXPORT" | "RECOVER" {
+          if (!insideComment) {
+            sensitivePhraseSanitizationAllowed = true;
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -239,9 +239,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private abstract class DmlOperation extends Operation {}
-
-  private class Select extends DmlOperation {
+  private class Select extends Operation {
     // you can reference a table in the FROM clause in one of the following ways:
     //   table
     //   table t
@@ -315,7 +313,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Insert extends DmlOperation {
+  private class Insert extends Operation {
     boolean expectingTableName = false;
 
     boolean handleInto() {
@@ -333,7 +331,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Delete extends DmlOperation {
+  private class Delete extends Operation {
     boolean expectingTableName = false;
 
     boolean handleFrom() {
@@ -352,7 +350,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** Operation that extracts the first identifier as the main identifier. */
-  private class SimpleOperation extends DmlOperation {
+  private class SimpleOperation extends Operation {
     boolean handleIdentifier() {
       mainIdentifier = readIdentifierName();
       return true;

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -453,25 +453,11 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "GRANT" | "VALIDATE" | "CHECK" | "EXPORT" | "RECOVER" {
+  "CONNECT" | "GRANT" | "VALIDATE" | "CHECK" | "EXPORT" | "IMPORT" | "RECOVER" {
           if (!insideComment && operation == NoOp.INSTANCE) {
             sensitivePhraseSanitizationAllowed = true;
           }
           appendCurrentFragment();
-          if (isOverLimit()) return YYEOF;
-      }
-  "CONNECT" {
-          appendCurrentFragment();
-          // sanitize SAP HANA CONNECT statement
-          // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
-          // we check that operation is not set to avoid triggering sanitization when a field named
-          // connect is used or CONNECT BY clause is used in a SELECT statement
-          if (!insideComment && operation == NoOp.INSTANCE) {
-            // CONNECT statement could contain an unquoted password. We are not going to try
-            // figuring out whether that is the case or not, just sanitize the whole statement.
-            builder.append(" ?");
-            return YYEOF;
-          }
           if (isOverLimit()) return YYEOF;
       }
   "FROM" {

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -454,7 +454,7 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "GRANT" | "VALIDATE" | "CHECK" | "EXPORT" | "RECOVER" {
-          if (!insideComment) {
+          if (!insideComment && operation == NoOp.INSTANCE) {
             sensitivePhraseSanitizationAllowed = true;
           }
           appendCurrentFragment();

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -137,6 +137,16 @@ WHITESPACE           = [ \t\r\n]+
     this.operation = operation;
   }
 
+  private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    return !insideComment
+        && !(operation instanceof Select)
+        && !(operation instanceof Insert)
+        && !(operation instanceof Delete)
+        && !(operation instanceof Update)
+        && !(operation instanceof Merge)
+        && !(operation instanceof Call);
+  }
+
   /** Push current operation onto stack and reset to none for subquery processing. */
   private void pushOperation() {
     operationStack.push(operation);
@@ -1014,13 +1024,23 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "USER" {
+          if (!insideComment && operation.expectingOperationTarget()) {
+            operation.handleOperationTarget(yytext());
+          }
           appendCurrentFragment();
-          if (!insideComment && (operation instanceof Create || operation instanceof Alter)) {
-            // CREATE USER and ALTER USER statements could contain an unquoted password. We are not
-            // going to try figuring out whether that is the case or not, just sanitize the whole
-            // statement.
-            // https://docs.oracle.com/cd/B13789_01/server.101/b10759/statements_8003.htm
-            // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
+          if (isOverLimit()) return YYEOF;
+      }
+  "PASSWORD" {
+          appendCurrentFragment();
+          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+            builder.append(" ?");
+            return YYEOF;
+          }
+          if (isOverLimit()) return YYEOF;
+      }
+  "IDENTIFIED" {WHITESPACE}+ "BY" {
+          appendCurrentFragment();
+          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -192,6 +192,9 @@ WHITESPACE           = [ \t\r\n]+
     boolean expectingOperationTarget() {
       return false;
     }
+    boolean isCapturingIdentifier() {
+      return false;
+    }
     boolean shouldSanitizeRemainderAfterPassword() {
       return false;
     }
@@ -222,6 +225,11 @@ WHITESPACE           = [ \t\r\n]+
       operationTarget = target;
       expectingOperationTarget = false;
       appendOperationToSummary(operationTarget);
+    }
+
+    boolean isCapturingIdentifier() {
+      return (!identifierCaptured && !inEmbeddedSelect)
+          || (inEmbeddedSelect && expectingTableName && parenLevel == selectParenLevel);
     }
 
     /** Returns true for DDL targets where PASSWORD is treated as an identifier, not a secret clause. */
@@ -1052,12 +1060,14 @@ WHITESPACE           = [ \t\r\n]+
           if (isOverLimit()) return YYEOF;
       }
   "PASSWORD" {
+          boolean passwordTokenIsIdentifier = false;
           if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
+            passwordTokenIsIdentifier = operation.isCapturingIdentifier();
             operation.handleIdentifier();
           }
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterPassword()) {
+          if (!passwordTokenIsIdentifier && !insideComment && shouldSanitizeRemainderAfterPassword()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -1046,7 +1046,7 @@ WHITESPACE           = [ \t\r\n]+
             operation.handleIdentifier();
           }
           appendCurrentFragment();
-          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }
@@ -1054,7 +1054,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "IDENTIFIED" {WHITESPACE}+ "BY" {
           appendCurrentFragment();
-          if (shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -138,14 +138,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
-    return !insideComment
-        && !(operation instanceof DmlOperation)
-        && !isSafeDdlOperation();
-  }
-
-  private boolean isSafeDdlOperation() {
-    return operation instanceof DdlOperation
-        && ((DdlOperation) operation).hasSafeDdlTarget();
+    return !insideComment && operation.shouldSanitizeRemainderAfterSensitivePhrase();
   }
 
   /** Push current operation onto stack and reset to none for subquery processing. */
@@ -195,6 +188,9 @@ WHITESPACE           = [ \t\r\n]+
     boolean expectingOperationTarget() {
       return false;
     }
+    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+      return false;
+    }
     /** Returns true if open paren should start a subquery context. */
     boolean isEnteringSubquery() {
       return false;
@@ -227,6 +223,10 @@ WHITESPACE           = [ \t\r\n]+
           || "INDEX".equals(operationTarget)
           || "PROCEDURE".equals(operationTarget)
           || "VIEW".equals(operationTarget);
+    }
+
+    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+      return !hasSafeDdlTarget();
     }
 
     void handleIdentifier() {
@@ -525,7 +525,13 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** VALUES operation - no table to capture. */
-  private class Values extends Operation {}
+  private class Values extends DmlOperation {}
+
+  private class SensitivePhraseOperation extends Operation {
+    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+      return true;
+    }
+  }
 
   /** EXECUTE/EXEC operation for stored procedures. */
   private class Execute extends SimpleOperation {
@@ -543,7 +549,7 @@ WHITESPACE           = [ \t\r\n]+
   private class Alter extends DdlOperation {}
 
   /** TRUNCATE operation - captures TABLE keyword and table name. */
-  private class Truncate extends Operation {
+  private class Truncate extends DmlOperation {
     boolean tableCaptured = false;
     boolean identifierCaptured = false;
 
@@ -565,7 +571,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** REPLACE operation (MySQL) - like INSERT, captures table name. */
-  private class Replace extends Operation {
+  private class Replace extends DmlOperation {
     boolean expectingTableName = false;
     boolean tableCaptured = false;
 
@@ -583,7 +589,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** LOCK operation - captures TABLE/TABLES keyword and table name. */
-  private class Lock extends Operation {
+  private class Lock extends DmlOperation {
     boolean tableCaptured = false;
     boolean identifierCaptured = false;
 
@@ -621,7 +627,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** GRANT operation - blocks other keywords from being parsed. */
-  private class Grant extends Operation {}
+  private class Grant extends SensitivePhraseOperation {}
 
   /** REVOKE operation - blocks other keywords from being parsed. */
   private class Revoke extends Operation {}
@@ -917,6 +923,13 @@ WHITESPACE           = [ \t\r\n]+
           if (shouldStartNewOperation()) {
             setOperation(new Show());
             appendOperationToSummary("SHOW");
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "VALIDATE" | "CHECK" | "EXPORT" | "RECOVER" {
+          if (shouldStartNewOperation()) {
+            setOperation(new SensitivePhraseOperation());
           }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -925,7 +925,7 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "VALIDATE" | "CHECK" | "EXPORT" | "RECOVER" {
+  "CONNECT" | "VALIDATE" | "CHECK" | "EXPORT" | "IMPORT" | "RECOVER" {
           if (shouldStartNewOperation()) {
             setOperation(new SensitivePhraseOperation());
           }
@@ -939,20 +939,6 @@ WHITESPACE           = [ \t\r\n]+
             appendOperationToSummary("EXPLAIN");
           }
           appendCurrentFragment();
-          if (isOverLimit()) return YYEOF;
-      }
-  "CONNECT" {
-          appendCurrentFragment();
-          // sanitize SAP HANA CONNECT statement
-          // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
-          // we check that operation is not set to avoid triggering sanitization when a field named
-          // connect is used or CONNECT BY clause is used in a SELECT statement
-          if (!insideComment && operation == none) {
-            // CONNECT statement could contain an unquoted password. We are not going to try
-            // figuring out whether that is the case or not, just sanitize the whole statement.
-            builder.append(" ?");
-            return YYEOF;
-          }
           if (isOverLimit()) return YYEOF;
       }
   "FROM" {

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -137,8 +137,12 @@ WHITESPACE           = [ \t\r\n]+
     this.operation = operation;
   }
 
-  private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
-    return !insideComment && operation.shouldSanitizeRemainderAfterSensitivePhrase();
+  private boolean shouldSanitizeRemainderAfterPassword() {
+    return !insideComment && operation.shouldSanitizeRemainderAfterPassword();
+  }
+
+  private boolean shouldSanitizeRemainderAfterIdentifiedBy() {
+    return !insideComment && operation.shouldSanitizeRemainderAfterIdentifiedBy();
   }
 
   /** Push current operation onto stack and reset to none for subquery processing. */
@@ -188,8 +192,11 @@ WHITESPACE           = [ \t\r\n]+
     boolean expectingOperationTarget() {
       return false;
     }
-    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    boolean shouldSanitizeRemainderAfterPassword() {
       return false;
+    }
+    boolean shouldSanitizeRemainderAfterIdentifiedBy() {
+      return shouldSanitizeRemainderAfterPassword();
     }
     /** Returns true if open paren should start a subquery context. */
     boolean isEnteringSubquery() {
@@ -225,7 +232,7 @@ WHITESPACE           = [ \t\r\n]+
           || "VIEW".equals(operationTarget);
     }
 
-    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    boolean shouldSanitizeRemainderAfterPassword() {
       return !hasSafeDdlTarget();
     }
 
@@ -526,7 +533,7 @@ WHITESPACE           = [ \t\r\n]+
   private class Values extends Operation {}
 
   private class SensitivePhraseOperation extends Operation {
-    boolean shouldSanitizeRemainderAfterSensitivePhrase() {
+    boolean shouldSanitizeRemainderAfterPassword() {
       return true;
     }
   }
@@ -625,7 +632,11 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** GRANT operation - blocks other keywords from being parsed. */
-  private class Grant extends SensitivePhraseOperation {}
+  private class Grant extends Operation {
+    boolean shouldSanitizeRemainderAfterIdentifiedBy() {
+      return true;
+    }
+  }
 
   /** REVOKE operation - blocks other keywords from being parsed. */
   private class Revoke extends Operation {}
@@ -1046,7 +1057,7 @@ WHITESPACE           = [ \t\r\n]+
             operation.handleIdentifier();
           }
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterPassword()) {
             builder.append(" ?");
             return YYEOF;
           }
@@ -1054,7 +1065,7 @@ WHITESPACE           = [ \t\r\n]+
       }
   "IDENTIFIED" {WHITESPACE}+ "BY" {
           appendCurrentFragment();
-          if (!insideComment && shouldSanitizeRemainderAfterSensitivePhrase()) {
+          if (!insideComment && shouldSanitizeRemainderAfterIdentifiedBy()) {
             builder.append(" ?");
             return YYEOF;
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -139,12 +139,13 @@ WHITESPACE           = [ \t\r\n]+
 
   private boolean shouldSanitizeRemainderAfterSensitivePhrase() {
     return !insideComment
-        && !(operation instanceof Select)
-        && !(operation instanceof Insert)
-        && !(operation instanceof Delete)
-        && !(operation instanceof Update)
-        && !(operation instanceof Merge)
-        && !(operation instanceof Call);
+        && !(operation instanceof DmlOperation)
+        && !isSafeDdlOperation();
+  }
+
+  private boolean isSafeDdlOperation() {
+    return operation instanceof DdlOperation
+        && ((DdlOperation) operation).hasSafeDdlTarget();
   }
 
   /** Push current operation onto stack and reset to none for subquery processing. */
@@ -220,6 +221,14 @@ WHITESPACE           = [ \t\r\n]+
       appendOperationToSummary(operationTarget);
     }
 
+    /** Returns true for DDL targets where PASSWORD is treated as an identifier, not a secret clause. */
+    boolean hasSafeDdlTarget() {
+      return "TABLE".equals(operationTarget)
+          || "INDEX".equals(operationTarget)
+          || "PROCEDURE".equals(operationTarget)
+          || "VIEW".equals(operationTarget);
+    }
+
     void handleIdentifier() {
       if (!identifierCaptured && !inEmbeddedSelect) {
         appendTargetToSummary();
@@ -243,7 +252,9 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Select extends Operation {
+  private abstract class DmlOperation extends Operation {}
+
+  private class Select extends DmlOperation {
     // Max identifiers in a table reference: "table", "table alias", or "table as alias"
     private static final int TABLE_REF_MAX_IDENTIFIERS = 3;
 
@@ -394,7 +405,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Insert extends Operation {
+  private class Insert extends DmlOperation {
     boolean expectingTableName = false;
 
     void handleInto() {
@@ -414,7 +425,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Delete extends Operation {
+  private class Delete extends DmlOperation {
     boolean expectingTableName = false;
     boolean identifierCaptured = false;
 
@@ -451,7 +462,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Update extends Operation {
+  private class Update extends DmlOperation {
     boolean identifierCaptured = false;
 
     void handleSelect() {
@@ -470,9 +481,18 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Merge extends SimpleOperation {}
+  private class Merge extends DmlOperation {
+    boolean identifierCaptured = false;
 
-  private class Call extends Operation {
+    void handleIdentifier() {
+      if (!identifierCaptured) {
+        appendTargetToSummary();
+        identifierCaptured = true;
+      }
+    }
+  }
+
+  private class Call extends DmlOperation {
     boolean identifierCaptured = false;
     // Track "NEXT VALUE FOR sequence" pattern - sequence name comes after FOR
     boolean sawNext = false;
@@ -1010,7 +1030,7 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" {
+  "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" | "USER" {
           if (!insideComment) {
             // If we see a reserved word where we expected a subquery, it's a parenthesized name
             cancelPendingSubqueryIfNeeded();
@@ -1023,14 +1043,11 @@ WHITESPACE           = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
-  "USER" {
-          if (!insideComment && operation.expectingOperationTarget()) {
-            operation.handleOperationTarget(yytext());
-          }
-          appendCurrentFragment();
-          if (isOverLimit()) return YYEOF;
-      }
   "PASSWORD" {
+          if (!insideComment) {
+            cancelPendingSubqueryIfNeeded();
+            operation.handleIdentifier();
+          }
           appendCurrentFragment();
           if (shouldSanitizeRemainderAfterSensitivePhrase()) {
             builder.append(" ?");

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -252,9 +252,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private abstract class DmlOperation extends Operation {}
-
-  private class Select extends DmlOperation {
+  private class Select extends Operation {
     // Max identifiers in a table reference: "table", "table alias", or "table as alias"
     private static final int TABLE_REF_MAX_IDENTIFIERS = 3;
 
@@ -405,7 +403,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Insert extends DmlOperation {
+  private class Insert extends Operation {
     boolean expectingTableName = false;
 
     void handleInto() {
@@ -425,7 +423,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Delete extends DmlOperation {
+  private class Delete extends Operation {
     boolean expectingTableName = false;
     boolean identifierCaptured = false;
 
@@ -462,7 +460,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Update extends DmlOperation {
+  private class Update extends Operation {
     boolean identifierCaptured = false;
 
     void handleSelect() {
@@ -481,7 +479,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Merge extends DmlOperation {
+  private class Merge extends Operation {
     boolean identifierCaptured = false;
 
     void handleIdentifier() {
@@ -492,7 +490,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  private class Call extends DmlOperation {
+  private class Call extends Operation {
     boolean identifierCaptured = false;
     // Track "NEXT VALUE FOR sequence" pattern - sequence name comes after FOR
     boolean sawNext = false;
@@ -525,7 +523,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** VALUES operation - no table to capture. */
-  private class Values extends DmlOperation {}
+  private class Values extends Operation {}
 
   private class SensitivePhraseOperation extends Operation {
     boolean shouldSanitizeRemainderAfterSensitivePhrase() {
@@ -549,7 +547,7 @@ WHITESPACE           = [ \t\r\n]+
   private class Alter extends DdlOperation {}
 
   /** TRUNCATE operation - captures TABLE keyword and table name. */
-  private class Truncate extends DmlOperation {
+  private class Truncate extends Operation {
     boolean tableCaptured = false;
     boolean identifierCaptured = false;
 
@@ -571,7 +569,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** REPLACE operation (MySQL) - like INSERT, captures table name. */
-  private class Replace extends DmlOperation {
+  private class Replace extends Operation {
     boolean expectingTableName = false;
     boolean tableCaptured = false;
 
@@ -589,7 +587,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   /** LOCK operation - captures TABLE/TABLES keyword and table name. */
-  private class Lock extends DmlOperation {
+  private class Lock extends Operation {
     boolean tableCaptured = false;
     boolean identifierCaptured = false;
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -87,9 +87,7 @@ class SqlQueryAnalyzerTest {
             "CREATE USER new_user PASSWORD ?",
             "CREATE USER new_user"),
         Arguments.of(
-            "ALTER USER user PASSWORD Password1",
-            "ALTER USER user PASSWORD ?",
-            "ALTER USER"),
+            "ALTER USER user PASSWORD Password1", "ALTER USER user PASSWORD ?", "ALTER USER"),
         // Other SAP HANA administrative statements can contain unquoted or double-quoted passwords
         // after a PASSWORD keyword.
         Arguments.of(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -123,6 +123,10 @@ class SqlQueryAnalyzerTest {
             "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY Password1",
             "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY ?",
             "GRANT"),
+        Arguments.of(
+            "GRANT SELECT ON users TO admin; SELECT password FROM users",
+            "GRANT SELECT ON users TO admin; SELECT password FROM users",
+            "GRANT; SELECT users"),
         // field names do not trigger sensitive statement sanitization
         Arguments.of("SELECT connect FROM TABLE", "SELECT connect FROM TABLE", "SELECT TABLE"),
         Arguments.of(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -77,6 +77,16 @@ class SqlQueryAnalyzerTest {
     }
   }
 
+    @Test
+    void sanitizeGrantObjectNamedPasswordWithSummary() {
+        SqlQuery result =
+                ANALYZER.analyzeWithSummary(
+                        "GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+
+        assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
+        assertThat(result.getQuerySummary()).isEqualTo("GRANT");
+    }
+
   private static Stream<Arguments> sensitiveArgs() {
     return Stream.of(
         // SAP HANA CREATE USER statements can contain unquoted password

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -79,9 +79,8 @@ class SqlQueryAnalyzerTest {
 
   private static Stream<Arguments> sensitiveArgs() {
     return Stream.of(
-        // SAP HANA CONNECT and CREATE USER statements can contain unquoted password
+        // SAP HANA CREATE USER statements can contain unquoted password
         // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
-        Arguments.of("CONNECT user PASSWORD Password1", "CONNECT ?", null),
         Arguments.of(
             "CREATE USER new_user PASSWORD Password1",
             "CREATE USER new_user PASSWORD ?",
@@ -90,6 +89,7 @@ class SqlQueryAnalyzerTest {
             "ALTER USER user PASSWORD Password1", "ALTER USER user PASSWORD ?", "ALTER USER user"),
         // Other SAP HANA administrative statements can contain unquoted or double-quoted passwords
         // after a PASSWORD keyword.
+        Arguments.of("CONNECT user PASSWORD Password1", "CONNECT user PASSWORD ?", null),
         Arguments.of(
             "VALIDATE USER user PASSWORD Password1", "VALIDATE USER user PASSWORD ?", null),
         Arguments.of("CHECK USER user PASSWORD \"Password1\"", "CHECK USER user PASSWORD ?", null),
@@ -104,6 +104,10 @@ class SqlQueryAnalyzerTest {
         Arguments.of(
             "EXPORT table AS BINARY ENCRYPTION PASSWORD Password1",
             "EXPORT table AS BINARY ENCRYPTION PASSWORD ?",
+            null),
+        Arguments.of(
+            "IMPORT MY_SCHEMA1.T1 FROM '/backup/export_dir' WITH ENCRYPTION PASSWORD Password1",
+            "IMPORT MY_SCHEMA1.T1 FROM ? WITH ENCRYPTION PASSWORD ?",
             null),
         Arguments.of(
             "RECOVER ENCRYPTION ROOT KEYS USING 'backup' PASSWORD Password1",

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -78,6 +78,13 @@ class SqlQueryAnalyzerTest {
   }
 
     @Test
+    void sanitizeGrantObjectNamedPassword() {
+        SqlQuery result = ANALYZER.analyze("GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+
+        assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
+    }
+
+    @Test
     void sanitizeGrantObjectNamedPasswordWithSummary() {
         SqlQuery result =
                 ANALYZER.analyzeWithSummary(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -86,6 +86,15 @@ class SqlQueryAnalyzerTest {
   }
 
   @Test
+  void sanitizeDdlObjectNamedPassword() {
+    SqlQuery result =
+        ANALYZER.analyze(
+            "CREATE USER password PASSWORD Password1", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+
+    assertThat(result.getQueryText()).isEqualTo("CREATE USER password PASSWORD ?");
+  }
+
+  @Test
   void sanitizeGrantObjectNamedPasswordWithSummary() {
     SqlQuery result =
         ANALYZER.analyzeWithSummary(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -129,6 +129,10 @@ class SqlQueryAnalyzerTest {
         Arguments.of(
             "SELECT identified_by FROM users", "SELECT identified_by FROM users", "SELECT users"),
         Arguments.of(
+            "TRUNCATE TABLE password", "TRUNCATE TABLE password", "TRUNCATE TABLE password"),
+        Arguments.of("REPLACE password VALUES (1)", "REPLACE password VALUES (?)", "REPLACE password"),
+        Arguments.of("VALUES (password)", "VALUES (password)", "VALUES"),
+        Arguments.of(
             "UPDATE users SET password = \"Password1\"",
             "UPDATE users SET password = ?",
             "UPDATE users"));

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -87,7 +87,7 @@ class SqlQueryAnalyzerTest {
             "CREATE USER new_user PASSWORD ?",
             "CREATE USER new_user"),
         Arguments.of(
-            "ALTER USER user PASSWORD Password1", "ALTER USER user PASSWORD ?", "ALTER USER"),
+            "ALTER USER user PASSWORD Password1", "ALTER USER user PASSWORD ?", "ALTER USER user"),
         // Other SAP HANA administrative statements can contain unquoted or double-quoted passwords
         // after a PASSWORD keyword.
         Arguments.of(
@@ -118,7 +118,7 @@ class SqlQueryAnalyzerTest {
         Arguments.of(
             "ALTER USER user IDENTIFIED BY Password1 REPLACE Password2",
             "ALTER USER user IDENTIFIED BY ?",
-            "ALTER USER"),
+            "ALTER USER user"),
         Arguments.of(
             "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY Password1",
             "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY ?",

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -86,6 +86,17 @@ class SqlQueryAnalyzerTest {
   }
 
   @Test
+  void sanitizeGrantIdentifiedByAfterPreviousStatement() {
+    SqlQuery result =
+        ANALYZER.analyze(
+            "SELECT 1; GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY Password1",
+            DOUBLE_QUOTES_ARE_STRING_LITERALS);
+
+    assertThat(result.getQueryText())
+        .isEqualTo("SELECT ?; GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY ?");
+  }
+
+  @Test
   void sanitizeDdlObjectNamedPassword() {
     SqlQuery result =
         ANALYZER.analyze(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -113,6 +113,10 @@ class SqlQueryAnalyzerTest {
             "RECOVER ENCRYPTION ROOT KEYS USING 'backup' PASSWORD Password1",
             "RECOVER ENCRYPTION ROOT KEYS USING ? PASSWORD ?",
             null),
+        Arguments.of(
+            "GRANT SELECT ON users TO admin /* PASSWORD Password1 */",
+            "GRANT SELECT ON users TO admin /* PASSWORD Password1 */",
+            "GRANT"),
         // Oracle CREATE USER statement can contain unquoted password
         // https://docs.oracle.com/cd/B13789_01/server.101/b10759/statements_8003.htm
         Arguments.of(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -104,6 +104,16 @@ class SqlQueryAnalyzerTest {
     assertThat(result.getQuerySummary()).isEqualTo("GRANT");
   }
 
+  @Test
+  void sanitizeDdlObjectNamedPasswordWithSummary() {
+    SqlQuery result =
+        ANALYZER.analyzeWithSummary(
+            "CREATE USER password PASSWORD Password1", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+
+    assertThat(result.getQueryText()).isEqualTo("CREATE USER password PASSWORD ?");
+    assertThat(result.getQuerySummary()).isEqualTo("CREATE USER password");
+  }
+
   private static Stream<Arguments> sensitiveArgs() {
     return Stream.of(
         // SAP HANA CREATE USER statements can contain unquoted password

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -888,6 +888,7 @@ class SqlQueryAnalyzerTest {
         Arguments.of("SELECT * FROM mytable insert", expect("SELECT", "mytable", "SELECT mytable")),
         Arguments.of(
             "SELECT * FROM mytable AS update", expect("SELECT", "mytable", "SELECT mytable")),
+        Arguments.of("SELECT * FROM user", expect("SELECT", "user", "SELECT user")),
 
         // CTEs (Common Table Expressions) - CTE names are filtered from query summary
         Arguments.of(
@@ -943,7 +944,33 @@ class SqlQueryAnalyzerTest {
                 "ALTER TABLE users ADD COLUMN email VARCHAR(?), DROP COLUMN legacy_id, MODIFY COLUMN status INT",
                 "ALTER TABLE",
                 "users",
-                "ALTER TABLE users")));
+                "ALTER TABLE users")),
+        Arguments.of(
+            "CREATE TABLE users (password VARCHAR(255))",
+            expect(
+                "CREATE TABLE users (password VARCHAR(?))",
+                "CREATE TABLE",
+                "users",
+                "CREATE TABLE users")),
+        Arguments.of(
+            "ALTER TABLE users ADD COLUMN password VARCHAR(255)",
+            expect(
+                "ALTER TABLE users ADD COLUMN password VARCHAR(?)",
+                "ALTER TABLE",
+                "users",
+                "ALTER TABLE users")),
+        Arguments.of(
+            "ALTER TABLE user ADD COLUMN name VARCHAR(255)",
+            expect(
+                "ALTER TABLE user ADD COLUMN name VARCHAR(?)",
+                "ALTER TABLE",
+                "user",
+                "ALTER TABLE user")),
+        Arguments.of(
+            "CREATE TABLE password (id INT)",
+            expect("CREATE TABLE", "password", "CREATE TABLE password")),
+        Arguments.of(
+            "DROP TABLE password", expect("DROP TABLE", "password", "DROP TABLE password")));
   }
 
   @ParameterizedTest

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -125,6 +125,10 @@ class SqlQueryAnalyzerTest {
             "GRANT"),
         // field names do not trigger sensitive statement sanitization
         Arguments.of("SELECT connect FROM TABLE", "SELECT connect FROM TABLE", "SELECT TABLE"),
+        Arguments.of(
+            "SELECT grant, password FROM users",
+            "SELECT grant, password FROM users",
+            "SELECT users"),
         Arguments.of("SELECT password FROM users", "SELECT password FROM users", "SELECT users"),
         Arguments.of(
             "SELECT identified_by FROM users", "SELECT identified_by FROM users", "SELECT users"),

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -82,15 +82,58 @@ class SqlQueryAnalyzerTest {
         // SAP HANA CONNECT and CREATE USER statements can contain unquoted password
         // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20d3b9ad751910148cdccc8205563a87.html?locale=en-US
         Arguments.of("CONNECT user PASSWORD Password1", "CONNECT ?", null),
-        Arguments.of("CREATE USER new_user PASSWORD Password1", "CREATE USER ?", "CREATE"),
-        Arguments.of("ALTER USER user PASSWORD Password1", "ALTER USER ?", "ALTER"),
+        Arguments.of(
+            "CREATE USER new_user PASSWORD Password1",
+            "CREATE USER new_user PASSWORD ?",
+            "CREATE USER new_user"),
+        Arguments.of(
+            "ALTER USER user PASSWORD Password1",
+            "ALTER USER user PASSWORD ?",
+            "ALTER USER"),
+        // Other SAP HANA administrative statements can contain unquoted or double-quoted passwords
+        // after a PASSWORD keyword.
+        Arguments.of(
+            "VALIDATE USER user PASSWORD Password1", "VALIDATE USER user PASSWORD ?", null),
+        Arguments.of("CHECK USER user PASSWORD \"Password1\"", "CHECK USER user PASSWORD ?", null),
+        Arguments.of(
+            "CREATE DATABASE db SYSTEM USER PASSWORD Password1",
+            "CREATE DATABASE db SYSTEM USER PASSWORD ?",
+            "CREATE DATABASE db"),
+        Arguments.of(
+            "ALTER SYSTEM SET SECURE STORE BACKUP PASSWORD \"Password1\"",
+            "ALTER SYSTEM SET SECURE STORE BACKUP PASSWORD ?",
+            "ALTER SYSTEM"),
+        Arguments.of(
+            "EXPORT table AS BINARY ENCRYPTION PASSWORD Password1",
+            "EXPORT table AS BINARY ENCRYPTION PASSWORD ?",
+            null),
+        Arguments.of(
+            "RECOVER ENCRYPTION ROOT KEYS USING 'backup' PASSWORD Password1",
+            "RECOVER ENCRYPTION ROOT KEYS USING ? PASSWORD ?",
+            null),
         // Oracle CREATE USER statement can contain unquoted password
         // https://docs.oracle.com/cd/B13789_01/server.101/b10759/statements_8003.htm
-        Arguments.of("CREATE USER new_user IDENTIFIED BY Password1", "CREATE USER ?", "CREATE"),
         Arguments.of(
-            "ALTER USER user IDENTIFIED BY Password1 REPLACE Password2", "ALTER USER ?", "ALTER"),
-        // field named "connect" does not trigger sanitization
-        Arguments.of("SELECT connect FROM TABLE", "SELECT connect FROM TABLE", "SELECT TABLE"));
+            "CREATE USER new_user IDENTIFIED BY Password1",
+            "CREATE USER new_user IDENTIFIED BY ?",
+            "CREATE USER new_user"),
+        Arguments.of(
+            "ALTER USER user IDENTIFIED BY Password1 REPLACE Password2",
+            "ALTER USER user IDENTIFIED BY ?",
+            "ALTER USER"),
+        Arguments.of(
+            "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY Password1",
+            "GRANT ALL PRIVILEGES ON database.* TO user IDENTIFIED BY ?",
+            "GRANT"),
+        // field names do not trigger sensitive statement sanitization
+        Arguments.of("SELECT connect FROM TABLE", "SELECT connect FROM TABLE", "SELECT TABLE"),
+        Arguments.of("SELECT password FROM users", "SELECT password FROM users", "SELECT users"),
+        Arguments.of(
+            "SELECT identified_by FROM users", "SELECT identified_by FROM users", "SELECT users"),
+        Arguments.of(
+            "UPDATE users SET password = \"Password1\"",
+            "UPDATE users SET password = ?",
+            "UPDATE users"));
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -77,22 +77,23 @@ class SqlQueryAnalyzerTest {
     }
   }
 
-    @Test
-    void sanitizeGrantObjectNamedPassword() {
-        SqlQuery result = ANALYZER.analyze("GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+  @Test
+  void sanitizeGrantObjectNamedPassword() {
+    SqlQuery result =
+        ANALYZER.analyze("GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
 
-        assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
-    }
+    assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
+  }
 
-    @Test
-    void sanitizeGrantObjectNamedPasswordWithSummary() {
-        SqlQuery result =
-                ANALYZER.analyzeWithSummary(
-                        "GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
+  @Test
+  void sanitizeGrantObjectNamedPasswordWithSummary() {
+    SqlQuery result =
+        ANALYZER.analyzeWithSummary(
+            "GRANT SELECT ON password TO admin", DOUBLE_QUOTES_ARE_STRING_LITERALS);
 
-        assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
-        assertThat(result.getQuerySummary()).isEqualTo("GRANT");
-    }
+    assertThat(result.getQueryText()).isEqualTo("GRANT SELECT ON password TO admin");
+    assertThat(result.getQuerySummary()).isEqualTo("GRANT");
+  }
 
   private static Stream<Arguments> sensitiveArgs() {
     return Stream.of(
@@ -163,7 +164,8 @@ class SqlQueryAnalyzerTest {
             "SELECT identified_by FROM users", "SELECT identified_by FROM users", "SELECT users"),
         Arguments.of(
             "TRUNCATE TABLE password", "TRUNCATE TABLE password", "TRUNCATE TABLE password"),
-        Arguments.of("REPLACE password VALUES (1)", "REPLACE password VALUES (?)", "REPLACE password"),
+        Arguments.of(
+            "REPLACE password VALUES (1)", "REPLACE password VALUES (?)", "REPLACE password"),
         Arguments.of("VALUES (password)", "VALUES (password)", "VALUES"),
         Arguments.of(
             "UPDATE users SET password = \"Password1\"",


### PR DESCRIPTION
Redact values following sensitive SQL password phrases in non-data statements so SAP HANA administrative commands and Oracle-style IDENTIFIED BY clauses do not expose unquoted or double-quoted passwords in sanitized query text. CREATE/ALTER USER statements now redact at PASSWORD or IDENTIFIED BY instead of stopping at USER, and regression coverage includes the additional password-bearing forms plus controls for normal password column usage.