### PR TITLE
Move nonstable semconv opt-ins to preview flag in 3.0

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -54,11 +54,11 @@ public final class SemconvStability {
     emitOldCodeSemconv = shouldEmitOld("code", v3Preview, optInValues);
     emitStableCodeSemconv = shouldEmitStable("code", v3Preview, optInValues);
 
-    emitOldServicePeerSemconv = shouldEmitOld("service.peer", v3Preview, optInValues);
-    emitStableServicePeerSemconv = shouldEmitStable("service.peer", v3Preview, optInValues);
+    emitOldServicePeerSemconv = shouldEmitOld("service.peer", v3Preview, v3Preview ? previewValues : optInValues);
+    emitStableServicePeerSemconv = shouldEmitStable("service.peer", v3Preview, v3Preview ? previewValues : optInValues);
 
-    emitOldRpcSemconv = shouldEmitOld("rpc", v3Preview, optInValues);
-    emitStableRpcSemconv = shouldEmitStable("rpc", v3Preview, optInValues);
+    emitOldRpcSemconv = shouldEmitOld("rpc", v3Preview, v3Preview ? previewValues : optInValues);
+    emitStableRpcSemconv = shouldEmitStable("rpc", v3Preview, v3Preview ? previewValues : optInValues);
 
     emitOldMessagingSemconv = shouldEmitOld("messaging", false, previewValues);
     emitStableMessagingSemconv = shouldEmitStable("messaging", false, previewValues);
@@ -83,14 +83,17 @@ public final class SemconvStability {
     return values;
   }
 
+  @Deprecated // to be removed in 3.0
   public static boolean v3Preview() {
     return v3Preview;
   }
 
+  @Deprecated // to be removed in 3.0
   public static boolean emitOldDatabaseSemconv() {
     return emitOldDatabaseSemconv;
   }
 
+  @Deprecated // to be removed in 3.0
   public static boolean emitStableDatabaseSemconv() {
     return emitStableDatabaseSemconv;
   }
@@ -128,10 +131,12 @@ public final class SemconvStability {
     return dbSystemName != null ? dbSystemName : oldDbSystem;
   }
 
+  @Deprecated // to be removed in 3.0
   public static boolean emitOldCodeSemconv() {
     return emitOldCodeSemconv;
   }
 
+  @Deprecated // to be removed in 3.0
   public static boolean emitStableCodeSemconv() {
     return emitStableCodeSemconv;
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -22,7 +22,6 @@ import java.util.Set;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-@SuppressWarnings("deprecation")
 public final class SemconvStability {
 
   private static final boolean v3Preview;
@@ -54,16 +53,18 @@ public final class SemconvStability {
     emitOldCodeSemconv = shouldEmitOld("code", v3Preview, optInValues);
     emitStableCodeSemconv = shouldEmitStable("code", v3Preview, optInValues);
 
-    emitOldServicePeerSemconv = shouldEmitOld("service.peer", v3Preview, v3Preview ? previewValues : optInValues);
-    emitStableServicePeerSemconv = shouldEmitStable("service.peer", v3Preview, v3Preview ? previewValues : optInValues);
+    Set<String> nonstableOptInValues = v3Preview ? previewValues : optInValues;
+    emitOldServicePeerSemconv = shouldEmitOld("service.peer", false, nonstableOptInValues);
+    emitStableServicePeerSemconv = shouldEmitStable("service.peer", false, nonstableOptInValues);
 
-    emitOldRpcSemconv = shouldEmitOld("rpc", v3Preview, v3Preview ? previewValues : optInValues);
-    emitStableRpcSemconv = shouldEmitStable("rpc", v3Preview, v3Preview ? previewValues : optInValues);
+    emitOldRpcSemconv = shouldEmitOld("rpc", false, nonstableOptInValues);
+    emitStableRpcSemconv = shouldEmitStable("rpc", false, nonstableOptInValues);
 
     emitOldMessagingSemconv = shouldEmitOld("messaging", false, previewValues);
     emitStableMessagingSemconv = shouldEmitStable("messaging", false, previewValues);
   }
 
+  @SuppressWarnings("deprecation") // using deprecated config property fallback
   private static Set<String> resolveOptInValues(OpenTelemetry openTelemetry, String flag) {
     // Try declarative config via GlobalOpenTelemetry first
     DeclarativeConfigProperties generalConfig = getGeneralInstrumentationConfig(openTelemetry);
@@ -83,18 +84,15 @@ public final class SemconvStability {
     return values;
   }
 
-  @Deprecated // to be removed in 3.0
-  public static boolean v3Preview() {
+  public static boolean v3Preview() { // to be removed in 3.0
     return v3Preview;
   }
 
-  @Deprecated // to be removed in 3.0
-  public static boolean emitOldDatabaseSemconv() {
+  public static boolean emitOldDatabaseSemconv() { // to be removed in 3.0
     return emitOldDatabaseSemconv;
   }
 
-  @Deprecated // to be removed in 3.0
-  public static boolean emitStableDatabaseSemconv() {
+  public static boolean emitStableDatabaseSemconv() { // to be removed in 3.0
     return emitStableDatabaseSemconv;
   }
 
@@ -131,13 +129,11 @@ public final class SemconvStability {
     return dbSystemName != null ? dbSystemName : oldDbSystem;
   }
 
-  @Deprecated // to be removed in 3.0
-  public static boolean emitOldCodeSemconv() {
+  public static boolean emitOldCodeSemconv() { // to be removed in 3.0
     return emitOldCodeSemconv;
   }
 
-  @Deprecated // to be removed in 3.0
-  public static boolean emitStableCodeSemconv() {
+  public static boolean emitStableCodeSemconv() { // to be removed in 3.0
     return emitStableCodeSemconv;
   }
 


### PR DESCRIPTION
Nonstable semconv (`xyz`) shouldn't be using `otel.semconv-stability.opt-in=xyz`, since this looks like a stable property per our VERSIONING.md.

Instead we've recently adopted `otel.semconv-stability.preview=xyz`.

This makes that change for existing usages in 3.0, except for the two semconv which we're planning to stabilize in 3.0: database and code.

Resolves #15849