### PR TITLE
Emit GenAI exceptions as logs under the opt-in preview

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractors.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.genai.internal;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.Experimental;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class GenAiExceptionEventExtractors {
+
+  /**
+   * Configures the GenAI client operation exception event name and severity. Only takes effect when
+   * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
+   * flag.
+   */
+  @CanIgnoreReturnValue
+  public static <REQUEST, RESPONSE>
+      InstrumenterBuilder<REQUEST, RESPONSE> setGenAiClientExceptionEventExtractor(
+          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+    Experimental.setExceptionEventExtractor(
+        builder,
+        (logRecordBuilder, context, request) -> {
+          logRecordBuilder.setEventName("gen_ai.client.operation.exception");
+          logRecordBuilder.setSeverity(Severity.WARN);
+        });
+    return builder;
+  }
+
+  private GenAiExceptionEventExtractors() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractors.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractors.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.genai.internal;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
@@ -21,17 +20,14 @@ public final class GenAiExceptionEventExtractors {
    * emitting exceptions as logs is enabled via the {@code otel.semconv.exception.signal.preview}
    * flag.
    */
-  @CanIgnoreReturnValue
-  public static <REQUEST, RESPONSE>
-      InstrumenterBuilder<REQUEST, RESPONSE> setGenAiClientExceptionEventExtractor(
-          InstrumenterBuilder<REQUEST, RESPONSE> builder) {
+  public static <REQUEST> void setGenAiClientExceptionEventExtractor(
+      InstrumenterBuilder<REQUEST, ?> builder) {
     Experimental.setExceptionEventExtractor(
         builder,
         (logRecordBuilder, context, request) -> {
           logRecordBuilder.setEventName("gen_ai.client.operation.exception");
           logRecordBuilder.setSeverity(Severity.WARN);
         });
-    return builder;
   }
 
   private GenAiExceptionEventExtractors() {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractorsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/internal/GenAiExceptionEventExtractorsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.genai.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import java.util.List;
+import org.assertj.core.api.AbstractAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class GenAiExceptionEventExtractorsTest {
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void genAiClientExceptionLog() {
+    InstrumenterBuilder<String, String> builder =
+        Instrumenter.builder(otelTesting.getOpenTelemetry(), "test", unused -> "span");
+    GenAiExceptionEventExtractors.setGenAiClientExceptionEventExtractor(builder);
+    Instrumenter<String, String> instrumenter = builder.buildInstrumenter();
+
+    Context context = instrumenter.start(Context.root(), "request");
+    IllegalStateException error = new IllegalStateException("test");
+    instrumenter.end(context, "request", "response", error);
+
+    List<LogRecordData> logs = otelTesting.getLogRecords();
+    if (emitExceptionAsLogs()) {
+      assertThat(logs).hasSize(1);
+      assertThat(logs.get(0))
+          .hasSeverity(Severity.WARN)
+          .hasEventName("gen_ai.client.operation.exception")
+          .hasAttributesSatisfyingExactly(
+              equalTo(EXCEPTION_TYPE, "java.lang.IllegalStateException"),
+              equalTo(EXCEPTION_MESSAGE, "test"),
+              satisfies(EXCEPTION_STACKTRACE, AbstractAssert::isNotNull));
+    } else {
+      assertThat(logs).isEmpty();
+    }
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
     // TODO run tests both with and without genai message capture
 
@@ -34,11 +34,11 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    systemProperty("otel.instrumentation.genai.capture-message-content", "true")
     filter {
       includeTestsMatching("EmbeddingsTest")
     }
     jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }
 
   check {

--- a/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
@@ -33,10 +33,6 @@ tasks {
   val testExceptionSignalLogs by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
-    filter {
-      includeTestsMatching("EmbeddingsTest")
-    }
     jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
     systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }

--- a/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/javaagent/build.gradle.kts
@@ -29,4 +29,19 @@ tasks {
     systemProperty("otel.instrumentation.genai.capture-message-content", "true")
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    systemProperty("otel.instrumentation.genai.capture-message-content", "true")
+    filter {
+      includeTestsMatching("EmbeddingsTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
@@ -5,11 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.openai.v1_1.AbstractChatTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +51,25 @@ class ChatTest extends AbstractChatTest {
     result.add(span);
     // Do a very simple assertion since the telemetry is not part of this library.
     result.add(s -> s.hasName("POST"));
+    return result;
+  }
+
+  @Override
+  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
+      Consumer<LogRecordDataAssert> logRecord) {
+    List<Consumer<LogRecordDataAssert>> result = new ArrayList<>();
+    result.add(
+        transportLog ->
+            transportLog
+                .hasSeverity(Severity.WARN)
+                .hasEventName("http.client.request.exception")
+                .hasAttributesSatisfyingExactly(
+                    equalTo(EXCEPTION_TYPE, "java.net.ConnectException"),
+                    satisfies(
+                        EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
+                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()))
+                .hasTotalAttributeCount(3));
+    result.add(logRecord);
     return result;
   }
 }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static java.util.Collections.singletonList;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -55,10 +56,8 @@ class ChatTest extends AbstractChatTest {
   }
 
   @Override
-  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
-      Consumer<LogRecordDataAssert> logRecord) {
-    List<Consumer<LogRecordDataAssert>> result = new ArrayList<>();
-    result.add(
+  protected List<Consumer<LogRecordDataAssert>> transportExceptionLogs() {
+    return singletonList(
         transportLog ->
             transportLog
                 .hasSeverity(Severity.WARN)
@@ -68,7 +67,5 @@ class ChatTest extends AbstractChatTest {
                     satisfies(
                         EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
                     satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
-    result.add(logRecord);
-    return result;
   }
 }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/ChatTest.java
@@ -67,8 +67,7 @@ class ChatTest extends AbstractChatTest {
                     equalTo(EXCEPTION_TYPE, "java.net.ConnectException"),
                     satisfies(
                         EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
-                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()))
-                .hasTotalAttributeCount(3));
+                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
     result.add(logRecord);
     return result;
   }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static java.util.Collections.singletonList;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
@@ -55,10 +56,8 @@ class EmbeddingsTest extends AbstractEmbeddingsTest {
   }
 
   @Override
-  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
-      Consumer<LogRecordDataAssert> logRecord) {
-    List<Consumer<LogRecordDataAssert>> result = new ArrayList<>();
-    result.add(
+  protected List<Consumer<LogRecordDataAssert>> transportExceptionLogs() {
+    return singletonList(
         transportLog ->
             transportLog
                 .hasSeverity(Severity.WARN)
@@ -68,7 +67,5 @@ class EmbeddingsTest extends AbstractEmbeddingsTest {
                     satisfies(
                         EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
                     satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
-    result.add(logRecord);
-    return result;
   }
 }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
@@ -67,8 +67,7 @@ class EmbeddingsTest extends AbstractEmbeddingsTest {
                     equalTo(EXCEPTION_TYPE, "java.net.ConnectException"),
                     satisfies(
                         EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
-                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()))
-                .hasTotalAttributeCount(3));
+                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
     result.add(logRecord);
     return result;
   }

--- a/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/openai/v1_1/EmbeddingsTest.java
@@ -5,11 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.openai.v1_1.AbstractEmbeddingsTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +51,25 @@ class EmbeddingsTest extends AbstractEmbeddingsTest {
     result.add(span);
     // Do a very simple assertion since the telemetry is not part of this library.
     result.add(s -> s.hasName("POST"));
+    return result;
+  }
+
+  @Override
+  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
+      Consumer<LogRecordDataAssert> logRecord) {
+    List<Consumer<LogRecordDataAssert>> result = new ArrayList<>();
+    result.add(
+        transportLog ->
+            transportLog
+                .hasSeverity(Severity.WARN)
+                .hasEventName("http.client.request.exception")
+                .hasAttributesSatisfyingExactly(
+                    equalTo(EXCEPTION_TYPE, "java.net.ConnectException"),
+                    satisfies(
+                        EXCEPTION_MESSAGE, val -> val.startsWith("Failed to connect to localhost")),
+                    satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()))
+                .hasTotalAttributeCount(3));
+    result.add(logRecord);
     return result;
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
   }
 

--- a/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
@@ -17,10 +17,6 @@ tasks {
   val testExceptionSignalLogs by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-
-    filter {
-      includeTestsMatching("EmbeddingsTest")
-    }
     jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
   }
 

--- a/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
+++ b/instrumentation/openai/openai-java-1.1/library/build.gradle.kts
@@ -13,4 +13,18 @@ tasks {
   test {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
   }
+
+  val testExceptionSignalLogs by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("EmbeddingsTest")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+  }
+
+  check {
+    dependsOn(testExceptionSignalLogs)
+  }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.internal.GenAiExceptionEventExtractors.setGenAiClientExceptionEventExtractor;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -49,22 +51,25 @@ public final class OpenAITelemetryBuilder {
   public OpenAITelemetry build() {
     ChatAttributesGetter chatAttributesGetter = new ChatAttributesGetter();
     Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter =
-        Instrumenter.<ChatCompletionCreateParams, ChatCompletion>builder(
-                openTelemetry,
-                INSTRUMENTATION_NAME,
-                GenAiSpanNameExtractor.create(chatAttributesGetter))
-            .addAttributesExtractor(GenAiAttributesExtractor.create(chatAttributesGetter))
-            .addOperationMetrics(GenAiClientMetrics.get())
+        setGenAiClientExceptionEventExtractor(
+                Instrumenter.<ChatCompletionCreateParams, ChatCompletion>builder(
+                        openTelemetry,
+                        INSTRUMENTATION_NAME,
+                        GenAiSpanNameExtractor.create(chatAttributesGetter))
+                    .addAttributesExtractor(GenAiAttributesExtractor.create(chatAttributesGetter))
+                    .addOperationMetrics(GenAiClientMetrics.get()))
             .buildInstrumenter();
 
     EmbeddingAttributesGetter embeddingAttributesGetter = new EmbeddingAttributesGetter();
     Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingsInstrumenter =
-        Instrumenter.<EmbeddingCreateParams, CreateEmbeddingResponse>builder(
-                openTelemetry,
-                INSTRUMENTATION_NAME,
-                GenAiSpanNameExtractor.create(embeddingAttributesGetter))
-            .addAttributesExtractor(GenAiAttributesExtractor.create(embeddingAttributesGetter))
-            .addOperationMetrics(GenAiClientMetrics.get())
+        setGenAiClientExceptionEventExtractor(
+                Instrumenter.<EmbeddingCreateParams, CreateEmbeddingResponse>builder(
+                        openTelemetry,
+                        INSTRUMENTATION_NAME,
+                        GenAiSpanNameExtractor.create(embeddingAttributesGetter))
+                    .addAttributesExtractor(
+                        GenAiAttributesExtractor.create(embeddingAttributesGetter))
+                    .addOperationMetrics(GenAiClientMetrics.get()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     Logger eventLogger = openTelemetry.getLogsBridge().get(INSTRUMENTATION_NAME);

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttribu
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 /** A builder of {@link OpenAITelemetry}. */
@@ -50,27 +51,28 @@ public final class OpenAITelemetryBuilder {
    */
   public OpenAITelemetry build() {
     ChatAttributesGetter chatAttributesGetter = new ChatAttributesGetter();
+    InstrumenterBuilder<ChatCompletionCreateParams, ChatCompletion> chatBuilder =
+        Instrumenter.<ChatCompletionCreateParams, ChatCompletion>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                GenAiSpanNameExtractor.create(chatAttributesGetter))
+            .addAttributesExtractor(GenAiAttributesExtractor.create(chatAttributesGetter))
+            .addOperationMetrics(GenAiClientMetrics.get());
+    setGenAiClientExceptionEventExtractor(chatBuilder);
     Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter =
-        setGenAiClientExceptionEventExtractor(
-                Instrumenter.<ChatCompletionCreateParams, ChatCompletion>builder(
-                        openTelemetry,
-                        INSTRUMENTATION_NAME,
-                        GenAiSpanNameExtractor.create(chatAttributesGetter))
-                    .addAttributesExtractor(GenAiAttributesExtractor.create(chatAttributesGetter))
-                    .addOperationMetrics(GenAiClientMetrics.get()))
-            .buildInstrumenter();
+        chatBuilder.buildInstrumenter();
 
     EmbeddingAttributesGetter embeddingAttributesGetter = new EmbeddingAttributesGetter();
+    InstrumenterBuilder<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingsBuilder =
+        Instrumenter.<EmbeddingCreateParams, CreateEmbeddingResponse>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                GenAiSpanNameExtractor.create(embeddingAttributesGetter))
+            .addAttributesExtractor(GenAiAttributesExtractor.create(embeddingAttributesGetter))
+            .addOperationMetrics(GenAiClientMetrics.get());
+    setGenAiClientExceptionEventExtractor(embeddingsBuilder);
     Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingsInstrumenter =
-        setGenAiClientExceptionEventExtractor(
-                Instrumenter.<EmbeddingCreateParams, CreateEmbeddingResponse>builder(
-                        openTelemetry,
-                        INSTRUMENTATION_NAME,
-                        GenAiSpanNameExtractor.create(embeddingAttributesGetter))
-                    .addAttributesExtractor(
-                        GenAiAttributesExtractor.create(embeddingAttributesGetter))
-                    .addOperationMetrics(GenAiClientMetrics.get()))
-            .buildInstrumenter(SpanKindExtractor.alwaysClient());
+        embeddingsBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     Logger eventLogger = openTelemetry.getLogsBridge().get(INSTRUMENTATION_NAME);
     return new OpenAITelemetry(

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.openai.v1_1;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
@@ -62,17 +64,20 @@ import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.openai.TestHelper;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -905,7 +910,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                 trace.hasSpansSatisfyingExactly(
                     maybeWithTransportSpan(
                         span ->
-                            span.hasException(thrown)
+                            span.hasException(emitExceptionAsSpanEvents() ? thrown : null)
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
@@ -930,14 +935,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
-    getTesting()
-        .waitAndAssertLogRecords(
-            log ->
-                log.hasAttributesSatisfyingExactly(
-                        equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
-                        equalTo(stringKey("event.name"), "gen_ai.user.message"))
-                    .hasSpanContext(spanCtx)
-                    .hasBody(Value.of(KeyValue.of("content", Value.of(TEST_CHAT_INPUT)))));
+    getTesting().waitAndAssertLogRecords(connectionErrorLogs(spanCtx, thrown));
   }
 
   @Test
@@ -1618,7 +1616,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                 trace.hasSpansSatisfyingExactly(
                     maybeWithTransportSpan(
                         span ->
-                            span.hasException(thrown)
+                            span.hasException(emitExceptionAsSpanEvents() ? thrown : null)
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
@@ -1643,14 +1641,34 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
 
     SpanContext spanCtx = getTesting().waitForTraces(1).get(0).get(0).getSpanContext();
 
-    getTesting()
-        .waitAndAssertLogRecords(
-            log ->
-                log.hasAttributesSatisfyingExactly(
-                        equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
-                        equalTo(stringKey("event.name"), "gen_ai.user.message"))
-                    .hasSpanContext(spanCtx)
-                    .hasBody(Value.of(KeyValue.of("content", Value.of(TEST_CHAT_INPUT)))));
+    getTesting().waitAndAssertLogRecords(connectionErrorLogs(spanCtx, thrown));
+  }
+
+  private List<Consumer<LogRecordDataAssert>> connectionErrorLogs(
+      SpanContext spanCtx, Throwable thrown) {
+    List<Consumer<LogRecordDataAssert>> assertions = new ArrayList<>();
+    assertions.add(
+        log ->
+            log.hasAttributesSatisfyingExactly(
+                    equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
+                    equalTo(stringKey("event.name"), "gen_ai.user.message"))
+                .hasSpanContext(spanCtx)
+                .hasBody(Value.of(KeyValue.of("content", Value.of(TEST_CHAT_INPUT)))));
+    if (emitExceptionAsLogs()) {
+      assertions.addAll(
+          maybeWithTransportExceptionLog(
+              log ->
+                  log.hasSeverity(Severity.WARN)
+                      .hasEventName("gen_ai.client.operation.exception")
+                      .hasException(thrown)
+                      .hasTotalAttributeCount(3)));
+    }
+    return assertions;
+  }
+
+  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
+      Consumer<LogRecordDataAssert> logRecord) {
+    return singletonList(logRecord);
   }
 
   protected static ChatCompletionMessageParam createUserMessage(String content) {

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.openai.v1_1;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -64,7 +63,6 @@ import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
-import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -1654,21 +1652,8 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                     equalTo(stringKey("event.name"), "gen_ai.user.message"))
                 .hasSpanContext(spanCtx)
                 .hasBody(Value.of(KeyValue.of("content", Value.of(TEST_CHAT_INPUT)))));
-    if (emitExceptionAsLogs()) {
-      assertions.addAll(
-          maybeWithTransportExceptionLog(
-              log ->
-                  log.hasSeverity(Severity.WARN)
-                      .hasEventName("gen_ai.client.operation.exception")
-                      .hasException(thrown)
-                      .hasTotalAttributeCount(3)));
-    }
+    assertions.addAll(genAiClientExceptionLogs(thrown));
     return assertions;
-  }
-
-  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
-      Consumer<LogRecordDataAssert> logRecord) {
-    return singletonList(logRecord);
   }
 
   protected static ChatCompletionMessageParam createUserMessage(String content) {

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -5,8 +5,14 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_ENCODING_FORMATS;
@@ -18,6 +24,7 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenA
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.OPENAI;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -28,11 +35,15 @@ import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
 import com.openai.errors.OpenAIIoException;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import java.util.List;
 import java.util.concurrent.CompletionException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -239,19 +250,26 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     maybeWithTransportSpan(
-                        span ->
-                            span.hasName("embeddings text-embedding-3-small")
-                                .hasKind(SpanKind.CLIENT)
-                                .hasException(thrown)
-                                .hasAttributesSatisfyingExactly(
-                                    equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
-                                    equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
-                                    equalTo(GEN_AI_REQUEST_MODEL, MODEL),
-                                    // Newer versions of the library populate base64 when unset by
-                                    // the user.
-                                    satisfies(
-                                        GEN_AI_REQUEST_ENCODING_FORMATS,
-                                        val -> val.isIn(singletonList("base64"), null))))));
+                        span -> {
+                          span.hasName("embeddings text-embedding-3-small")
+                              .hasKind(SpanKind.CLIENT)
+                              .hasAttributesSatisfyingExactly(
+                                  equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
+                                  equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
+                                  equalTo(GEN_AI_REQUEST_MODEL, MODEL),
+                                  // Newer versions of the library populate base64 when unset by
+                                  // the user.
+                                  satisfies(
+                                      GEN_AI_REQUEST_ENCODING_FORMATS,
+                                      val -> val.isIn(singletonList("base64"), null)));
+                          if (emitExceptionAsSpanEvents()) {
+                            span.hasException(thrown);
+                          }
+                        })));
+
+    if (emitExceptionAsLogs()) {
+      assertClientExceptionLog();
+    }
 
     getTesting()
         .waitAndAssertMetrics(
@@ -269,5 +287,24 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                             equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                             equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
                                             equalTo(GEN_AI_REQUEST_MODEL, MODEL)))));
+  }
+
+  private void assertClientExceptionLog() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              List<LogRecordData> logs =
+                  getTesting().logRecords().stream()
+                      .filter(log -> "gen_ai.client.operation.exception".equals(log.getEventName()))
+                      .collect(toList());
+              assertThat(logs).hasSize(1);
+              assertThat(logs.get(0))
+                  .hasSeverity(Severity.WARN)
+                  .hasEventName("gen_ai.client.operation.exception")
+                  .hasAttributesSatisfyingExactly(
+                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
+                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
+            });
   }
 }

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -10,9 +10,6 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSign
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_ENCODING_FORMATS;
@@ -39,7 +36,10 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
+import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -246,32 +246,30 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     maybeWithTransportSpan(
-                        span -> {
-                          span.hasName("embeddings text-embedding-3-small")
-                              .hasKind(SpanKind.CLIENT)
-                              .hasAttributesSatisfyingExactly(
-                                  equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
-                                  equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
-                                  equalTo(GEN_AI_REQUEST_MODEL, MODEL),
-                                  // Newer versions of the library populate base64 when unset by
-                                  // the user.
-                                  satisfies(
-                                      GEN_AI_REQUEST_ENCODING_FORMATS,
-                                      val -> val.isIn(singletonList("base64"), null)));
-                          span.hasException(emitExceptionAsSpanEvents() ? thrown : null);
-                        })));
+                        span ->
+                            span.hasName("embeddings text-embedding-3-small")
+                                .hasKind(SpanKind.CLIENT)
+                                .hasException(emitExceptionAsSpanEvents() ? thrown : null)
+                                .hasAttributesSatisfyingExactly(
+                                    equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
+                                    equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
+                                    equalTo(GEN_AI_REQUEST_MODEL, MODEL),
+                                    // Newer versions of the library populate base64 when unset by
+                                    // the user.
+                                    satisfies(
+                                        GEN_AI_REQUEST_ENCODING_FORMATS,
+                                        val -> val.isIn(singletonList("base64"), null))))));
 
     if (emitExceptionAsLogs()) {
       getTesting()
           .waitAndAssertLogRecords(
-              logRecord ->
-                  logRecord
-                      .hasSeverity(Severity.WARN)
-                      .hasEventName("gen_ai.client.operation.exception")
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(EXCEPTION_TYPE, thrown.getClass().getName()),
-                          equalTo(EXCEPTION_MESSAGE, thrown.getMessage()),
-                          satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
+              maybeWithTransportExceptionLog(
+                  logRecord ->
+                      logRecord
+                          .hasSeverity(Severity.WARN)
+                          .hasEventName("gen_ai.client.operation.exception")
+                          .hasException(thrown)
+                          .hasTotalAttributeCount(3)));
     }
 
     getTesting()
