### PR TITLE
fix(webflux): register reactor hook in createWebFilter and add filter.

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/webflux/SpringWebfluxInstrumentationAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/webflux/SpringWebfluxInstrumentationAutoConfiguration.java
@@ -42,8 +42,7 @@ public class SpringWebfluxInstrumentationAutoConfiguration {
 
   @Bean
   WebFilter telemetryFilter(OpenTelemetry openTelemetry) {
-    return WebClientBeanPostProcessor.getWebfluxServerTelemetry(openTelemetry)
-        .createWebFilterAndRegisterReactorHook();
+    return WebClientBeanPostProcessor.getWebfluxServerTelemetry(openTelemetry).createWebFilter();
   }
 
   @Configuration

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
@@ -78,7 +78,7 @@ public class WebClientConfig {
   // Adds instrumentation to Webflux server
   @Bean
   public WebFilter webFilter() {
-    return webfluxServerTelemetry.createWebFilterAndRegisterReactorHook();
+    return webfluxServerTelemetry.createWebFilter();
   }
 }
 ```

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetry.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientTelemetry.java
@@ -43,6 +43,7 @@ public final class SpringWebfluxClientTelemetry {
    * @param exchangeFilterFunctions existing filter functions
    */
   public void addFilter(List<ExchangeFilterFunction> exchangeFilterFunctions) {
+    ContextPropagationOperator.builder().build().registerOnEachOperator();
     for (ExchangeFilterFunction filterFunction : exchangeFilterFunctions) {
       if (filterFunction instanceof WebClientTracingFilter) {
         return;
@@ -52,18 +53,11 @@ public final class SpringWebfluxClientTelemetry {
   }
 
   /**
-   * Adds an instrumented {@link ExchangeFilterFunction} to the provided list. Also registers the
-   * Reactor context propagation hook for reactive pipelines.
-   *
-   * @param exchangeFilterFunctions existing filter functions
+   * @deprecated Use {@link #addFilter(List)} instead.
    */
+  @Deprecated
   public void addFilterAndRegisterReactorHook(
       List<ExchangeFilterFunction> exchangeFilterFunctions) {
-    registerReactorHook();
     addFilter(exchangeFilterFunctions);
-  }
-
-  private static void registerReactorHook() {
-    ContextPropagationOperator.builder().build().registerOnEachOperator();
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetry.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerTelemetry.java
@@ -34,19 +34,15 @@ public final class SpringWebfluxServerTelemetry {
 
   /** Returns a {@link WebFilter} that instruments HTTP server requests. */
   public WebFilter createWebFilter() {
+    ContextPropagationOperator.builder().build().registerOnEachOperator();
     return new TelemetryProducingWebFilter(serverInstrumenter);
   }
 
   /**
-   * Returns a {@link WebFilter} that instruments HTTP server requests. Also registers the Reactor
-   * context propagation hook for reactive pipelines.
+   * @deprecated Use {@link #createWebFilter()} instead.
    */
+  @Deprecated
   public WebFilter createWebFilterAndRegisterReactorHook() {
-    registerReactorHook();
     return this.createWebFilter();
-  }
-
-  private static void registerReactorHook() {
-    ContextPropagationOperator.builder().build().registerOnEachOperator();
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/ReactorHookRegistrationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/ReactorHookRegistrationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.webflux.v5_3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.reactor.v3_1.ContextPropagationOperator;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+class ReactorHookRegistrationTest {
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @BeforeEach
+  void setUp() {
+    ContextPropagationOperator.builder().build().resetOnEachOperator();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ContextPropagationOperator.builder().build().resetOnEachOperator();
+  }
+
+  @Test
+  void addFilterRegistersReactorHookSoContextPropagatesAcrossThreads() throws Exception {
+    SpringWebfluxClientTelemetry telemetry =
+        SpringWebfluxClientTelemetry.builder(testing.getOpenTelemetry()).build();
+    List<ExchangeFilterFunction> filters = new ArrayList<>();
+    telemetry.addFilter(filters); // must register hook internally
+
+    Tracer tracer = testing.getOpenTelemetry().getTracer("test");
+    AtomicReference<Span> capturedSpan = new AtomicReference<>();
+
+    Span parent = tracer.spanBuilder("parent").startSpan();
+    try (Scope ignored = parent.makeCurrent()) {
+      Mono.fromCallable(Span::current)
+          .subscribeOn(Schedulers.boundedElastic()) // thread switch
+          .doOnNext(capturedSpan::set)
+          .block();
+    } finally {
+      parent.end();
+    }
+
+    // Context must survive the thread switch — span IDs must match
+    assertThat(capturedSpan.get().getSpanContext().getSpanId())
+        .as("OTel context should propagate across thread boundary after addFilter()")
+        .isEqualTo(parent.getSpanContext().getSpanId());
+  }
+
+  @Test
+  void createWebFilterRegistersReactorHookSoContextPropagatesAcrossThreads() throws Exception {
+    SpringWebfluxServerTelemetry telemetry =
+        SpringWebfluxServerTelemetry.builder(testing.getOpenTelemetry()).build();
+    telemetry.createWebFilter(); // must register hook internally
+
+    Tracer tracer = testing.getOpenTelemetry().getTracer("test");
+    AtomicReference<Span> capturedSpan = new AtomicReference<>();
+
+    Span parent = tracer.spanBuilder("parent").startSpan();
+    try (Scope ignored = parent.makeCurrent()) {
+      Mono.fromCallable(Span::current)
+          .subscribeOn(Schedulers.boundedElastic()) // thread switch
+          .doOnNext(capturedSpan::set)
+          .block();
+    } finally {
+      parent.end();
+    }
+
+    assertThat(capturedSpan.get().getSpanContext().getSpanId())
+        .as("OTel context should propagate across thread boundary after createWebFilter()")
+        .isEqualTo(parent.getSpanContext().getSpanId());
+  }
+}

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientInstrumentationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientInstrumentationTest.java
@@ -27,7 +27,7 @@ class SpringWebfluxClientInstrumentationTest
             .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
             .setCapturedResponseHeaders(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
             .build();
-    return builder.filters(instrumentation::addFilterAndRegisterReactorHook);
+    return builder.filters(instrumentation::addFilter);
   }
 
   @Override

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
@@ -57,7 +57,7 @@ class TestWebfluxSpringBootApp {
         .setCapturedRequestHeaders(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
         .setCapturedResponseHeaders(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
         .build()
-        .createWebFilterAndRegisterReactorHook();
+        .createWebFilter();
   }
 
   @Controller


### PR DESCRIPTION
 Fixes #17858
 
`createWebFilter()` and `addFilter()` now always register the Reactor 
context propagation hook. The `AndRegisterReactorHook` variants are 
deprecated and delegate to these methods.