### PR TITLE
Change method to package private

### DIFF
--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
@@ -50,9 +50,7 @@ public class OpenTelemetryMeterRegistryAutoConfiguration {
 
   @Bean
   // static to avoid "is not eligible for getting processed by all BeanPostProcessors" warning
-  // must be public because this class is injected as a proxy when using non-inlined advice and that
-  // proxy contains only public methods
-  public static BeanPostProcessor postProcessCompositeMeterRegistry() {
+  static BeanPostProcessor postProcessCompositeMeterRegistry() {
     return new BeanPostProcessor() {
       @Override
       public Object postProcessAfterInitialization(Object bean, String beanName) {


### PR DESCRIPTION
Not needed since we don't use proxies to expose objects from instrumentation class loader any more.