### PR TITLE
Make waiting for gc ignore OutOfMemoryError

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
@@ -38,10 +38,11 @@ public class GcUtils {
             garbage.append(garbage);
           }
         }
-      } catch (OutOfMemoryError e) {
+      } catch (OutOfMemoryError ignored) {
         // ignore, we just want to trigger GC
       }
       garbage.setLength(0);
+      garbage.trimToSize();
       System.gc();
     }
     if (ref.get() != null) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
@@ -30,12 +30,16 @@ public class GcUtils {
         throw new InterruptedException();
       }
       // generate garbage to give gc some work
-      for (int i = 0; i < 26; i++) {
-        if (garbage.length() == 0) {
-          garbage.append("ab");
-        } else {
-          garbage.append(garbage);
+      try {
+        for (int i = 0; i < 26; i++) {
+          if (garbage.length() == 0) {
+            garbage.append("ab");
+          } else {
+            garbage.append(garbage);
+          }
         }
+      } catch (OutOfMemoryError e) {
+        // ignore, we just want to trigger GC
       }
       garbage.setLength(0);
       System.gc();


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/5sirm5yakqkik/tests/task/:instrumentation-api:test/details/io.opentelemetry.instrumentation.api.internal.cache.CacheTest$WeakKeys/computeIfAbsentDeadlock()?expanded-stacktrace=WyIwIl0&top-execution=1