### PR TITLE
finagle: set read timeout only for read timeout test

### DIFF
--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
@@ -56,7 +56,7 @@ public class FinagleClientExtension implements AfterAllCallback {
     ClientType type = ClientType.DEFAULT;
     if ("https".equals(uri.getScheme())) {
       type = ClientType.TLS;
-    } else if (uri.getPath().contains("/read-timeout")) {
+    } else if (uri.getPath().endsWith("/read-timeout")) {
       type = ClientType.READ_TIMEOUT;
     }
     return getService(uri, type);

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
@@ -56,7 +56,7 @@ public class FinagleClientExtension implements AfterAllCallback {
     ClientType type = ClientType.DEFAULT;
     if ("https".equals(uri.getScheme())) {
       type = ClientType.TLS;
-    } else if (uri.toString().contains("/read-timeout")) {
+    } else if (uri.getPath().contains("/read-timeout")) {
       type = ClientType.READ_TIMEOUT;
     }
     return getService(uri, type);

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/FinagleClientExtension.java
@@ -53,7 +53,13 @@ public class FinagleClientExtension implements AfterAllCallback {
   }
 
   public Service<Request, Response> getService(URI uri) {
-    return getService(uri, "https".equals(uri.getScheme()) ? ClientType.TLS : ClientType.DEFAULT);
+    ClientType type = ClientType.DEFAULT;
+    if ("https".equals(uri.getScheme())) {
+      type = ClientType.TLS;
+    } else if (uri.toString().contains("/read-timeout")) {
+      type = ClientType.READ_TIMEOUT;
+    }
+    return getService(uri, type);
   }
 
   public Service<Request, Response> getService(URI uri, ClientType type) {
@@ -73,8 +79,6 @@ public class FinagleClientExtension implements AfterAllCallback {
     Http.Client client =
         Http.client()
             .withTransport()
-            .readTimeout(Duration.fromMilliseconds(READ_TIMEOUT.toMillis()))
-            .withTransport()
             .connectTimeout(Duration.fromMilliseconds(CONNECTION_TIMEOUT.toMillis()))
             .withRetryBudget(RetryBudget.Empty());
 
@@ -84,6 +88,10 @@ public class FinagleClientExtension implements AfterAllCallback {
         break;
       case SINGLE_CONN:
         client = client.withSessionPool().maxSize(1);
+        break;
+      case READ_TIMEOUT:
+        client =
+            client.withTransport().readTimeout(Duration.fromMilliseconds(READ_TIMEOUT.toMillis()));
         break;
       case DEFAULT:
         break;

--- a/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/Utils.java
+++ b/instrumentation/finagle-http-23.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/finaglehttp/v23_11/Utils.java
@@ -23,8 +23,6 @@ class Utils {
     Http.Client client =
         Http.client()
             .withTransport()
-            .readTimeout(Duration.fromMilliseconds(READ_TIMEOUT.toMillis()))
-            .withTransport()
             .connectTimeout(Duration.fromMilliseconds(CONNECTION_TIMEOUT.toMillis()))
             // disable automatic retries -- retries will result in under-counting traces in the
             // tests
@@ -37,6 +35,10 @@ class Utils {
       case SINGLE_CONN:
         client = client.withSessionPool().maxSize(1);
         break;
+      case READ_TIMEOUT:
+        client =
+            client.withTransport().readTimeout(Duration.fromMilliseconds(READ_TIMEOUT.toMillis()));
+        break;
       case DEFAULT:
         break;
     }
@@ -47,6 +49,7 @@ class Utils {
   enum ClientType {
     TLS,
     SINGLE_CONN,
+    READ_TIMEOUT,
     DEFAULT;
   }
 


### PR DESCRIPTION
Hopefully resolves https://develocity.opentelemetry.io/s/koqfksplkqyei/tests/task/:instrumentation:finagle-http-23.11:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.finaglehttp.v23_11.ClientH1ImmediateTest/highConcurrencyWithCallback()?expanded-stacktrace=WyIwIl0&top-execution=1