### PR TITLE
Rename logging properties to include -key suffix

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -9633,19 +9633,19 @@ libraries:
       Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: |
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: |
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: |
       Specifies the key name used to store the trace flags in the logging context.
@@ -9675,19 +9675,19 @@ libraries:
       Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: |
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: |
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: |
       Specifies the key name used to store the trace flags in the logging context.
@@ -9711,19 +9711,19 @@ libraries:
   javaagent_target_versions:
   - log4j:log4j:[1.2,)
   configurations:
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: |
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: |
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: |
       Specifies the key name used to store the trace flags in the logging context.
@@ -9832,19 +9832,19 @@ libraries:
       Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: |
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: |
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: |
       Specifies the key name used to store the trace flags in the logging context.

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/javaagent/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/javaagent/README.md
@@ -4,6 +4,6 @@
 |-------------------------------------------------------|---------|---------------|--------------------------------------------------------------------|
 | `otel.instrumentation.log4j-context-data.add-baggage` | Boolean | `false`       | Enable exposing baggage attributes through MDC.                    |
 | `otel.instrumentation.common.mdc.resource-attributes` | String  |               | Comma separated list of resource attributes to expose through MDC. |
-| `otel.instrumentation.common.logging.trace-id`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
-| `otel.instrumentation.common.logging.span-id`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
-| `otel.instrumentation.common.logging.trace-flags`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |
+| `otel.instrumentation.common.logging.trace-id-key`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
+| `otel.instrumentation.common.logging.span-id-key`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
+| `otel.instrumentation.common.logging.trace-flags-key`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/javaagent/build.gradle.kts
@@ -68,9 +68,9 @@ testing {
       targets {
         all {
           testTask.configure {
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-id=trace_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.span-id=span_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags=trace_flags_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-id-key=trace_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.span-id-key=span_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags-key=trace_flags_test")
             jvmArgs("-Dlog4j2.enable.threadlocals=true")
           }
         }

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
@@ -44,11 +44,11 @@ will be added to the context when a log statement is made when a span is active:
 
 These keys can be customized using the following system properties or environment variables:
 
-| System property                                       | Environment variable                              |
-|-------------------------------------------------------|---------------------------------------------------|
-| `otel.instrumentation.common.logging.trace-id-key`        | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_ID`    |
-| `otel.instrumentation.common.logging.span-id-key`         | `OTEL_INSTRUMENTATION_COMMON_LOGGING_SPAN_ID`     |
-| `otel.instrumentation.common.logging.trace-flags-key`     | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_FLAGS` |
+| System property                                       | Environment variable                                  |
+|-------------------------------------------------------|-------------------------------------------------------|
+| `otel.instrumentation.common.logging.trace-id-key`    | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_ID_KEY`    |
+| `otel.instrumentation.common.logging.span-id-key`     | `OTEL_INSTRUMENTATION_COMMON_LOGGING_SPAN_ID_KEY`     |
+| `otel.instrumentation.common.logging.trace-flags-key` | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_FLAGS_KEY` |
 
 If the `otel.instrumentation.log4j-context-data.add-baggage` system property (or the
 `OTEL_INSTRUMENTATION_LOG4J_CONTEXT_DATA_ADD_BAGGAGE` environment variable) is set to `true`,

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
@@ -46,9 +46,9 @@ These keys can be customized using the following system properties or environmen
 
 | System property                                       | Environment variable                              |
 |-------------------------------------------------------|---------------------------------------------------|
-| `otel.instrumentation.common.logging.trace-id`        | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_ID`    |
-| `otel.instrumentation.common.logging.span-id`         | `OTEL_INSTRUMENTATION_COMMON_LOGGING_SPAN_ID`     |
-| `otel.instrumentation.common.logging.trace-flags`     | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_FLAGS` |
+| `otel.instrumentation.common.logging.trace-id-key`        | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_ID`    |
+| `otel.instrumentation.common.logging.span-id-key`         | `OTEL_INSTRUMENTATION_COMMON_LOGGING_SPAN_ID`     |
+| `otel.instrumentation.common.logging.trace-flags-key`     | `OTEL_INSTRUMENTATION_COMMON_LOGGING_TRACE_FLAGS` |
 
 If the `otel.instrumentation.log4j-context-data.add-baggage` system property (or the
 `OTEL_INSTRUMENTATION_LOG4J_CONTEXT_DATA_ADD_BAGGAGE` environment variable) is set to `true`,

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/build.gradle.kts
@@ -34,9 +34,9 @@ tasks {
     filter {
       includeTestsMatching("LibraryLog4j2LoggingKeysTest")
     }
-    jvmArgs("-Dotel.instrumentation.common.logging.trace-id=trace_id_test")
-    jvmArgs("-Dotel.instrumentation.common.logging.span-id=span_id_test")
-    jvmArgs("-Dotel.instrumentation.common.logging.trace-flags=trace_flags_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.trace-id-key=trace_id_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.span-id-key=span_id_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.trace-flags-key=trace_flags_test")
   }
 
   named("check") {

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
@@ -29,15 +29,15 @@ public final class ContextDataKeys {
         logging.getString(
             "trace_id",
             ConfigPropertiesUtil.getString(
-                "otel.instrumentation.common.logging.trace-id", LoggingContextConstants.TRACE_ID)),
+                "otel.instrumentation.common.logging.trace-id-key", LoggingContextConstants.TRACE_ID)),
         logging.getString(
             "span_id",
             ConfigPropertiesUtil.getString(
-                "otel.instrumentation.common.logging.span-id", LoggingContextConstants.SPAN_ID)),
+                "otel.instrumentation.common.logging.span-id-key", LoggingContextConstants.SPAN_ID)),
         logging.getString(
             "trace_flags",
             ConfigPropertiesUtil.getString(
-                "otel.instrumentation.common.logging.trace-flags",
+                "otel.instrumentation.common.logging.trace-flags-key",
                 LoggingContextConstants.TRACE_FLAGS)));
   }
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/metadata.yaml
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/metadata.yaml
@@ -10,19 +10,19 @@ configurations:
       Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: >
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: >
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: >
       Specifies the key name used to store the trace flags in the logging context.

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/build.gradle.kts
@@ -45,9 +45,9 @@ tasks {
     filter {
       includeTestsMatching("Log4j27LoggingKeysTest")
     }
-    jvmArgs("-Dotel.instrumentation.common.logging.trace-id=trace_id_test")
-    jvmArgs("-Dotel.instrumentation.common.logging.span-id=span_id_test")
-    jvmArgs("-Dotel.instrumentation.common.logging.trace-flags=trace_flags_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.trace-id-key=trace_id_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.span-id-key=span_id_test")
+    jvmArgs("-Dotel.instrumentation.common.logging.trace-flags-key=trace_flags_test")
   }
 
   named("check") {

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/metadata.yaml
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/metadata.yaml
@@ -10,19 +10,19 @@ configurations:
       Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: >
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: >
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: >
       Specifies the key name used to store the trace flags in the logging context.

--- a/instrumentation/log4j/log4j-mdc-1.2/javaagent/README.md
+++ b/instrumentation/log4j/log4j-mdc-1.2/javaagent/README.md
@@ -3,6 +3,6 @@
 | System property                                       | Type    | Default       | Description                                                        |
 |-------------------------------------------------------|---------|---------------|--------------------------------------------------------------------|
 | `otel.instrumentation.common.mdc.resource-attributes` | String  |               | Comma separated list of resource attributes to expose through MDC. |
-| `otel.instrumentation.common.logging.trace-id`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
-| `otel.instrumentation.common.logging.span-id`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
-| `otel.instrumentation.common.logging.trace-flags`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |
+| `otel.instrumentation.common.logging.trace-id-key`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
+| `otel.instrumentation.common.logging.span-id-key`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
+| `otel.instrumentation.common.logging.trace-flags-key`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |

--- a/instrumentation/log4j/log4j-mdc-1.2/metadata.yaml
+++ b/instrumentation/log4j/log4j-mdc-1.2/metadata.yaml
@@ -4,19 +4,19 @@ description: >
 display_name: Log4j
 library_link: https://logging.apache.org/log4j/1.2/
 configurations:
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: >
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: >
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: >
       Specifies the key name used to store the trace flags in the logging context.

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/README.md
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/README.md
@@ -4,6 +4,6 @@
 |-------------------------------------------------------|---------|---------------|--------------------------------------------------------------------|
 | `otel.instrumentation.logback-mdc.add-baggage`        | Boolean | `false`       | Enable exposing baggage attributes through MDC.                    |
 | `otel.instrumentation.common.mdc.resource-attributes` | String  |               | Comma separated list of resource attributes to expose through MDC. |
-| `otel.instrumentation.common.logging.trace-id`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
-| `otel.instrumentation.common.logging.span-id`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
-| `otel.instrumentation.common.logging.trace-flags`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |
+| `otel.instrumentation.common.logging.trace-id-key`        | String  | `trace_id`    | Customize MDC key name for the trace id.                           |
+| `otel.instrumentation.common.logging.span-id-key`         | String  | `span_id`     | Customize MDC key name for the span id.                            |
+| `otel.instrumentation.common.logging.trace-flags-key`     | String  | `trace_flags` | Customize MDC key name for the trace flags.                        |

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
@@ -26,9 +26,9 @@ testing {
       targets {
         all {
           testTask.configure {
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-id=trace_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.span-id=span_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags=trace_flags_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-id-key=trace_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.span-id-key=span_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags-key=trace_flags_test")
           }
         }
       }

--- a/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
@@ -18,9 +18,9 @@ testing {
       targets {
         all {
           testTask.configure {
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-id=trace_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.span-id=span_id_test")
-            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags=trace_flags_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-id-key=trace_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.span-id-key=span_id_test")
+            jvmArgs("-Dotel.instrumentation.common.logging.trace-flags-key=trace_flags_test")
           }
         }
       }

--- a/instrumentation/logback/logback-mdc-1.0/metadata.yaml
+++ b/instrumentation/logback/logback-mdc-1.0/metadata.yaml
@@ -10,19 +10,19 @@ configurations:
       Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
     type: boolean
     default: false
-  - name: otel.instrumentation.common.logging.trace-id
+  - name: otel.instrumentation.common.logging.trace-id-key
     declarative_name: java.common.logging.trace_id
     description: >
       Specifies the key name used to store the trace ID in the logging context.
     type: string
     default: trace_id
-  - name: otel.instrumentation.common.logging.span-id
+  - name: otel.instrumentation.common.logging.span-id-key
     declarative_name: java.common.logging.span_id
     description: >
       Specifies the key name used to store the span ID in the logging context.
     type: string
     default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags
+  - name: otel.instrumentation.common.logging.trace-flags-key
     declarative_name: java.common.logging.trace_flags
     description: >
       Specifies the key name used to store the trace flags in the logging context.

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
@@ -219,7 +219,7 @@ class LogbackAppenderInstaller {
     String traceIdKey =
         applicationEnvironmentPreparedEvent
             .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.trace-id", String.class);
+            .getProperty("otel.instrumentation.common.logging.trace-id-key", String.class);
     if (traceIdKey != null) {
       openTelemetryAppender.setTraceIdKey(traceIdKey);
     }
@@ -227,7 +227,7 @@ class LogbackAppenderInstaller {
     String spanIdKey =
         applicationEnvironmentPreparedEvent
             .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.span-id", String.class);
+            .getProperty("otel.instrumentation.common.logging.span-id-key", String.class);
     if (spanIdKey != null) {
       openTelemetryAppender.setSpanIdKey(spanIdKey);
     }
@@ -235,7 +235,7 @@ class LogbackAppenderInstaller {
     String traceFlagsKey =
         applicationEnvironmentPreparedEvent
             .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.trace-flags", String.class);
+            .getProperty("otel.instrumentation.common.logging.trace-flags-key", String.class);
     if (traceFlagsKey != null) {
       openTelemetryAppender.setTraceFlagsKey(traceFlagsKey);
     }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -498,19 +498,19 @@
       "defaultValue": false
     },
     {
-      "name": "otel.instrumentation.common.logging.trace-id",
+      "name": "otel.instrumentation.common.logging.trace-id-key",
       "type": "java.lang.String",
       "description": "Customize MDC key name for the trace id.",
       "defaultValue": "trace_id"
     },
     {
-      "name": "otel.instrumentation.common.logging.span-id",
+      "name": "otel.instrumentation.common.logging.span-id-key",
       "type": "java.lang.String",
       "description": "Customize MDC key name for the span id.",
       "defaultValue": "span_id"
     },
     {
-      "name": "otel.instrumentation.common.logging.trace-flags",
+      "name": "otel.instrumentation.common.logging.trace-flags-key",
       "type": "java.lang.String",
       "description": "Customize MDC key name for the trace flags.",
       "defaultValue": "trace_flags"

--- a/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
@@ -155,9 +155,9 @@ class LogbackAppenderTest {
     properties.put("logging.config", "classpath:logback-test.xml");
     properties.put("otel.instrumentation.logback-appender.enabled", "false");
     properties.put("otel.instrumentation.logback-mdc.add-baggage", "true");
-    properties.put("otel.instrumentation.common.logging.trace-id", "traceid");
-    properties.put("otel.instrumentation.common.logging.span-id", "spanid");
-    properties.put("otel.instrumentation.common.logging.trace-flags", "traceflags");
+    properties.put("otel.instrumentation.common.logging.trace-id-key", "traceid");
+    properties.put("otel.instrumentation.common.logging.span-id-key", "spanid");
+    properties.put("otel.instrumentation.common.logging.trace-flags-key", "traceflags");
 
     SpringApplication app =
         new SpringApplication(


### PR DESCRIPTION
Rename common logging properties to include -key suffix

Renamed the following properties to clarify they configure key names:
- otel.instrumentation.common.logging.trace-id → trace-id-key
- otel.instrumentation.common.logging.span-id → span-id-key  
- otel.instrumentation.common.logging.trace-flags → trace-flags-key

This change affects Log4j context-data (2.7, 2.17), Log4j MDC 1.2,
Logback MDC 1.0, and Spring Boot autoconfigure modules.

Fixes #18470
/breaking-change