### PR TITLE
Align 3.0 deprecation markers in javaagent-extension-api

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
@@ -29,9 +29,9 @@ public interface IgnoredTypesConfigurer extends Ordered {
    * Configure the passed {@code builder} and define which classes should be ignored when
    * instrumenting.
    *
-   * @deprecated Use {@link #configure(IgnoredTypesBuilder)} instead.
+   * @deprecated Use {@link #configure(IgnoredTypesBuilder)} instead. Will be removed in 3.0.
    */
-  @Deprecated
+  @Deprecated // to be removed in 3.0
   default void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
     configure(builder);
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -96,7 +96,7 @@ public abstract class InstrumentationModule implements Ordered {
    *
    * @deprecated Use {@link #defaultEnabled()} instead.
    */
-  @Deprecated // will be removed in 3.0.0
+  @Deprecated // to be removed in 3.0
   public boolean defaultEnabled(ConfigProperties config) {
     return defaultEnabled();
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/V3PreviewFallbackEnabledInstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/V3PreviewFallbackEnabledInstrumentationModule.java
@@ -14,7 +14,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-@Deprecated // will be removed in 3.0.0
+@Deprecated // to be removed in 3.0
 public abstract class V3PreviewFallbackEnabledInstrumentationModule extends InstrumentationModule {
 
   protected V3PreviewFallbackEnabledInstrumentationModule(


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15806

## What changed
- added the missing deprecation-removal note to `IgnoredTypesConfigurer#configure(IgnoredTypesBuilder, ConfigProperties)`
- normalized the `javaagent-extension-api` deprecation markers to the repo's more common `3.0` wording
- updated existing `3.0.0` markers in the same module to `3.0`

## Why
Issue #15806 called out that `IgnoredTypesConfigurer` should have the same temporary removal marker comment used in other places.

While fixing that, this also aligns the nearby `javaagent-extension-api` code with the more common repository pattern:
- `@Deprecated // to be removed in 3.0`
- Javadoc `Will be removed in 3.0.`

## Impact
No functional behavior change. This is a comment / deprecation-marker consistency cleanup that also makes the future 3.0 removal audit easier.

## Validation
- `./gradlew :javaagent-extension-api:compileJava`

## Follow-up
- Closes #15806
- Related: #18903