### PR TITLE
Emit RPC exceptions as logs under the opt-in preview

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractors.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
@@ -20,34 +19,28 @@ public final class RpcExceptionEventExtractors {
    * Configures the RPC client exception event name and severity. Only takes effect when emitting
    * exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview} flag.
    */
-  @CanIgnoreReturnValue
-  public static <REQUEST, RESPONSE>
-      InstrumenterBuilder<REQUEST, RESPONSE> setRpcClientExceptionEventExtractor(
-          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+  public static <REQUEST> void setRpcClientExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder) {
     Experimental.setExceptionEventExtractor(
         builder,
         (logRecordBuilder, context, request) -> {
           logRecordBuilder.setEventName("rpc.client.call.exception");
           logRecordBuilder.setSeverity(Severity.WARN);
         });
-    return builder;
   }
 
   /**
    * Configures the RPC server exception event name and severity. Only takes effect when emitting
    * exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview} flag.
    */
-  @CanIgnoreReturnValue
-  public static <REQUEST, RESPONSE>
-      InstrumenterBuilder<REQUEST, RESPONSE> setRpcServerExceptionEventExtractor(
-          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+  public static <REQUEST> void setRpcServerExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder) {
     Experimental.setExceptionEventExtractor(
         builder,
         (logRecordBuilder, context, request) -> {
           logRecordBuilder.setEventName("rpc.server.call.exception");
           logRecordBuilder.setSeverity(Severity.ERROR);
         });
-    return builder;
   }
 
   private RpcExceptionEventExtractors() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractors.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class RpcExceptionEventExtractors {
+
+  /**
+   * Configures the RPC client exception event name and severity. Only takes effect when emitting
+   * exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview} flag.
+   */
+  @CanIgnoreReturnValue
+  public static <REQUEST, RESPONSE>
+      InstrumenterBuilder<REQUEST, RESPONSE> setRpcClientExceptionEventExtractor(
+          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) -> {
+          logRecordBuilder.setEventName("rpc.client.call.exception");
+          logRecordBuilder.setSeverity(Severity.WARN);
+        });
+    return builder;
+  }
+
+  /**
+   * Configures the RPC server exception event name and severity. Only takes effect when emitting
+   * exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview} flag.
+   */
+  @CanIgnoreReturnValue
+  public static <REQUEST, RESPONSE>
+      InstrumenterBuilder<REQUEST, RESPONSE> setRpcServerExceptionEventExtractor(
+          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) -> {
+          logRecordBuilder.setEventName("rpc.server.call.exception");
+          logRecordBuilder.setSeverity(Severity.ERROR);
+        });
+    return builder;
+  }
+
+  private RpcExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractorsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/internal/RpcExceptionEventExtractorsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import java.util.List;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RpcExceptionEventExtractorsTest {
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void rpcServerExceptionLog() {
+    assertExceptionLog(
+        RpcExceptionEventExtractors::setRpcServerExceptionEventExtractor,
+        "rpc.server.call.exception",
+        Severity.ERROR);
+  }
+
+  @Test
+  void rpcClientExceptionLog() {
+    assertExceptionLog(
+        RpcExceptionEventExtractors::setRpcClientExceptionEventExtractor,
+        "rpc.client.call.exception",
+        Severity.WARN);
+  }
+
+  private static void assertExceptionLog(
+      Consumer<InstrumenterBuilder<String, String>> configure,
+      String expectedEventName,
+      Severity expectedSeverity) {
+    InstrumenterBuilder<String, String> builder =
+        Instrumenter.builder(otelTesting.getOpenTelemetry(), "test", unused -> "span");
+    configure.accept(builder);
+    Instrumenter<String, String> instrumenter = builder.buildInstrumenter();
+
+    Context context = instrumenter.start(Context.root(), "request");
+    IllegalStateException error = new IllegalStateException("test");
+    instrumenter.end(context, "request", "response", error);
+
+    List<LogRecordData> logs = otelTesting.getLogRecords();
+    if (emitExceptionAsLogs()) {
+      assertThat(logs).hasSize(1);
+      assertThat(logs.get(0))
+          .hasSeverity(expectedSeverity)
+          .hasEventName(expectedEventName)
+          .hasAttributesSatisfyingExactly(
+              equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+              equalTo(EXCEPTION_MESSAGE, "test"),
+              satisfies(EXCEPTION_STACKTRACE, AbstractAssert::isNotNull));
+    } else {
+      assertThat(logs).isEmpty();
+    }
+  }
+}

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboClientNetworkAttributesGetter;
@@ -101,6 +104,7 @@ public final class DubboTelemetryBuilder {
             .addOperationMetrics(RpcServerMetrics.get())
             .addContextCustomizer(
                 RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(serverInstrumenterBuilder);
 
     InstrumenterBuilder<DubboRequest, Result> clientInstrumenterBuilder =
         Instrumenter.<DubboRequest, Result>builder(
@@ -112,6 +116,7 @@ public final class DubboTelemetryBuilder {
             .addOperationMetrics(RpcClientMetrics.get())
             .addContextCustomizer(
                 RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcClientExceptionEventExtractor(clientInstrumenterBuilder);
 
     return new DubboTelemetry(
         serverInstrumenterBuilder.buildServerInstrumenter(new DubboHeadersGetter()),

--- a/instrumentation/grpc-1.6/javaagent/build.gradle.kts
+++ b/instrumentation/grpc-1.6/javaagent/build.gradle.kts
@@ -53,6 +53,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=rpc/dup")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
+  }
+
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
     // The agent context debug mechanism isn't compatible with the bridge approach which may add a
@@ -74,7 +82,7 @@ tasks {
   }
 
   check {
-    dependsOn(testExperimental, testStableSemconv, testBothSemconv)
+    dependsOn(testExperimental, testStableSemconv, testBothSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/grpc-1.6/library/build.gradle.kts
+++ b/instrumentation/grpc-1.6/library/build.gradle.kts
@@ -38,8 +38,15 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=rpc/dup")
   }
 
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+  }
+
   check {
-    dependsOn(testStableSemconv, testBothSemconv)
+    dependsOn(testStableSemconv, testBothSemconv, testExceptionSignalLogs)
   }
 }
 

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -183,6 +185,7 @@ public final class GrpcTelemetryBuilder {
         .addOperationMetrics(RpcClientMetrics.get())
         .addContextCustomizer(
             RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcClientExceptionEventExtractor(clientInstrumenterBuilder);
     Experimental.addOperationListenerAttributesExtractor(
         clientInstrumenterBuilder, RpcSizeAttributesExtractor.create(rpcAttributesGetter));
     serverInstrumenterBuilder
@@ -197,6 +200,7 @@ public final class GrpcTelemetryBuilder {
         .addOperationMetrics(RpcServerMetrics.get())
         .addContextCustomizer(
             RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(serverInstrumenterBuilder);
     Experimental.addOperationListenerAttributesExtractor(
         serverInstrumenterBuilder, RpcSizeAttributesExtractor.create(rpcAttributesGetter));
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -17,9 +17,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -36,7 +33,6 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SY
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -75,7 +71,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
@@ -88,7 +83,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -670,7 +664,14 @@ public abstract class AbstractGrpcTest {
                                 })));
 
     if (emitExceptionAsLogs() && status.getCause() != null) {
-      assertServerExceptionLog(status.getCause());
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.ERROR)
+                      .hasEventName("rpc.server.call.exception")
+                      .hasException(status.getCause())
+                      .hasTotalAttributeCount(3));
     }
 
     assertMetrics(server, status.getCode());
@@ -807,45 +808,17 @@ public abstract class AbstractGrpcTest {
                                 })));
 
     if (emitExceptionAsLogs()) {
-      assertServerExceptionLog(status.asRuntimeException());
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.ERROR)
+                      .hasEventName("rpc.server.call.exception")
+                      .hasException(status.asRuntimeException())
+                      .hasTotalAttributeCount(3));
     }
 
     assertMetrics(server, Status.Code.UNKNOWN);
