### PR TITLE
Increase timeout

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/JaxMultithreadedClientTest.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/JaxMultithreadedClientTest.java
@@ -82,7 +82,7 @@ class JaxMultithreadedClientTest {
           .start();
     }
 
-    assertThat(latch.await(10, SECONDS)).isTrue();
+    assertThat(latch.await(20, SECONDS)).isTrue();
     assertThat(hadErrors).isFalse();
   }
 }


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/keqday3ex43f2/tests/task/:instrumentation:jaxrs-client:jaxrs-client-2.0-testing:test/details/io.opentelemetry.javaagent.instrumentation.jaxrsclient.JaxMultithreadedClientTest/testMultipleThreads()?expanded-stacktrace=WyIwIl0&top-execution=1
Looks like requests don't complete in 10s