### PR TITLE
Disable coroutine WithSpan by default in v3 preview

### DIFF
--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
@@ -53,3 +53,15 @@ kotlin {
     javaParameters = true
   }
 }
+
+tasks {
+  val testV3Preview by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
+  }
+}

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
@@ -32,6 +33,11 @@ public class AnnotationInstrumentationModule extends InstrumentationModule
   public int order() {
     // Run after other instrumentations.
     return 1000;
+  }
+
+  @Override
+  public boolean defaultEnabled() {
+    return super.defaultEnabled() && !AgentCommonConfig.get().isV3Preview();
   }
 
   @Override

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
@@ -80,6 +80,8 @@ class KotlinCoroutinesInstrumentationTest {
 
   val tracer = testing.openTelemetry.getTracer("test")
 
+  private fun v3Preview(): Boolean = java.lang.Boolean.getBoolean("otel.instrumentation.common.v3-preview")
+
   @ParameterizedTest
   @MethodSource("dispatchersSourceArguments")
   fun `cancellation prevents trace`(dispatcher: DispatcherWrapper) {
@@ -377,6 +379,11 @@ class KotlinCoroutinesInstrumentationTest {
       annotated1()
     }
 
+    if (v3Preview()) {
+      assertThat(testing.spans()).isEmpty()
+      return
+    }
+
     val assertions = codeFunctionAssertions(this.javaClass, "annotated2")
     assertions.add(equalTo(AttributeKey.longKey("byteValue"), 1))
     assertions.add(equalTo(AttributeKey.longKey("intValue"), 4))
@@ -437,6 +444,11 @@ class KotlinCoroutinesInstrumentationTest {
     runBlocking {
       val classDefaultConstructorArguments = ClazzWithDefaultConstructorArguments()
       classDefaultConstructorArguments.sayHello()
+    }
+
+    if (v3Preview()) {
+      assertThat(testing.spans()).isEmpty()
+      return
     }
 
     testing.waitAndAssertTraces(

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/metadata.yaml
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/metadata.yaml
@@ -1,6 +1,6 @@
 description: >
   This instrumentation enables context propagation for Kotlin coroutines and adds support for
-  @WithSpan annotations on Kotlin suspend functions.
+  @WithSpan annotations on Kotlin suspend functions by default unless v3 preview mode is enabled.
 display_name: Kotlin Coroutines
 features:
   - CONTEXT_PROPAGATION


### PR DESCRIPTION
Closes #18899

Disable Kotlin coroutine suspend-function `@WithSpan` instrumentation by default when v3 preview is enabled.
