### PR TITLE
Fallback to old muzzle resolution when pinned versions file is missing

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -547,6 +547,10 @@ jobs:
         run: ./gradlew assemble ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
         working-directory: benchmark-overhead
 
+      - name: Run muzzle check against distro
+        run: ./gradlew :instrumentation:servlet-3:muzzle --init-script ../../.github/scripts/local.init.gradle.kts
+        working-directory: examples/distro
+
       - name: Run muzzle check against extension
         run: ./gradlew muzzle --init-script ../../.github/scripts/local.init.gradle.kts
         working-directory: examples/extension

--- a/examples/distro/instrumentation/servlet-3/build.gradle.kts
+++ b/examples/distro/instrumentation/servlet-3/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   compileOnly(project(":bootstrap"))
   compileOnly("javax.servlet:javax.servlet-api:3.0.1")
 
+  add("muzzleBootstrap", project(":bootstrap"))
   add("codegen", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$opentelemetryJavaagentAlphaVersion")
   add("muzzleBootstrap", "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support:$opentelemetryJavaagentAlphaVersion")
   add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:$opentelemetryJavaagentAlphaVersion")

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -39,11 +39,17 @@ val RANGE_COUNT_LIMIT = Integer.getInteger("otel.javaagent.muzzle.versions.limit
 // Read pinned latest-dep versions to cap muzzle's open-ended version ranges,
 // preventing failures when new library versions are released to Maven Central.
 //
-// External users of the muzzle plugin may not have this repo-specific file. In that case,
-// fall back to the old behavior and resolve versions directly from configured repositories.
+// External users of the muzzle plugin may not have this pinned versions file in their project
+// layout. In that case, fall back to the old behavior and resolve versions directly from
+// configured repositories.
 val muzzlePinnedVersions: Map<String, String>? by lazy {
   val file = generateSequence(rootProject.projectDir) { it.parentFile }
-    .map { File(it, ".github/config/latest-dep-versions.json") }
+    .flatMap {
+      sequenceOf(
+        File(it, ".github/config/latest-dep-versions.json"),
+        File(it, "config/latest-dep-versions.json")
+      )
+    }
     .firstOrNull { it.exists() }
   if (file == null) {
     logger.info(

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -210,9 +210,12 @@ tasks.register("printMuzzleReferences") {
 val hasRelevantTask = gradle.startParameter.taskNames.any {
   // removing leading ':' if present
   val taskName = it.removePrefix(":")
-  val projectPath = project.path.substring(1)
+  val projectPath = project.path.removePrefix(":")
+  val muzzleTaskName = if (projectPath.isEmpty()) "muzzle" else "$projectPath:muzzle"
   // Either the specific muzzle task in this project or a top level muzzle task.
-  taskName == "${projectPath}:muzzle" || taskName.startsWith("instrumentation:muzzle") ||
+  taskName == muzzleTaskName ||
+    taskName.startsWith("instrumentation:muzzle") ||
+    taskName.startsWith("muzzle-Assert") ||
     taskName.contains(":muzzle-Assert")
 }
 

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -76,8 +76,7 @@ val muzzlePinnedVersions: Map<String, String>? by lazy {
  * the agent uses shaded/in-repo classes rather than the external library). With "0.0" as the
  * upper bound, {@code filterVersions} rejects all real versions (none are <= 0.0), so no
  * muzzle tasks are created and the directive is silently skipped. To add a sentinel entry,
- * manually add {@code "group:module#+": "0.0"} to
- * {@code .github/config/latest-dep-versions.json}.
+ * manually add {@code "group:module#+": "0.0"} to the pinned latest-dep versions file.
  *
  * <p>Returns {@code null} when the pinned versions file is not present, which preserves the old
  * behavior of resolving the full version range from configured repositories.
@@ -89,7 +88,7 @@ fun resolveUpperBound(group: String, module: String): Version? {
     ?: throw GradleException(
       "Pinned version missing for muzzle artifact \"$key\". " +
         "Run ./gradlew resolveLatestDepVersions -PtestLatestDeps=true -PresolveLatestDeps=true " +
-        "to regenerate .github/config/latest-dep-versions.json"
+        "to regenerate the pinned latest-dep versions file"
     )
   return GenericVersionScheme().parseVersion(pinnedVersion)
 }

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -23,6 +23,7 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory
 import org.eclipse.aether.transport.http.HttpTransporterFactory
 import org.eclipse.aether.util.version.GenericVersionScheme
 import org.eclipse.aether.version.Version
+import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
 import java.util.stream.StreamSupport
@@ -41,14 +42,17 @@ val RANGE_COUNT_LIMIT = Integer.getInteger("otel.javaagent.muzzle.versions.limit
 // External users of the muzzle plugin may not have this repo-specific file. In that case,
 // fall back to the old behavior and resolve versions directly from configured repositories.
 val muzzlePinnedVersions: Map<String, String>? by lazy {
-  val file = rootProject.file(".github/config/latest-dep-versions.json")
-  if (!file.exists()) {
+  val file = generateSequence(rootProject.projectDir) { it.parentFile }
+    .map { File(it, ".github/config/latest-dep-versions.json") }
+    .firstOrNull { it.exists() }
+  if (file == null) {
     logger.info(
-      "Pinned latest-dep versions file is missing: ${file}; falling back to repository " +
+      "Pinned latest-dep versions file is missing under ${rootProject.projectDir}; falling back to repository " +
         "version resolution for muzzle checks."
     )
     null
   } else {
+    logger.info("Using pinned latest-dep versions file: ${file}")
     @Suppress("UNCHECKED_CAST")
     groovy.json.JsonSlurper().parse(file) as Map<String, String>
   }

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -37,13 +37,21 @@ val RANGE_COUNT_LIMIT = Integer.getInteger("otel.javaagent.muzzle.versions.limit
 
 // Read pinned latest-dep versions to cap muzzle's open-ended version ranges,
 // preventing failures when new library versions are released to Maven Central.
-val muzzlePinnedVersions: Map<String, String> by lazy {
+//
+// External users of the muzzle plugin may not have this repo-specific file. In that case,
+// fall back to the old behavior and resolve versions directly from configured repositories.
+val muzzlePinnedVersions: Map<String, String>? by lazy {
   val file = rootProject.file(".github/config/latest-dep-versions.json")
   if (!file.exists()) {
-    throw GradleException("Pinned latest-dep versions file is missing: ${file}.")
+    logger.info(
+      "Pinned latest-dep versions file is missing: ${file}; falling back to repository " +
+        "version resolution for muzzle checks."
+    )
+    null
+  } else {
+    @Suppress("UNCHECKED_CAST")
+    groovy.json.JsonSlurper().parse(file) as Map<String, String>
   }
-  @Suppress("UNCHECKED_CAST")
-  groovy.json.JsonSlurper().parse(file) as Map<String, String>
 }
 
 /**
@@ -60,10 +68,14 @@ val muzzlePinnedVersions: Map<String, String> by lazy {
  * muzzle tasks are created and the directive is silently skipped. To add a sentinel entry,
  * manually add {@code "group:module#+": "0.0"} to
  * {@code .github/config/latest-dep-versions.json}.
+ *
+ * <p>Returns {@code null} when the pinned versions file is not present, which preserves the old
+ * behavior of resolving the full version range from configured repositories.
  */
-fun resolveUpperBound(group: String, module: String): Version {
+fun resolveUpperBound(group: String, module: String): Version? {
+  val pinnedVersions = muzzlePinnedVersions ?: return null
   val key = "$group:$module#+"
-  val pinnedVersion = muzzlePinnedVersions[key]
+  val pinnedVersion = pinnedVersions[key]
     ?: throw GradleException(
       "Pinned version missing for muzzle artifact \"$key\". " +
         "Run ./gradlew resolveLatestDepVersions -PtestLatestDeps=true -PresolveLatestDeps=true " +
@@ -442,9 +454,10 @@ fun inverseOf(muzzleDirective: MuzzleDirective, system: RepositorySystem, sessio
   return inverseDirectives
 }
 
-fun filterVersions(range: VersionRangeResult, skipVersions: Set<String>, upperBound: Version) = sequence {
+fun filterVersions(range: VersionRangeResult, skipVersions: Set<String>, upperBound: Version?) = sequence {
   val predicate = AcceptableVersions(skipVersions)
-  fun accept(version: Version?): Boolean = version != null && predicate.test(version) && version <= upperBound
+  fun accept(version: Version?): Boolean =
+    version != null && predicate.test(version) && (upperBound == null || version <= upperBound)
   if (accept(range.lowestVersion)) {
     yield(range.lowestVersion.toString())
   }


### PR DESCRIPTION
When `.github/config/latest-dep-versions.json` is present, keep using it to cap open-ended muzzle ranges for reproducible in-repo builds.

When that file is absent, fall back to the old behavior and resolve the full version range from the configured repositories instead of failing immediately.

This keeps the pinned-version behavior for this repository while restoring compatibility for external users such as distros and extension authors that apply the muzzle check plugin outside this repo.