@@ -290,5 +288,10 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                             equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                             equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
                                             equalTo(GEN_AI_REQUEST_MODEL, MODEL)))));
+  }
+
+  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
+      Consumer<LogRecordDataAssert> logRecord) {
+    return singletonList(logRecord);
   }
 }

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -24,7 +24,6 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenA
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.OPENAI;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -40,10 +39,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
-import java.util.List;
 import java.util.concurrent.CompletionException;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -268,7 +264,16 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                         })));
 
     if (emitExceptionAsLogs()) {
-      assertClientExceptionLog();
+      getTesting()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("gen_ai.client.operation.exception")
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(EXCEPTION_TYPE, thrown.getClass().getName()),
+                          equalTo(EXCEPTION_MESSAGE, thrown.getMessage()),
+                          satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull())));
     }
 
     getTesting()
@@ -287,24 +292,5 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                             equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                             equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
                                             equalTo(GEN_AI_REQUEST_MODEL, MODEL)))));
-  }
-
-  private void assertClientExceptionLog() {
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              List<LogRecordData> logs =
-                  getTesting().logRecords().stream()
-                      .filter(log -> "gen_ai.client.operation.exception".equals(log.getEventName()))
-                      .collect(toList());
-              assertThat(logs).hasSize(1);
-              assertThat(logs.get(0))
-                  .hasSeverity(Severity.WARN)
-                  .hasEventName("gen_ai.client.operation.exception")
-                  .hasAttributesSatisfyingExactly(
-                      satisfies(EXCEPTION_TYPE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_MESSAGE, val -> val.isNotNull()),
-                      satisfies(EXCEPTION_STACKTRACE, val -> val.isNotNull()));
-            });
   }
 }

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -31,15 +30,11 @@ import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
 import com.openai.errors.OpenAIIoException;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
