### PR TITLE
Record no-op module cleanup reviews

### DIFF
--- a/.github/scripts/module-cleanup/export-cleanup-patch.sh
+++ b/.github/scripts/module-cleanup/export-cleanup-patch.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Final action invoked by the LLM agent: format-patch the cleanup commit
-# range into /tmp/gh-aw/agent/cleanup.patch so gh-aw's auto-uploader
-# includes it in the `agent` workflow artifact. The finalize job then
-# downloads that artifact and applies the patch onto otelbot/module-cleanup-wip.
+# Final action invoked by the LLM agent: write the cleanup result into
+# /tmp/gh-aw/agent so gh-aw's auto-uploader includes it in the `agent`
+# workflow artifact. The finalize job then downloads that artifact and either
+# applies cleanup.patch onto otelbot/module-cleanup-wip or records cleanup.noop
+# as an explicit no-op.
 #
 # Idempotent and write-only to /tmp. Does NOT push anything.
 #
@@ -14,13 +15,15 @@ set -euo pipefail
 SHORT="${1:?short_name argument required}"
 OUT_DIR="${OUT_DIR:-/tmp/gh-aw/agent}"
 mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR/cleanup.patch" "$OUT_DIR/cleanup.noop"
 
 if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
     git fetch origin main --depth=1
 fi
 
 if [ -z "$(git log origin/main..HEAD --oneline)" ]; then
-    echo "No commit produced by agent for $SHORT; nothing to export."
+    echo "$SHORT" > "$OUT_DIR/cleanup.noop"
+    echo "No commit produced by agent for $SHORT; wrote $OUT_DIR/cleanup.noop."
     exit 0
 fi
 

--- a/.github/scripts/module-cleanup/finalize.sh
+++ b/.github/scripts/module-cleanup/finalize.sh
@@ -196,7 +196,7 @@ echo "queue remaining:   $QUEUE_REMAINING"
 echo "threshold:         $THRESHOLD"
 
 SHOULD_FLUSH=false
-if [ "$AHEAD" -gt 0 ]; then
+if [ "$AHEAD" -gt 0 ] && [ "$FILE_COUNT" -gt 0 ]; then
     if [ "$FILE_COUNT" -ge "$THRESHOLD" ]; then
         SHOULD_FLUSH=true
         echo "Flushing: file count >= threshold."
@@ -204,6 +204,8 @@ if [ "$AHEAD" -gt 0 ]; then
         SHOULD_FLUSH=true
         echo "Flushing: queue exhausted."
     fi
+elif [ "$AHEAD" -gt 0 ]; then
+    echo "Skipping flush: wip branch has no file changes."
 fi
 
 OPENED_PR=false

--- a/.github/scripts/module-cleanup/finalize.sh
+++ b/.github/scripts/module-cleanup/finalize.sh
@@ -9,7 +9,9 @@
 #      module is recorded as "processed" (so it isn't retried in a loop)
 #      AND logged as a failure for diagnostics.
 #   2. If the agent produced a cleanup patch, apply it onto the fixed
-#      otelbot/module-cleanup-wip branch and push.
+#      otelbot/module-cleanup-wip branch and push. If the agent succeeded
+#      without a cleanup patch, append an empty "Cleanup for <short> (empty)"
+#      commit so the eventual batch PR records the module as reviewed.
 #   3. If wip diff vs origin/main has reached FLUSH_THRESHOLD files OR
 #      the queue is empty, atomically rename wip to a
 #      otelbot/module-cleanup-batch-<run_id> branch and open the PR. The wip
@@ -133,6 +135,14 @@ if [ -n "$PATCH_SRC" ]; then
                 git push origin "$MEMORY_BRANCH" || true
             )
         fi
+    )
+elif [ "$AGENT_RESULT" = "success" ]; then
+    (
+        cd "$WIP_WT"
+        git commit --allow-empty \
+            -m "Cleanup for $SHORT (empty)" \
+            -m "No cleanup changes needed."
+        git push origin "$WIP_BRANCH"
     )
 fi
 