-  }
-
-  private void assertServerExceptionLog(Throwable expectedException) {
-    assertExceptionLog(expectedException, "rpc.server.call.exception", Severity.ERROR);
-  }
-
-  private void assertClientExceptionLog(Throwable expectedException) {
-    assertExceptionLog(expectedException, "rpc.client.call.exception", Severity.WARN);
-  }
-
-  private void assertExceptionLog(
-      Throwable expectedException, String expectedEventName, Severity expectedSeverity) {
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              List<LogRecordData> logs =
-                  testing().logRecords().stream()
-                      .filter(log -> expectedEventName.equals(log.getEventName()))
-                      .collect(toList());
-
-              assertThat(logs).hasSize(1);
-              assertThat(logs.get(0))
-                  .hasSeverity(expectedSeverity)
-                  .hasEventName(expectedEventName)
-                  .hasAttributesSatisfyingExactly(
-                      equalTo(EXCEPTION_TYPE, expectedException.getClass().getName()),
-                      satisfies(
-                          EXCEPTION_MESSAGE,
-                          val -> {
-                            if (expectedException.getMessage() != null) {
-                              val.isEqualTo(expectedException.getMessage());
-                            }
-                          }),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
-            });
   }
 
   private static Stream<Arguments> provideErrorArguments() {
@@ -1242,7 +1215,14 @@ public abstract class AbstractGrpcTest {
                                             equalTo(MESSAGE_ID, 1L)))));
 
     if (emitExceptionAsLogs()) {
-      assertClientExceptionLog(thrown);
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("rpc.client.call.exception")
+                      .hasException(thrown)
+                      .hasTotalAttributeCount(3));
     }
   }
 

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static io.opentelemetry.instrumentation.grpc.v1_6.ExperimentalTestHelper.GRPC_RECEIVED_MESSAGE_COUNT;
@@ -15,6 +17,9 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -31,6 +36,7 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SY
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -64,10 +70,12 @@ import io.grpc.reflection.v1alpha.ServerReflectionResponse;
 import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.ArrayList;
