### PR TITLE
Fix peer service declarative config names metadata

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationType.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationType.java
@@ -18,7 +18,8 @@ public enum ConfigurationType {
   STRING("string"),
   INT("int"),
   MAP("map"),
-  LIST("list");
+  LIST("list"),
+  STRUCTURED_LIST("structured_list");
 
   ConfigurationType(String unused) {}
 

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
@@ -125,6 +125,13 @@ class DeclarativeConfigValidationTest {
       case INT -> new TestValue("42", 42);
       case LIST -> new TestValue("item1,item2,item3", List.of("item1", "item2", "item3"));
       case MAP -> new TestValue("key1=value1,key2=value2", "key1=value1,key2=value2");
+      // The only structured_list config is the common peer-service-mapping. Its flat form is a
+      // host=service map, which the bridge turns into a list of {peer, service_name} entries.
+      // readPeerServiceMappingAsMap below rebuilds the host->service map from those entries, so the
+      // comparison exercises getStructuredList (what the consumer uses) rather than a string
+      // lookup.
+      case STRUCTURED_LIST ->
+          new TestValue("host1=svc1,host2=svc2", Map.of("host1", "svc1", "host2", "svc2"));
     };
   }
 
@@ -157,7 +164,28 @@ class DeclarativeConfigValidationTest {
       case INT -> current.getInt(lastSegment);
       case LIST -> current.getScalarList(lastSegment, String.class);
       case MAP -> current.getString(lastSegment);
+      case STRUCTURED_LIST -> readPeerServiceMappingAsMap(current, lastSegment);
     };
+  }
+
+  /**
+   * Reads the peer-service-mapping structured list through the bridge (the same {@code
+   * getStructuredList} call {@code ServicePeerResolver} makes) and collapses its {@code {peer,
+   * service_name}} entries back into a {@code host -> service} map, so it can be compared against
+   * the flat-property value the test fed in. This is specific to peer-service-mapping, which is
+   * currently the only {@code structured_list} config.
+   */
+  private static Object readPeerServiceMappingAsMap(
+      DeclarativeConfigProperties current, String lastSegment) {
+    List<DeclarativeConfigProperties> entries = current.getStructuredList(lastSegment);
+    if (entries == null) {
+      return null;
+    }
+    Map<String, String> mapping = new HashMap<>();
+    for (DeclarativeConfigProperties entry : entries) {
+      mapping.put(entry.getString("peer"), entry.getString("service_name"));
+    }
+    return mapping;
   }
 
   private record ValidationResult(

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -30,9 +30,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/apache-dubbo-2.7/metadata.yaml
+++ b/instrumentation/apache-dubbo-2.7/metadata.yaml
@@ -10,7 +10,7 @@ semantic_conventions:
 library_link: https://github.com/apache/dubbo/
 configurations:
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ''

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -29,9 +29,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
@@ -25,8 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -25,9 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -25,9 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/http-url-connection/metadata.yaml
+++ b/instrumentation/http-url-connection/metadata.yaml
@@ -25,8 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/java-http-client/metadata.yaml
+++ b/instrumentation/java-http-client/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/java-http-server/metadata.yaml
+++ b/instrumentation/java-http-server/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.server.emit-experimental-telemetry
     declarative_name: java.common.http.server.emit_experimental_telemetry/development

--- a/instrumentation/jdbc/metadata.yaml
+++ b/instrumentation/jdbc/metadata.yaml
@@ -36,9 +36,9 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.jdbc.experimental.capture-query-parameters
     declarative_name: java.jdbc.capture_query_parameters/development

--- a/instrumentation/jedis/jedis-1.4/metadata.yaml
+++ b/instrumentation/jedis/jedis-1.4/metadata.yaml
@@ -11,7 +11,7 @@ configurations:
     type: boolean
     default: true
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""

--- a/instrumentation/jedis/jedis-3.0/metadata.yaml
+++ b/instrumentation/jedis/jedis-3.0/metadata.yaml
@@ -11,7 +11,7 @@ configurations:
     type: boolean
     default: true
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/jodd-http-4.2/metadata.yaml
+++ b/instrumentation/jodd-http-4.2/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/ktor/ktor-2.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-2.0/metadata.yaml
@@ -47,9 +47,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/ktor/ktor-3.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-3.0/metadata.yaml
@@ -47,9 +47,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/kubernetes-client-7.0/metadata.yaml
+++ b/instrumentation/kubernetes-client-7.0/metadata.yaml
@@ -30,9 +30,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/lettuce/lettuce-4.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-4.0/metadata.yaml
@@ -18,7 +18,7 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""

--- a/instrumentation/lettuce/lettuce-5.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-5.0/metadata.yaml
@@ -25,7 +25,7 @@ configurations:
     type: boolean
     default: true
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""

--- a/instrumentation/netty/netty-3.8/metadata.yaml
+++ b/instrumentation/netty/netty-3.8/metadata.yaml
@@ -27,9 +27,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/netty/netty-4.0/metadata.yaml
+++ b/instrumentation/netty/netty-4.0/metadata.yaml
@@ -27,9 +27,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/netty/netty-4.1/metadata.yaml
+++ b/instrumentation/netty/netty-4.1/metadata.yaml
@@ -27,9 +27,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/okhttp/okhttp-2.2/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-2.2/metadata.yaml
@@ -22,9 +22,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/okhttp/okhttp-3.0/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-3.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/pekko/pekko-http-1.0/metadata.yaml
+++ b/instrumentation/pekko/pekko-http-1.0/metadata.yaml
@@ -30,9 +30,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/r2dbc-1.0/metadata.yaml
+++ b/instrumentation/r2dbc-1.0/metadata.yaml
@@ -29,7 +29,7 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""

--- a/instrumentation/ratpack/ratpack-1.7/metadata.yaml
+++ b/instrumentation/ratpack/ratpack-1.7/metadata.yaml
@@ -54,9 +54,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
@@ -25,9 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
@@ -25,9 +25,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
@@ -23,9 +23,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
@@ -24,9 +24,9 @@ configurations:
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development

--- a/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
@@ -13,7 +13,7 @@ configurations:
     type: boolean
     default: true
   - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.peer_service_mapping
+    declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
+    type: structured_list
     default: ""


### PR DESCRIPTION
Update the peer service declarative configs to match the [actual value](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/48ca9d71aaeb4f6cc909edf915e9ece158168c92/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/ServicePeerMapping.java#L22)

Also introduced a new `structured_list` type to help us differentiate these from standard maps.

Related:

- https://github.com/open-telemetry/opentelemetry.io/pull/10114
- https://github.com/open-telemetry/opentelemetry-java-examples/pull/1159