### PR TITLE
Ensure docker is started before running windows smoke tests

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -424,6 +424,16 @@ jobs:
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
 
+      # sometimes on windows docker isn't running
+      # https://github.com/actions/runner-images/issues/13729
+      - name: Docker issue workaround
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
+          }
+
       - name: Set up JDK for running Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/zdctjnsvvoebg
There is a bug in windows github runners where docker sometimes isn't started.