### PR TITLE
JDBC url parsing for Amazon Aurora

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -152,6 +152,8 @@ public final class JdbcConnectionUrlParser {
     if (connectionUrl.startsWith("jdbc:tracing:")) {
       // see https://github.com/opentracing-contrib/java-jdbc
       return connectionUrl.substring("jdbc:tracing:".length());
+    } else if (connectionUrl.startsWith("jdbc:aws-dsql:")) {
+      return connectionUrl.substring("jdbc:aws-dsql:".length());
     } else if (connectionUrl.startsWith("jdbc:")) {
       return connectionUrl.substring("jdbc:".length());
     } else if (connectionUrl.startsWith("jdbc-secretsmanager:tracing:")) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -153,7 +153,11 @@ public final class JdbcConnectionUrlParser {
       // see https://github.com/opentracing-contrib/java-jdbc
       return connectionUrl.substring("jdbc:tracing:".length());
     } else if (connectionUrl.startsWith("jdbc:aws-dsql:")) {
+      // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
       return connectionUrl.substring("jdbc:aws-dsql:".length());
+    } else if (connectionUrl.startsWith("jdbc:aws-wrapper:")) {
+      // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Connecting.html#Aurora.Connecting.JDBCDriverPostgreSQL
+      return connectionUrl.substring("jdbc:aws-wrapper:".length());
     } else if (connectionUrl.startsWith("jdbc:")) {
       return connectionUrl.substring("jdbc:".length());
     } else if (connectionUrl.startsWith("jdbc-secretsmanager:tracing:")) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -153,9 +153,11 @@ public final class JdbcConnectionUrlParser {
       // see https://github.com/opentracing-contrib/java-jdbc
       return connectionUrl.substring("jdbc:tracing:".length());
     } else if (connectionUrl.startsWith("jdbc:aws-dsql:")) {
+      // Amazon Aurora DSQL uses jdbc:aws-dsql: prefix, see
       // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
       return connectionUrl.substring("jdbc:aws-dsql:".length());
     } else if (connectionUrl.startsWith("jdbc:aws-wrapper:")) {
+      // Amazon Aurora uses jdbc:aws-wrapper: prefix, see
       // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Connecting.html#Aurora.Connecting.JDBCDriverPostgreSQL
       return connectionUrl.substring("jdbc:aws-wrapper:".length());
     } else if (connectionUrl.startsWith("jdbc:")) {

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -1632,15 +1632,15 @@ class JdbcConnectionUrlParserTest {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
-  // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
-  private static Stream<Arguments> amazonAuroraDsqlArguments() {
+  private static Stream<Arguments> amazonAuroraArguments() {
     return args(
+        // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
         arg("jdbc:aws-dsql:postgresql://your-cluster.dsql.us-east-1.on.aws/postgres")
             .setShortUrl("postgresql://your-cluster.dsql.us-east-1.on.aws:5432")
             .setSystem(POSTGRESQL)
             .setHost("your-cluster.dsql.us-east-1.on.aws")
             .setPort(5432)
-            .setNamespace("postgres")
+            .setName("postgres")
             .build(),
         arg("jdbc:aws-dsql:postgresql://your-cluster.dsql.us-east-1.on.aws:5432/postgres?user=admin")
             .setShortUrl("postgresql://your-cluster.dsql.us-east-1.on.aws:5432")
@@ -1650,12 +1650,34 @@ class JdbcConnectionUrlParserTest {
             .setUser("admin")
             .setNamespace("postgres|admin")
             .setName("postgres")
+            .build(),
+        // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Connecting.html#Aurora.Connecting.JDBCDriverMySQL
+        arg("jdbc:aws-wrapper:mysql://")
+            .setShortUrl("mysql://localhost:3306")
+            .setSystem(MYSQL)
+            .setHost("localhost")
+            .setPort(3306)
+            .build(),
+        arg("jdbc:aws-wrapper:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
+            .setShortUrl("mariadb://mdb.host:33")
+            .setSystem(MARIADB)
+            .setUser("mdbuser")
+            .setHost("mdb.host")
+            .setPort(33)
+            .setName("mdbdb")
+            .build(),
+        // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Connecting.html#Aurora.Connecting.JDBCDriverPostgreSQL
+        arg("jdbc:aws-wrapper:postgresql://")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
             .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")
-  @MethodSource("amazonAuroraDsqlArguments")
-  void testAmazonAuroraDsqlParsing(ParseTestArgument argument) {
+  @MethodSource("amazonAuroraArguments")
+  void testAmazonAuroraParsing(ParseTestArgument argument) {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -1632,6 +1632,33 @@ class JdbcConnectionUrlParserTest {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
+  // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
+  private static Stream<Arguments> amazonAuroraDsqlArguments() {
+    return args(
+        arg("jdbc:aws-dsql:postgresql://your-cluster.dsql.us-east-1.on.aws/postgres")
+            .setShortUrl("postgresql://your-cluster.dsql.us-east-1.on.aws:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("your-cluster.dsql.us-east-1.on.aws")
+            .setPort(5432)
+            .setNamespace("postgres")
+            .build(),
+        arg("jdbc:aws-dsql:postgresql://your-cluster.dsql.us-east-1.on.aws:5432/postgres?user=admin")
+            .setShortUrl("postgresql://your-cluster.dsql.us-east-1.on.aws:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("your-cluster.dsql.us-east-1.on.aws")
+            .setPort(5432)
+            .setUser("admin")
+            .setNamespace("postgres|admin")
+            .setName("postgres")
+            .build());
+  }
+
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("amazonAuroraDsqlArguments")
+  void testAmazonAuroraDsqlParsing(ParseTestArgument argument) {
+    testVerifySystemSubtypeParsingOfUrl(argument);
+  }
+
   private static void testVerifySystemSubtypeParsingOfUrl(ParseTestArgument argument) {
     DbInfo info = parse(argument.url, argument.properties);
     DbInfo expected = argument.dbInfo;


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18825
As suggested in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/18825 just stripping the prefix and let postgres, mysql and mariadb parsers handle the rest.