### PR TITLE
Clarify annotation instrumentation method matching

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AddingSpanAttributesInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AddingSpanAttributesInstrumentation.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.instrumentation.instrumentationannotati
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.whereAny;
@@ -19,7 +20,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
@@ -27,16 +27,18 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 class AddingSpanAttributesInstrumentation implements TypeInstrumentation {
 
-  private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
+  private final ElementMatcher.Junction<MethodDescription> annotatedMethodMatcher;
   private final ElementMatcher.Junction<MethodDescription> annotatedParametersMatcher;
   // this matcher matches all methods that should be excluded from transformation
   private final ElementMatcher.Junction<MethodDescription> excludedMethodsMatcher;
 
   AddingSpanAttributesInstrumentation() {
     annotatedMethodMatcher =
-        isAnnotatedWith(
-                named(
-                    "application.io.opentelemetry.instrumentation.annotations.AddingSpanAttributes"))
+        isMethod()
+            .and(
+                isAnnotatedWith(
+                    named(
+                        "application.io.opentelemetry.instrumentation.annotations.AddingSpanAttributes")))
             // Avoid repeat extraction if method is already annotated with WithSpan
             .and(
                 not(

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/WithSpanInstrumentation.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
-import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
@@ -34,14 +33,17 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 class WithSpanInstrumentation implements TypeInstrumentation {
 
-  private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
+  private final ElementMatcher.Junction<MethodDescription> annotatedMethodMatcher;
   private final ElementMatcher.Junction<MethodDescription> annotatedParametersMatcher;
   // this matcher matches all methods that should be excluded from transformation
   private final ElementMatcher.Junction<MethodDescription> excludedMethodsMatcher;
 
   WithSpanInstrumentation() {
     annotatedMethodMatcher =
-        isAnnotatedWith(named("application.io.opentelemetry.instrumentation.annotations.WithSpan"));
+        isMethod()
+            .and(
+                isAnnotatedWith(
+                    named("application.io.opentelemetry.instrumentation.annotations.WithSpan")));
     annotatedParametersMatcher =
         hasParameters(
             whereAny(
@@ -69,13 +71,12 @@ class WithSpanInstrumentation implements TypeInstrumentation {
         tracedMethods.and(not(annotatedParametersMatcher));
 
     transformer.applyAdviceToMethod(
-        tracedMethodsWithoutParameters.and(isMethod()), getClass().getName() + "$WithSpanAdvice");
+        tracedMethodsWithoutParameters, getClass().getName() + "$WithSpanAdvice");
 
     // Only apply advice for tracing parameters as attributes if any of the parameters are annotated
     // with @SpanAttribute to avoid unnecessarily copying the arguments into an array.
     transformer.applyAdviceToMethod(
-        tracedMethodsWithParameters.and(isMethod()),
-        getClass().getName() + "$WithSpanAttributesAdvice");
+        tracedMethodsWithParameters, getClass().getName() + "$WithSpanAttributesAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/AddingSpanAttributesInstrumentationTest.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil;
-import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,8 +82,6 @@ class AddingSpanAttributesInstrumentationTest {
 
   @Test
   void constructorOnlyAddingSpanAttributesDoesNotTransformType() {
-    // Current behavior: the type matcher only considers declared methods, so a class with only an
-    // @AddingSpanAttributes constructor is not transformed.
     testing.runWithSpan(
         "root", () -> new ConstructorOnlyAddingSpanAttributes("foo", "bar", null, "baz"));
 
@@ -99,17 +96,7 @@ class AddingSpanAttributesInstrumentationTest {
   }
 
   @Test
-  void constructorAndMethodAddingSpanAttributesDoesNotAddAttributes() {
-    // Current behavior: once the annotated method makes the class eligible for transformation, the
-    // annotated constructor is also matched and fails because @Advice.Origin Method cannot
-    // represent constructors.
-    TestAgentListenerAccess.addSkipErrorCondition(
-        (typeName, t) ->
-            typeName.equals(ConstructedWithAddingSpanAttributes.class.getName())
-                && t.getMessage() != null
-                && t.getMessage().startsWith("Cannot represent ")
-                && t.getMessage().endsWith(" as the specified constant"));
-
+  void constructorAndMethodAddingSpanAttributesIgnoresConstructor() {
     testing.runWithSpan(
         "root",
         () ->
@@ -123,7 +110,8 @@ class AddingSpanAttributesInstrumentationTest {
                     span.hasName("root")
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
-                        .hasTotalAttributeCount(0)));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(stringKey("methodAttribute"), "method"))));
   }
 
   @Test


### PR DESCRIPTION
Resolves confusing implementation around constructor annotations, now that #13941 has documented current behavior.