### PR TITLE
Capture pulsar message id earlier

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
@@ -11,7 +11,6 @@ import static java.util.Collections.singletonList;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.naming.TopicName;
 
 final class PulsarMessagingAttributesGetter
@@ -64,12 +63,7 @@ final class PulsarMessagingAttributesGetter
   @Nullable
   @Override
   public String getMessageId(PulsarRequest request, @Nullable Void response) {
-    Message<?> message = request.getMessage();
-    if (message.getMessageId() != null) {
-      return message.getMessageId().toString();
-    }
-
-    return null;
+    return request.getMessageId();
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -14,6 +14,7 @@ import org.apache.pulsar.client.api.Message;
 
 public class PulsarRequest extends BasePulsarRequest {
   private final Message<?> message;
+  private final String messageId;
 
   public static PulsarRequest create(Message<?> message) {
     return new PulsarRequest(message, message.getTopicName(), null);
@@ -34,9 +35,20 @@ public class PulsarRequest extends BasePulsarRequest {
   private PulsarRequest(Message<?> message, String destination, @Nullable UrlData urlData) {
     super(destination, urlData);
     this.message = message;
+    // for producer spans message id is not available when the PulsarRequest is created, so we will
+    // try to get it later when it's available
+    this.messageId = message.getMessageId() != null ? message.getMessageId().toString() : null;
   }
 
   public Message<?> getMessage() {
     return message;
+  }
+
+  @Nullable
+  public String getMessageId() {
+    if (messageId != null) {
+      return messageId;
+    }
+    return message.getMessageId() != null ? message.getMessageId().toString() : null;
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.ProducerData;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 
 public class PulsarRequest extends BasePulsarRequest {
   private final Message<?> message;
@@ -37,7 +38,8 @@ public class PulsarRequest extends BasePulsarRequest {
     this.message = message;
     // for producer spans message id is not available when the PulsarRequest is created, so we will
     // try to get it later when it's available
-    this.messageId = message.getMessageId() != null ? message.getMessageId().toString() : null;
+    MessageId id = message.getMessageId();
+    this.messageId = id != null ? id.toString() : null;
   }
 
   public Message<?> getMessage() {
@@ -49,6 +51,7 @@ public class PulsarRequest extends BasePulsarRequest {
     if (messageId != null) {
       return messageId;
     }
-    return message.getMessageId() != null ? message.getMessageId().toString() : null;
+    MessageId id = message.getMessageId();
+    return id != null ? id.toString() : null;
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
-import static java.util.logging.Level.FINE;
-
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
@@ -32,14 +30,12 @@ import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.VirtualFieldStore;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
 
 public class PulsarSingletons {
-  private static final Logger logger = Logger.getLogger(PulsarSingletons.class.getName());
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.pulsar-2.8";
 
@@ -59,8 +55,6 @@ public class PulsarSingletons {
       createConsumerBatchReceiveInstrumenter();
   private static final Instrumenter<PulsarRequest, Void> producerInstrumenter =
       createProducerInstrumenter();
-
-  private static final boolean debug = Boolean.getBoolean("io.opentelemetry.pulsar-2.8.debug");
 
   public static Instrumenter<PulsarRequest, Void> consumerProcessInstrumenter() {
     return consumerProcessInstrumenter;
@@ -168,9 +162,6 @@ public class PulsarSingletons {
       @Nullable Throwable throwable) {
     if (message == null) {
       return null;
-    }
-    if (debug && message.getMessageId() == null) {
-      logger.log(FINE, "Null message id: " + message, new Exception());
     }
     String brokerUrl = VirtualFieldStore.extract(consumer);
     PulsarRequest request = PulsarRequest.create(message, brokerUrl);


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/ss5j6fnzoaah2/tests/task/:instrumentation:pulsar:pulsar-2.8:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.PulsarClientTest/testConsumeMultiTopics()?expanded-stacktrace=WyIwIl0&top-execution=1
Does not show the debug statement for `null` message id. Perhaps the message id isn't available at the end of the request where it is used, so lets try capturing it earlier.