### PR TITLE
Fix missing metric metadata for jdbc and oshi

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -69,13 +69,13 @@ class InstrumentationAnalyzer {
 
     module.setAgentTargetVersions(getVersionInformation(module));
 
-    // Handle telemetry merging (manual + emitted)
-    setMergedTelemetry(module, metaData);
-
     InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
     if (scopeInfo != null) {
       module.setScopeInfo(scopeInfo);
     }
+
+    // Handle telemetry merging (manual + emitted)
+    setMergedTelemetry(module, metaData);
   }
 
   @Nullable

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -47,26 +49,17 @@ public class EmittedScopeParser {
       return null;
     }
 
-    EmittedScope.Scope scope =
-        scopes.stream()
-            .filter(
-                item ->
-                    item.getName() != null
-                        && item.getName().contains(module.getInstrumentationName()))
-            .min(Comparator.comparing(item -> item.getSchemaUrl() == null ? 1 : 0))
-            .orElse(null);
+    String defaultScopeName = module.getScopeInfo().getName();
+    EmittedScope.Scope scope = getMatchingScope(scopes, defaultScopeName);
     if (scope == null) {
       return null;
     }
 
-    String instrumentationName = "io.opentelemetry." + module.getInstrumentationName();
-    InstrumentationScopeInfoBuilder builder = InstrumentationScopeInfo.builder(instrumentationName);
-
-    // This will identify any module that might deviate from the standard naming convention
-    if (scope.getName() != null && !scope.getName().equals(instrumentationName)) {
-      logger.severe(
-          "Scope name mismatch. Expected: " + instrumentationName + ", got: " + scope.getName());
+    String scopeName = scope.getName();
+    if (scopeName == null) {
+      return null;
     }
+    InstrumentationScopeInfoBuilder builder = InstrumentationScopeInfo.builder(scopeName);
 
     if (scope.getSchemaUrl() != null) {
       builder.setSchemaUrl(scope.getSchemaUrl());
@@ -76,6 +69,46 @@ public class EmittedScopeParser {
     }
 
     return builder.build();
+  }
+
+  @Nullable
+  private static EmittedScope.Scope getMatchingScope(
+      Set<EmittedScope.Scope> scopes, String defaultScopeName) {
+    EmittedScope.Scope exactMatch =
+        scopes.stream()
+            .filter(scope -> defaultScopeName.equals(scope.getName()))
+            .min(Comparator.comparing(scope -> scope.getSchemaUrl() == null ? 1 : 0))
+            .orElse(null);
+    if (exactMatch != null) {
+      return exactMatch;
+    }
+
+    Map<String, List<EmittedScope.Scope>> nonSdkScopes =
+        scopes.stream()
+            .filter(scope -> isInstrumentationScope(scope.getName()))
+            .collect(groupingBy(scope -> requireNonNull(scope.getName())));
+
+    if (nonSdkScopes.size() == 1) {
+      return nonSdkScopes.values().stream()
+          .flatMap(List::stream)
+          .min(Comparator.comparing(scope -> scope.getSchemaUrl() == null ? 1 : 0))
+          .orElse(null);
+    }
+
+    if (nonSdkScopes.size() > 1) {
+      logger.warning(
+          "Unable to choose instrumentation scope for "
+              + defaultScopeName
+              + ". Candidates: "
+              + nonSdkScopes.keySet());
+    }
+    return null;
+  }
+
+  private static boolean isInstrumentationScope(@Nullable String scopeName) {
+    return scopeName != null
+        && scopeName.startsWith("io.opentelemetry.")
+        && !scopeName.startsWith("io.opentelemetry.sdk.");
   }
 
   /**

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
@@ -8,12 +8,18 @@ package io.opentelemetry.instrumentation.docs;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.parsers.ModuleParser;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("NullAway")
 class InstrumentationAnalyzerTest {
@@ -103,5 +109,54 @@ class InstrumentationAnalyzerTest {
                 .anyMatch(
                     m -> m.getGroup().equals("group2") && m.getNamespace().equals("namespace2")))
         .isTrue();
+  }
+
+  @Test
+  void testAnalyzeAppliesEmittedScopeBeforeFilteringTelemetry(@TempDir Path tempDir)
+      throws IOException {
+    Path instrumentationDir = tempDir.resolve("instrumentation").resolve("oshi-5.0");
+    Files.createDirectories(instrumentationDir.resolve("javaagent"));
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    Files.writeString(
+        telemetryDir.resolve("scope-abc123.yaml"),
+        """
+        scopes:
+          - name: io.opentelemetry.sdk.metrics
+            version: null
+            schemaUrl: null
+          - name: io.opentelemetry.oshi
+            version: 2.14.0
+            schemaUrl: null
+        """);
+    Files.writeString(
+        telemetryDir.resolve("metrics-abc123.yaml"),
+        """
+        when: default
+        metrics_by_scope:
+        - scope: io.opentelemetry.oshi
+          metrics:
+          - name: system.memory.usage
+            description: System memory usage
+            type: LONG_SUM
+            unit: By
+            attributes:
+            - name: state
+              type: STRING
+            is_monotonic: false
+        """);
+
+    List<InstrumentationModule> modules =
+        new InstrumentationAnalyzer(new FileManager(tempDir + "/")).analyze();
+
+    assertThat(modules).hasSize(1);
+    InstrumentationModule module = modules.get(0);
+    assertThat(module.getInstrumentationName()).isEqualTo("oshi-5.0");
+    assertThat(module.getScopeInfo().getName()).isEqualTo("io.opentelemetry.oshi");
+    assertThat(module.getMetrics()).containsOnlyKeys("default");
+    assertThat(module.getMetrics().get("default"))
+        .extracting(EmittedMetrics.Metric::getName)
+        .containsExactly("system.memory.usage");
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -232,6 +232,66 @@ class EmittedScopeParserTest {
   }
 
   @Test
+  void testGetScopeUsesSingleNonSdkScopeWhenDefaultDoesNotMatch(@TempDir Path tempDir)
+      throws IOException {
+    Path instrumentationDir = tempDir.resolve("test-instrumentation");
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    String scopeContent =
+        """
+        scopes:
+          - name: io.opentelemetry.sdk.metrics
+            version: null
+            schemaUrl: null
+          - name: io.opentelemetry.oshi
+            version: 2.14.0
+            schemaUrl: null
+        """;
+
+    Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
+
+    FileManager fileManager = new FileManager(tempDir + "/");
+    InstrumentationModule module =
+        new InstrumentationModule.Builder("oshi-5.0").srcPath("test-instrumentation").build();
+
+    InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
+
+    assertThat(scopeInfo).isNotNull();
+    assertThat(scopeInfo.getName()).isEqualTo("io.opentelemetry.oshi");
+  }
+
+  @Test
+  void testGetScopePrefersExactDefaultScopeMatch(@TempDir Path tempDir) throws IOException {
+    Path instrumentationDir = tempDir.resolve("test-instrumentation");
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    String scopeContent =
+        """
+        scopes:
+          - name: io.opentelemetry.test-lib
+            version: 2.14.0
+            schemaUrl: null
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/1.21.0
+        """;
+
+    Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
+
+    FileManager fileManager = new FileManager(tempDir + "/");
+    InstrumentationModule module =
+        new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
+
+    InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
+
+    assertThat(scopeInfo).isNotNull();
+    assertThat(scopeInfo.getName()).isEqualTo("io.opentelemetry.test-lib-1.0");
+    assertThat(scopeInfo.getSchemaUrl()).isEqualTo("https://opentelemetry.io/schemas/1.21.0");
+  }
+
+  @Test
   void testGetScopeMultipleScopesOneMatches(@TempDir Path tempDir) throws IOException {
     Path instrumentationDir = tempDir.resolve("test-instrumentation");
     Path telemetryDir = instrumentationDir.resolve(".telemetry");


### PR DESCRIPTION
Updated the docs analyzer so emitted scope metadata is applied before telemetry filtering, which lets metrics/spans be matched against the real emitted scope instead of the default `io.opentelemetry.{moduleName}` fallback.

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18857#discussion_r3308782794