### PR TITLE
Emit DB exceptions as logs under the opt-in preview

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractors.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
@@ -21,17 +20,14 @@ public final class DbExceptionEventExtractors {
    * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
    * flag.
    */
-  @CanIgnoreReturnValue
-  public static <REQUEST, RESPONSE>
-      InstrumenterBuilder<REQUEST, RESPONSE> setDbClientExceptionEventExtractor(
-          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+  public static <REQUEST> void setDbClientExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder) {
     Experimental.setExceptionEventExtractor(
         builder,
         (logRecordBuilder, context, request) -> {
           logRecordBuilder.setEventName("db.client.operation.exception");
           logRecordBuilder.setSeverity(Severity.WARN);
         });
-    return builder;
   }
 
   private DbExceptionEventExtractors() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractors.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class DbExceptionEventExtractors {
+
+  /**
+   * Configures the database client exception event name and severity. Only takes effect when
+   * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
+   * flag.
+   */
+  @CanIgnoreReturnValue
+  public static <REQUEST, RESPONSE>
+      InstrumenterBuilder<REQUEST, RESPONSE> setDbClientExceptionEventExtractor(
+          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) -> {
+          logRecordBuilder.setEventName("db.client.operation.exception");
+          logRecordBuilder.setSeverity(Severity.WARN);
+        });
+    return builder;
+  }
+
+  private DbExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractorsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbExceptionEventExtractorsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import java.util.List;
+import org.assertj.core.api.AbstractAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DbExceptionEventExtractorsTest {
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void dbClientExceptionLog() {
+    InstrumenterBuilder<String, String> builder =
+        Instrumenter.builder(otelTesting.getOpenTelemetry(), "test", unused -> "span");
+    DbExceptionEventExtractors.setDbClientExceptionEventExtractor(builder);
+    Instrumenter<String, String> instrumenter = builder.buildInstrumenter();
+
+    Context context = instrumenter.start(Context.root(), "request");
+    IllegalStateException error = new IllegalStateException("test");
+    instrumenter.end(context, "request", "response", error);
+
+    List<LogRecordData> logs = otelTesting.getLogRecords();
+    if (emitExceptionAsLogs()) {
+      assertThat(logs).hasSize(1);
+      assertThat(logs.get(0))
+          .hasSeverity(Severity.WARN)
+          .hasEventName("db.client.operation.exception")
+          .hasAttributesSatisfyingExactly(
+              equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+              equalTo(EXCEPTION_MESSAGE, "test"),
+              satisfies(EXCEPTION_STACKTRACE, AbstractAssert::isNotNull));
+    } else {
+      assertThat(logs).isEmpty();
+    }
+  }
+}

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
 
 import com.datastax.driver.core.ExecutionInfo;
