### PR TITLE
Use GraphQL to find the existing dashboard issue

### DIFF
--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -49,11 +49,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          number=$(gh api \
-            --paginate \
-            "repos/$GITHUB_REPOSITORY/issues?state=open&labels=$DASHBOARD_LABEL&per_page=100" \
-            --jq '.[] | select(.pull_request == null and .title == env.DASHBOARD_TITLE) | .number' \
-            | sort -n \
+          # Use GraphQL instead of the REST `/repos/{repo}/issues` list
+          # endpoint because that endpoint has been observed to omit pinned
+          # issues from its results, which would cause this step to create a
+          # duplicate dashboard issue instead of updating the existing one.
+          owner="${GITHUB_REPOSITORY%/*}"
+          name="${GITHUB_REPOSITORY#*/}"
+          number=$(gh api graphql --paginate \
+            -F owner="$owner" -F name="$name" -F label="$DASHBOARD_LABEL" \
+            -f query='
+              query ($owner: String!, $name: String!, $label: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  issues(
+                    first: 100
+                    after: $endCursor
+                    states: OPEN
+                    filterBy: { labels: [$label] }
+                    orderBy: { field: CREATED_AT, direction: ASC }
+                  ) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes { number title }
+                  }
+                }
+              }' \
+            --jq ".data.repository.issues.nodes[] | select(.title == \"$DASHBOARD_TITLE\") | .number" \
             | sed -n '1p')
 
           if [[ -n "$number" ]]; then


### PR DESCRIPTION
The REST `/repos/{repo}/issues` list endpoint has been observed to omit pinned issues from its results. When that happens, the publish step finds no existing dashboard issue and creates a duplicate instead of updating the pinned one.

Switch the lookup to a paginated GraphQL query, which returns pinned issues consistently.

Ported from https://github.com/open-telemetry/semantic-conventions-genai/pull/199