### PR TITLE
Increase server stop timeout for finalge tests

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/AbstractServerTest.java
@@ -62,7 +62,7 @@ abstract class AbstractServerTest extends AbstractHttpServerTest<ListeningServer
 
   @Override
   protected void stopServer(ListeningServer server) throws Exception {
-    Await.ready(server.close(), Duration.fromSeconds(2));
+    Await.ready(server.close(), Duration.fromSeconds(10));
   }
 
   static class TestService extends Service<Request, Response> implements Logging {


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/45f2mypnxvehq/tests/task/:instrumentation:finagle-http-23.11:javaagent:testStableSemconv/details/io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.ServerH1OffloadedTest?expanded-stacktrace=WyIwLTEiLCIwIl0&top-execution=1