### PR TITLE
Document constructor annotation behavior

### DIFF
--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
@@ -11,8 +11,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation marks that an execution of this method or constructor is able to add attributes
- * to the current span {@link io.opentelemetry.api.trace.Span}.
+ * This annotation marks that an execution of this method is able to add attributes to the current
+ * span {@link io.opentelemetry.api.trace.Span}.
+ *
+ * <p>Applying this annotation to constructors is not supported by OpenTelemetry instrumentation.
+ * The constructor target is deprecated and will be removed in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that attributes annotated with the {@link
@@ -30,6 +33,6 @@ import java.lang.annotation.Target;
  * <p>If you are a library developer, then probably you should NOT use this annotation, because it
  * is non-functional without some form of auto-instrumentation.
  */
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR}) // CONSTRUCTOR target to be removed in 3.0
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AddingSpanAttributes {}

--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
@@ -15,8 +15,8 @@ import java.lang.annotation.Target;
  * span {@link io.opentelemetry.api.trace.Span}.
  *
  * <p>Using this annotation on constructors is not supported by OpenTelemetry instrumentation. The
- * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and will be removed
- * in the 3.0 release.
+ * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and is planned to
+ * be removed in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that attributes annotated with the {@link

--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/AddingSpanAttributes.java
@@ -14,8 +14,9 @@ import java.lang.annotation.Target;
  * This annotation marks that an execution of this method is able to add attributes to the current
  * span {@link io.opentelemetry.api.trace.Span}.
  *
- * <p>Applying this annotation to constructors is not supported by OpenTelemetry instrumentation.
- * The constructor target is deprecated and will be removed in the 3.0 release.
+ * <p>Using this annotation on constructors is not supported by OpenTelemetry instrumentation. The
+ * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and will be removed
+ * in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that attributes annotated with the {@link

--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
@@ -16,8 +16,9 @@ import java.lang.annotation.Target;
  * This annotation marks that an execution of this method should result in a new {@link
  * io.opentelemetry.api.trace.Span}.
  *
- * <p>Applying this annotation to constructors is not supported by OpenTelemetry instrumentation.
- * The constructor target is deprecated and will be removed in the 3.0 release.
+ * <p>Using this annotation on constructors is not supported by OpenTelemetry instrumentation. The
+ * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and will be removed
+ * in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that a new span should be created whenever the marked method is executed.

--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
@@ -13,16 +13,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation marks that an execution of this method or constructor should result in a new
- * {@link io.opentelemetry.api.trace.Span}.
+ * This annotation marks that an execution of this method should result in a new {@link
+ * io.opentelemetry.api.trace.Span}.
+ *
+ * <p>Applying this annotation to constructors is not supported by OpenTelemetry instrumentation.
+ * The constructor target is deprecated and will be removed in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
- * that a new span should be created whenever marked method is executed.
+ * that a new span should be created whenever the marked method is executed.
  *
  * <p>If you are a library developer, then probably you should NOT use this annotation, because it
  * is non-functional without some form of auto-instrumentation.
  */
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR}) // CONSTRUCTOR target to be removed in 3.0
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithSpan {
   /**

--- a/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
+++ b/instrumentation-annotations/src/main/java/io/opentelemetry/instrumentation/annotations/WithSpan.java
@@ -17,8 +17,8 @@ import java.lang.annotation.Target;
  * io.opentelemetry.api.trace.Span}.
  *
  * <p>Using this annotation on constructors is not supported by OpenTelemetry instrumentation. The
- * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and will be removed
- * in the 3.0 release.
+ * {@link ElementType#CONSTRUCTOR} target exists only for backward compatibility and is planned to
+ * be removed in the 3.0 release.
  *
  * <p>Application developers can use this annotation to signal OpenTelemetry auto-instrumentation
  * that a new span should be created whenever the marked method is executed.

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -110,6 +110,14 @@ class WithSpanInstrumentationTest {
   }
 
   @Test
+  void annotatedConstructorDoesNotCreateSpan() throws InterruptedException {
+    new TracedWithSpan("unused");
+
+    Thread.sleep(500); // sleep a bit just to make sure no span is captured
+    assertThat(testing.waitForTraces(0)).isEmpty();
+  }
+
+  @Test
   void completedCompletionStage() {
     CompletableFuture<String> future = CompletableFuture.completedFuture("Done");
     new TracedWithSpan().completionStage(future);

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
@@ -110,20 +110,24 @@ class AddingSpanAttributesInstrumentationTest {
                 && t.getMessage().startsWith("Cannot represent ")
                 && t.getMessage().endsWith(" as the specified constant"));
 
-    testing.runWithSpan(
-        "root",
-        () ->
-            new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz")
-                .addAttributes("method"));
+    try {
+      testing.runWithSpan(
+          "root",
+          () ->
+              new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz")
+                  .addAttributes("method"));
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName("root")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasNoParent()
-                        .hasTotalAttributeCount(0)));
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("root")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasNoParent()
+                          .hasTotalAttributeCount(0)));
+    } finally {
+      TestAgentListenerAccess.reset();
+    }
   }
 
   @Test

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
@@ -110,24 +110,20 @@ class AddingSpanAttributesInstrumentationTest {
                 && t.getMessage().startsWith("Cannot represent ")
                 && t.getMessage().endsWith(" as the specified constant"));
 
-    try {
-      testing.runWithSpan(
-          "root",
-          () ->
-              new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz")
-                  .addAttributes("method"));
+    testing.runWithSpan(
+        "root",
+        () ->
+            new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz")
+                .addAttributes("method"));
 
-      testing.waitAndAssertTraces(
-          trace ->
-              trace.hasSpansSatisfyingExactly(
-                  span ->
-                      span.hasName("root")
-                          .hasKind(SpanKind.INTERNAL)
-                          .hasNoParent()
-                          .hasTotalAttributeCount(0)));
-    } finally {
-      TestAgentListenerAccess.reset();
-    }
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("root")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasNoParent()
+                        .hasTotalAttributeCount(0)));
   }
 
   @Test

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
+import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,9 +82,39 @@ class AddingSpanAttributesInstrumentationTest {
   }
 
   @Test
-  void annotatedConstructorDoesNotAddAttributes() {
+  void constructorOnlyAddingSpanAttributesDoesNotTransformType() {
+    // Current behavior: the type matcher only considers declared methods, so a class with only an
+    // @AddingSpanAttributes constructor is not transformed.
     testing.runWithSpan(
-        "root", () -> new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz"));
+        "root", () -> new ConstructorOnlyAddingSpanAttributes("foo", "bar", null, "baz"));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("root")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasNoParent()
+                        .hasTotalAttributeCount(0)));
+  }
+
+  @Test
+  void constructorAndMethodAddingSpanAttributesDoesNotAddAttributes() {
+    // Current behavior: once the annotated method makes the class eligible for transformation, the
+    // annotated constructor is also matched and fails because @Advice.Origin Method cannot
+    // represent constructors.
+    TestAgentListenerAccess.addSkipErrorCondition(
+        (typeName, t) ->
+            typeName.equals(ConstructedWithAddingSpanAttributes.class.getName())
+                && t.getMessage() != null
+                && t.getMessage().startsWith("Cannot represent ")
+                && t.getMessage().endsWith(" as the specified constant"));
+
+    testing.runWithSpan(
+        "root",
+        () ->
+            new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz")
+                .addAttributes("method"));
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
@@ -81,6 +81,21 @@ class AddingSpanAttributesInstrumentationTest {
   }
 
   @Test
+  void annotatedConstructorDoesNotAddAttributes() {
+    testing.runWithSpan(
+        "root", () -> new ConstructedWithAddingSpanAttributes("foo", "bar", null, "baz"));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("root")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasNoParent()
+                        .hasTotalAttributeCount(0)));
+  }
+
+  @Test
   void overwriteAttributes() {
     testing.runWithSpan(
         "root",

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/ConstructedWithAddingSpanAttributes.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/ConstructedWithAddingSpanAttributes.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.test.annotation;
+
+import io.opentelemetry.instrumentation.annotations.AddingSpanAttributes;
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
+
+class ConstructedWithAddingSpanAttributes {
+
+  @AddingSpanAttributes
+  ConstructedWithAddingSpanAttributes(
+      @SpanAttribute String implicitName,
+      @SpanAttribute("explicitName") String parameter,
+      @SpanAttribute("nullAttribute") String nullAttribute,
+      String notTraced) {}
+}

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/ConstructorOnlyAddingSpanAttributes.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/ConstructorOnlyAddingSpanAttributes.java
@@ -8,15 +8,12 @@ package io.opentelemetry.test.annotation;
 import io.opentelemetry.instrumentation.annotations.AddingSpanAttributes;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 
-class ConstructedWithAddingSpanAttributes {
+class ConstructorOnlyAddingSpanAttributes {
 
   @AddingSpanAttributes
-  ConstructedWithAddingSpanAttributes(
+  ConstructorOnlyAddingSpanAttributes(
       @SpanAttribute String implicitName,
       @SpanAttribute("explicitName") String parameter,
       @SpanAttribute("nullAttribute") String nullAttribute,
       String notTraced) {}
-
-  @AddingSpanAttributes
-  void addAttributes(@SpanAttribute("methodAttribute") String methodAttribute) {}
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -134,6 +134,14 @@ class WithSpanInstrumentationTest {
   }
 
   @Test
+  void annotatedConstructorDoesNotCreateSpan() throws InterruptedException {
+    new TracedWithSpan("unused");
+
+    Thread.sleep(500); // sleep a bit just to make sure no span is captured
+    assertThat(testing.waitForTraces(0)).isEmpty();
+  }
+
+  @Test
   void completedCompletionStage() {
     CompletableFuture<String> future = CompletableFuture.completedFuture("Done");
     new TracedWithSpan().completionStage(future);


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13941

Turns out that constructors aren't supported by the WithSpan instrumentation anyways.