--- a/.github/scripts/module-cleanup/finalize.sh
+++ b/.github/scripts/module-cleanup/finalize.sh
@@ -10,8 +10,10 @@
 #      AND logged as a failure for diagnostics.
 #   2. If the agent produced a cleanup patch, apply it onto the fixed
 #      otelbot/module-cleanup-wip branch and push. If the agent succeeded
-#      without a cleanup patch, append an empty "Cleanup for <short> (empty)"
-#      commit so the eventual batch PR records the module as reviewed.
+#      and explicitly wrote a cleanup.noop marker, append an empty "Cleanup for
+#      <short> (empty)" commit so the eventual batch PR records the module as
+#      reviewed. If neither cleanup.patch nor cleanup.noop is present, record a
+#      failure instead of treating it as a no-op.
 #   3. If wip diff vs origin/main has reached FLUSH_THRESHOLD files OR
 #      the queue is empty, atomically rename wip to a
 #      otelbot/module-cleanup-batch-<run_id> branch and open the PR. The wip
@@ -32,7 +34,7 @@
 #   SHORT_NAME        - the module short_name processed this run
 #   AGENT_RESULT      - github.needs.agent.result ('success'|'failure'|...)
 #   ARTIFACT_DIR      - directory of the downloaded `agent` artifact
-#                       (may or may not contain cleanup.patch)
+#                       (may or may not contain cleanup.patch / cleanup.noop)
 #   QUEUE_REMAINING   - count of unprocessed modules left after this one
 #
 # Optional env:
@@ -50,6 +52,42 @@ REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
 SHORT="${SHORT_NAME:?SHORT_NAME required}"
 AGENT_RESULT="${AGENT_RESULT:-failure}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-./agent-artifact}"
+
+PATCH_SRC=""
+for candidate in \
+    "$ARTIFACT_DIR/agent/cleanup.patch" \
+    "$ARTIFACT_DIR/tmp/gh-aw/agent/cleanup.patch" \
+    "$ARTIFACT_DIR/cleanup.patch"; do
+    if [ -f "$candidate" ]; then
+        # Absolute path so the value survives the cd into $WIP_WT below.
+        PATCH_SRC="$(realpath "$candidate")"
+        echo "Found cleanup patch at $PATCH_SRC"
+        break
+    fi
+done
+
+NOOP_SRC=""
+if [ -z "$PATCH_SRC" ]; then
+    for candidate in \
+        "$ARTIFACT_DIR/agent/cleanup.noop" \
+        "$ARTIFACT_DIR/tmp/gh-aw/agent/cleanup.noop" \
+        "$ARTIFACT_DIR/cleanup.noop"; do
+        if [ -f "$candidate" ]; then
+            NOOP_SRC="$(realpath "$candidate")"
+            echo "Found cleanup no-op marker at $NOOP_SRC"
+            break
+        fi
+    done
+fi
+
+if [ -z "$PATCH_SRC" ] && [ -z "$NOOP_SRC" ]; then
+    echo "No cleanup.patch or cleanup.noop marker (missing artifact or agent failed before export)."
+fi
+
+ARTIFACT_FAILURE_REASON=""
+if [ "$AGENT_RESULT" = "success" ] && [ -z "$PATCH_SRC" ] && [ -z "$NOOP_SRC" ]; then
+    ARTIFACT_FAILURE_REASON="agent artifact missing cleanup.patch/cleanup.noop"
+fi
 
 # Full history is required for `origin/main..origin/$WIP_BRANCH` log/diff
 # below. The finalize job's checkout uses `fetch-depth: 0`, so don't
@@ -77,37 +115,26 @@ if ! grep -Fxq "$SHORT" "$PROCESSED"; then
     echo "$SHORT" >> "$PROCESSED"
 fi
 
