### PR TITLE
Stream spotless output in PR triage script

### DIFF
--- a/.github/scripts/pr-triage/common.py
+++ b/.github/scripts/pr-triage/common.py
@@ -110,9 +110,24 @@ def progress(message: str) -> None:
     print(f"[pr-triage] {message}", flush=True)
 
 
-def run(cmd: list[str], summary: Summary | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run(
+    cmd: list[str],
+    summary: Summary | None = None,
+    check: bool = True,
+    *,
+    stream_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
     if summary is not None:
         progress(f"Running: {format_cmd(cmd)}")
+    if stream_output:
+        return subprocess.run(
+            cmd,
+            cwd=REPO_ROOT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=check,
+        )
     return subprocess.run(
         cmd,
         cwd=REPO_ROOT,

--- a/.github/scripts/pr-triage/run_spotless.py
+++ b/.github/scripts/pr-triage/run_spotless.py
@@ -33,7 +33,7 @@ def main() -> int:
 
     def body(summary: Summary) -> int:
         progress("Running Spotless")
-        run(gradlew_cmd("spotlessApply"), summary)
+        run(gradlew_cmd("spotlessApply"), summary, stream_output=True)
         progress("Checking Spotless changes")
         diff_check(summary)
 


### PR DESCRIPTION
## Summary
- add an opt-in streaming mode to the PR triage subprocess helper
- use it for the long-running spotlessApply Gradle task so terminal output appears live