### PR TITLE
Fix flaky tomcat exception tests

### DIFF
--- a/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
+++ b/instrumentation/servlet/servlet-3.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/TestServlet3.java
@@ -158,7 +158,7 @@ public class TestServlet3 {
                       resp.setStatus(endpoint.getStatus());
                       PrintWriter writer = resp.getWriter();
                       writer.print(endpoint.getBody());
-                      if (req.getClass().getName().contains("catalina")) {
+                      if (req.getServletContext().getClass().getName().contains("catalina")) {
                         // on tomcat close the writer to ensure response is sent immediately,
                         // otherwise there is a chance that tomcat resets the connection before the
                         // response is sent

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5AsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5AsyncTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod;

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5FakeAsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5FakeAsyncTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 
 class JettyServlet5FakeAsyncTest extends JettyServlet5Test {

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5MappingTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5MappingTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5MappingTest;
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5MappingTest;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5SyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5SyncTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 
 class JettyServlet5SyncTest extends JettyServlet5Test {

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServlet5Test.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServletHandlerTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/JettyServletHandlerTest.java
@@ -8,11 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5DispatchAsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5DispatchAsyncTest.java
@@ -15,7 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5DispatchImmediateTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5DispatchImmediateTest.java
@@ -15,7 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5ForwardTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5ForwardTest.java
@@ -15,8 +15,8 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.RequestDispatcherServlet;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5IncludeTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty11-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty/dispatch/JettyServlet5IncludeTest.java
@@ -15,9 +15,9 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.RequestDispatcherServlet;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5AsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5AsyncTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod;

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5FakeAsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5FakeAsyncTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty12;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 
 class Jetty12Servlet5FakeAsyncTest extends Jetty12Servlet5Test {

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5SyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5SyncTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty12;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 
 class Jetty12Servlet5SyncTest extends Jetty12Servlet5Test {

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/Jetty12Servlet5Test.java
@@ -7,10 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.jetty12;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import jakarta.servlet.Servlet;
 import java.net.InetSocketAddress;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5DispatchAsyncTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5DispatchAsyncTest.java
@@ -15,7 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5DispatchImmediateTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5DispatchImmediateTest.java
@@ -15,7 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5ForwardTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5ForwardTest.java
@@ -15,8 +15,8 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.RequestDispatcherServlet;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5IncludeTest.java
+++ b/instrumentation/servlet/servlet-5.0/jetty12-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/jetty12/dispatch/Jetty12Servlet5IncludeTest.java
@@ -15,9 +15,9 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.RequestDispatcherServlet;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 

--- a/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TomcatDispatchTest.java
+++ b/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TomcatDispatchTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat.BaseTomcatDispatchTest;
 import org.apache.catalina.Context;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat.BaseTomcatServlet5Test;
 import org.apache.catalina.Context;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/AbstractServlet5MappingTest.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/AbstractServlet5MappingTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
+package io.opentelemetry.instrumentation.servlet.v5_0;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/AbstractServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/AbstractServlet5Test.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
+package io.opentelemetry.instrumentation.servlet.v5_0;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.AUTH_REQUIRED;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/RequestDispatcherServlet.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/RequestDispatcherServlet.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
+package io.opentelemetry.instrumentation.servlet.v5_0;
 
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import jakarta.servlet.RequestDispatcher;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/TestServlet5.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/TestServlet5.java
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0;
+package io.opentelemetry.instrumentation.servlet.v5_0;
 
+import static io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_PRINT_WRITER;
+import static io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_SERVLET_OUTPUT_STREAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.controller;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_PARAMETERS;
@@ -14,8 +16,6 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
-import static io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_PRINT_WRITER;
-import static io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test.HTML_SERVLET_OUTPUT_STREAM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
@@ -156,7 +156,7 @@ public class TestServlet5 {
                       resp.setStatus(endpoint.getStatus());
                       PrintWriter writer = resp.getWriter();
                       writer.print(endpoint.getBody());
-                      if (req.getClass().getName().contains("catalina")) {
+                      if (req.getServletContext().getClass().getName().contains("catalina")) {
                         // on tomcat close the writer to ensure response is sent immediately,
                         // otherwise there is a chance that tomcat resets the connection before the
                         // response is sent
@@ -239,11 +239,12 @@ public class TestServlet5 {
                 resp.setStatus(endpoint.getStatus());
                 PrintWriter writer = resp.getWriter();
                 writer.print(endpoint.getBody());
-                if (req.getClass().getName().contains("catalina")) {
+                if (req.getServletContext().getClass().getName().contains("catalina")) {
                   // on tomcat close the writer to ensure response is sent immediately,
                   // otherwise there is a chance that tomcat resets the connection before the
                   // response is sent
                   writer.close();
+                  resp.flushBuffer();
                 }
                 throw new IllegalStateException(endpoint.getBody());
               } else if (HTML_PRINT_WRITER.equals(endpoint)) {

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/AbstractTomcatServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/AbstractTomcatServlet5Test.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
+package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.ERROR;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.NOT_FOUND;
@@ -13,9 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5Test;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.SpanData;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/BaseTomcatDispatchTest.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/BaseTomcatDispatchTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
+package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.AUTH_REQUIRED;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.CAPTURE_HEADERS;
@@ -15,9 +15,9 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.RequestDispatcherServlet;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.RequestDispatcherServlet;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
 import jakarta.servlet.Servlet;
 import org.apache.catalina.Context;
 import org.junit.jupiter.params.AfterParameterizedClassInvocation;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/BaseTomcatServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/BaseTomcatServlet5Test.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
+package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.TestServlet5;
+import io.opentelemetry.instrumentation.servlet.v5_0.TestServlet5;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/ErrorHandlerValve.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/ErrorHandlerValve.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
+package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import java.io.IOException;
 import org.apache.catalina.connector.Request;

--- a/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TestAccessLogValve.java
+++ b/instrumentation/servlet/servlet-5.0/testing/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/tomcat/TestAccessLogValve.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
+package io.opentelemetry.instrumentation.servlet.v5_0.tomcat;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatDispatchTest.java
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatDispatchTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.tomcat.BaseTomcatDispatchTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/TomcatServlet5Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat;
 
+import io.opentelemetry.instrumentation.servlet.v5_0.tomcat.BaseTomcatServlet5Test;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/mapping/TomcatServlet5MappingTest.java
+++ b/instrumentation/servlet/servlet-5.0/tomcat-testing/src/test/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/tomcat/mapping/TomcatServlet5MappingTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v5_0.tomcat.mapping;
 
-import io.opentelemetry.javaagent.instrumentation.servlet.v5_0.AbstractServlet5MappingTest;
+import io.opentelemetry.instrumentation.servlet.v5_0.AbstractServlet5MappingTest;
 import jakarta.servlet.Servlet;
 import java.io.File;
 import java.nio.file.Files;


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/tylqqfiaa62hm/tests/task/:instrumentation:servlet:servlet-5.0:library:test/details/io.opentelemetry.instrumentation.servlet.v5_0.tomcat.TomcatServlet5Test/requestWithException()%5B2%5D?expanded-stacktrace=WyIwIiwiMC0xIl0&top-execution=1
In servlet we detect tomcat with `req.getClass().getName().contains("catalina")` and flush request before throwing an exception. This doesn't work for library tests because we wrap the request so the request class name doesn't contain catalina.