### PR TITLE
Emit FaaS exceptions as logs under the opt-in preview

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractors.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.faas.internal;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
@@ -21,17 +20,14 @@ public final class FaasExceptionEventExtractors {
    * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
    * flag.
    */
-  @CanIgnoreReturnValue
-  public static <REQUEST, RESPONSE>
-      InstrumenterBuilder<REQUEST, RESPONSE> setFaasInvocationExceptionEventExtractor(
-          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+  public static <REQUEST> void setFaasInvocationExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder) {
     Experimental.setExceptionEventExtractor(
         builder,
         (logRecordBuilder, context, request) -> {
           logRecordBuilder.setEventName("faas.invocation.exception");
           logRecordBuilder.setSeverity(Severity.ERROR);
         });
-    return builder;
   }
 
   private FaasExceptionEventExtractors() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractors.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.faas.internal;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class FaasExceptionEventExtractors {
+
+  /**
+   * Configures the FaaS invocation exception event name and severity. Only takes effect when
+   * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
+   * flag.
+   */
+  @CanIgnoreReturnValue
+  public static <REQUEST, RESPONSE>
+      InstrumenterBuilder<REQUEST, RESPONSE> setFaasInvocationExceptionEventExtractor(
+          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) -> {
+          logRecordBuilder.setEventName("faas.invocation.exception");
+          logRecordBuilder.setSeverity(Severity.ERROR);
+        });
+    return builder;
+  }
+
+  private FaasExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractorsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/faas/internal/FaasExceptionEventExtractorsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.faas.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import java.util.List;
+import org.assertj.core.api.AbstractAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class FaasExceptionEventExtractorsTest {
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void faasInvocationExceptionLog() {
+    InstrumenterBuilder<String, String> builder =
+        Instrumenter.builder(otelTesting.getOpenTelemetry(), "test", unused -> "span");
+    FaasExceptionEventExtractors.setFaasInvocationExceptionEventExtractor(builder);
+    Instrumenter<String, String> instrumenter = builder.buildInstrumenter();
+
+    Context context = instrumenter.start(Context.root(), "request");
+    IllegalStateException error = new IllegalStateException("test");
+    instrumenter.end(context, "request", "response", error);
+
+    List<LogRecordData> logs = otelTesting.getLogRecords();
+    if (emitExceptionAsLogs()) {
+      assertThat(logs).hasSize(1);
+      assertThat(logs.get(0))
+          .hasSeverity(Severity.ERROR)
+          .hasEventName("faas.invocation.exception")
+          .hasAttributesSatisfyingExactly(
+              equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+              equalTo(EXCEPTION_MESSAGE, "test"),
+              satisfies(EXCEPTION_STACKTRACE, AbstractAssert::isNotNull));
+    } else {
+      assertThat(logs).isEmpty();
+    }
+  }
+}

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/build.gradle.kts
@@ -34,9 +34,6 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    filter {
-      includeTestsMatching("AwsLambdaTest")
-    }
     jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
     systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/build.gradle.kts
@@ -20,11 +20,28 @@ dependencies {
   testImplementation(project(":instrumentation:aws-lambda:aws-lambda-core-1.0:testing"))
 }
 