@@ -28,18 +29,20 @@ class CassandraSingletons {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
     instrumenter =
-        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(attributesGetter))
-            .addAttributesExtractor(
-                SqlClientAttributesExtractor.builder(attributesGetter)
-                    .setTableAttribute(DB_CASSANDRA_TABLE)
-                    .setQuerySanitizationEnabled(
-                        DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
-                    .build())
-            .addAttributesExtractor(new CassandraAttributesExtractor())
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(attributesGetter))
+                    .addAttributesExtractor(
+                        SqlClientAttributesExtractor.builder(attributesGetter)
+                            .setTableAttribute(DB_CASSANDRA_TABLE)
+                            .setQuerySanitizationEnabled(
+                                DbConfig.isQuerySanitizationEnabled(
+                                    GlobalOpenTelemetry.get(), "cassandra"))
+                            .build())
+                    .addAttributesExtractor(new CassandraAttributesExtractor())
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -28,22 +29,22 @@ class CassandraSingletons {
   static {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(attributesGetter))
-                    .addAttributesExtractor(
-                        SqlClientAttributesExtractor.builder(attributesGetter)
-                            .setTableAttribute(DB_CASSANDRA_TABLE)
-                            .setQuerySanitizationEnabled(
-                                DbConfig.isQuerySanitizationEnabled(
-                                    GlobalOpenTelemetry.get(), "cassandra"))
-                            .build())
-                    .addAttributesExtractor(new CassandraAttributesExtractor())
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<CassandraRequest, ExecutionInfo> builder =
+        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(attributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(attributesGetter)
+                    .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setQuerySanitizationEnabled(
+                        DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
+                    .build())
+            .addAttributesExtractor(new CassandraAttributesExtractor())
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -27,22 +28,22 @@ class CassandraSingletons {
   static {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(attributesGetter))
-                    .addAttributesExtractor(
-                        SqlClientAttributesExtractor.builder(attributesGetter)
-                            .setTableAttribute(DB_CASSANDRA_TABLE)
-                            .setQuerySanitizationEnabled(
-                                DbConfig.isQuerySanitizationEnabled(
-                                    GlobalOpenTelemetry.get(), "cassandra"))
-                            .build())
-                    .addAttributesExtractor(new CassandraAttributesExtractor())
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<CassandraRequest, ExecutionInfo> builder =
+        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(attributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(attributesGetter)
+                    .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setQuerySanitizationEnabled(
+                        DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
+                    .build())
+            .addAttributesExtractor(new CassandraAttributesExtractor())
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.cassandra.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
 
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -27,18 +28,20 @@ class CassandraSingletons {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
     instrumenter =
-        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(attributesGetter))
-            .addAttributesExtractor(
-                SqlClientAttributesExtractor.builder(attributesGetter)
-                    .setTableAttribute(DB_CASSANDRA_TABLE)
-                    .setQuerySanitizationEnabled(
-                        DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
-                    .build())
-            .addAttributesExtractor(new CassandraAttributesExtractor())
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(attributesGetter))
+                    .addAttributesExtractor(
+                        SqlClientAttributesExtractor.builder(attributesGetter)
+                            .setTableAttribute(DB_CASSANDRA_TABLE)
+                            .setQuerySanitizationEnabled(
+                                DbConfig.isQuerySanitizationEnabled(
+                                    GlobalOpenTelemetry.get(), "cassandra"))
+                            .build())
+                    .addAttributesExtractor(new CassandraAttributesExtractor())
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.cassandra.v4_4;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
@@ -56,15 +58,18 @@ public final class CassandraTelemetryBuilder {
       OpenTelemetry openTelemetry, boolean querySanitizationEnabled) {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    return Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-            openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(attributesGetter))
-        .addAttributesExtractor(
-            SqlClientAttributesExtractor.builder(attributesGetter)
-                .setTableAttribute(DB_CASSANDRA_TABLE)
-                .setQuerySanitizationEnabled(querySanitizationEnabled)
-                .build())
-        .addAttributesExtractor(new CassandraAttributesExtractor())
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                    openTelemetry,
+                    INSTRUMENTATION_NAME,
+                    DbClientSpanNameExtractor.create(attributesGetter))
+                .addAttributesExtractor(
+                    SqlClientAttributesExtractor.builder(attributesGetter)
+                        .setTableAttribute(DB_CASSANDRA_TABLE)
+                        .setQuerySanitizationEnabled(querySanitizationEnabled)
+                        .build())
+                .addAttributesExtractor(new CassandraAttributesExtractor())
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 /** A builder of {@link CassandraTelemetry}. */
@@ -58,18 +59,19 @@ public final class CassandraTelemetryBuilder {
       OpenTelemetry openTelemetry, boolean querySanitizationEnabled) {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<CassandraRequest, ExecutionInfo>builder(
-                    openTelemetry,
-                    INSTRUMENTATION_NAME,
-                    DbClientSpanNameExtractor.create(attributesGetter))
-                .addAttributesExtractor(
-                    SqlClientAttributesExtractor.builder(attributesGetter)
-                        .setTableAttribute(DB_CASSANDRA_TABLE)
-                        .setQuerySanitizationEnabled(querySanitizationEnabled)
-                        .build())
-                .addAttributesExtractor(new CassandraAttributesExtractor())
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<CassandraRequest, ExecutionInfo> builder =
+        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(attributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(attributesGetter)
+                    .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setQuerySanitizationEnabled(querySanitizationEnabled)
+                    .build())
+            .addAttributesExtractor(new CassandraAttributesExtractor())
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseInstrumenterFactory.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseInstrumenterFactory.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import java.util.function.Function;
 
@@ -24,20 +25,21 @@ public class ClickHouseInstrumenterFactory {
     ClickHouseAttributesGetter dbAttributesGetter =
         new ClickHouseAttributesGetter(errorCodeExtractor);
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<ClickHouseDbRequest, Void>builder(
-                    GlobalOpenTelemetry.get(),
-                    instrumenterName,
-                    DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
-                .addAttributesExtractor(
-                    SqlClientAttributesExtractor.builder(dbAttributesGetter)
-                        .setTableAttribute(null)
-                        .setQuerySanitizationEnabled(
-                            DbConfig.isQuerySanitizationEnabled(
-                                GlobalOpenTelemetry.get(), "clickhouse"))
-                        .build())
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<ClickHouseDbRequest, Void> builder =
+        Instrumenter.<ClickHouseDbRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                instrumenterName,
+                DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(dbAttributesGetter)
+                    .setTableAttribute(null)
+                    .setQuerySanitizationEnabled(
+                        DbConfig.isQuerySanitizationEnabled(
+                            GlobalOpenTelemetry.get(), "clickhouse"))
+                    .build())
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private ClickHouseInstrumenterFactory() {}

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseInstrumenterFactory.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -22,17 +24,19 @@ public class ClickHouseInstrumenterFactory {
     ClickHouseAttributesGetter dbAttributesGetter =
         new ClickHouseAttributesGetter(errorCodeExtractor);
 
-    return Instrumenter.<ClickHouseDbRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            instrumenterName,
-            DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
-        .addAttributesExtractor(
-            SqlClientAttributesExtractor.builder(dbAttributesGetter)
-                .setTableAttribute(null)
-                .setQuerySanitizationEnabled(
-                    DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "clickhouse"))
-                .build())
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<ClickHouseDbRequest, Void>builder(
+                    GlobalOpenTelemetry.get(),
+                    instrumenterName,
+                    DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
+                .addAttributesExtractor(
+                    SqlClientAttributesExtractor.builder(dbAttributesGetter)
+                        .setTableAttribute(null)
+                        .setQuerySanitizationEnabled(
+                            DbConfig.isQuerySanitizationEnabled(
+                                GlobalOpenTelemetry.get(), "clickhouse"))
+                        .build())
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
@@ -35,6 +37,7 @@ public class CouchbaseSingletons {
                 (context, couchbaseRequest, startAttributes) ->
                     CouchbaseRequestInfo.init(context, couchbaseRequest))
             .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
 
     if (DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "couchbase")
         .getBoolean("experimental_span_attributes/development", false)) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.List;
@@ -43,15 +44,15 @@ public final class ElasticsearchRestInstrumenterFactory {
         spanNameExtractorTransformer.apply(
             new ElasticsearchSpanNameExtractor(dbClientAttributesGetter));
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<ElasticsearchRestRequest, Response>builder(
-                    openTelemetry, instrumentationName, spanNameExtractor)
-                .addAttributesExtractor(
-                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
-                .addAttributesExtractor(esClientAttributesExtractor)
-                .addAttributesExtractors(attributesExtractors)
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<ElasticsearchRestRequest, Response> builder =
+        Instrumenter.<ElasticsearchRestRequest, Response>builder(
+                openTelemetry, instrumentationName, spanNameExtractor)
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(esClientAttributesExtractor)
+            .addAttributesExtractors(attributesExtractors)
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private ElasticsearchRestInstrumenterFactory() {}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -41,12 +43,14 @@ public final class ElasticsearchRestInstrumenterFactory {
         spanNameExtractorTransformer.apply(
             new ElasticsearchSpanNameExtractor(dbClientAttributesGetter));
 
-    return Instrumenter.<ElasticsearchRestRequest, Response>builder(
-            openTelemetry, instrumentationName, spanNameExtractor)
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(esClientAttributesExtractor)
-        .addAttributesExtractors(attributesExtractors)
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<ElasticsearchRestRequest, Response>builder(
+                    openTelemetry, instrumentationName, spanNameExtractor)
+                .addAttributesExtractor(
+                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
+                .addAttributesExtractor(esClientAttributesExtractor)
+                .addAttributesExtractors(attributesExtractors)
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
@@ -33,6 +35,7 @@ public class ElasticsearchTransportInstrumenterFactory {
                 DbClientSpanNameExtractor.create(dbClientAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
             .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(instrumenterBuilder);
 
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       instrumenterBuilder.addAttributesExtractor(experimentalAttributesExtractor);

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeSingletons.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 class GeodeSingletons {
@@ -22,16 +23,16 @@ class GeodeSingletons {
   static {
     GeodeDbAttributesGetter dbClientAttributesGetter = new GeodeDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<GeodeRequest, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-                    .addAttributesExtractor(
-                        DbClientAttributesExtractor.create(dbClientAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<GeodeRequest, Void> builder =
+        Instrumenter.<GeodeRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   static Instrumenter<GeodeRequest, Void> instrumenter() {

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeSingletons.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.geode.v1_4;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -21,12 +23,14 @@ class GeodeSingletons {
     GeodeDbAttributesGetter dbClientAttributesGetter = new GeodeDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<GeodeRequest, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<GeodeRequest, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+                    .addAttributesExtractor(
+                        DbClientAttributesExtractor.create(dbClientAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.influxdb.v2_4;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
@@ -21,15 +23,16 @@ public class InfluxDbSingletons {
     InfluxDbAttributesGetter dbAttributesGetter = new InfluxDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<InfluxDbRequest, Void>builder(
-                GlobalOpenTelemetry.get(),
-                "io.opentelemetry.influxdb-2.4",
-                DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
-            .addAttributesExtractor(
-                SqlClientAttributesExtractor.builder(dbAttributesGetter)
-                    .setTableAttribute(null)
-                    .build())
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<InfluxDbRequest, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        "io.opentelemetry.influxdb-2.4",
+                        DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
+                    .addAttributesExtractor(
+                        SqlClientAttributesExtractor.builder(dbAttributesGetter)
+                            .setTableAttribute(null)
+                            .build())
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 @SuppressWarnings("deprecation") // to support old semconv
@@ -22,18 +23,19 @@ public class InfluxDbSingletons {
   static {
     InfluxDbAttributesGetter dbAttributesGetter = new InfluxDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<InfluxDbRequest, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        "io.opentelemetry.influxdb-2.4",
-                        DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
-                    .addAttributesExtractor(
-                        SqlClientAttributesExtractor.builder(dbAttributesGetter)
-                            .setTableAttribute(null)
-                            .build())
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<InfluxDbRequest, Void> builder =
+        Instrumenter.<InfluxDbRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                "io.opentelemetry.influxdb-2.4",
+                DbClientSpanNameExtractor.createWithGenericOldSpanName(dbAttributesGetter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(dbAttributesGetter)
+                    .setTableAttribute(null)
+                    .build())
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<InfluxDbRequest, Void> instrumenter() {

--- a/instrumentation/jdbc/javaagent/build.gradle.kts
+++ b/instrumentation/jdbc/javaagent/build.gradle.kts
@@ -111,6 +111,20 @@ tasks {
     jvmArgs("-Dotel.instrumentation.jdbc.experimental.capture-query-parameters=true")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      excludeTestsMatching("SlickTest")
+      excludeTestsMatching("SqlCommenterTest")
+      excludeTestsMatching("PreparedStatementParametersTest")
+    }
+    jvmArgs("-Dotel.instrumentation.jdbc-datasource.enabled=true")
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
+  }
+
   test {
     filter {
       excludeTestsMatching("SlickTest")
@@ -126,6 +140,7 @@ tasks {
     dependsOn(testStableSemconv)
     dependsOn(testSlickStableSemconv)
     dependsOn(testCaptureParameters)
+    dependsOn(testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/jdbc/library/build.gradle.kts
+++ b/instrumentation/jdbc/library/build.gradle.kts
@@ -70,8 +70,15 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -74,16 +75,17 @@ public final class JdbcInstrumenterFactory {
       boolean querySanitizationEnabled,
       boolean captureQueryParameters) {
     JdbcAttributesGetter getter = new JdbcAttributesGetter();
-    return Instrumenter.<DbRequest, Void>builder(
-            openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(getter))
-        .addAttributesExtractor(
-            SqlClientAttributesExtractor.builder(getter)
-                .setQuerySanitizationEnabled(querySanitizationEnabled)
-                .setCaptureQueryParameters(captureQueryParameters)
-                .build())
-        .addAttributesExtractors(extractors)
-        .addOperationMetrics(DbClientMetrics.get())
-        .setEnabled(enabled)
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<DbRequest, Void>builder(
+                    openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(getter))
+                .addAttributesExtractor(
+                    SqlClientAttributesExtractor.builder(getter)
+                        .setQuerySanitizationEnabled(querySanitizationEnabled)
+                        .setCaptureQueryParameters(captureQueryParameters)
+                        .build())
+                .addAttributesExtractors(extractors)
+                .addOperationMetrics(DbClientMetrics.get())
+                .setEnabled(enabled))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
@@ -75,18 +76,19 @@ public final class JdbcInstrumenterFactory {
       boolean querySanitizationEnabled,
       boolean captureQueryParameters) {
     JdbcAttributesGetter getter = new JdbcAttributesGetter();
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<DbRequest, Void>builder(
-                    openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(getter))
-                .addAttributesExtractor(
-                    SqlClientAttributesExtractor.builder(getter)
-                        .setQuerySanitizationEnabled(querySanitizationEnabled)
-                        .setCaptureQueryParameters(captureQueryParameters)
-                        .build())
-                .addAttributesExtractors(extractors)
-                .addOperationMetrics(DbClientMetrics.get())
-                .setEnabled(enabled))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<DbRequest, Void> builder =
+        Instrumenter.<DbRequest, Void>builder(
+                openTelemetry, INSTRUMENTATION_NAME, DbClientSpanNameExtractor.create(getter))
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(getter)
+                    .setQuerySanitizationEnabled(querySanitizationEnabled)
+                    .setCaptureQueryParameters(captureQueryParameters)
+                    .build())
+            .addAttributesExtractors(extractors)
+            .addOperationMetrics(DbClientMetrics.get())
+            .setEnabled(enabled);
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<DataSource, DbInfo> createDataSourceInstrumenter(

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -36,6 +36,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.HSQLDB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OTHER_SQL;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -51,6 +52,7 @@ import io.opentelemetry.instrumentation.jdbc.TestConnection;
 import io.opentelemetry.instrumentation.jdbc.TestDriver;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
@@ -76,6 +78,7 @@ import javax.sql.DataSource;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.assertj.core.api.ThrowingConsumer;
+import org.awaitility.Awaitility;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.jupiter.api.BeforeAll;
@@ -456,17 +459,28 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasException(emitExceptionAsSpanEvents() ? error : null)));
 
     if (emitExceptionAsLogs()) {
-      testing()
-          .waitAndAssertLogRecords(
-              logRecord ->
-                  logRecord
-                      .hasSeverity(Severity.WARN)
-                      .hasEventName("db.client.operation.exception")
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(EXCEPTION_TYPE, error.getClass().getName()),
-                          equalTo(EXCEPTION_MESSAGE, error.getMessage()),
-                          satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
+      assertExceptionLog();
     }
+  }
+
+  private void assertExceptionLog() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              List<LogRecordData> logs =
+                  testing().logRecords().stream()
+                      .filter(log -> "db.client.operation.exception".equals(log.getEventName()))
+                      .collect(toList());
+
+              assertThat(logs).hasSize(1);
+              assertThat(logs.get(0))
+                  .hasSeverity(Severity.WARN)
+                  .hasEventName("db.client.operation.exception")
+                  .hasAttributesSatisfyingExactly(
+                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
+            });
   }
 
   static Stream<Arguments> preparedStatementStream() throws SQLException {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -427,6 +427,7 @@ public abstract class AbstractJdbcInstrumentationTest {
   @Test
   void testFailedStatement() throws SQLException {
     Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+    cleanup.deferCleanup(connection);
     Statement statement = connection.createStatement();
     cleanup.deferCleanup(statement);
 

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -37,7 +37,9 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OTHER_SQL;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -435,13 +437,15 @@ public abstract class AbstractJdbcInstrumentationTest {
     Statement statement = connection.createStatement();
     cleanup.deferCleanup(statement);
 
-    assertThatThrownBy(
+    Throwable error =
+        catchThrowable(
             () ->
                 testing()
                     .runWithSpan(
                         "parent",
-                        () -> statement.executeQuery("SELECT * FROM table_does_not_exist")))
-        .isInstanceOf(SQLException.class);
+                        () -> statement.executeQuery("SELECT * FROM table_does_not_exist")));
+
+    assertThat(error).isInstanceOf(SQLException.class);
 
     testing()
         .waitAndAssertTraces(
@@ -452,16 +456,7 @@ public abstract class AbstractJdbcInstrumentationTest {
                         span.hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasStatus(StatusData.error())
-                            .satisfies(
-                                spanData -> {
-                                  if (emitExceptionAsSpanEvents()) {
-                                    assertThat(spanData.getEvents()).hasSize(1);
-                                    assertThat(spanData.getEvents().get(0).getName())
-                                        .isEqualTo("exception");
-                                  } else {
-                                    assertThat(spanData.getEvents()).isEmpty();
-                                  }
-                                })));
+                            .hasException(emitExceptionAsSpanEvents() ? error : null)));
 
     if (emitExceptionAsLogs()) {
       assertExceptionLog();

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -36,7 +36,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.HSQLDB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OTHER_SQL;
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -52,7 +51,6 @@ import io.opentelemetry.instrumentation.jdbc.TestConnection;
 import io.opentelemetry.instrumentation.jdbc.TestDriver;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
@@ -78,7 +76,6 @@ import javax.sql.DataSource;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.assertj.core.api.ThrowingConsumer;
-import org.awaitility.Awaitility;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.jupiter.api.BeforeAll;
@@ -459,28 +456,17 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasException(emitExceptionAsSpanEvents() ? error : null)));
 
     if (emitExceptionAsLogs()) {
-      assertExceptionLog();
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("db.client.operation.exception")
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(EXCEPTION_TYPE, error.getClass().getName()),
+                          equalTo(EXCEPTION_MESSAGE, error.getMessage()),
+                          satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
     }
-  }
-
-  private void assertExceptionLog() {
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              List<LogRecordData> logs =
-                  testing().logRecords().stream()
-                      .filter(log -> "db.client.operation.exception".equals(log.getEventName()))
-                      .collect(toList());
-
-              assertThat(logs).hasSize(1);
-              assertThat(logs.get(0))
-                  .hasSeverity(Severity.WARN)
-                  .hasEventName("db.client.operation.exception")
-                  .hasAttributesSatisfyingExactly(
-                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
-            });
   }
 
   static Stream<Arguments> preparedStatementStream() throws SQLException {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.jdbc.testing;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
@@ -14,11 +16,15 @@ import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServ
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -30,6 +36,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.HSQLDB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OTHER_SQL;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
@@ -37,14 +44,17 @@ import com.google.common.collect.Maps;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.jdbc.TestConnection;
 import io.opentelemetry.instrumentation.jdbc.TestDriver;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.trace.data.StatusData;
 import java.beans.PropertyVetoException;
 import java.io.Closeable;
 import java.sql.CallableStatement;
@@ -66,6 +76,7 @@ import javax.sql.DataSource;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.assertj.core.api.ThrowingConsumer;
+import org.awaitility.Awaitility;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.jupiter.api.BeforeAll;
@@ -416,6 +427,65 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     assertDurationMetric(
         testing(), "io.opentelemetry.jdbc", DB_SYSTEM_NAME, DB_NAMESPACE, DB_QUERY_SUMMARY);
+  }
+
+  @Test
+  void testFailedStatement() throws SQLException {
+    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+    Statement statement = connection.createStatement();
+    cleanup.deferCleanup(statement);
+
+    assertThatThrownBy(
+            () ->
+                testing()
+                    .runWithSpan(
+                        "parent",
+                        () -> statement.executeQuery("SELECT * FROM table_does_not_exist")))
+        .isInstanceOf(SQLException.class);
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasStatus(StatusData.error())
+                            .satisfies(
+                                spanData -> {
+                                  if (emitExceptionAsSpanEvents()) {
+                                    assertThat(spanData.getEvents()).hasSize(1);
+                                    assertThat(spanData.getEvents().get(0).getName())
+                                        .isEqualTo("exception");
+                                  } else {
+                                    assertThat(spanData.getEvents()).isEmpty();
+                                  }
+                                })));
+
+    if (emitExceptionAsLogs()) {
+      assertExceptionLog();
+    }
+  }
+
+  private void assertExceptionLog() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              List<LogRecordData> logs =
+                  testing().logRecords().stream()
+                      .filter(log -> "db.client.operation.exception".equals(log.getEventName()))
+                      .collect(toList());
+
+              assertThat(logs).hasSize(1);
+              assertThat(logs.get(0))
+                  .hasSeverity(Severity.WARN)
+                  .hasEventName("db.client.operation.exception")
+                  .hasAttributesSatisfyingExactly(
+                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
+            });
   }
 
   static Stream<Arguments> preparedStatementStream() throws SQLException {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -16,15 +16,11 @@ import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServ
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -36,7 +32,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.HSQLDB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OTHER_SQL;
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -52,7 +47,6 @@ import io.opentelemetry.instrumentation.jdbc.TestConnection;
 import io.opentelemetry.instrumentation.jdbc.TestDriver;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
@@ -78,7 +72,6 @@ import javax.sql.DataSource;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.derby.jdbc.EmbeddedDriver;
 import org.assertj.core.api.ThrowingConsumer;
-import org.awaitility.Awaitility;
 import org.h2.jdbcx.JdbcDataSource;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.jupiter.api.BeforeAll;
@@ -459,28 +452,21 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasException(emitExceptionAsSpanEvents() ? error : null)));
 
     if (emitExceptionAsLogs()) {
-      assertExceptionLog();
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("db.client.operation.exception")
+                      .hasException(error)
+                      .hasTotalAttributeCount(3),
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("exception")
+                      .hasException(error)
+                      .hasTotalAttributeCount(3));
     }
-  }
-
-  private void assertExceptionLog() {
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              List<LogRecordData> logs =
-                  testing().logRecords().stream()
-                      .filter(log -> "db.client.operation.exception".equals(log.getEventName()))
-                      .collect(toList());
-
-              assertThat(logs).hasSize(1);
-              assertThat(logs.get(0))
-                  .hasSeverity(Severity.WARN)
-                  .hasEventName("db.client.operation.exception")
-                  .hasAttributesSatisfyingExactly(
-                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
-            });
   }
 
   static Stream<Arguments> preparedStatementStream() throws SQLException {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -22,15 +24,16 @@ class JedisSingletons {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<JedisRequest, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(
-                ServicePeerAttributesExtractor.create(
-                    dbAttributesGetter, GlobalOpenTelemetry.get()))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<JedisRequest, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(
+                        ServicePeerAttributesExtractor.create(
+                            dbAttributesGetter, GlobalOpenTelemetry.get()))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 class JedisSingletons {
@@ -23,18 +24,19 @@ class JedisSingletons {
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<JedisRequest, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(
-                        ServicePeerAttributesExtractor.create(
-                            dbAttributesGetter, GlobalOpenTelemetry.get()))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<JedisRequest, Void> builder =
+        Instrumenter.<JedisRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(
+                ServicePeerAttributesExtractor.create(
+                    dbAttributesGetter, GlobalOpenTelemetry.get()))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -22,15 +24,16 @@ public class JedisSingletons {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<JedisRequest, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(
-                ServicePeerAttributesExtractor.create(
-                    dbAttributesGetter, GlobalOpenTelemetry.get()))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<JedisRequest, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(
+                        ServicePeerAttributesExtractor.create(
+                            dbAttributesGetter, GlobalOpenTelemetry.get()))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class JedisSingletons {
@@ -23,18 +24,19 @@ public class JedisSingletons {
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<JedisRequest, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(
-                        ServicePeerAttributesExtractor.create(
-                            dbAttributesGetter, GlobalOpenTelemetry.get()))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<JedisRequest, Void> builder =
+        Instrumenter.<JedisRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(
+                ServicePeerAttributesExtractor.create(
+                    dbAttributesGetter, GlobalOpenTelemetry.get()))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -21,12 +23,13 @@ public class JedisSingletons {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<JedisRequest, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<JedisRequest, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class JedisSingletons {
@@ -22,15 +23,16 @@ public class JedisSingletons {
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<JedisRequest, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<JedisRequest, Void> builder =
+        Instrumenter.<JedisRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
@@ -38,15 +39,16 @@ public class LettuceSingletons {
   static {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<RedisCommand<?, ?, ?>, Void> builder =
+        Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetworkAttributesGetter netAttributesGetter =
         new LettuceConnectNetworkAttributesGetter();

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.protocol.AsyncCommand;
 import com.lambdaworks.redis.protocol.RedisCommand;
@@ -37,12 +39,13 @@ public class LettuceSingletons {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetworkAttributesGetter netAttributesGetter =

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
@@ -38,15 +39,16 @@ public class LettuceSingletons {
   static {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<RedisCommand<?, ?, ?>, Void> builder =
+        Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetworkAttributesGetter connectNetworkAttributesGetter =
         new LettuceConnectNetworkAttributesGetter();

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.protocol.AsyncCommand;
 import io.lettuce.core.protocol.RedisCommand;
@@ -37,12 +39,13 @@ public class LettuceSingletons {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
     instrumenter =
-        Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<RedisCommand<?, ?, ?>, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetworkAttributesGetter connectNetworkAttributesGetter =

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
 
@@ -59,24 +60,26 @@ public final class LettuceTelemetryBuilder {
   public LettuceTelemetry build() {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
+    InstrumenterBuilder<LettuceRequest, LettuceResponse> builder =
+        Instrumenter.<LettuceRequest, LettuceResponse>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get())
+            .setSpanStatusExtractor(
+                (spanStatusBuilder, request, response, error) -> {
+                  if (response != null && response.getErrorMessage() != null) {
+                    spanStatusBuilder.setStatus(StatusCode.ERROR);
+                  } else {
+                    SpanStatusExtractor.getDefault()
+                        .extract(spanStatusBuilder, request, response, error);
+                  }
+                });
+    setDbClientExceptionEventExtractor(builder);
+
     Instrumenter<LettuceRequest, LettuceResponse> instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<LettuceRequest, LettuceResponse>builder(
-                        openTelemetry,
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get())
-                    .setSpanStatusExtractor(
-                        (spanStatusBuilder, request, response, error) -> {
-                          if (response != null && response.getErrorMessage() != null) {
-                            spanStatusBuilder.setStatus(StatusCode.ERROR);
-                          } else {
-                            SpanStatusExtractor.getDefault()
-                                .extract(spanStatusBuilder, request, response, error);
-                          }
-                        }))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+        builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     return new LettuceTelemetry(instrumenter, querySanitizationEnabled, encodingEventsEnabled);
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.lettuce.v5_1.LettuceTelemetry.INSTRUMENTATION_NAME;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -59,21 +60,22 @@ public final class LettuceTelemetryBuilder {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
 
     Instrumenter<LettuceRequest, LettuceResponse> instrumenter =
-        Instrumenter.<LettuceRequest, LettuceResponse>builder(
-                openTelemetry,
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
-            .setSpanStatusExtractor(
-                (spanStatusBuilder, request, response, error) -> {
-                  if (response != null && response.getErrorMessage() != null) {
-                    spanStatusBuilder.setStatus(StatusCode.ERROR);
-                  } else {
-                    SpanStatusExtractor.getDefault()
-                        .extract(spanStatusBuilder, request, response, error);
-                  }
-                })
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<LettuceRequest, LettuceResponse>builder(
+                        openTelemetry,
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get())
+                    .setSpanStatusExtractor(
+                        (spanStatusBuilder, request, response, error) -> {
+                          if (response != null && response.getErrorMessage() != null) {
+                            spanStatusBuilder.setStatus(StatusCode.ERROR);
+                          } else {
+                            SpanStatusExtractor.getDefault()
+                                .extract(spanStatusBuilder, request, response, error);
+                          }
+                        }))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     return new LettuceTelemetry(instrumenter, querySanitizationEnabled, encodingEventsEnabled);

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoInstrumenterFactory.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.mongo.v3_1.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
@@ -42,11 +44,12 @@ public final class MongoInstrumenterFactory {
     SpanNameExtractor<CommandStartedEvent> spanNameExtractor =
         new MongoSpanNameExtractor(dbAttributesGetter, attributesExtractor);
 
-    return Instrumenter.<CommandStartedEvent, Void>builder(
-            openTelemetry, instrumentationName, spanNameExtractor)
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-        .addAttributesExtractor(attributesExtractor)
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<CommandStartedEvent, Void>builder(
+                    openTelemetry, instrumentationName, spanNameExtractor)
+                .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                .addAttributesExtractor(attributesExtractor)
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoInstrumenterFactory.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoInstrumenterFactory.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
@@ -44,13 +45,14 @@ public final class MongoInstrumenterFactory {
     SpanNameExtractor<CommandStartedEvent> spanNameExtractor =
         new MongoSpanNameExtractor(dbAttributesGetter, attributesExtractor);
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<CommandStartedEvent, Void>builder(
-                    openTelemetry, instrumentationName, spanNameExtractor)
-                .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                .addAttributesExtractor(attributesExtractor)
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<CommandStartedEvent, Void> builder =
+        Instrumenter.<CommandStartedEvent, Void>builder(
+                openTelemetry, instrumentationName, spanNameExtractor)
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(attributesExtractor)
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private MongoInstrumenterFactory() {}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 class OpenSearchSingletons {
@@ -29,15 +30,15 @@ class OpenSearchSingletons {
   private static Instrumenter<OpenSearchRequest, Void> createInstrumenter() {
     OpenSearchAttributesGetter dbClientAttributesGetter = new OpenSearchAttributesGetter();
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<OpenSearchRequest, Void>builder(
-                    GlobalOpenTelemetry.get(),
-                    "io.opentelemetry.opensearch-java-3.0",
-                    DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-                .addAttributesExtractor(
-                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<OpenSearchRequest, Void> builder =
+        Instrumenter.<OpenSearchRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                "io.opentelemetry.opensearch-java-3.0",
+                DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private OpenSearchSingletons() {}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
@@ -27,12 +29,14 @@ class OpenSearchSingletons {
   private static Instrumenter<OpenSearchRequest, Void> createInstrumenter() {
     OpenSearchAttributesGetter dbClientAttributesGetter = new OpenSearchAttributesGetter();
 
-    return Instrumenter.<OpenSearchRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            "io.opentelemetry.opensearch-java-3.0",
-            DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<OpenSearchRequest, Void>builder(
+                    GlobalOpenTelemetry.get(),
+                    "io.opentelemetry.opensearch-java-3.0",
+                    DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+                .addAttributesExtractor(
+                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestInstrumenterFactory.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -18,12 +20,14 @@ public class OpenSearchRestInstrumenterFactory {
       String instrumentationName) {
     OpenSearchRestAttributesGetter dbClientAttributesGetter = new OpenSearchRestAttributesGetter();
 
-    return Instrumenter.<OpenSearchRestRequest, OpenSearchRestResponse>builder(
-            GlobalOpenTelemetry.get(),
-            instrumentationName,
-            DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<OpenSearchRestRequest, OpenSearchRestResponse>builder(
+                    GlobalOpenTelemetry.get(),
+                    instrumentationName,
+                    DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+                .addAttributesExtractor(
+                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestInstrumenterFactory.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestInstrumenterFactory.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class OpenSearchRestInstrumenterFactory {
@@ -20,15 +21,15 @@ public class OpenSearchRestInstrumenterFactory {
       String instrumentationName) {
     OpenSearchRestAttributesGetter dbClientAttributesGetter = new OpenSearchRestAttributesGetter();
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<OpenSearchRestRequest, OpenSearchRestResponse>builder(
-                    GlobalOpenTelemetry.get(),
-                    instrumentationName,
-                    DbClientSpanNameExtractor.create(dbClientAttributesGetter))
-                .addAttributesExtractor(
-                    DbClientAttributesExtractor.create(dbClientAttributesGetter))
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<OpenSearchRestRequest, OpenSearchRestResponse> builder =
+        Instrumenter.<OpenSearchRestRequest, OpenSearchRestResponse>builder(
+                GlobalOpenTelemetry.get(),
+                instrumentationName,
+                DbClientSpanNameExtractor.create(dbClientAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private OpenSearchRestInstrumenterFactory() {}

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -49,14 +51,15 @@ public final class R2dbcInstrumenterBuilder {
         spanNameExtractorTransformer.apply(
             DbClientSpanNameExtractor.create(new R2dbcSqlAttributesGetter()));
 
-    return Instrumenter.<DbExecution, Void>builder(
-            openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
-        .addAttributesExtractor(
-            SqlClientAttributesExtractor.builder(new R2dbcSqlAttributesGetter())
-                .setQuerySanitizationEnabled(querySanitizationEnabled)
-                .build())
-        .addAttributesExtractors(additionalExtractors)
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<DbExecution, Void>builder(
+                    openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
+                .addAttributesExtractor(
+                    SqlClientAttributesExtractor.builder(new R2dbcSqlAttributesGetter())
+                        .setQuerySanitizationEnabled(querySanitizationEnabled)
+                        .build())
+                .addAttributesExtractors(additionalExtractors)
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
@@ -14,6 +14,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.ArrayList;
@@ -51,15 +52,16 @@ public final class R2dbcInstrumenterBuilder {
         spanNameExtractorTransformer.apply(
             DbClientSpanNameExtractor.create(new R2dbcSqlAttributesGetter()));
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<DbExecution, Void>builder(
-                    openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
-                .addAttributesExtractor(
-                    SqlClientAttributesExtractor.builder(new R2dbcSqlAttributesGetter())
-                        .setQuerySanitizationEnabled(querySanitizationEnabled)
-                        .build())
-                .addAttributesExtractors(additionalExtractors)
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<DbExecution, Void> builder =
+        Instrumenter.<DbExecution, Void>builder(
+                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
+            .addAttributesExtractor(
+                SqlClientAttributesExtractor.builder(new R2dbcSqlAttributesGetter())
+                    .setQuerySanitizationEnabled(querySanitizationEnabled)
+                    .build())
+            .addAttributesExtractors(additionalExtractors)
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import redis.RedisCommand;
 
@@ -24,15 +25,16 @@ public class RediscalaSingletons {
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<RedisCommand<?, ?>, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<RedisCommand<?, ?>, Void> builder =
+        Instrumenter.<RedisCommand<?, ?>, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<RedisCommand<?, ?>, Void> instrumenter() {

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -23,12 +25,13 @@ public class RediscalaSingletons {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();
 
     instrumenter =
-        Instrumenter.<RedisCommand<?, ?>, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addOperationMetrics(DbClientMetrics.get())
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<RedisCommand<?, ?>, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -17,12 +19,13 @@ public class RedissonInstrumenterFactory {
   public static Instrumenter<RedissonRequest, Void> createInstrumenter(String instrumentationName) {
     RedissonDbAttributesGetter dbAttributesGetter = new RedissonDbAttributesGetter();
 
-    return Instrumenter.<RedissonRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            instrumentationName,
-            DbClientSpanNameExtractor.create(dbAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
+    return setDbClientExceptionEventExtractor(
+            Instrumenter.<RedissonRequest, Void>builder(
+                    GlobalOpenTelemetry.get(),
+                    instrumentationName,
+                    DbClientSpanNameExtractor.create(dbAttributesGetter))
+                .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                .addOperationMetrics(DbClientMetrics.get()))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class RedissonInstrumenterFactory {
@@ -19,14 +20,15 @@ public class RedissonInstrumenterFactory {
   public static Instrumenter<RedissonRequest, Void> createInstrumenter(String instrumentationName) {
     RedissonDbAttributesGetter dbAttributesGetter = new RedissonDbAttributesGetter();
 
-    return setDbClientExceptionEventExtractor(
-            Instrumenter.<RedissonRequest, Void>builder(
-                    GlobalOpenTelemetry.get(),
-                    instrumentationName,
-                    DbClientSpanNameExtractor.create(dbAttributesGetter))
-                .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                .addOperationMetrics(DbClientMetrics.get()))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<RedissonRequest, Void> builder =
+        Instrumenter.<RedissonRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                instrumentationName,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private RedissonInstrumenterFactory() {}

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
@@ -51,8 +51,8 @@ public class SpymemcachedSingletons {
                       SpymemcachedRequest request,
                       @Nullable Object object,
                       @Nullable Throwable error) {
-                    // For spymemcached, we can only extract server attributes at the
-                    // end of the request because they are not available at the start.
+                    // For spymemcached, we can only extract server attributes at the end of the
+                    // request because they are not available at the start.
                     serverAttributesExtractor.onStart(attributes, context, request);
                   }
                 })

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spymemcached.v2_12;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -30,32 +32,36 @@ public class SpymemcachedSingletons {
         ServerAttributesExtractor.create(serverAttributesGetter);
 
     instrumenter =
-        Instrumenter.builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(
-                new AttributesExtractor<SpymemcachedRequest, Object>() {
-                  @Override
-                  public void onStart(
-                      AttributesBuilder attributes, Context context, SpymemcachedRequest request) {}
+        setDbClientExceptionEventExtractor(
+                Instrumenter.<SpymemcachedRequest, Object>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        DbClientSpanNameExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+                    .addAttributesExtractor(
+                        new AttributesExtractor<SpymemcachedRequest, Object>() {
+                          @Override
+                          public void onStart(
+                              AttributesBuilder attributes,
+                              Context context,
+                              SpymemcachedRequest request) {}
 
-                  @Override
-                  public void onEnd(
-                      AttributesBuilder attributes,
-                      Context context,
-                      SpymemcachedRequest request,
-                      @Nullable Object object,
-                      @Nullable Throwable error) {
-                    // For spymemcached, we can only extract server attributes at the end of the
-                    // request because they are not available at the start.
-                    serverAttributesExtractor.onStart(attributes, context, request);
-                  }
-                })
-            .addContextCustomizer(
-                (context, request, attributes) -> SpymemcachedRequestHolder.init(context, request))
-            .addOperationMetrics(DbClientMetrics.get())
+                          @Override
+                          public void onEnd(
+                              AttributesBuilder attributes,
+                              Context context,
+                              SpymemcachedRequest request,
+                              @Nullable Object object,
+                              @Nullable Throwable error) {
+                            // For spymemcached, we can only extract server attributes at the
+                            // end of the request because they are not available at the start.
+                            serverAttributesExtractor.onStart(attributes, context, request);
+                          }
+                        })
+                    .addContextCustomizer(
+                        (context, request, attributes) ->
+                            SpymemcachedRequestHolder.init(context, request))
+                    .addOperationMetrics(DbClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedSingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import javax.annotation.Nullable;
@@ -31,38 +32,36 @@ public class SpymemcachedSingletons {
     ServerAttributesExtractor<SpymemcachedRequest, Void> serverAttributesExtractor =
         ServerAttributesExtractor.create(serverAttributesGetter);
 
-    instrumenter =
-        setDbClientExceptionEventExtractor(
-                Instrumenter.<SpymemcachedRequest, Object>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        DbClientSpanNameExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-                    .addAttributesExtractor(
-                        new AttributesExtractor<SpymemcachedRequest, Object>() {
-                          @Override
-                          public void onStart(
-                              AttributesBuilder attributes,
-                              Context context,
-                              SpymemcachedRequest request) {}
+    InstrumenterBuilder<SpymemcachedRequest, Object> builder =
+        Instrumenter.<SpymemcachedRequest, Object>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(
+                new AttributesExtractor<SpymemcachedRequest, Object>() {
+                  @Override
+                  public void onStart(
+                      AttributesBuilder attributes, Context context, SpymemcachedRequest request) {}
 
-                          @Override
-                          public void onEnd(
-                              AttributesBuilder attributes,
-                              Context context,
-                              SpymemcachedRequest request,
-                              @Nullable Object object,
-                              @Nullable Throwable error) {
-                            // For spymemcached, we can only extract server attributes at the
-                            // end of the request because they are not available at the start.
-                            serverAttributesExtractor.onStart(attributes, context, request);
-                          }
-                        })
-                    .addContextCustomizer(
-                        (context, request, attributes) ->
-                            SpymemcachedRequestHolder.init(context, request))
-                    .addOperationMetrics(DbClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+                  @Override
+                  public void onEnd(
+                      AttributesBuilder attributes,
+                      Context context,
+                      SpymemcachedRequest request,
+                      @Nullable Object object,
+                      @Nullable Throwable error) {
+                    // For spymemcached, we can only extract server attributes at the
+                    // end of the request because they are not available at the start.
+                    serverAttributesExtractor.onStart(attributes, context, request);
+                  }
+                })
+            .addContextCustomizer(
+                (context, request, attributes) -> SpymemcachedRequestHolder.init(context, request))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<SpymemcachedRequest, Object> instrumenter() {

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientSingletons.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.redisclient.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -48,6 +50,7 @@ public class VertxRedisClientSingletons {
             .addAttributesExtractor(
                 ServicePeerAttributesExtractor.create(getter, GlobalOpenTelemetry.get()))
             .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
 
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/common/v4_0/VertxSqlInstrumenterFactory.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/common/v4_0/VertxSqlInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -36,6 +38,7 @@ public class VertxSqlInstrumenterFactory {
             .addAttributesExtractor(
                 ServicePeerAttributesExtractor.create(attributesGetter, GlobalOpenTelemetry.get()))
             .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
 
     return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }


### PR DESCRIPTION
Under `otel.semconv.exception.signal.preview=logs` (introduced in #16259), database client instrumentations now emit their exceptions as log records instead of span events.

Part of follow-up work after #16259.