-import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
-import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
-import java.util.List;
 import java.util.concurrent.CompletionException;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -260,17 +255,7 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                         GEN_AI_REQUEST_ENCODING_FORMATS,
                                         val -> val.isIn(singletonList("base64"), null))))));
 
-    if (emitExceptionAsLogs()) {
-      getTesting()
-          .waitAndAssertLogRecords(
-              maybeWithTransportExceptionLog(
-                  logRecord ->
-                      logRecord
-                          .hasSeverity(Severity.WARN)
-                          .hasEventName("gen_ai.client.operation.exception")
-                          .hasException(thrown)
-                          .hasTotalAttributeCount(3)));
-    }
+    getTesting().waitAndAssertLogRecords(genAiClientExceptionLogs(thrown));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -288,10 +273,5 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                             equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                             equalTo(GEN_AI_OPERATION_NAME, EMBEDDINGS),
                                             equalTo(GEN_AI_REQUEST_MODEL, MODEL)))));
-  }
-
-  protected List<Consumer<LogRecordDataAssert>> maybeWithTransportExceptionLog(
-      Consumer<LogRecordDataAssert> logRecord) {
-    return singletonList(logRecord);
   }
 }

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -258,9 +258,7 @@ public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
                                   satisfies(
                                       GEN_AI_REQUEST_ENCODING_FORMATS,
                                       val -> val.isIn(singletonList("base64"), null)));
