### PR TITLE
Fix flaky finagle future pool test

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/TwitterUtilCoreInstrumentationTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/TwitterUtilCoreInstrumentationTest.java
@@ -172,7 +172,6 @@ class TwitterUtilCoreInstrumentationTest {
                     .map(
                         fn1(
                             abc -> {
-                              threadsSeen.add(Thread.currentThread().getName());
                               testing.runWithSpan("stage-4-terminal", () -> {});
                               return abc + "d";
                             })));


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/honlnmtw4dhzs/tests/task/:instrumentation:finagle-http-23.11:javaagent:testStableSemconv/details/io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.TwitterUtilCoreInstrumentationTest/futurePoolMultiLayerPropagatesContextAcrossPools()?expanded-stacktrace=WyIwIl0&top-execution=1
The test assumes that non of the chained functions are executed on the test worker thread, but that is not true. The last stage can execute on test worker thread when other stages have completed by the time `map` is called. Callback on already completed future can be executed by the tread that adds the callback.