### PR TITLE
Preserve log total attribute count in tests

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/TelemetryConverter.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/TelemetryConverter.java
@@ -313,7 +313,9 @@ public class TelemetryConverter {
                     TraceState.getDefault())) // logs proto doesn't have trace state
             .setSeverity(fromProto(logRecord.getSeverityNumber()))
             .setSeverityText(logRecord.getSeverityText())
-            .setAttributes(fromProto(logRecord.getAttributesList()));
+            .setAttributes(fromProto(logRecord.getAttributesList()))
+            .setTotalAttributeCount(
+                logRecord.getAttributesCount() + logRecord.getDroppedAttributesCount());
     if (canUseValue) {
       builder.setBodyValue(getBodyValue(logRecord.getBody()));
     } else {
@@ -340,7 +342,9 @@ public class TelemetryConverter {
             .setSeverity(fromProto(logRecord.getSeverityNumber()))
             .setSeverityText(logRecord.getSeverityText())
             .setEventName(logRecord.getEventName())
-            .setBodyValue(getBodyValue(logRecord.getBody()));
+            .setBodyValue(getBodyValue(logRecord.getBody()))
+            .setTotalAttributeCount(
+                logRecord.getAttributesCount() + logRecord.getDroppedAttributesCount());
     if (hasExtendedAttributes) {
       builder.setExtendedAttributes(fromProtoExtended(logRecord.getAttributesList()));
     } else {

--- a/testing/agent-for-testing/src/test/java/io/opentelemetry/javaagent/testing/AgentForTestingTest.java
+++ b/testing/agent-for-testing/src/test/java/io/opentelemetry/javaagent/testing/AgentForTestingTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.testing;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -51,10 +52,13 @@ class AgentForTestingTest {
   @Test
   void exportAndRetrieveLogRecords() {
     Logger logger = GlobalOpenTelemetry.get().getLogsBridge().loggerBuilder("test").build();
-    logger.logRecordBuilder().setBody("testBody").emit();
+    logger.logRecordBuilder().setBody("testBody").setAttribute("testKey", "testValue").emit();
 
     List<LogRecordData> logRecords = AgentTestingExporterAccess.getExportedLogRecords();
-    assertThat(logRecords.size()).isEqualTo(1);
-    assertThat(logRecords.get(0).getBodyValue().getValue()).isEqualTo("testBody");
+    assertThat(logRecords).hasSize(1);
+    LogRecordData logRecord = logRecords.get(0);
+    assertThat(logRecord.getBodyValue().getValue()).isEqualTo("testBody");
+    assertThat(logRecord.getAttributes().get(stringKey("testKey"))).isEqualTo("testValue");
+    assertThat(logRecord.getTotalAttributeCount()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
Preserve log total attribute counts when javaagent test logs are converted back from OTLP into SDK log data, and add a regression assertion that exported log records round-trip both attributes and total attribute count.