### PR TITLE
Fix flaky tomcat requestWithException test

### DIFF
--- a/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
@@ -163,6 +163,7 @@ public class TestServlet3 {
                         // otherwise there is a chance that tomcat resets the connection before the
                         // response is sent
                         writer.close();
+                        resp.flushBuffer();
                       }
                       throw new IllegalStateException(endpoint.getBody());
                     } else if (HTML_PRINT_WRITER.equals(endpoint)) {

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/TestServlet5.java
@@ -161,6 +161,7 @@ public class TestServlet5 {
                         // otherwise there is a chance that tomcat resets the connection before the
                         // response is sent
                         writer.close();
+                        resp.flushBuffer();
                       }
                       throw new IllegalStateException(endpoint.getBody());
                     } else if (HTML_PRINT_WRITER.equals(endpoint)) {


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/ss5j6fnzoaah2/tests/task/:instrumentation:servlet:servlet-5.0:library:test/details/io.opentelemetry.instrumentation.servlet.v5_0.tomcat.TomcatServlet5Test/requestWithException()%5B2%5D?top-execution=1
See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18498#discussion_r3227249538
I wasn't able to reproduce locally.