### PR TITLE
Set instrumentation version on emitted Meter scopes

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
@@ -37,13 +37,24 @@ public final class DbConnectionPoolMetrics {
 
   public static DbConnectionPoolMetrics create(
       OpenTelemetry openTelemetry, String instrumentationName, String poolName) {
-
     MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(instrumentationName);
     String version = EmbeddedInstrumentationProperties.findVersion(instrumentationName);
     if (version != null) {
       meterBuilder.setInstrumentationVersion(version);
     }
-    return new DbConnectionPoolMetrics(meterBuilder.build(), Attributes.of(POOL_NAME, poolName));
+    return create(meterBuilder.build(), poolName);
+  }
+
+  /**
+   * Like {@link #create(OpenTelemetry, String, String)}, but accepts a pre-built {@link Meter}.
+   *
+   * @deprecated Exists only so the {@code tomcat-jdbc-8.5} javaagent can emit the pre-rename {@code
+   *     io.opentelemetry.tomcat-jdbc} scope by default; to be removed in 3.0 once v3-preview
+   *     becomes the default.
+   */
+  @Deprecated
+  public static DbConnectionPoolMetrics create(Meter meter, String poolName) {
+    return new DbConnectionPoolMetrics(meter, Attributes.of(POOL_NAME, poolName));
   }
 
   private final Meter meter;

--- a/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/v4_0/DropwizardMetricsAdapter.java
+++ b/instrumentation/dropwizard/dropwizard-metrics-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardmetrics/v4_0/DropwizardMetricsAdapter.java
@@ -19,7 +19,9 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,7 +59,13 @@ public class DropwizardMetricsAdapter implements MetricRegistryListener {
   private final Map<String, Timer> dropwizardTimers = new ConcurrentHashMap<>();
 
   public DropwizardMetricsAdapter(OpenTelemetry openTelemetry) {
-    this.otelMeter = openTelemetry.getMeter("io.opentelemetry.dropwizard-metrics-4.0");
+    String instrumentationName = "io.opentelemetry.dropwizard-metrics-4.0";
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(instrumentationName);
+    String version = EmbeddedInstrumentationProperties.findVersion(instrumentationName);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    this.otelMeter = meterBuilder.build();
   }
 
   /**

--- a/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
+++ b/instrumentation/failsafe-3.0/library/src/main/java/io/opentelemetry/instrumentation/failsafe/v3_0/FailsafeTelemetry.java
@@ -22,6 +22,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 
 /** Entrypoint for instrumenting Failsafe components. */
 public final class FailsafeTelemetry {
@@ -53,7 +55,7 @@ public final class FailsafeTelemetry {
   public <R> CircuitBreaker<R> createCircuitBreaker(
       CircuitBreaker<R> delegate, String circuitBreakerName) {
     CircuitBreakerConfig<R> userConfig = delegate.getConfig();
-    Meter meter = openTelemetry.getMeter(INSTRUMENTATION_NAME);
+    Meter meter = getMeter();
     LongCounter executionCounter =
         meter
             .counterBuilder("failsafe.circuit_breaker.execution.count")
@@ -86,7 +88,7 @@ public final class FailsafeTelemetry {
    */
   public <R> RetryPolicy<R> createRetryPolicy(RetryPolicy<R> delegate, String retryPolicyName) {
     RetryPolicyConfig<R> userConfig = delegate.getConfig();
-    Meter meter = openTelemetry.getMeter(INSTRUMENTATION_NAME);
+    Meter meter = getMeter();
     LongCounter executionCounter =
         meter
             .counterBuilder("failsafe.retry_policy.execution.count")
@@ -112,5 +114,14 @@ public final class FailsafeTelemetry {
             RetryPolicyEventListenerBuilders.buildInstrumentedSuccessListener(
                 userConfig, executionCounter, attemptsHistogram, attributes))
         .build();
+  }
+
+  private Meter getMeter() {
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    return meterBuilder.build();
   }
 }

--- a/instrumentation/iceberg-1.8/library/src/main/java/io/opentelemetry/instrumentation/iceberg/v1_8/IcebergMetricsReporter.java
+++ b/instrumentation/iceberg-1.8/library/src/main/java/io/opentelemetry/instrumentation/iceberg/v1_8/IcebergMetricsReporter.java
@@ -15,6 +15,8 @@ import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.util.List;
 import org.apache.iceberg.metrics.CounterResult;
 import org.apache.iceberg.metrics.MetricsReport;
@@ -48,7 +50,12 @@ final class IcebergMetricsReporter implements MetricsReporter {
   private final LongCounter deleteManifestsCount;
 
   IcebergMetricsReporter(OpenTelemetry openTelemetry) {
-    Meter meter = openTelemetry.getMeter(INSTRUMENTATION_NAME);
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    Meter meter = meterBuilder.build();
 
     planningDuration =
         applyAdvice(BASE_ADVICE, ScanMetricsBuilderFactory.totalPlanningDuration(meter, "s"))

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/JmxMetricInsight.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/JmxMetricInsight.java
@@ -25,6 +25,9 @@ public class JmxMetricInsight {
   private static final Logger logger = Logger.getLogger(JmxMetricInsight.class.getName());
 
   private static final String INSTRUMENTATION_SCOPE = "io.opentelemetry.jmx";
+  // version file is generated from the gradle module name; look it up explicitly so the legacy
+  // scope name still resolves to a version
+  private static final String VERSION_LOOKUP_NAME = "io.opentelemetry.jmx-metrics";
 
   private final OpenTelemetry openTelemetry;
   private final long discoveryDelay;
@@ -77,7 +80,8 @@ public class JmxMetricInsight {
           "Empty JMX configuration, no metrics will be collected for InstrumentationScope "
               + INSTRUMENTATION_SCOPE);
     } else {
-      MetricRegistrar registrar = new MetricRegistrar(openTelemetry, INSTRUMENTATION_SCOPE);
+      MetricRegistrar registrar =
+          new MetricRegistrar(openTelemetry, INSTRUMENTATION_SCOPE, VERSION_LOOKUP_NAME);
       BeanFinder finder = new BeanFinder(registrar, discoveryDelay);
       finder.discoverBeans(conf, connections);
     }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/MetricRegistrar.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/engine/MetricRegistrar.java
@@ -14,8 +14,10 @@ import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -31,8 +33,14 @@ class MetricRegistrar {
 
   private final Meter meter;
 
-  MetricRegistrar(OpenTelemetry openTelemetry, String instrumentationScope) {
-    meter = openTelemetry.getMeter(instrumentationScope);
+  MetricRegistrar(
+      OpenTelemetry openTelemetry, String instrumentationScope, String versionLookupName) {
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(instrumentationScope);
+    String version = EmbeddedInstrumentationProperties.findVersion(versionLookupName);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    meter = meterBuilder.build();
   }
 
   /**

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
@@ -15,6 +15,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.util.concurrent.TimeUnit;
 
 /** A builder of {@link OpenTelemetryMeterRegistry}. */
@@ -95,11 +97,12 @@ public final class OpenTelemetryMeterRegistryBuilder {
             ? DistributionStatisticConfigModifier.IDENTITY
             : DistributionStatisticConfigModifier.DISABLE_HISTOGRAM_GAUGES;
 
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
     return new OpenTelemetryMeterRegistry(
-        clock,
-        baseTimeUnit,
-        namingConvention,
-        modifier,
-        openTelemetry.getMeterProvider().get(INSTRUMENTATION_NAME));
+        clock, baseTimeUnit, namingConvention, modifier, meterBuilder.build());
   }
 }

--- a/instrumentation/oshi-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/MetricsRegistration.java
+++ b/instrumentation/oshi-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/MetricsRegistration.java
@@ -6,31 +6,58 @@
 package io.opentelemetry.javaagent.instrumentation.oshi.v5_0;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import io.opentelemetry.instrumentation.oshi.v5_0.ProcessMetrics;
 import io.opentelemetry.instrumentation.oshi.v5_0.SystemMetrics;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class MetricsRegistration {
 
+  // version file is generated from the gradle module name; look it up explicitly so the legacy
+  // scope name still resolves to a version
+  private static final String VERSION_LOOKUP_NAME = "io.opentelemetry.oshi-5.0";
+  // under v3-preview switch the emitted scope name to match the gradle module name, otherwise
+  // keep the pre-rename scope so existing dashboards/filters on
+  // otel.scope.name="io.opentelemetry.oshi" continue to work
+  private static final String INSTRUMENTATION_NAME =
+      AgentCommonConfig.get().isV3Preview() ? VERSION_LOOKUP_NAME : "io.opentelemetry.oshi";
+
   private static final AtomicBoolean registered = new AtomicBoolean();
 
+  // deprecated registerObservers(Meter) overloads exist solely so we can keep emitting the legacy
+  // io.opentelemetry.oshi scope by default; both go away in 3.0 once v3-preview becomes default
+  @SuppressWarnings("deprecation")
   public static void register() {
     if (registered.compareAndSet(false, true)) {
+      Meter meter = buildMeter();
       List<AutoCloseable> observables = new ArrayList<>();
-      observables.addAll(SystemMetrics.registerObservers(GlobalOpenTelemetry.get()));
+      observables.addAll(SystemMetrics.registerObservers(meter));
 
       // ProcessMetrics don't follow the spec
       if (DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "oshi")
           .get("experimental_metrics/development")
           .getBoolean("enabled", false)) {
-        observables.addAll(ProcessMetrics.registerObservers(GlobalOpenTelemetry.get()));
+        observables.addAll(ProcessMetrics.registerObservers(meter));
       }
       Thread cleanupTelemetry = new Thread(() -> MetricsRegistration.closeObservables(observables));
       Runtime.getRuntime().addShutdownHook(cleanupTelemetry);
     }
+  }
+
+  private static Meter buildMeter() {
+    MeterBuilder meterBuilder =
+        GlobalOpenTelemetry.get().getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(VERSION_LOOKUP_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    return meterBuilder.build();
   }
 
   private static void closeObservables(List<AutoCloseable> observables) {

--- a/instrumentation/oshi-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/ProcessMetricsTest.java
+++ b/instrumentation/oshi-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/ProcessMetricsTest.java
@@ -22,4 +22,10 @@ class ProcessMetricsTest extends AbstractProcessMetricsTest {
   protected InstrumentationExtension testing() {
     return testing;
   }
+
+  @Override
+  @SuppressWarnings("deprecation") // overriding a deprecated abstract method
+  protected String scopeName() {
+    return "io.opentelemetry.oshi";
+  }
 }

--- a/instrumentation/oshi-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/SystemMetricsTest.java
+++ b/instrumentation/oshi-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/SystemMetricsTest.java
@@ -22,4 +22,10 @@ class SystemMetricsTest extends AbstractSystemMetricsTest {
   protected InstrumentationExtension testing() {
     return testing;
   }
+
+  @Override
+  @SuppressWarnings("deprecation") // overriding a deprecated abstract method
+  protected String scopeName() {
+    return "io.opentelemetry.oshi";
+  }
 }

--- a/instrumentation/oshi-5.0/library/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/ProcessMetrics.java
+++ b/instrumentation/oshi-5.0/library/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/ProcessMetrics.java
@@ -9,6 +9,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +21,9 @@ import oshi.software.os.OperatingSystem;
 
 /** Java Runtime Metrics Utility. */
 public final class ProcessMetrics {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.oshi-5.0";
+
   private static final AttributeKey<String> TYPE_KEY = AttributeKey.stringKey("type");
 
   // getResidentSetSize() was deprecated in oshi 6.11.0 and removed in 7.0.0; the replacement
@@ -39,7 +44,17 @@ public final class ProcessMetrics {
 
   /** Register observers for java runtime metrics. */
   public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
-    Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
+    return registerObservers(buildMeter(openTelemetry));
+  }
+
+  /**
+   * Like {@link #registerObservers(OpenTelemetry)}, but accepts a pre-built {@link Meter}.
+   *
+   * @deprecated Exists only so the javaagent can emit the pre-rename {@code io.opentelemetry.oshi}
+   *     scope by default; to be removed in 3.0 once v3-preview becomes the default.
+   */
+  @Deprecated
+  public static List<AutoCloseable> registerObservers(Meter meter) {
     SystemInfo systemInfo = new SystemInfo();
     OperatingSystem osInfo = systemInfo.getOperatingSystem();
     OSProcess processInfo = osInfo.getProcess(osInfo.getProcessId());
@@ -80,6 +95,15 @@ public final class ProcessMetrics {
     } catch (ReflectiveOperationException ignored) {
       return 0;
     }
+  }
+
+  private static Meter buildMeter(OpenTelemetry openTelemetry) {
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    return meterBuilder.build();
   }
 
   private ProcessMetrics() {}

--- a/instrumentation/oshi-5.0/library/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/SystemMetrics.java
+++ b/instrumentation/oshi-5.0/library/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/SystemMetrics.java
@@ -9,6 +9,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import java.util.ArrayList;
 import java.util.List;
 import oshi.SystemInfo;
@@ -19,6 +21,9 @@ import oshi.hardware.NetworkIF;
 
 /** System Metrics Utility. */
 public final class SystemMetrics {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.oshi-5.0";
+
   private static final AttributeKey<String> DEVICE_KEY = AttributeKey.stringKey("device");
   private static final AttributeKey<String> DIRECTION_KEY = AttributeKey.stringKey("direction");
 
@@ -29,7 +34,17 @@ public final class SystemMetrics {
 
   /** Register observers for system metrics. */
   public static List<AutoCloseable> registerObservers(OpenTelemetry openTelemetry) {
-    Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
+    return registerObservers(buildMeter(openTelemetry));
+  }
+
+  /**
+   * Like {@link #registerObservers(OpenTelemetry)}, but accepts a pre-built {@link Meter}.
+   *
+   * @deprecated Exists only so the javaagent can emit the pre-rename {@code io.opentelemetry.oshi}
+   *     scope by default; to be removed in 3.0 once v3-preview becomes the default.
+   */
+  @Deprecated
+  public static List<AutoCloseable> registerObservers(Meter meter) {
     SystemInfo systemInfo = new SystemInfo();
     HardwareAbstractionLayer hal = systemInfo.getHardware();
     List<AutoCloseable> observables = new ArrayList<>();
@@ -146,6 +161,15 @@ public final class SystemMetrics {
                 }));
 
     return observables;
+  }
+
+  private static Meter buildMeter(OpenTelemetry openTelemetry) {
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(INSTRUMENTATION_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    return meterBuilder.build();
   }
 
   private SystemMetrics() {}

--- a/instrumentation/oshi-5.0/library/src/test/java/io/opentelemetry/instrumentation/oshi/v5_0/ProcessMetricsTest.java
+++ b/instrumentation/oshi-5.0/library/src/test/java/io/opentelemetry/instrumentation/oshi/v5_0/ProcessMetricsTest.java
@@ -39,6 +39,12 @@ class ProcessMetricsTest extends AbstractProcessMetricsTest {
     return testing;
   }
 
+  @Override
+  @SuppressWarnings("deprecation") // overriding a deprecated abstract method
+  protected String scopeName() {
+    return "io.opentelemetry.oshi-5.0";
+  }
+
   @Test
   void verifyObservablesAreNotEmpty() {
     assertThat(observables).isNotEmpty();

--- a/instrumentation/oshi-5.0/library/src/test/java/io/opentelemetry/instrumentation/oshi/v5_0/SystemMetricsTest.java
+++ b/instrumentation/oshi-5.0/library/src/test/java/io/opentelemetry/instrumentation/oshi/v5_0/SystemMetricsTest.java
@@ -39,6 +39,12 @@ class SystemMetricsTest extends AbstractSystemMetricsTest {
     return testing;
   }
 
+  @Override
+  @SuppressWarnings("deprecation") // overriding a deprecated abstract method
+  protected String scopeName() {
+    return "io.opentelemetry.oshi-5.0";
+  }
+
   @Test
   void verifyObservablesAreNotEmpty() {
     assertThat(observables).isNotEmpty();

--- a/instrumentation/oshi-5.0/testing/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/AbstractProcessMetricsTest.java
+++ b/instrumentation/oshi-5.0/testing/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/AbstractProcessMetricsTest.java
@@ -13,11 +13,19 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@SuppressWarnings("deprecation") // uses the deprecated scopeName() bridge
 public abstract class AbstractProcessMetricsTest {
 
   protected abstract void registerMetrics();
 
   protected abstract InstrumentationExtension testing();
+
+  /**
+   * @deprecated Exists only so the javaagent test can pin the pre-rename {@code
+   *     io.opentelemetry.oshi} scope; to be removed in 3.0 once v3-preview becomes the default.
+   */
+  @Deprecated // to be remove
+  protected abstract String scopeName();
 
   @Test
   @EnabledIfSystemProperty(named = "testExperimental", matches = "true")
@@ -28,7 +36,7 @@ public abstract class AbstractProcessMetricsTest {
     // then
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "runtime.java.memory",
             metrics ->
                 metrics.anySatisfy(
@@ -50,7 +58,7 @@ public abstract class AbstractProcessMetricsTest {
                                                 .hasValueSatisfying(v -> v.isPositive())))));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "runtime.java.cpu_time",
             metrics ->
                 metrics.anySatisfy(

--- a/instrumentation/oshi-5.0/testing/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/AbstractSystemMetricsTest.java
+++ b/instrumentation/oshi-5.0/testing/src/main/java/io/opentelemetry/instrumentation/oshi/v5_0/AbstractSystemMetricsTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // uses the deprecated scopeName() bridge
 public abstract class AbstractSystemMetricsTest {
 
   private static final AttributeKey<String> STATE = AttributeKey.stringKey("state");
@@ -19,6 +20,13 @@ public abstract class AbstractSystemMetricsTest {
   protected abstract void registerMetrics();
 
   protected abstract InstrumentationExtension testing();
+
+  /**
+   * @deprecated Exists only so the javaagent test can pin the pre-rename {@code
+   *     io.opentelemetry.oshi} scope; to be removed in 3.0 once v3-preview becomes the default.
+   */
+  @Deprecated
+  protected abstract String scopeName();
 
   @Test
   void test() {
@@ -28,7 +36,7 @@ public abstract class AbstractSystemMetricsTest {
     // then
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.memory.usage",
             metrics ->
                 metrics.anySatisfy(
@@ -50,7 +58,7 @@ public abstract class AbstractSystemMetricsTest {
                                                 .hasValueSatisfying(v -> v.isNotNegative())))));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.memory.utilization",
             metrics ->
                 metrics.anySatisfy(
@@ -72,14 +80,14 @@ public abstract class AbstractSystemMetricsTest {
                                                 .hasValueSatisfying(v -> v.isNotNegative())))));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.network.io",
             metrics ->
                 metrics.anySatisfy(
                     metric -> assertThat(metric).hasUnit("By").hasLongSumSatisfying(sum -> {})));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.network.packets",
             metrics ->
                 metrics.anySatisfy(
@@ -87,7 +95,7 @@ public abstract class AbstractSystemMetricsTest {
                         assertThat(metric).hasUnit("{packets}").hasLongSumSatisfying(sum -> {})));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.network.errors",
             metrics ->
                 metrics.anySatisfy(
@@ -95,14 +103,14 @@ public abstract class AbstractSystemMetricsTest {
                         assertThat(metric).hasUnit("{errors}").hasLongSumSatisfying(sum -> {})));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.disk.io",
             metrics ->
                 metrics.anySatisfy(
                     metric -> assertThat(metric).hasUnit("By").hasLongSumSatisfying(sum -> {})));
     testing()
         .waitAndAssertMetrics(
-            "io.opentelemetry.oshi",
+            scopeName(),
             "system.disk.operations",
             metrics ->
                 metrics.anySatisfy(

--- a/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/RuntimeTelemetryBuilder.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/RuntimeTelemetryBuilder.java
@@ -118,7 +118,10 @@ public final class RuntimeTelemetryBuilder {
 
   private static Meter getMeter(OpenTelemetry openTelemetry, String instrumentationName) {
     MeterBuilder meterBuilder = openTelemetry.meterBuilder(instrumentationName);
-    String version = EmbeddedInstrumentationProperties.findVersion(instrumentationName);
+    // version file is generated from the gradle module name; the emitted scope may be a legacy
+    // name from a previously-renamed module (e.g. runtime-telemetry-java8) that has no version
+    // file of its own, so always look the version up under the current module name
+    String version = EmbeddedInstrumentationProperties.findVersion(DEFAULT_INSTRUMENTATION_NAME);
     if (version != null) {
       meterBuilder.setInstrumentationVersion(version);
     }

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
@@ -9,8 +9,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbConnectionPoolMetrics;
+import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tomcat.jdbc.pool.DataSourceProxy;
@@ -18,7 +22,16 @@ import org.apache.tomcat.jdbc.pool.DataSourceProxy;
 public class TomcatConnectionPoolMetrics {
 
   private static final OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.tomcat-jdbc";
+  // version file is generated from the gradle module name; look it up explicitly so the legacy
+  // scope name still resolves to a version
+  private static final String VERSION_LOOKUP_NAME = "io.opentelemetry.tomcat-jdbc-8.5";
+  private static final String INSTRUMENTATION_NAME =
+      AgentCommonConfig.get().isV3Preview()
+          ? VERSION_LOOKUP_NAME
+          // keep the pre-rename scope name so existing dashboards/filters on
+          // otel.scope.name="io.opentelemetry.tomcat-jdbc" continue to work
+          : "io.opentelemetry.tomcat-jdbc";
+  private static final Meter meter = buildMeter();
 
   // a weak map does not make sense here because each Meter holds a reference to the dataSource
   // DataSourceProxy does not implement equals()/hashCode(), so it's safe to keep them in a plain
@@ -30,10 +43,13 @@ public class TomcatConnectionPoolMetrics {
     dataSourceMetrics.computeIfAbsent(dataSource, TomcatConnectionPoolMetrics::createInstruments);
   }
 
+  // deprecated DbConnectionPoolMetrics.create(Meter, String) overload exists solely so we can keep
+  // emitting the legacy io.opentelemetry.tomcat-jdbc scope by default; goes away in 3.0 once
+  // v3-preview becomes default
+  @SuppressWarnings("deprecation")
   private static BatchCallback createInstruments(DataSourceProxy dataSource) {
     DbConnectionPoolMetrics metrics =
-        DbConnectionPoolMetrics.create(
-            openTelemetry, INSTRUMENTATION_NAME, dataSource.getPoolName());
+        DbConnectionPoolMetrics.create(meter, dataSource.getPoolName());
 
     ObservableLongMeasurement connections = metrics.connections();
     ObservableLongMeasurement minIdleConnections = metrics.minIdleConnections();
@@ -66,6 +82,15 @@ public class TomcatConnectionPoolMetrics {
     if (callback != null) {
       callback.close();
     }
+  }
+
+  private static Meter buildMeter() {
+    MeterBuilder meterBuilder = openTelemetry.getMeterProvider().meterBuilder(INSTRUMENTATION_NAME);
+    String version = EmbeddedInstrumentationProperties.findVersion(VERSION_LOOKUP_NAME);
+    if (version != null) {
+      meterBuilder.setInstrumentationVersion(version);
+    }
+    return meterBuilder.build();
   }
 
   private TomcatConnectionPoolMetrics() {}

--- a/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTestController.java
+++ b/smoke-tests-otel-starter/spring-boot-common/src/main/java/io/opentelemetry/spring/smoketest/OtelSpringStarterSmokeTestController.java
@@ -17,7 +17,7 @@ public class OtelSpringStarterSmokeTestController {
   public static final String PING = "/ping";
   public static final String TEST = "/test";
   public static final String TEST_HISTOGRAM = "histogram-test-otel-spring-starter";
-  public static final String METER_SCOPE_NAME = "scope";
+  public static final String METER_SCOPE_NAME = "test-scope";
   private final LongHistogram histogram;
   private final SpringComponent component;
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
@@ -185,6 +185,8 @@ public abstract class InstrumentationTestRunner {
                             data.getInstrumentationScopeInfo().getName().equals(instrumentationName)
                                 && data.getName().equals(metricName))));
 
+    TelemetryDataUtil.assertMetricScopeVersion(metricsForScope(instrumentationName));
+
     if (Boolean.getBoolean("collectMetadata")) {
       collectEmittedMetrics(getExportedMetrics());
     }
@@ -206,9 +208,17 @@ public abstract class InstrumentationTestRunner {
           }
         });
 
+    TelemetryDataUtil.assertMetricScopeVersion(metricsForScope(instrumentationName));
+
     if (Boolean.getBoolean("collectMetadata")) {
       collectEmittedMetrics(getExportedMetrics());
     }
+  }
+
+  private List<MetricData> metricsForScope(String instrumentationName) {
+    return getExportedMetrics().stream()
+        .filter(m -> m.getInstrumentationScopeInfo().getName().equals(instrumentationName))
+        .collect(toList());
   }
 
   private void collectEmittedMetrics(List<MetricData> metrics) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtil.java
@@ -16,8 +16,10 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -96,17 +98,29 @@ public class TelemetryDataUtil {
     Set<String> missingScopeVersionErrors = new LinkedHashSet<>();
     for (List<SpanData> trace : traces) {
       for (SpanData span : trace) {
-        InstrumentationScopeInfo scopeInfo = span.getInstrumentationScopeInfo();
-        if (!scopeInfo.getName().startsWith("test") && scopeInfo.getVersion() == null) {
-          missingScopeVersionErrors.add(
-              "Instrumentation version of module "
-                  + scopeInfo.getName()
-                  + " was empty; make sure that the instrumentation name matches the gradle"
-                  + " module name");
-        }
+        recordIfMissingScopeVersion(span.getInstrumentationScopeInfo(), missingScopeVersionErrors);
       }
     }
     assertThat(missingScopeVersionErrors).isEmpty();
+  }
+
+  public static void assertMetricScopeVersion(Collection<MetricData> metrics) {
+    Set<String> missingScopeVersionErrors = new LinkedHashSet<>();
+    for (MetricData metric : metrics) {
+      recordIfMissingScopeVersion(metric.getInstrumentationScopeInfo(), missingScopeVersionErrors);
+    }
+    assertThat(missingScopeVersionErrors).isEmpty();
+  }
+
+  private static void recordIfMissingScopeVersion(
+      InstrumentationScopeInfo scopeInfo, Set<String> errors) {
+    if (!scopeInfo.getName().startsWith("test") && scopeInfo.getVersion() == null) {
+      errors.add(
+          "Instrumentation version of module "
+              + scopeInfo.getName()
+              + " was empty; make sure that the instrumentation name matches the gradle"
+              + " module name");
+    }
   }
 
   private static long elapsedSeconds(long startTime) {


### PR DESCRIPTION
Background
----------

[`TelemetryDataUtil.assertScopeVersion`](testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtil.java) only walked `SpanData`, so metric-only modules whose emitted scope name did not match the gradle module name slipped through CI. This is what allowed the recent `tomcat-jdbc-8.5` and `oshi-5.0` module renames (#18838, #18854) to ship while still emitting the pre-rename scope names \u2014 the docs telemetry parser noticed in #18860, but the agent's own test runner did not.

Changes
-------

* Broaden `assertScopeVersion` to also walk `MetricData` (gated by the existing `startsWith("test")` carve-out) and hook it into `InstrumentationTestRunner.waitAndAssertMetrics(...)` so the same protection covers meters.
* `failsafe-3.0`, `dropwizard-metrics-4.0`, `iceberg-1.8`, `micrometer-1.5`: scope already matches the module name; switch `getMeter(...)` to `meterBuilder(...)` with `EmbeddedInstrumentationProperties` version lookup so the version actually flows through.
* `oshi-5.0`: scope was a pre-rename literal. The **library** module is alpha so flip its emitted scope directly to the module-name-aligned `io.opentelemetry.oshi-5.0` (the existing version-properties lookup just works once the names match). The **javaagent** is stable so apply the [`CxfSingletons` pattern](.github/agents/knowledge/api-deprecation-policy.md): emit the legacy `io.opentelemetry.oshi` scope by default to preserve dashboards/filters, switch to the new scope under `AgentCommonConfig.get().isV3Preview()`. Add `SystemMetrics`/`ProcessMetrics.registerObservers(Meter)` overloads so the javaagent can inject a meter with the legacy scope while reusing the library observer-registration code.
* `tomcat-jdbc-8.5`: javaagent-only, no library. Apply the CxfSingletons pattern: legacy `io.opentelemetry.tomcat-jdbc` scope by default, new `io.opentelemetry.tomcat-jdbc-8.5` under v3-preview, always look up version under the new module name. Add a `DbConnectionPoolMetrics.create(Meter, String)` overload so tomcat-jdbc can build its own meter and inject it.
* `jmx-metrics`: pre-existing scope mismatch (emits `io.opentelemetry.jmx`, module is `jmx-metrics`). Add a `versionLookupName` parameter to `MetricRegistrar` and pass `io.opentelemetry.jmx-metrics` from `JmxMetricInsight` so the emitted scope finally has a version.

Does **not** include the docs allow-list overrides from #18860 \u2014 once this lands the `tomcat-jdbc-8.5` entry can be dropped.