### PR TITLE
Run @WithSpan instrumetnation after other instrumentations

### DIFF
--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentationModule.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentationModule.java
@@ -20,6 +20,12 @@ public class ExternalAnnotationInstrumentationModule extends InstrumentationModu
   }
 
   @Override
+  public int order() {
+    // Run after other instrumentations.
+    return 1000;
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new ExternalAnnotationInstrumentation());
   }

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
@@ -30,9 +30,8 @@ public class AnnotationInstrumentationModule extends InstrumentationModule
 
   @Override
   public int order() {
-    // Run first to ensure other automatic instrumentation is added after and therefore is executed
-    // earlier in the instrumented method and create the span to attach attributes to.
-    return -1000;
+    // Run after other instrumentations.
+    return 1000;
   }
 
   @Override

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/v1_0/WithSpanInstrumentationModule.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/v1_0/WithSpanInstrumentationModule.java
@@ -20,6 +20,12 @@ public class WithSpanInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public int order() {
+    // Run after other instrumentations.
+    return 1000;
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new WithSpanInstrumentation());
   }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AnnotationInstrumentationModule.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AnnotationInstrumentationModule.java
@@ -28,9 +28,8 @@ public class AnnotationInstrumentationModule extends V3PreviewFallbackEnabledIns
 
   @Override
   public int order() {
-    // Run first to ensure other automatic instrumentation is added after and therefore is executed
-    // earlier in the instrumented method and create the span to attach attributes to.
-    return -1000;
+    // Run after other instrumentations.
+    return 1000;
   }
 
   @Override


### PR DESCRIPTION
Run @WithSpan and other similar instrumetnation after other instrumentations. Based on the comments this seems to be the intended behavior. Running after other instrumentations allows for example adding attributes to the spans created by some other instrumentation.