-tasks.test {
-  // required on jdk17
-  jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
-  jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
-  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+tasks {
+  withType<Test>().configureEach {
+    // required on jdk17
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 
-  systemProperty("collectMetadata", otelProps.collectMetadata)
+    systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("AwsLambdaTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaStreamHandlerTest.java
@@ -5,15 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -86,8 +89,18 @@ class AwsLambdaStreamHandlerTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
+
+    if (emitExceptionAsLogs()) {
+      testing.waitAndAssertLogRecords(
+          logRecord ->
+              logRecord
+                  .hasSeverity(Severity.ERROR)
+                  .hasEventName("faas.invocation.exception")
+                  .hasException(thrown)
+                  .hasTotalAttributeCount(3));
+    }
   }
 
   private static class RequestStreamHandlerTestImpl implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
@@ -34,3 +34,19 @@ tasks.withType<Test>().configureEach {
   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }
+
+tasks {
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("AwsLambdaTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
+}

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/build.gradle.kts
@@ -40,9 +40,6 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    filter {
-      includeTestsMatching("AwsLambdaTest")
-    }
     jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.faas.internal.FaasExceptionEventExtractors.setFaasInvocationExceptionEventExtractor;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
@@ -19,11 +21,12 @@ public final class AwsLambdaFunctionInstrumenterFactory {
   public static AwsLambdaFunctionInstrumenter createInstrumenter(OpenTelemetry openTelemetry) {
     return new AwsLambdaFunctionInstrumenter(
         openTelemetry,
-        Instrumenter.builder(
-                openTelemetry,
-                "io.opentelemetry.aws-lambda-core-1.0",
-                AwsLambdaFunctionInstrumenterFactory::spanName)
-            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
+        setFaasInvocationExceptionEventExtractor(
+                Instrumenter.builder(
+                        openTelemetry,
+                        "io.opentelemetry.aws-lambda-core-1.0",
+                        AwsLambdaFunctionInstrumenterFactory::spanName)
+                    .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor()))
             .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.faas.intern
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 
@@ -19,15 +20,16 @@ import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 public final class AwsLambdaFunctionInstrumenterFactory {
 
   public static AwsLambdaFunctionInstrumenter createInstrumenter(OpenTelemetry openTelemetry) {
+    InstrumenterBuilder<AwsLambdaRequest, Object> builder =
+        Instrumenter.<AwsLambdaRequest, Object>builder(
+                openTelemetry,
+                "io.opentelemetry.aws-lambda-core-1.0",
+                AwsLambdaFunctionInstrumenterFactory::spanName)
+            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor());
+    setFaasInvocationExceptionEventExtractor(builder);
+
     return new AwsLambdaFunctionInstrumenter(
-        openTelemetry,
-        setFaasInvocationExceptionEventExtractor(
-                Instrumenter.builder(
-                        openTelemetry,
-                        "io.opentelemetry.aws-lambda-core-1.0",
-                        AwsLambdaFunctionInstrumenterFactory::spanName)
-                    .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor()))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer()));
+        openTelemetry, builder.buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 
   private static String spanName(AwsLambdaRequest input) {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperHttpPropagationTest.java
@@ -5,12 +5,14 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +21,7 @@ import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambda;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -126,13 +129,23 @@ class AwsLambdaStreamWrapperHttpPropagationTest {
                         .hasTraceId("4fd0b6131f19f39af59518d127b0cafe")
                         .hasParentSpanId("0000000000000456")
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
                             equalTo(CLOUD_ACCOUNT_ID, "123456789"),
                             equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
+
+    if (emitExceptionAsLogs()) {
+      testing.waitAndAssertLogRecords(
+          logRecord ->
+              logRecord
+                  .hasSeverity(Severity.ERROR)
+                  .hasEventName("faas.invocation.exception")
+                  .hasException(thrown)
+                  .hasTotalAttributeCount(3));
+    }
   }
 
   public static class TestRequestHandler implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AwsLambdaStreamWrapperTest.java
@@ -5,17 +5,20 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.WrappedLambda;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -107,13 +110,23 @@ class AwsLambdaStreamWrapperTest {
                     span.hasName("my_function")
                         .hasKind(SpanKind.SERVER)
                         .hasStatus(StatusData.error())
-                        .hasException(thrown)
+                        .hasException(emitExceptionAsSpanEvents() ? thrown : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(
                                 CLOUD_RESOURCE_ID,
                                 "arn:aws:lambda:us-east-1:123456789:function:test"),
                             equalTo(CLOUD_ACCOUNT_ID, "123456789"),
                             equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
+
+    if (emitExceptionAsLogs()) {
+      testing.waitAndAssertLogRecords(
+          logRecord ->
+              logRecord
+                  .hasSeverity(Severity.ERROR)
+                  .hasEventName("faas.invocation.exception")
+                  .hasException(thrown)
+                  .hasTotalAttributeCount(3));
+    }
   }
 
   public static class TestRequestHandler implements RequestStreamHandler {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -9,12 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSign
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
@@ -23,10 +18,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import java.util.List;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -100,27 +92,15 @@ public abstract class AbstractAwsLambdaTest {
                     }));
 
     if (emitExceptionAsLogs()) {
-      assertInvocationExceptionLog();
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.ERROR)
+                      .hasEventName("faas.invocation.exception")
+                      .hasException(thrown)
+                      .hasTotalAttributeCount(3));
     }
-  }
-
-  private void assertInvocationExceptionLog() {
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              List<LogRecordData> logs =
-                  testing().logRecords().stream()
-                      .filter(log -> "faas.invocation.exception".equals(log.getEventName()))
-                      .collect(toList());
-              assertThat(logs).hasSize(1);
-              assertThat(logs.get(0))
-                  .hasSeverity(Severity.ERROR)
-                  .hasEventName("faas.invocation.exception")
-                  .hasAttributesSatisfyingExactly(
-                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
-            });
   }
 
   /**

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -83,13 +83,13 @@ public abstract class AbstractAwsLambdaTest {
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span -> {
-                      span.hasName("my_function")
-                          .hasKind(SpanKind.SERVER)
-                          .hasStatus(StatusData.error())
-                          .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"));
-                      span.hasException(emitExceptionAsSpanEvents() ? thrown : null);
-                    }));
+                    span ->
+                        span.hasName("my_function")
+                            .hasKind(SpanKind.SERVER)
+                            .hasStatus(StatusData.error())
+                            .hasException(emitExceptionAsSpanEvents() ? thrown : null)
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
 
     if (emitExceptionAsLogs()) {
       testing()

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -5,17 +5,28 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,13 +91,36 @@ public abstract class AbstractAwsLambdaTest {
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName("my_function")
-                            .hasKind(SpanKind.SERVER)
-                            .hasStatus(StatusData.error())
-                            .hasException(thrown)
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(FAAS_INVOCATION_ID, "1-22-333"))));
+                    span -> {
+                      span.hasName("my_function")
+                          .hasKind(SpanKind.SERVER)
+                          .hasStatus(StatusData.error())
+                          .hasAttributesSatisfyingExactly(equalTo(FAAS_INVOCATION_ID, "1-22-333"));
+                      span.hasException(emitExceptionAsSpanEvents() ? thrown : null);
+                    }));
+
+    if (emitExceptionAsLogs()) {
+      assertInvocationExceptionLog();
+    }
+  }
+
+  private void assertInvocationExceptionLog() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              List<LogRecordData> logs =
+                  testing().logRecords().stream()
+                      .filter(log -> "faas.invocation.exception".equals(log.getEventName()))
+                      .collect(toList());
+              assertThat(logs).hasSize(1);
+              assertThat(logs.get(0))
+                  .hasSeverity(Severity.ERROR)
+                  .hasEventName("faas.invocation.exception")
+                  .hasAttributesSatisfyingExactly(
+                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
+            });
   }
 
   /**

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.faas.intern
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.AwsLambdaFunctionAttributesExtractor;
@@ -24,16 +25,15 @@ public final class AwsLambdaEventsInstrumenterFactory {
 
   public static AwsLambdaFunctionInstrumenter createInstrumenter(
       OpenTelemetry openTelemetry, String instrumentationName, Set<String> knownMethods) {
+    InstrumenterBuilder<AwsLambdaRequest, Object> builder =
+        Instrumenter.<AwsLambdaRequest, Object>builder(
+                openTelemetry, instrumentationName, AwsLambdaEventsInstrumenterFactory::spanName)
+            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
+            .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor(knownMethods));
+    setFaasInvocationExceptionEventExtractor(builder);
+
     return new AwsLambdaFunctionInstrumenter(
-        openTelemetry,
-        setFaasInvocationExceptionEventExtractor(
-                Instrumenter.builder(
-                        openTelemetry,
-                        instrumentationName,
-                        AwsLambdaEventsInstrumenterFactory::spanName)
-                    .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
-                    .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor(knownMethods)))
-            .buildInstrumenter(SpanKindExtractor.alwaysServer()));
+        openTelemetry, builder.buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 
   private static String spanName(AwsLambdaRequest input) {

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.faas.internal.FaasExceptionEventExtractors.setFaasInvocationExceptionEventExtractor;
+
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -24,10 +26,13 @@ public final class AwsLambdaEventsInstrumenterFactory {
       OpenTelemetry openTelemetry, String instrumentationName, Set<String> knownMethods) {
     return new AwsLambdaFunctionInstrumenter(
         openTelemetry,
-        Instrumenter.builder(
-                openTelemetry, instrumentationName, AwsLambdaEventsInstrumenterFactory::spanName)
-            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
-            .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor(knownMethods))
+        setFaasInvocationExceptionEventExtractor(
+                Instrumenter.builder(
+                        openTelemetry,
+                        instrumentationName,
+                        AwsLambdaEventsInstrumenterFactory::spanName)
+                    .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
+                    .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor(knownMethods)))
             .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 


### PR DESCRIPTION
Under `otel.semconv.exception.signal.preview=logs` (introduced in #16259), FaaS instrumentations now emit their exceptions as log records instead of span events.

Part of follow-up work after #16259.