-                          if (emitExceptionAsSpanEvents()) {
-                            span.hasException(thrown);
-                          }
+                          span.hasException(emitExceptionAsSpanEvents() ? thrown : null);
                         })));
 
     if (emitExceptionAsLogs()) {

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractOpenAiTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractOpenAiTest.java
@@ -5,17 +5,22 @@
 
 package io.opentelemetry.instrumentation.openai.v1_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static java.util.Collections.emptyList;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.instrumentation.openai.TestHelper;
 import io.opentelemetry.instrumentation.openai.v3_0.OpenAi3TestHelper;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.recording.RecordingExtension;
+import io.opentelemetry.sdk.testing.assertj.LogRecordDataAssert;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -89,6 +94,36 @@ abstract class AbstractOpenAiTest {
 
   protected abstract List<Consumer<SpanDataAssert>> maybeWithTransportSpan(
       Consumer<SpanDataAssert> span);
+
+  /**
+   * Returns the log record assertions expected when a GenAI client operation fails. Empty unless
+   * exceptions are emitted as logs, in which case it contains the {@code
+   * gen_ai.client.operation.exception} log, preceded by any transport-level exception logs supplied
+   * by {@link #transportExceptionLogs}.
+   */
+  protected final List<Consumer<LogRecordDataAssert>> genAiClientExceptionLogs(Throwable thrown) {
+    if (!emitExceptionAsLogs()) {
+      return emptyList();
+    }
+    List<Consumer<LogRecordDataAssert>> logs = new ArrayList<>(transportExceptionLogs());
+    logs.add(
+        logRecord ->
+            logRecord
+                .hasSeverity(Severity.WARN)
+                .hasEventName("gen_ai.client.operation.exception")
+                .hasException(thrown)
+                .hasTotalAttributeCount(3));
+    return logs;
+  }
+
+  /**
+   * Returns the transport-level exception log assertions emitted by additional instrumentation
+   * (e.g. the HTTP client under the javaagent), ordered before the GenAI exception log. Empty by
+   * default.
+   */
+  protected List<Consumer<LogRecordDataAssert>> transportExceptionLogs() {
+    return emptyList();
+  }
 
   @Parameter protected TestType testType;
 }


### PR DESCRIPTION
Under `otel.semconv.exception.signal.preview=logs` (introduced in #16259), the OpenAI GenAI client instrumentation now emits its exceptions as log records instead of span events.

The AWS SDK GenAI client instrumentation (Bedrock runtime) is wired in the stacked follow-up PR #18894, which keeps all AWS SDK changes (Bedrock=GenAI, DynamoDB=DB, SQS=messaging) together.

Part of follow-up work after #16259.