@@ -80,6 +88,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -652,13 +661,17 @@ public abstract class AbstractGrpcTest {
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  if (status.getCause() == null) {
+                                  if (status.getCause() == null || !emitExceptionAsSpanEvents()) {
                                     assertThat(events).hasSize(1);
                                   } else {
                                     assertThat(events).hasSize(2);
                                     span.hasException(status.getCause());
                                   }
                                 })));
+
+    if (emitExceptionAsLogs() && status.getCause() != null) {
+      assertServerExceptionLog(status.getCause());
+    }
 
     assertMetrics(server, status.getCode());
   }
@@ -780,16 +793,59 @@ public abstract class AbstractGrpcTest {
                                 satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()))
                             .hasEventsSatisfying(
                                 events -> {
-                                  assertThat(events).hasSize(2);
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  span.hasException(status.asRuntimeException());
+                                  if (emitExceptionAsSpanEvents()) {
+                                    assertThat(events).hasSize(2);
+                                    span.hasException(status.asRuntimeException());
+                                  } else {
+                                    assertThat(events).hasSize(1);
+                                  }
                                 })));
 
+    if (emitExceptionAsLogs()) {
+      assertServerExceptionLog(status.asRuntimeException());
+    }
+
     assertMetrics(server, Status.Code.UNKNOWN);
+  }
+
+  private void assertServerExceptionLog(Throwable expectedException) {
+    assertExceptionLog(expectedException, "rpc.server.call.exception", Severity.ERROR);
+  }
+
+  private void assertClientExceptionLog(Throwable expectedException) {
+    assertExceptionLog(expectedException, "rpc.client.call.exception", Severity.WARN);
+  }
+
+  private void assertExceptionLog(
+      Throwable expectedException, String expectedEventName, Severity expectedSeverity) {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              List<LogRecordData> logs =
+                  testing().logRecords().stream()
+                      .filter(log -> expectedEventName.equals(log.getEventName()))
+                      .collect(toList());
+
+              assertThat(logs).hasSize(1);
+              assertThat(logs.get(0))
+                  .hasSeverity(expectedSeverity)
+                  .hasEventName(expectedEventName)
+                  .hasAttributesSatisfyingExactly(
+                      equalTo(EXCEPTION_TYPE, expectedException.getClass().getName()),
+                      satisfies(
+                          EXCEPTION_MESSAGE,
+                          val -> {
+                            if (expectedException.getMessage() != null) {
+                              val.isEqualTo(expectedException.getMessage());
+                            }
+                          }),
+                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
+            });
   }
 
   private static Stream<Arguments> provideErrorArguments() {
@@ -1123,7 +1179,6 @@ public abstract class AbstractGrpcTest {
                                     equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfying(
                                 events -> {
-                                  assertThat(events).hasSize(3);
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
@@ -1133,7 +1188,12 @@ public abstract class AbstractGrpcTest {
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  span.hasException(thrown);
+                                  if (emitExceptionAsSpanEvents()) {
+                                    assertThat(events).hasSize(3);
+                                    span.hasException(thrown);
+                                  } else {
+                                    assertThat(events).hasSize(2);
+                                  }
                                 }),
                     span ->
                         span.hasName("example.Greeter/SayMultipleHello")
@@ -1180,6 +1240,10 @@ public abstract class AbstractGrpcTest {
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(MESSAGE_TYPE, "SENT"),
                                             equalTo(MESSAGE_ID, 1L)))));
