### PR TITLE
Preserve Spring resource provider class names

### DIFF
--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceNameDetector.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceNameDetector.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.resources;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+
+// In 3.0, switch the AutoService annotation to
+// io.opentelemetry.javaagent.instrumentation.spring.boot.resources.
+@Deprecated // to be removed in 3.0
+@AutoService(ResourceProvider.class)
+public class SpringBootServiceNameDetector
+    extends io.opentelemetry.javaagent.instrumentation.spring.boot.resources
+        .SpringBootServiceNameDetector {}

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceVersionDetector.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringBootServiceVersionDetector.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.resources;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+
+// In 3.0, switch the AutoService annotation to
+// io.opentelemetry.javaagent.instrumentation.spring.boot.resources.
+@Deprecated // to be removed in 3.0
+@AutoService(ResourceProvider.class)
+public class SpringBootServiceVersionDetector
+    extends io.opentelemetry.javaagent.instrumentation.spring.boot.resources
+        .SpringBootServiceVersionDetector {}

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringResourceComponentProvider.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/instrumentation/spring/resources/SpringResourceComponentProvider.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.resources;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+
+// In 3.0, switch the AutoService annotation to
+// io.opentelemetry.javaagent.instrumentation.spring.boot.resources.
+@Deprecated // to be removed in 3.0
+@AutoService(ComponentProvider.class)
+public class SpringResourceComponentProvider
+    extends io.opentelemetry.javaagent.instrumentation.spring.boot.resources
+        .SpringResourceComponentProvider {}

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringBootServiceNameDetector.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringBootServiceNameDetector.java
@@ -9,10 +9,8 @@ import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 
-import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
@@ -55,7 +53,6 @@ import org.snakeyaml.engine.v2.api.LoadSettings;
  * <p>Note: The spring starter already includes provider in
  * io.opentelemetry.instrumentation.spring.autoconfigure.resources.SpringResourceProvider
  */
-@AutoService(ResourceProvider.class)
 public class SpringBootServiceNameDetector implements ConditionalResourceProvider {
 
   private static final Logger logger =

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringBootServiceVersionDetector.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringBootServiceVersionDetector.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.spring.boot.resources;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 import static java.util.logging.Level.FINE;
 
-import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
@@ -23,7 +22,6 @@ import java.util.logging.Logger;
  * Note: The spring starter already includes provider in
  * io.opentelemetry.instrumentation.spring.autoconfigure.resources.SpringResourceProvider
  */
-@AutoService(ResourceProvider.class)
 public class SpringBootServiceVersionDetector implements ResourceProvider {
 
   private static final Logger logger =

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringResourceComponentProvider.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/resources/SpringResourceComponentProvider.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.boot.resources;
 
-import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.resources.Resource;
@@ -16,7 +15,6 @@ import io.opentelemetry.sdk.resources.Resource;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-@AutoService(ComponentProvider.class)
 public class SpringResourceComponentProvider implements ComponentProvider {
 
   @Override


### PR DESCRIPTION
Follow up to #18746 by keeping the old Spring Boot resource provider class names as deprecated AutoService wrappers while the implementation remains in the javaagent package. This preserves existing resource-provider configuration that names the providers by FQCN until the wrappers can be removed in 3.0.