-if [ "$AGENT_RESULT" != "success" ]; then
+MEMORY_REASON="agent_result=$AGENT_RESULT"
+if [ -n "$ARTIFACT_FAILURE_REASON" ]; then
+    MEMORY_REASON="$ARTIFACT_FAILURE_REASON"
+fi
+
+if [ "$AGENT_RESULT" != "success" ] || [ -n "$ARTIFACT_FAILURE_REASON" ]; then
     ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    echo -e "$SHORT\t$ts\tagent_result=$AGENT_RESULT" >> "$FAILED"
+    echo -e "$SHORT\t$ts\t$MEMORY_REASON" >> "$FAILED"
 fi
 
 (
     cd "$MEM_WT"
     git add -A
     if ! git diff --cached --quiet; then
-        git commit -m "Mark $SHORT processed (agent_result=$AGENT_RESULT)"
+        git commit -m "Mark $SHORT processed ($MEMORY_REASON)"
         git push origin "$MEMORY_BRANCH"
     fi
 )
 
 # ---- 2. Apply cleanup patch (if any) onto wip ----
-
-PATCH_SRC=""
-for candidate in \
-    "$ARTIFACT_DIR/agent/cleanup.patch" \
-    "$ARTIFACT_DIR/tmp/gh-aw/agent/cleanup.patch" \
-    "$ARTIFACT_DIR/cleanup.patch"; do
-    if [ -f "$candidate" ]; then
-        # Absolute path so the value survives the cd into $WIP_WT below.
-        PATCH_SRC="$(realpath "$candidate")"
-        echo "Found cleanup patch at $PATCH_SRC"
-        break
-    fi
-done
-if [ -z "$PATCH_SRC" ]; then
-    echo "No cleanup.patch (no-op or agent failed before commit)."
-fi
 
 WIP_WT=/tmp/wip-wt
 rm -rf "$WIP_WT"
@@ -136,7 +163,7 @@ if [ -n "$PATCH_SRC" ]; then
             )
         fi
     )
-elif [ "$AGENT_RESULT" = "success" ]; then
+elif [ "$AGENT_RESULT" = "success" ] && [ -n "$NOOP_SRC" ]; then
     (
         cd "$WIP_WT"
         git commit --allow-empty \
@@ -144,6 +171,8 @@ elif [ "$AGENT_RESULT" = "success" ]; then
             -m "No cleanup changes needed."
         git push origin "$WIP_BRANCH"
     )
+elif [ -n "$ARTIFACT_FAILURE_REASON" ]; then
+    echo "Skipping empty cleanup commit: $ARTIFACT_FAILURE_REASON."
 fi
 
 git fetch origin "$WIP_BRANCH" 2>/dev/null || true

--- a/.github/workflows/module-cleanup.md
+++ b/.github/workflows/module-cleanup.md
@@ -241,13 +241,13 @@ instructions imported into this prompt are yours; execute them yourself.
    bash .github/scripts/module-cleanup/export-cleanup-patch.sh "$MODULE_SHORT_NAME"
    ```
 
-   This writes `/tmp/gh-aw/agent/cleanup.patch` (a `git format-patch` of
-   your commit range) so gh-aw's auto-uploader includes it in the
-   workflow's `agent` artifact. The finalize job downloads that artifact
-   and applies the patch to the `otelbot/module-cleanup-wip` branch. The script
-   is idempotent and exits cleanly with no patch if you produced no
-   commit. **Run it exactly once as your last action.** If you do not run
-   it, your work is lost.
+    This writes `/tmp/gh-aw/agent/cleanup.patch` (a `git format-patch` of
+    your commit range) or `/tmp/gh-aw/agent/cleanup.noop` (an explicit no-op
+    marker) so gh-aw's auto-uploader includes the result in the workflow's
+    `agent` artifact. The finalize job downloads that artifact and applies the
+    patch to the `otelbot/module-cleanup-wip` branch or records the no-op. The
+    script is idempotent. **Run it exactly once as your last action.** If you do
+    not run it, your work is lost.
 
 ## What you must NOT do
 


### PR DESCRIPTION
Record successful no-op module cleanup runs as empty commits on the wip branch. This lets generated batch PRs list every reviewed module from the existing commit-subject list, while leaving the detailed commit sections to describe modules that actually changed.