+
+    if (emitExceptionAsLogs()) {
+      assertClientExceptionLog(thrown);
+    }
   }
 
   @Test

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -649,18 +649,21 @@ public abstract class AbstractGrpcTest {
                                 satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()))
                             .hasEventsSatisfying(
                                 events -> {
+                                  assertThat(events)
+                                      .hasSize(
+                                          status.getCause() != null && emitExceptionAsSpanEvents()
+                                              ? 2
+                                              : 1);
                                   assertThat(events).isNotEmpty();
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  if (status.getCause() == null || !emitExceptionAsSpanEvents()) {
-                                    assertThat(events).hasSize(1);
-                                  } else {
-                                    assertThat(events).hasSize(2);
-                                    span.hasException(status.getCause());
-                                  }
+                                  span.hasException(
+                                      status.getCause() != null && emitExceptionAsSpanEvents()
+                                          ? status.getCause()
+                                          : null);
                                 })));
 
     if (emitExceptionAsLogs() && status.getCause() != null) {
@@ -794,17 +797,16 @@ public abstract class AbstractGrpcTest {
                                 satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()))
                             .hasEventsSatisfying(
                                 events -> {
+                                  assertThat(events).hasSize(emitExceptionAsSpanEvents() ? 2 : 1);
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  if (emitExceptionAsSpanEvents()) {
-                                    assertThat(events).hasSize(2);
-                                    span.hasException(status.asRuntimeException());
-                                  } else {
-                                    assertThat(events).hasSize(1);
-                                  }
+                                  span.hasException(
+                                      emitExceptionAsSpanEvents()
+                                          ? status.asRuntimeException()
+                                          : null);
                                 })));
 
     if (emitExceptionAsLogs()) {
@@ -1152,6 +1154,7 @@ public abstract class AbstractGrpcTest {
                                     equalTo(SERVER_PORT, (long) server.getPort())))
                             .hasEventsSatisfying(
                                 events -> {
+                                  assertThat(events).hasSize(emitExceptionAsSpanEvents() ? 3 : 2);
                                   assertThat(events.get(0))
                                       .hasName("message")
                                       .hasAttributesSatisfyingExactly(
@@ -1161,12 +1164,7 @@ public abstract class AbstractGrpcTest {
                                       .hasAttributesSatisfyingExactly(
                                           equalTo(MESSAGE_TYPE, "RECEIVED"),
                                           equalTo(MESSAGE_ID, 1L));
-                                  if (emitExceptionAsSpanEvents()) {
-                                    assertThat(events).hasSize(3);
-                                    span.hasException(thrown);
-                                  } else {
-                                    assertThat(events).hasSize(2);
-                                  }
+                                  span.hasException(emitExceptionAsSpanEvents() ? thrown : null);
                                 }),
                     span ->
                         span.hasName("example.Greeter/SayMultipleHello")

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtSingletons.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import java.lang.reflect.Method;
 
@@ -26,15 +27,15 @@ public class GwtSingletons {
 
   static {
     GwtRpcAttributesGetter rpcAttributesGetter = new GwtRpcAttributesGetter();
-    instrumenter =
-        setRpcServerExceptionEventExtractor(
-                Instrumenter.<Method, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        INSTRUMENTATION_NAME,
-                        RpcSpanNameExtractor.create(rpcAttributesGetter))
-                    .addAttributesExtractor(
-                        RpcServerAttributesExtractor.create(rpcAttributesGetter)))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer());
+    InstrumenterBuilder<Method, Void> builder =
+        Instrumenter.<Method, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtSingletons.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/v2_0/GwtSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.gwt.v2_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
@@ -25,11 +27,13 @@ public class GwtSingletons {
   static {
     GwtRpcAttributesGetter rpcAttributesGetter = new GwtRpcAttributesGetter();
     instrumenter =
-        Instrumenter.<Method, Void>builder(
-                GlobalOpenTelemetry.get(),
-                INSTRUMENTATION_NAME,
-                RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
+        setRpcServerExceptionEventExtractor(
+                Instrumenter.<Method, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        INSTRUMENTATION_NAME,
+                        RpcSpanNameExtractor.create(rpcAttributesGetter))
+                    .addAttributesExtractor(
+                        RpcServerAttributesExtractor.create(rpcAttributesGetter)))
             .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import java.lang.reflect.Method;
 
@@ -21,15 +22,15 @@ public class RmiClientSingletons {
   static {
     RmiClientAttributesGetter rpcAttributesGetter = new RmiClientAttributesGetter();
 
-    instrumenter =
-        setRpcClientExceptionEventExtractor(
-                Instrumenter.<Method, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        "io.opentelemetry.rmi",
-                        RpcSpanNameExtractor.create(rpcAttributesGetter))
-                    .addAttributesExtractor(
-                        RpcClientAttributesExtractor.create(rpcAttributesGetter)))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<Method, Void> builder =
+        Instrumenter.<Method, Void>builder(
+                GlobalOpenTelemetry.get(),
+                "io.opentelemetry.rmi",
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter));
+    setRpcClientExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.client;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
@@ -20,11 +22,13 @@ public class RmiClientSingletons {
     RmiClientAttributesGetter rpcAttributesGetter = new RmiClientAttributesGetter();
 
     instrumenter =
-        Instrumenter.<Method, Void>builder(
-                GlobalOpenTelemetry.get(),
-                "io.opentelemetry.rmi",
-                RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
+        setRpcClientExceptionEventExtractor(
+                Instrumenter.<Method, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        "io.opentelemetry.rmi",
+                        RpcSpanNameExtractor.create(rpcAttributesGetter))
+                    .addAttributesExtractor(
+                        RpcClientAttributesExtractor.create(rpcAttributesGetter)))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.server;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
@@ -20,11 +22,13 @@ public class RmiServerSingletons {
     RmiServerAttributesGetter rpcAttributesGetter = new RmiServerAttributesGetter();
 
     instrumenter =
-        Instrumenter.<ClassAndMethod, Void>builder(
-                GlobalOpenTelemetry.get(),
-                "io.opentelemetry.rmi",
-                RpcSpanNameExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
+        setRpcServerExceptionEventExtractor(
+                Instrumenter.<ClassAndMethod, Void>builder(
+                        GlobalOpenTelemetry.get(),
+                        "io.opentelemetry.rmi",
+                        RpcSpanNameExtractor.create(rpcAttributesGetter))
+                    .addAttributesExtractor(
+                        RpcServerAttributesExtractor.create(rpcAttributesGetter)))
             .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttri
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class RmiServerSingletons {
@@ -21,15 +22,15 @@ public class RmiServerSingletons {
   static {
     RmiServerAttributesGetter rpcAttributesGetter = new RmiServerAttributesGetter();
 
-    instrumenter =
-        setRpcServerExceptionEventExtractor(
-                Instrumenter.<ClassAndMethod, Void>builder(
-                        GlobalOpenTelemetry.get(),
-                        "io.opentelemetry.rmi",
-                        RpcSpanNameExtractor.create(rpcAttributesGetter))
-                    .addAttributesExtractor(
-                        RpcServerAttributesExtractor.create(rpcAttributesGetter)))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer());
+    InstrumenterBuilder<ClassAndMethod, Void> builder =
+        Instrumenter.<ClassAndMethod, Void>builder(
+                GlobalOpenTelemetry.get(),
+                "io.opentelemetry.rmi",
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(builder);
+
+    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttributesExtractor;
@@ -26,22 +29,24 @@ public class SpringRmiSingletons {
   private static Instrumenter<Method, Void> buildClientInstrumenter() {
     ClientAttributesGetter rpcAttributesGetter = new ClientAttributesGetter();
 
-    return Instrumenter.<Method, Void>builder(
-            GlobalOpenTelemetry.get(),
-            INSTRUMENTATION_NAME,
-            RpcSpanNameExtractor.create(rpcAttributesGetter))
-        .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
+    return setRpcClientExceptionEventExtractor(
+            Instrumenter.<Method, Void>builder(
+                    GlobalOpenTelemetry.get(),
+                    INSTRUMENTATION_NAME,
+                    RpcSpanNameExtractor.create(rpcAttributesGetter))
+                .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter)))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private static Instrumenter<ClassAndMethod, Void> buildServerInstrumenter() {
     ServerAttributesGetter rpcAttributesGetter = new ServerAttributesGetter();
 
-    return Instrumenter.<ClassAndMethod, Void>builder(
-            GlobalOpenTelemetry.get(),
-            INSTRUMENTATION_NAME,
-            RpcSpanNameExtractor.create(rpcAttributesGetter))
-        .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
+    return setRpcServerExceptionEventExtractor(
+            Instrumenter.<ClassAndMethod, Void>builder(
+                    GlobalOpenTelemetry.get(),
+                    INSTRUMENTATION_NAME,
+                    RpcSpanNameExtractor.create(rpcAttributesGetter))
+                .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter)))
         .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/SpringRmiSingletons.java
@@ -14,6 +14,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcServerAttri
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0.client.ClientAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.spring.rmi.v4_0.server.ServerAttributesGetter;
@@ -29,25 +30,27 @@ public class SpringRmiSingletons {
   private static Instrumenter<Method, Void> buildClientInstrumenter() {
     ClientAttributesGetter rpcAttributesGetter = new ClientAttributesGetter();
 
-    return setRpcClientExceptionEventExtractor(
-            Instrumenter.<Method, Void>builder(
-                    GlobalOpenTelemetry.get(),
-                    INSTRUMENTATION_NAME,
-                    RpcSpanNameExtractor.create(rpcAttributesGetter))
-                .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter)))
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<Method, Void> builder =
+        Instrumenter.<Method, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter));
+    setRpcClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private static Instrumenter<ClassAndMethod, Void> buildServerInstrumenter() {
     ServerAttributesGetter rpcAttributesGetter = new ServerAttributesGetter();
 
-    return setRpcServerExceptionEventExtractor(
-            Instrumenter.<ClassAndMethod, Void>builder(
-                    GlobalOpenTelemetry.get(),
-                    INSTRUMENTATION_NAME,
-                    RpcSpanNameExtractor.create(rpcAttributesGetter))
-                .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter)))
-        .buildInstrumenter(SpanKindExtractor.alwaysServer());
+    InstrumenterBuilder<ClassAndMethod, Void> builder =
+        Instrumenter.<ClassAndMethod, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                RpcSpanNameExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<Method, Void> clientInstrumenter() {

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ThriftInstrumenterFactory.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ThriftInstrumenterFactory.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.thrift.v0_13.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcServerExceptionEventExtractor;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
@@ -74,6 +77,7 @@ public final class ThriftInstrumenterFactory {
         .addOperationMetrics(RpcClientMetrics.get())
         .addContextCustomizer(
             RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcClientExceptionEventExtractor(clientInstrumenterBuilder);
 
     return clientInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
@@ -105,6 +109,7 @@ public final class ThriftInstrumenterFactory {
         .addOperationMetrics(RpcServerMetrics.get())
         .addContextCustomizer(
             RpcMetricsContextCustomizers.dualEmitContextCustomizer(rpcAttributesGetter));
+    setRpcServerExceptionEventExtractor(serverInstrumenterBuilder);
     Experimental.addOperationListenerAttributesExtractor(
         serverInstrumenterBuilder, RpcSizeAttributesExtractor.create(rpcAttributesGetter));
 


### PR DESCRIPTION
Under `otel.semconv.exception.signal.preview=logs` (introduced in #16259), RPC client and server instrumentations now emit their exceptions as log records instead of span events.

Part of follow-up work after #16259.