### PR TITLE
Emit stable Cassandra operation and collection attributes

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -7,7 +7,9 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
@@ -61,17 +63,20 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
   @Nullable private final AttributeKey<String> oldSemconvTableAttribute;
   private final boolean querySanitizationEnabled;
   private final boolean captureQueryParameters;
+  private final boolean singleOperationAndCollection;
 
   SqlClientAttributesExtractor(
       SqlClientAttributesGetter<REQUEST, RESPONSE> getter,
       @Nullable AttributeKey<String> oldSemconvTableAttribute,
       boolean querySanitizationEnabled,
-      boolean captureQueryParameters) {
+      boolean captureQueryParameters,
+      boolean singleOperationAndCollection) {
     this.getter = getter;
     this.oldSemconvTableAttribute = oldSemconvTableAttribute;
     // capturing query parameters disables query sanitization
     this.querySanitizationEnabled = !captureQueryParameters && querySanitizationEnabled;
     this.captureQueryParameters = captureQueryParameters;
+    this.singleOperationAndCollection = singleOperationAndCollection;
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(getter, emitOldDatabaseSemconv(), false);
     serverAttributesExtractor = ServerAttributesExtractor.create(getter);
@@ -114,6 +119,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         attributes.put(
             DB_QUERY_SUMMARY,
             isBatch && querySummary != null ? "BATCH " + querySummary : querySummary);
+        if (singleOperationAndCollection) {
+          attributes.put(DB_OPERATION_NAME, analyzedQuery.getOperationName());
+          attributes.put(DB_COLLECTION_NAME, analyzedQuery.getCollectionName());
+        }
         attributes.put(DB_STORED_PROCEDURE_NAME, analyzedQuery.getStoredProcedureName());
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorBuilder.java
@@ -20,6 +20,7 @@ public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @Nullable AttributeKey<String> oldSemconvTableAttribute = DB_SQL_TABLE;
   boolean querySanitizationEnabled = true;
   boolean captureQueryParameters = false;
+  boolean singleOperationAndCollection = false;
 
   SqlClientAttributesExtractorBuilder(SqlClientAttributesGetter<REQUEST, RESPONSE> getter) {
     this.getter = getter;
@@ -67,11 +68,28 @@ public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
   }
 
   /**
+   * Sets whether the instrumentation knows that its SQL-like language or request shape is limited
+   * to a single operation and collection.
+   *
+   * <p>For most instrumentations, enabling this will produce invalid semantic conventions.
+   */
+  @CanIgnoreReturnValue
+  public SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> setSingleOperationAndCollection(
+      boolean singleOperationAndCollection) {
+    this.singleOperationAndCollection = singleOperationAndCollection;
+    return this;
+  }
+
+  /**
    * Returns a new {@link SqlClientAttributesExtractor} with the settings of this {@link
    * SqlClientAttributesExtractorBuilder}.
    */
   public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new SqlClientAttributesExtractor<>(
-        getter, oldSemconvTableAttribute, querySanitizationEnabled, captureQueryParameters);
+        getter,
+        oldSemconvTableAttribute,
+        querySanitizationEnabled,
+        captureQueryParameters,
+        singleOperationAndCollection);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQuery.java
@@ -19,10 +19,19 @@ public abstract class SqlQuery {
       @Nullable String queryText,
       @Nullable String storedProcedureName,
       @Nullable String querySummary) {
+    return createWithSummary(queryText, null, null, storedProcedureName, querySummary);
+  }
+
+  /** Creates a SqlQuery for stable semconv (uses querySummary). */
+  static SqlQuery createWithSummary(
+      @Nullable String queryText,
+      @Nullable String operationName,
+      @Nullable String collectionName,
+      @Nullable String storedProcedureName,
+      @Nullable String querySummary) {
     String truncatedQuerySummary = truncateQuerySummary(querySummary);
-    // In stable semconv: operationName and collectionName are always null
     return new AutoValue_SqlQuery(
-        queryText, null, null, storedProcedureName, truncatedQuerySummary);
+        queryText, operationName, collectionName, storedProcedureName, truncatedQuerySummary);
   }
 
   /**
@@ -59,6 +68,7 @@ public abstract class SqlQuery {
   public abstract String getQueryText();
 
   @Nullable
+  @Deprecated // to be changed to package-private in 3.0
   public abstract String getOperationName();
 
   /**
@@ -67,6 +77,7 @@ public abstract class SqlQuery {
    * @see #getStoredProcedureName()
    */
   @Nullable
+  @Deprecated // to be changed to package-private in 3.0
   public abstract String getCollectionName();
 
   /** Returns the stored procedure name for CALL operations, or null for other operations. */

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -76,6 +76,8 @@ WHITESPACE           = [ \t\r\n]+
 
   private final StringBuilder builder = new StringBuilder();
   private final StringBuilder querySummaryBuilder = new StringBuilder();
+  private String operationName = null;
+  private String collectionName = null;
   private String storedProcedureName = null;
   private String dollarTag = null;
 
@@ -109,6 +111,24 @@ WHITESPACE           = [ \t\r\n]+
       querySummaryBuilder.append(' ');
     }
     querySummaryBuilder.append(yytext());
+  }
+
+  private void recordOperationName(String operationName) {
+    if (this.operationName == null) {
+      this.operationName = operationName;
+    }
+  }
+
+  private void refineOperationName(String operationTarget) {
+    if (operationName != null) {
+      operationName = operationName + " " + operationTarget;
+    }
+  }
+
+  private void recordCollectionName() {
+    if (collectionName == null) {
+      collectionName = yytext();
+    }
   }
 
   private int parenLevel = 0;
@@ -233,6 +253,7 @@ WHITESPACE           = [ \t\r\n]+
       operationTarget = target;
       expectingOperationTarget = false;
       appendOperationToSummary(operationTarget);
+      refineOperationName(operationTarget);
     }
 
     boolean isCapturingIdentifier() {
@@ -255,9 +276,13 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (!identifierCaptured && !inEmbeddedSelect) {
         appendTargetToSummary();
+        if (operationTarget.equalsIgnoreCase("TABLE")) {
+          recordCollectionName();
+        }
         identifierCaptured = true;
       } else if (inEmbeddedSelect && expectingTableName && parenLevel == selectParenLevel) {
         appendTargetToSummary();
+        recordCollectionName();
         expectingTableName = false;
       }
     }
@@ -387,6 +412,7 @@ WHITESPACE           = [ \t\r\n]+
       if (captureSingleTable && identifierCount == 1) {
         if (!isCteReference) {
           appendTargetToSummary();
+          recordCollectionName();
         }
         captureSingleTable = false;
         identifierCount = 0;
@@ -397,6 +423,7 @@ WHITESPACE           = [ \t\r\n]+
       if (captureTableList && identifierCount == 1) {
         if (!isCteReference) {
           appendTargetToSummary();
+          recordCollectionName();
         }
         captureTableList = false;
         // Don't reset identifierCount - keep counting for implicit join detection
@@ -441,6 +468,7 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (expectingTableName) {
         appendTargetToSummary();
+        recordCollectionName();
         expectingTableName = false;
       }
     }
@@ -465,6 +493,7 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (expectingTableName) {
         appendTargetToSummary();
+        recordCollectionName();
         expectingTableName = false;
         identifierCaptured = true;
       }
@@ -497,6 +526,7 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (!identifierCaptured) {
         appendTargetToSummary();
+        recordCollectionName();
         identifierCaptured = true;
       }
     }
@@ -508,6 +538,7 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (!identifierCaptured) {
         appendTargetToSummary();
+        recordCollectionName();
         identifierCaptured = true;
       }
     }
@@ -580,6 +611,7 @@ WHITESPACE           = [ \t\r\n]+
       if (text.equalsIgnoreCase("TABLE")) {
         if (!tableCaptured) {
           appendTargetToSummary();
+          refineOperationName("TABLE");
           tableCaptured = true;
         }
         return;
@@ -603,6 +635,7 @@ WHITESPACE           = [ \t\r\n]+
     void handleIdentifier() {
       if (!tableCaptured) {
         appendTargetToSummary();
+        recordCollectionName();
         tableCaptured = true;
         expectingTableName = false;
       }
@@ -626,6 +659,7 @@ WHITESPACE           = [ \t\r\n]+
       }
       if (!identifierCaptured) {
         appendTargetToSummary();
+        recordCollectionName();
         identifierCaptured = true;
       }
     }
@@ -720,7 +754,12 @@ WHITESPACE           = [ \t\r\n]+
       summary = summary.substring(0, summary.length() - 1);
     }
 
-    return SqlQuery.createWithSummary(normalizedStatement, storedProcedureName, summary);
+    return SqlQuery.createWithSummary(
+      normalizedStatement,
+      operationName,
+      collectionName,
+      storedProcedureName,
+      summary);
   }
 
 %}
@@ -748,6 +787,7 @@ WHITESPACE           = [ \t\r\n]+
             confirmPendingSubqueryIfNeeded();
             if (shouldStartMainOperation()) {
               setOperation(new Select());
+              recordOperationName("SELECT");
               appendOperationToSummary();
             } else if (operation instanceof Select) {
               // nested SELECT (subquery) - append SELECT to summary
@@ -761,6 +801,7 @@ WHITESPACE           = [ \t\r\n]+
   "INSERT" {
           if (shouldStartMainOperation()) {
             setOperation(new Insert());
+            recordOperationName("INSERT");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -772,6 +813,7 @@ WHITESPACE           = [ \t\r\n]+
   "DELETE" {
           if (shouldStartMainOperation()) {
             setOperation(new Delete());
+            recordOperationName("DELETE");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -783,6 +825,7 @@ WHITESPACE           = [ \t\r\n]+
   "UPDATE" {
           if (shouldStartMainOperation()) {
             setOperation(new Update());
+            recordOperationName("UPDATE");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -794,6 +837,7 @@ WHITESPACE           = [ \t\r\n]+
   "CALL" {
           if (shouldStartNewOperation()) {
             setOperation(new Call());
+            recordOperationName("CALL");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -805,6 +849,7 @@ WHITESPACE           = [ \t\r\n]+
   "MERGE" {
           if (shouldStartNewOperation()) {
             setOperation(new Merge());
+            recordOperationName("MERGE");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -816,6 +861,7 @@ WHITESPACE           = [ \t\r\n]+
   "CREATE" {
           if (shouldStartNewOperation()) {
             setOperation(new Create());
+            recordOperationName("CREATE");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -827,6 +873,7 @@ WHITESPACE           = [ \t\r\n]+
   "DROP" {
           if (shouldStartNewOperation()) {
             setOperation(new Drop());
+            recordOperationName("DROP");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -838,6 +885,7 @@ WHITESPACE           = [ \t\r\n]+
   "ALTER" {
           if (shouldStartNewOperation()) {
             setOperation(new Alter());
+            recordOperationName("ALTER");
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -854,6 +902,7 @@ WHITESPACE           = [ \t\r\n]+
               setOperation(new Values());
               // Only append VALUES to summary if at top level (not inside a subquery or CTE body)
               if (operationStack.isEmpty()) {
+                recordOperationName("VALUES");
                 appendOperationToSummary();
               }
             }
@@ -864,6 +913,7 @@ WHITESPACE           = [ \t\r\n]+
   "EXECUTE" | "EXEC" {
           if (shouldStartNewOperation()) {
             setOperation(new Execute());
+            recordOperationName(yytext());
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -875,6 +925,7 @@ WHITESPACE           = [ \t\r\n]+
   "TRUNCATE" {
           if (shouldStartNewOperation()) {
             setOperation(new Truncate());
+            recordOperationName("TRUNCATE");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -883,6 +934,7 @@ WHITESPACE           = [ \t\r\n]+
   "REPLACE" {
           if (shouldStartNewOperation()) {
             setOperation(new Replace());
+            recordOperationName("REPLACE");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -891,6 +943,7 @@ WHITESPACE           = [ \t\r\n]+
   "LOCK" {
           if (shouldStartNewOperation()) {
             setOperation(new Lock());
+            recordOperationName("LOCK");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -899,6 +952,7 @@ WHITESPACE           = [ \t\r\n]+
   "USE" {
           if (shouldStartNewOperation()) {
             setOperation(new Use());
+            recordOperationName("USE");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -907,6 +961,7 @@ WHITESPACE           = [ \t\r\n]+
   "BEGIN" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
+            recordOperationName("BEGIN");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -915,6 +970,7 @@ WHITESPACE           = [ \t\r\n]+
   "COMMIT" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
+            recordOperationName("COMMIT");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -923,6 +979,7 @@ WHITESPACE           = [ \t\r\n]+
   "ROLLBACK" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
+            recordOperationName("ROLLBACK");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -931,6 +988,7 @@ WHITESPACE           = [ \t\r\n]+
   "GRANT" {
           if (shouldStartNewOperation()) {
             setOperation(new Grant());
+            recordOperationName("GRANT");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -939,6 +997,7 @@ WHITESPACE           = [ \t\r\n]+
   "REVOKE" {
           if (shouldStartNewOperation()) {
             setOperation(new Revoke());
+            recordOperationName("REVOKE");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -947,6 +1006,7 @@ WHITESPACE           = [ \t\r\n]+
   "SHOW" {
           if (shouldStartNewOperation()) {
             setOperation(new Show());
+            recordOperationName("SHOW");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -963,6 +1023,7 @@ WHITESPACE           = [ \t\r\n]+
           // EXPLAIN is a prefix command - append to summary but don't set an operation,
           // so the inner statement (SELECT, INSERT, etc.) gets processed normally.
           if (!insideComment && operation == none) {
+            recordOperationName("EXPLAIN");
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -974,6 +1035,7 @@ WHITESPACE           = [ \t\r\n]+
               // hql/jpql queries may skip SELECT and start with FROM clause
               // treat such queries as SELECT queries
               setOperation(new Select());
+                recordOperationName("SELECT");
               // Derive the synthetic SELECT case from the matched FROM token.
               appendOperationToSummary(
                   Character.isUpperCase(zzBuffer[zzStartRead]) ? "SELECT" : "select");

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -119,6 +119,10 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
+  private void recordOperationName() {
+    recordOperationName(yytext());
+  }
+
   private void refineOperationName(String operationTarget) {
     if (operationName != null) {
       operationName = operationName + " " + operationTarget;
@@ -611,7 +615,7 @@ WHITESPACE           = [ \t\r\n]+
       if (text.equalsIgnoreCase("TABLE")) {
         if (!tableCaptured) {
           appendTargetToSummary();
-          refineOperationName("TABLE");
+          refineOperationName(text);
           tableCaptured = true;
         }
         return;
@@ -790,7 +794,7 @@ WHITESPACE           = [ \t\r\n]+
             confirmPendingSubqueryIfNeeded();
             if (shouldStartMainOperation()) {
               setOperation(new Select());
-              recordOperationName("SELECT");
+              recordOperationName();
               appendOperationToSummary();
             } else if (operation instanceof Select) {
               // nested SELECT (subquery) - append SELECT to summary
@@ -804,7 +808,7 @@ WHITESPACE           = [ \t\r\n]+
   "INSERT" {
           if (shouldStartMainOperation()) {
             setOperation(new Insert());
-            recordOperationName("INSERT");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -816,7 +820,7 @@ WHITESPACE           = [ \t\r\n]+
   "DELETE" {
           if (shouldStartMainOperation()) {
             setOperation(new Delete());
-            recordOperationName("DELETE");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -828,7 +832,7 @@ WHITESPACE           = [ \t\r\n]+
   "UPDATE" {
           if (shouldStartMainOperation()) {
             setOperation(new Update());
-            recordOperationName("UPDATE");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -840,7 +844,7 @@ WHITESPACE           = [ \t\r\n]+
   "CALL" {
           if (shouldStartNewOperation()) {
             setOperation(new Call());
-            recordOperationName("CALL");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -852,7 +856,7 @@ WHITESPACE           = [ \t\r\n]+
   "MERGE" {
           if (shouldStartNewOperation()) {
             setOperation(new Merge());
-            recordOperationName("MERGE");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -864,7 +868,7 @@ WHITESPACE           = [ \t\r\n]+
   "CREATE" {
           if (shouldStartNewOperation()) {
             setOperation(new Create());
-            recordOperationName("CREATE");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -876,7 +880,7 @@ WHITESPACE           = [ \t\r\n]+
   "DROP" {
           if (shouldStartNewOperation()) {
             setOperation(new Drop());
-            recordOperationName("DROP");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -888,7 +892,7 @@ WHITESPACE           = [ \t\r\n]+
   "ALTER" {
           if (shouldStartNewOperation()) {
             setOperation(new Alter());
-            recordOperationName("ALTER");
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -905,7 +909,7 @@ WHITESPACE           = [ \t\r\n]+
               setOperation(new Values());
               // Only append VALUES to summary if at top level (not inside a subquery or CTE body)
               if (operationStack.isEmpty()) {
-                recordOperationName("VALUES");
+                recordOperationName();
                 appendOperationToSummary();
               }
             }
@@ -916,7 +920,7 @@ WHITESPACE           = [ \t\r\n]+
   "EXECUTE" | "EXEC" {
           if (shouldStartNewOperation()) {
             setOperation(new Execute());
-            recordOperationName(yytext());
+            recordOperationName();
             appendOperationToSummary();
           } else if (!insideComment) {
             cancelPendingSubqueryIfNeeded();
@@ -928,7 +932,7 @@ WHITESPACE           = [ \t\r\n]+
   "TRUNCATE" {
           if (shouldStartNewOperation()) {
             setOperation(new Truncate());
-            recordOperationName("TRUNCATE");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -937,7 +941,7 @@ WHITESPACE           = [ \t\r\n]+
   "REPLACE" {
           if (shouldStartNewOperation()) {
             setOperation(new Replace());
-            recordOperationName("REPLACE");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -946,7 +950,7 @@ WHITESPACE           = [ \t\r\n]+
   "LOCK" {
           if (shouldStartNewOperation()) {
             setOperation(new Lock());
-            recordOperationName("LOCK");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -955,7 +959,7 @@ WHITESPACE           = [ \t\r\n]+
   "USE" {
           if (shouldStartNewOperation()) {
             setOperation(new Use());
-            recordOperationName("USE");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -964,7 +968,7 @@ WHITESPACE           = [ \t\r\n]+
   "BEGIN" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
-            recordOperationName("BEGIN");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -973,7 +977,7 @@ WHITESPACE           = [ \t\r\n]+
   "COMMIT" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
-            recordOperationName("COMMIT");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -982,7 +986,7 @@ WHITESPACE           = [ \t\r\n]+
   "ROLLBACK" {
           if (shouldStartNewOperation()) {
             setOperation(new TransactionControl());
-            recordOperationName("ROLLBACK");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -991,7 +995,7 @@ WHITESPACE           = [ \t\r\n]+
   "GRANT" {
           if (shouldStartNewOperation()) {
             setOperation(new Grant());
-            recordOperationName("GRANT");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -1000,7 +1004,7 @@ WHITESPACE           = [ \t\r\n]+
   "REVOKE" {
           if (shouldStartNewOperation()) {
             setOperation(new Revoke());
-            recordOperationName("REVOKE");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -1009,7 +1013,7 @@ WHITESPACE           = [ \t\r\n]+
   "SHOW" {
           if (shouldStartNewOperation()) {
             setOperation(new Show());
-            recordOperationName("SHOW");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -1026,7 +1030,7 @@ WHITESPACE           = [ \t\r\n]+
           // EXPLAIN is a prefix command - append to summary but don't set an operation,
           // so the inner statement (SELECT, INSERT, etc.) gets processed normally.
           if (!insideComment && operation == none) {
-            recordOperationName("EXPLAIN");
+            recordOperationName();
             appendOperationToSummary();
           }
           appendCurrentFragment();
@@ -1038,10 +1042,10 @@ WHITESPACE           = [ \t\r\n]+
               // hql/jpql queries may skip SELECT and start with FROM clause
               // treat such queries as SELECT queries
               setOperation(new Select());
-                recordOperationName("SELECT");
               // Derive the synthetic SELECT case from the matched FROM token.
-              appendOperationToSummary(
-                  Character.isUpperCase(zzBuffer[zzStartRead]) ? "SELECT" : "select");
+              String operationName = Character.isUpperCase(zzBuffer[zzStartRead]) ? "SELECT" : "select";
+              recordOperationName(operationName);
+              appendOperationToSummary(operationName);
             }
             operation.handleFrom();
           }

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -618,6 +618,9 @@ WHITESPACE           = [ \t\r\n]+
       }
       if (!identifierCaptured) {
         appendTargetToSummary();
+        if (tableCaptured) {
+          recordCollectionName();
+        }
         identifierCaptured = true;
       }
     }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -1263,11 +1263,7 @@ class SqlQueryAnalyzerTest {
         Arguments.of(
             "create table ks.users ( id UUID PRIMARY KEY, name text )",
             expect(
-                "CREATE table",
-                "ks.users",
-                "create table",
-                "ks.users",
-                "create table ks.users")),
+                "CREATE table", "ks.users", "create table", "ks.users", "create table ks.users")),
         Arguments.of("CREATE KEYSPACE sync_test", expect("CREATE", null, "CREATE KEYSPACE")),
         Arguments.of(
             "CREATE TABLE IF NOT EXISTS table",
@@ -1370,6 +1366,7 @@ class SqlQueryAnalyzerTest {
       assertThat(result.getQuerySummary()).isNull();
     }
   }
+
   private static Stream<Arguments> doubleQuotesAsIdentifiersArgs() {
     return Stream.of(
         // When dialect treats double quotes as identifiers, quoted text is preserved in query

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@SuppressWarnings("deprecation") // testing deprecated old semconv operation
+@SuppressWarnings("deprecation") // testing deprecated old db semconv accessors
 class SqlQueryAnalyzerTest {
 
   private static final SqlQueryAnalyzer ANALYZER = SqlQueryAnalyzer.create(true);
@@ -1258,6 +1258,18 @@ class SqlQueryAnalyzerTest {
             "CREATE TABLE `table`",
             expect("CREATE TABLE", "table", "CREATE TABLE", "`table`", "CREATE TABLE `table`")),
         Arguments.of(
+            "CREATE TABLE ks.users ( id UUID PRIMARY KEY, name text )",
+            expect("CREATE TABLE", "ks.users", "CREATE TABLE ks.users")),
+        Arguments.of(
+            "create table ks.users ( id UUID PRIMARY KEY, name text )",
+            expect(
+                "CREATE table",
+                "ks.users",
+                "create table",
+                "ks.users",
+                "create table ks.users")),
+        Arguments.of("CREATE KEYSPACE sync_test", expect("CREATE", null, "CREATE KEYSPACE")),
+        Arguments.of(
             "CREATE TABLE IF NOT EXISTS table",
             expect("CREATE TABLE", "table", "CREATE TABLE table")),
         Arguments.of(
@@ -1358,55 +1370,6 @@ class SqlQueryAnalyzerTest {
       assertThat(result.getQuerySummary()).isNull();
     }
   }
-
-  @ParameterizedTest
-  @MethodSource("stableMetadataArgs")
-  void stableOperationAndCollectionMetadata(
-      String sql,
-      String expectedOperationName,
-      String expectedCollectionName,
-      String expectedSummary) {
-    assumeTrue(emitStableDatabaseSemconv());
-
-    SqlQuery result = ANALYZER.analyzeWithSummary(sql, DOUBLE_QUOTES_ARE_IDENTIFIERS);
-
-    assertThat(result.getOperationName()).isEqualTo(expectedOperationName);
-    assertThat(result.getCollectionName()).isEqualTo(expectedCollectionName);
-    assertThat(result.getQuerySummary()).isEqualTo(expectedSummary);
-  }
-
-  private static Stream<Arguments> stableMetadataArgs() {
-    return Stream.of(
-        Arguments.of("SELECT * FROM users", "SELECT", "users", "SELECT users"),
-        Arguments.of(
-            "INSERT INTO ks.users (id, name) values (uuid(), 'alice')",
-            "INSERT",
-            "ks.users",
-            "INSERT ks.users"),
-        Arguments.of(
-            "CREATE TABLE ks.users ( id UUID PRIMARY KEY, name text )",
-            "CREATE TABLE",
-            "ks.users",
-            "CREATE TABLE ks.users"),
-        Arguments.of(
-            "create table ks.users ( id UUID PRIMARY KEY, name text )",
-            "create table",
-            "ks.users",
-            "create table ks.users"),
-        Arguments.of("CREATE KEYSPACE sync_test", "CREATE", null, "CREATE KEYSPACE"),
-        Arguments.of("USE sync_test", "USE", null, "USE sync_test"),
-        Arguments.of(
-            "SELECT * FROM users JOIN orders ON users.id = orders.user_id",
-            "SELECT",
-            "users",
-            "SELECT users orders"),
-        Arguments.of(
-            "SELECT * FROM users; SELECT * FROM orders",
-            "SELECT",
-            "users",
-            "SELECT users; SELECT orders"));
-  }
-
   private static Stream<Arguments> doubleQuotesAsIdentifiersArgs() {
     return Stream.of(
         // When dialect treats double quotes as identifiers, quoted text is preserved in query

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -730,7 +730,7 @@ class SqlQueryAnalyzerTest {
                 "metrics.users",
                 "INSERT",
                 "metrics.users",
-                "INSERT metrics.users")),
+                "insert metrics.users")),
         Arguments.of(
             "insert insert into table where lalala", // invalid SQL
             expect("INSERT", "table", "insert table")),
@@ -1345,7 +1345,7 @@ class SqlQueryAnalyzerTest {
             "create table ks.users ( id UUID PRIMARY KEY, name text )",
             "CREATE table",
             "ks.users",
-            "CREATE table ks.users"),
+            "create table ks.users"),
         Arguments.of("CREATE KEYSPACE sync_test", "CREATE", null, "CREATE KEYSPACE"),
         Arguments.of("USE sync_test", "USE", null, "USE sync_test"),
         Arguments.of(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("deprecation") // testing deprecated old semconv operation
 class SqlQueryAnalyzerTest {
 
   private static final SqlQueryAnalyzer ANALYZER = SqlQueryAnalyzer.create(true);
@@ -54,8 +55,8 @@ class SqlQueryAnalyzerTest {
     SqlQuery expected = expectedFunction.apply(original);
     assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
     if (emitStableDatabaseSemconv()) {
-      assertThat(result.getOperationName()).isNull();
-      assertThat(result.getCollectionName()).isNull();
+      assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
+      assertThat(result.getCollectionName()).isEqualTo(expected.getCollectionName());
       assertThat(result.getQuerySummary()).isEqualTo(expected.getQuerySummary());
     } else {
       assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
@@ -217,8 +218,8 @@ class SqlQueryAnalyzerTest {
 
     assertThat(result.getQueryText()).isEqualTo(analyzedQuery);
     if (emitStableDatabaseSemconv()) {
-      assertThat(result.getOperationName()).isNull();
-      assertThat(result.getCollectionName()).isNull();
+      assertThat(result.getOperationName()).isEqualTo("SELECT");
+      assertThat(result.getCollectionName()).isEqualTo("table");
       assertThat(result.getQuerySummary()).isEqualTo("SELECT table");
     } else {
       assertThat(result.getOperationName()).isEqualTo("SELECT");
@@ -234,8 +235,8 @@ class SqlQueryAnalyzerTest {
     SqlQuery expected = expectFunc.apply(actual);
     assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
     if (emitStableDatabaseSemconv()) {
-      assertThat(result.getOperationName()).isNull();
-      assertThat(result.getCollectionName()).isNull();
+      assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
+      assertThat(result.getCollectionName()).isEqualTo(expected.getCollectionName());
       assertThat(result.getQuerySummary()).isEqualTo(expected.getQuerySummary());
     } else {
       assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
@@ -528,17 +529,38 @@ class SqlQueryAnalyzerTest {
 
   private static Function<String, SqlQuery> expect(
       String operation, String collectionName, String querySummary) {
+    return expect(operation, collectionName, operation, collectionName, querySummary);
+  }
+
+  private static Function<String, SqlQuery> expect(
+      String operation,
+      String collectionName,
+      String stableOperationName,
+      String stableCollectionName,
+      String querySummary) {
     return sql ->
         emitStableDatabaseSemconv()
-            ? SqlQuery.createWithSummary(sql, null, querySummary)
+            ? SqlQuery.createWithSummary(
+                sql, stableOperationName, stableCollectionName, null, querySummary)
             : SqlQuery.create(sql, operation, collectionName);
   }
 
   private static Function<String, SqlQuery> expect(
       String sql, String operation, String collectionName, String querySummary) {
+    return expect(sql, operation, collectionName, operation, collectionName, querySummary);
+  }
+
+  private static Function<String, SqlQuery> expect(
+      String sql,
+      String operation,
+      String collectionName,
+      String stableOperationName,
+      String stableCollectionName,
+      String querySummary) {
     return ignored ->
         emitStableDatabaseSemconv()
-            ? SqlQuery.createWithSummary(sql, null, querySummary)
+            ? SqlQuery.createWithSummary(
+                sql, stableOperationName, stableCollectionName, null, querySummary)
             : SqlQuery.create(sql, operation, collectionName);
   }
 
@@ -546,7 +568,7 @@ class SqlQueryAnalyzerTest {
       String operation, String storedProcedureName, String querySummary) {
     return sql ->
         emitStableDatabaseSemconv()
-            ? SqlQuery.createWithSummary(sql, storedProcedureName, querySummary)
+            ? SqlQuery.createWithSummary(sql, operation, null, storedProcedureName, querySummary)
             : SqlQuery.create(sql, operation, storedProcedureName);
   }
 
@@ -554,7 +576,7 @@ class SqlQueryAnalyzerTest {
       String sql, String operation, String storedProcedureName, String querySummary) {
     return ignored ->
         emitStableDatabaseSemconv()
-            ? SqlQuery.createWithSummary(sql, storedProcedureName, querySummary)
+            ? SqlQuery.createWithSummary(sql, operation, null, storedProcedureName, querySummary)
             : SqlQuery.create(sql, operation, storedProcedureName);
   }
 
@@ -563,16 +585,22 @@ class SqlQueryAnalyzerTest {
         // Select
         Arguments.of(
             "SELECT x, y, z FROM schema.table",
-            expect("SELECT", "schema.table", "SELECT schema.table")),
+            expect("SELECT", "schema.table", "SELECT", "schema.table", "SELECT schema.table")),
         Arguments.of(
             "SELECT x, y, z FROM `schema table`",
-            expect("SELECT", "schema table", "SELECT `schema table`")),
+            expect("SELECT", "schema table", "SELECT", "`schema table`", "SELECT `schema table`")),
         Arguments.of(
             "SELECT x, y, z FROM `schema`.`table`",
             expect("SELECT", "`schema`.`table`", "SELECT `schema`.`table`")),
         Arguments.of(
             "SELECT x, y, z FROM \"schema table\"",
-            expect("SELECT x, y, z FROM ?", "SELECT", "schema table", "SELECT \"schema table\"")),
+            expect(
+                "SELECT x, y, z FROM ?",
+                "SELECT",
+                "schema table",
+                "SELECT",
+                "\"schema table\"",
+                "SELECT \"schema table\"")),
         // double-quoted dot-separated identifiers are matched as IDENTIFIER, not DOUBLE_QUOTED_STR,
         // so they are always preserved regardless of dialect
         Arguments.of(
@@ -580,10 +608,10 @@ class SqlQueryAnalyzerTest {
             expect("SELECT", "\"schema\".\"table\"", "SELECT \"schema\".\"table\"")),
         Arguments.of(
             "WITH subquery as (select a from b) SELECT x, y, z FROM table",
-            expect("SELECT", null, "select b SELECT table")),
+            expect("SELECT", null, "SELECT", "b", "select b SELECT table")),
         Arguments.of(
             "SELECT x, y, (select a from b) as z FROM table",
-            expect("SELECT", null, "SELECT select b table")),
+            expect("SELECT", null, "SELECT", "b", "SELECT select b table")),
         Arguments.of(
             "select delete, insert into, merge, update from table", // invalid SQL
             expect("SELECT", "table", "select table")),
@@ -591,61 +619,73 @@ class SqlQueryAnalyzerTest {
             "select col /* from table2 */ from table", expect("SELECT", "table", "select table")),
         Arguments.of(
             "select col from table join anotherTable",
-            expect("SELECT", null, "select table anotherTable")),
+            expect("SELECT", null, "SELECT", "table", "select table anotherTable")),
         Arguments.of(
             "SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id JOIN t3 ON t2.x = t3.x",
-            expect("SELECT", null, "SELECT t1 t2 t3")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT t1 t2 t3")),
         Arguments.of(
             "select col from (select * from anotherTable)",
-            expect("SELECT", null, "select select anotherTable")),
+            expect("SELECT", null, "SELECT", "anotherTable", "select select anotherTable")),
         Arguments.of(
             "select col from (select * from anotherTable) alias",
-            expect("SELECT", null, "select select anotherTable")),
+            expect("SELECT", null, "SELECT", "anotherTable", "select select anotherTable")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM t1) sub, t3",
-            expect("SELECT", null, "SELECT SELECT t1 t3")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT SELECT t1 t3")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM t1) s1, (SELECT * FROM t2) s2",
-            expect("SELECT", null, "SELECT SELECT t1 SELECT t2")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT SELECT t1 SELECT t2")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM t1) sub, t2 JOIN t3 ON t2.id = t3.id",
-            expect("SELECT", null, "SELECT SELECT t1 t2 t3")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT SELECT t1 t2 t3")),
         Arguments.of(
             "select col from table1 union select col from table2",
-            expect("SELECT", null, "select table1 select table2")),
+            expect("SELECT", null, "SELECT", "table1", "select table1 select table2")),
         Arguments.of(
             "SELECT id, name FROM employees UNION ALL SELECT id, name FROM contractors UNION SELECT id, name FROM vendors",
-            expect("SELECT", null, "SELECT employees SELECT contractors SELECT vendors")),
+            expect(
+                "SELECT",
+                null,
+                "SELECT",
+                "employees",
+                "SELECT employees SELECT contractors SELECT vendors")),
         // Parenthesized table with UNION - identifier cancels pending subquery push
         Arguments.of(
             "SELECT * FROM (t UNION SELECT * FROM t2), t3",
-            expect("SELECT", null, "SELECT t SELECT t2")),
+            expect("SELECT", null, "SELECT", "t", "SELECT t SELECT t2")),
         Arguments.of(
             "select id, (select max(foo) from (select foo from foos union all select foo from bars)) as foo from main_table",
-            expect("SELECT", null, "select select select foos select bars main_table")),
+            expect(
+                "SELECT",
+                null,
+                "SELECT",
+                "foos",
+                "select select select foos select bars main_table")),
         Arguments.of(
             "select col from table where col in (select * from anotherTable)",
-            expect("SELECT", null, "select table select anotherTable")),
+            expect("SELECT", null, "SELECT", "table", "select table select anotherTable")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM inner1 JOIN inner2 ON inner1.id = inner2.id) AS sub",
-            expect("SELECT", null, "SELECT SELECT inner1 inner2")),
+            expect("SELECT", null, "SELECT", "inner1", "SELECT SELECT inner1 inner2")),
         Arguments.of(
             "SELECT * FROM (VALUES (1,2), (3,4)) AS t(a, b)",
             expect("SELECT * FROM (VALUES (?,?), (?,?)) AS t(a, b)", "SELECT", null, "SELECT")),
         Arguments.of("SELECT * FROM t1 CROSS APPLY t2", expect("SELECT", "t1", "SELECT t1 t2")),
         Arguments.of(
             "SELECT * FROM t1 OUTER APPLY (SELECT * FROM t2 WHERE t2.id = t1.id)",
-            expect("SELECT", null, "SELECT t1 SELECT t2")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT t1 SELECT t2")),
         Arguments.of(
             "SELECT * FROM t1, LATERAL (SELECT * FROM t2 WHERE t2.id = t1.id)",
-            expect("SELECT", null, "SELECT t1 SELECT t2")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT t1 SELECT t2")),
         Arguments.of(
-            "select col from table1, table2", expect("SELECT", null, "select table1 table2")),
+            "select col from table1, table2",
+            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
         Arguments.of(
-            "select col from table1 t1, table2 t2", expect("SELECT", null, "select table1 table2")),
+            "select col from table1 t1, table2 t2",
+            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
         Arguments.of(
             "select col from table1 as t1, table2 as t2",
-            expect("SELECT", null, "select table1 table2")),
+            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
         Arguments.of(
             "select col from table where col in (1, 2, 3)",
             expect("select col from table where col in (?)", "SELECT", "table", "select table")),
@@ -671,7 +711,8 @@ class SqlQueryAnalyzerTest {
 
         // EXPLAIN - preserved as prefix command in summary
         Arguments.of(
-            "EXPLAIN SELECT * FROM users", expect("SELECT", "users", "EXPLAIN SELECT users")),
+            "EXPLAIN SELECT * FROM users",
+            expect("SELECT", "users", "EXPLAIN", "users", "EXPLAIN SELECT users")),
 
         // hibernate/jpa
         Arguments.of("from schema.table", expect("SELECT", "schema.table", "select schema.table")),
@@ -682,16 +723,31 @@ class SqlQueryAnalyzerTest {
         // Insert
         Arguments.of(" insert into table where lalala", expect("INSERT", "table", "insert table")),
         Arguments.of(
+            "insert into metrics.users (id) values (1)",
+            expect(
+                "insert into metrics.users (id) values (?)",
+                "INSERT",
+                "metrics.users",
+                "INSERT",
+                "metrics.users",
+                "INSERT metrics.users")),
+        Arguments.of(
             "insert insert into table where lalala", // invalid SQL
             expect("INSERT", "table", "insert table")),
         Arguments.of(
             "insert into db.table where lalala", expect("INSERT", "db.table", "insert db.table")),
         Arguments.of(
             "insert into `db table` where lalala",
-            expect("INSERT", "db table", "insert `db table`")),
+            expect("INSERT", "db table", "INSERT", "`db table`", "insert `db table`")),
         Arguments.of(
             "insert into \"db table\" where lalala",
-            expect("insert into ? where lalala", "INSERT", "db table", "insert \"db table\"")),
+            expect(
+                "insert into ? where lalala",
+                "INSERT",
+                "db table",
+                "INSERT",
+                "\"db table\"",
+                "insert \"db table\"")),
         Arguments.of("insert without i-n-t-o", expect("INSERT", null, "insert")),
 
         // Delete
@@ -700,13 +756,15 @@ class SqlQueryAnalyzerTest {
             expect("DELETE", "table", "delete table")),
         Arguments.of(
             "delete from `my table` where something something",
-            expect("DELETE", "my table", "delete `my table`")),
+            expect("DELETE", "my table", "DELETE", "`my table`", "delete `my table`")),
         Arguments.of(
             "delete from \"my table\" where something something",
             expect(
                 "delete from ? where something something",
                 "DELETE",
                 "my table",
+                "DELETE",
+                "\"my table\"",
                 "delete \"my table\"")),
         Arguments.of(
             "delete from foo where x IN (1,2,3)",
@@ -720,17 +778,31 @@ class SqlQueryAnalyzerTest {
             expect("update table set answer=?", "UPDATE", "table", "update table")),
         Arguments.of(
             "update `my table` set answer=42",
-            expect("update `my table` set answer=?", "UPDATE", "my table", "update `my table`")),
+            expect(
+                "update `my table` set answer=?",
+                "UPDATE",
+                "my table",
+                "UPDATE",
+                "`my table`",
+                "update `my table`")),
         Arguments.of(
             "update `my table` set answer=42 where x IN('a', 'b') AND y In ('a',  'b')",
             expect(
                 "update `my table` set answer=? where x IN(?) AND y In (?)",
                 "UPDATE",
                 "my table",
+                "UPDATE",
+                "`my table`",
                 "update `my table`")),
         Arguments.of(
             "update \"my table\" set answer=42",
-            expect("update ? set answer=?", "UPDATE", "my table", "update \"my table\"")),
+            expect(
+                "update ? set answer=?",
+                "UPDATE",
+                "my table",
+                "UPDATE",
+                "\"my table\"",
+                "update \"my table\"")),
         Arguments.of("update /*table", expect("UPDATE", null, "update")),
 
         // Call
@@ -749,10 +821,18 @@ class SqlQueryAnalyzerTest {
 
         // Merge
         Arguments.of("merge into table", expect("MERGE", "table", "merge table")),
-        Arguments.of("merge into `my table`", expect("MERGE", "my table", "merge `my table`")),
+        Arguments.of(
+            "merge into `my table`",
+            expect("MERGE", "my table", "MERGE", "`my table`", "merge `my table`")),
         Arguments.of(
             "merge into \"my table\"",
-            expect("merge into ?", "MERGE", "my table", "merge \"my table\"")),
+            expect(
+                "merge into ?",
+                "MERGE",
+                "my table",
+                "MERGE",
+                "\"my table\"",
+                "merge \"my table\"")),
         Arguments.of(
             "merge table (into is optional in some dbs)", expect("MERGE", "table", "merge table")),
         Arguments.of("merge (into )))", expect("MERGE", null, "merge")),
@@ -774,7 +854,13 @@ class SqlQueryAnalyzerTest {
         // Multi-statement SQL with semicolons
         Arguments.of(
             "SELECT * FROM t1; SELECT * FROM t2",
-            expect("SELECT * FROM t1; SELECT * FROM t2", "SELECT", null, "SELECT t1; SELECT t2")),
+            expect(
+                "SELECT * FROM t1; SELECT * FROM t2",
+                "SELECT",
+                null,
+                "SELECT",
+                "t1",
+                "SELECT t1; SELECT t2")),
         Arguments.of(
             "SELECT * FROM t1; INSERT INTO t2 VALUES (1)",
             expect(
@@ -790,18 +876,37 @@ class SqlQueryAnalyzerTest {
         // PostgreSQL ONLY keyword (inherits from parent table only, not children)
         Arguments.of(
             "SELECT * FROM ONLY parent",
-            expect("SELECT * FROM ONLY parent", "SELECT", "ONLY", "SELECT parent")),
+            expect(
+                "SELECT * FROM ONLY parent",
+                "SELECT",
+                "ONLY",
+                "SELECT",
+                "parent",
+                "SELECT parent")),
         Arguments.of(
             "DELETE FROM ONLY parent WHERE id = 1",
-            expect("DELETE FROM ONLY parent WHERE id = ?", "DELETE", "ONLY", "DELETE parent")),
+            expect(
+                "DELETE FROM ONLY parent WHERE id = ?",
+                "DELETE",
+                "ONLY",
+                "DELETE",
+                "parent",
+                "DELETE parent")),
         Arguments.of(
             "UPDATE ONLY parent SET x = 1",
-            expect("UPDATE ONLY parent SET x = ?", "UPDATE", "ONLY", "UPDATE parent")),
+            expect(
+                "UPDATE ONLY parent SET x = ?",
+                "UPDATE",
+                "ONLY",
+                "UPDATE",
+                "parent",
+                "UPDATE parent")),
 
         // Standalone VALUES clause
-        Arguments.of("VALUES (1)", expect("VALUES (?)", null, null, "VALUES")),
+        Arguments.of("VALUES (1)", expect("VALUES (?)", null, null, "VALUES", null, "VALUES")),
         Arguments.of(
-            "VALUES (1, 'a'), (2, 'b')", expect("VALUES (?, ?), (?, ?)", null, null, "VALUES")),
+            "VALUES (1, 'a'), (2, 'b')",
+            expect("VALUES (?, ?), (?, ?)", null, null, "VALUES", null, "VALUES")),
 
         // EXECUTE/EXEC stored procedure calls
         Arguments.of(
@@ -820,16 +925,20 @@ class SqlQueryAnalyzerTest {
                 : expect("EXECUTE db.my_procedure @param=?", null, null, null)),
 
         // SQL Server bracket-quoted identifiers
-        Arguments.of("SELECT * FROM [my table]", expect("SELECT", "my", "SELECT [my table]")),
+        Arguments.of(
+            "SELECT * FROM [my table]",
+            expect("SELECT", "my", "SELECT", "[my table]", "SELECT [my table]")),
         Arguments.of(
             "SELECT * FROM [schema].[table]",
-            expect("SELECT", "schema", "SELECT [schema].[table]")),
+            expect("SELECT", "schema", "SELECT", "[schema].[table]", "SELECT [schema].[table]")),
         Arguments.of(
             "SELECT [column] FROM [table] WHERE [field] = 1",
             expect(
                 "SELECT [column] FROM [table] WHERE [field] = ?",
                 "SELECT",
                 "table",
+                "SELECT",
+                "[table]",
                 "SELECT [table]")),
 
         // MySQL escaped backticks
@@ -837,13 +946,15 @@ class SqlQueryAnalyzerTest {
             "SELECT * FROM `my``table`",
             // collection name should be "my`table"
             // not fixing as collection name is only captured by old semconv jflex
-            expect("SELECT", "my", "SELECT `my``table`")),
+            expect("SELECT", "my", "SELECT", "`my``table`", "SELECT `my``table`")),
         Arguments.of(
             "SELECT * FROM `table` WHERE `col``name` = 1",
             expect(
                 "SELECT * FROM `table` WHERE `col``name` = ?",
                 "SELECT",
                 "table",
+                "SELECT",
+                "`table`",
                 "SELECT `table`")),
 
         // Empty and trivial statements should have null query summary
@@ -886,105 +997,184 @@ class SqlQueryAnalyzerTest {
 
         // Subqueries in comma-separated FROM lists - state properly isolated via operation stack
         Arguments.of(
-            "SELECT * FROM a, (SELECT * FROM b), c", expect("SELECT", null, "SELECT a SELECT b c")),
+            "SELECT * FROM a, (SELECT * FROM b), c",
+            expect("SELECT", null, "SELECT", "a", "SELECT a SELECT b c")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM inner1), (SELECT * FROM inner2), outer_table",
-            expect("SELECT", null, "SELECT SELECT inner1 SELECT inner2 outer_table")),
+            expect(
+                "SELECT",
+                null,
+                "SELECT",
+                "inner1",
+                "SELECT SELECT inner1 SELECT inner2 outer_table")),
 
         // Parenthesized table name - not a subquery - valid on MySQL
-        Arguments.of("SELECT * FROM (TABLE)", expect("SELECT", null, "SELECT TABLE")),
+        Arguments.of(
+            "SELECT * FROM (TABLE)", expect("SELECT", null, "SELECT", "TABLE", "SELECT TABLE")),
 
         // TRUNCATE statement
         Arguments.of(
             "TRUNCATE TABLE users",
-            expect("TRUNCATE TABLE users", null, null, "TRUNCATE TABLE users")),
-        Arguments.of("TRUNCATE users", expect("TRUNCATE users", null, null, "TRUNCATE users")),
+            expect(
+                "TRUNCATE TABLE users",
+                null,
+                null,
+                "TRUNCATE TABLE",
+                null,
+                "TRUNCATE TABLE users")),
+        Arguments.of(
+            "TRUNCATE users",
+            expect("TRUNCATE users", null, null, "TRUNCATE", null, "TRUNCATE users")),
         Arguments.of(
             "TRUNCATE TABLE schema.table",
-            expect("TRUNCATE TABLE schema.table", null, null, "TRUNCATE TABLE schema.table")),
+            expect(
+                "TRUNCATE TABLE schema.table",
+                null,
+                null,
+                "TRUNCATE TABLE",
+                null,
+                "TRUNCATE TABLE schema.table")),
 
         // REPLACE statement (MySQL)
         Arguments.of(
             "REPLACE INTO users VALUES (1, 'name')",
-            expect("REPLACE INTO users VALUES (?, ?)", null, null, "REPLACE users")),
+            expect(
+                "REPLACE INTO users VALUES (?, ?)",
+                null,
+                null,
+                "REPLACE",
+                "users",
+                "REPLACE users")),
         Arguments.of(
             "REPLACE users SET name = 'foo'",
-            expect("REPLACE users SET name = ?", null, null, "REPLACE users")),
+            expect("REPLACE users SET name = ?", null, null, "REPLACE", "users", "REPLACE users")),
         Arguments.of(
             "REPLACE INTO db.table (col) VALUES (1)",
-            expect("REPLACE INTO db.table (col) VALUES (?)", null, null, "REPLACE db.table")),
+            expect(
+                "REPLACE INTO db.table (col) VALUES (?)",
+                null,
+                null,
+                "REPLACE",
+                "db.table",
+                "REPLACE db.table")),
 
         // Transaction control statements
-        Arguments.of("BEGIN", expect("BEGIN", null, null, "BEGIN")),
+        Arguments.of("BEGIN", expect("BEGIN", null, null, "BEGIN", null, "BEGIN")),
         Arguments.of(
-            "BEGIN TRANSACTION", expect("BEGIN TRANSACTION", null, null, "BEGIN TRANSACTION")),
-        Arguments.of("COMMIT", expect("COMMIT", null, null, "COMMIT")),
+            "BEGIN TRANSACTION",
+            expect("BEGIN TRANSACTION", null, null, "BEGIN", null, "BEGIN TRANSACTION")),
+        Arguments.of("COMMIT", expect("COMMIT", null, null, "COMMIT", null, "COMMIT")),
         Arguments.of(
-            "COMMIT TRANSACTION", expect("COMMIT TRANSACTION", null, null, "COMMIT TRANSACTION")),
-        Arguments.of("ROLLBACK", expect("ROLLBACK", null, null, "ROLLBACK")),
+            "COMMIT TRANSACTION",
+            expect("COMMIT TRANSACTION", null, null, "COMMIT", null, "COMMIT TRANSACTION")),
+        Arguments.of("ROLLBACK", expect("ROLLBACK", null, null, "ROLLBACK", null, "ROLLBACK")),
         Arguments.of(
             "ROLLBACK TRANSACTION",
-            expect("ROLLBACK TRANSACTION", null, null, "ROLLBACK TRANSACTION")),
+            expect("ROLLBACK TRANSACTION", null, null, "ROLLBACK", null, "ROLLBACK TRANSACTION")),
 
         // LOCK statement
         Arguments.of(
-            "LOCK TABLE users", expect("LOCK TABLE users", null, null, "LOCK TABLE users")),
+            "LOCK TABLE users",
+            expect("LOCK TABLE users", null, null, "LOCK", "users", "LOCK TABLE users")),
         Arguments.of(
             "LOCK TABLE users IN EXCLUSIVE MODE",
-            expect("LOCK TABLE users IN EXCLUSIVE MODE", null, null, "LOCK TABLE users")),
+            expect(
+                "LOCK TABLE users IN EXCLUSIVE MODE",
+                null,
+                null,
+                "LOCK",
+                "users",
+                "LOCK TABLE users")),
         Arguments.of(
             "LOCK TABLES users WRITE, orders READ",
-            expect("LOCK TABLES users WRITE, orders READ", null, null, "LOCK TABLES users")),
+            expect(
+                "LOCK TABLES users WRITE, orders READ",
+                null,
+                null,
+                "LOCK",
+                "users",
+                "LOCK TABLES users")),
 
         // USE statement
-        Arguments.of("USE mydb", expect("USE mydb", null, null, "USE mydb")),
+        Arguments.of("USE mydb", expect("USE mydb", null, null, "USE", null, "USE mydb")),
         Arguments.of(
-            "USE `my database`", expect("USE `my database`", null, null, "USE `my database`")),
+            "USE `my database`",
+            expect("USE `my database`", null, null, "USE", null, "USE `my database`")),
 
         // GRANT statement
         Arguments.of(
             "GRANT SELECT ON users TO some_user",
-            expect("GRANT SELECT ON users TO some_user", "SELECT", null, "GRANT")),
+            expect("GRANT SELECT ON users TO some_user", "SELECT", null, "GRANT", null, "GRANT")),
         Arguments.of(
             "GRANT ALL PRIVILEGES ON database.* TO 'user'@'host'",
-            expect("GRANT ALL PRIVILEGES ON database.* TO ?@?", null, null, "GRANT")),
+            expect(
+                "GRANT ALL PRIVILEGES ON database.* TO ?@?", null, null, "GRANT", null, "GRANT")),
 
         // REVOKE statement
         Arguments.of(
             "REVOKE SELECT ON users FROM some_user",
-            expect("REVOKE SELECT ON users FROM some_user", "SELECT", "some_user", "REVOKE")),
+            expect(
+                "REVOKE SELECT ON users FROM some_user",
+                "SELECT",
+                "some_user",
+                "REVOKE",
+                null,
+                "REVOKE")),
         Arguments.of(
             "REVOKE ALL PRIVILEGES ON database.* FROM 'user'@'host'",
-            expect("REVOKE ALL PRIVILEGES ON database.* FROM ?@?", "SELECT", null, "REVOKE")),
+            expect(
+                "REVOKE ALL PRIVILEGES ON database.* FROM ?@?",
+                "SELECT",
+                null,
+                "REVOKE",
+                null,
+                "REVOKE")),
 
         // SHOW statement
-        Arguments.of("SHOW TABLES", expect("SHOW TABLES", null, null, "SHOW")),
+        Arguments.of("SHOW TABLES", expect("SHOW TABLES", null, null, "SHOW", null, "SHOW")),
         Arguments.of(
             "SHOW CREATE TABLE users",
-            expect("SHOW CREATE TABLE users", "CREATE TABLE", "users", "SHOW")),
-        Arguments.of("SHOW DATABASES", expect("SHOW DATABASES", null, null, "SHOW")),
+            expect("SHOW CREATE TABLE users", "CREATE TABLE", "users", "SHOW", null, "SHOW")),
+        Arguments.of("SHOW DATABASES", expect("SHOW DATABASES", null, null, "SHOW", null, "SHOW")),
 
         // SQL keywords used as identifiers (table names)
         // Note: old semconv path (collectionName) doesn't handle keywords as identifiers
         Arguments.of(
             "SELECT * FROM insert WHERE x = 1",
-            expect("SELECT * FROM insert WHERE x = ?", "SELECT", "WHERE", "SELECT insert")),
-        Arguments.of("SELECT * FROM update", expect("SELECT", null, "SELECT update")),
-        Arguments.of("SELECT * FROM delete", expect("SELECT", null, "SELECT delete")),
-        Arguments.of("SELECT * FROM call", expect("SELECT", null, "SELECT call")),
-        Arguments.of("SELECT * FROM merge", expect("SELECT", null, "SELECT merge")),
-        Arguments.of("SELECT * FROM create", expect("SELECT", null, "SELECT create")),
-        Arguments.of("SELECT * FROM drop", expect("SELECT", null, "SELECT drop")),
-        Arguments.of("SELECT * FROM alter", expect("SELECT", null, "SELECT alter")),
+            expect(
+                "SELECT * FROM insert WHERE x = ?",
+                "SELECT",
+                "WHERE",
+                "SELECT",
+                "insert",
+                "SELECT insert")),
+        Arguments.of(
+            "SELECT * FROM update", expect("SELECT", null, "SELECT", "update", "SELECT update")),
+        Arguments.of(
+            "SELECT * FROM delete", expect("SELECT", null, "SELECT", "delete", "SELECT delete")),
+        Arguments.of("SELECT * FROM call", expect("SELECT", null, "SELECT", "call", "SELECT call")),
+        Arguments.of(
+            "SELECT * FROM merge", expect("SELECT", null, "SELECT", "merge", "SELECT merge")),
+        Arguments.of(
+            "SELECT * FROM create", expect("SELECT", null, "SELECT", "create", "SELECT create")),
+        Arguments.of("SELECT * FROM drop", expect("SELECT", null, "SELECT", "drop", "SELECT drop")),
+        Arguments.of(
+            "SELECT * FROM alter", expect("SELECT", null, "SELECT", "alter", "SELECT alter")),
         Arguments.of("SELECT * FROM exec", expect("SELECT", "exec", "SELECT exec")),
         Arguments.of("SELECT * FROM execute", expect("SELECT", "execute", "SELECT execute")),
 
         // Oracle database link syntax (table@dblink)
         Arguments.of(
-            "SELECT * FROM users@remote_db", expect("SELECT", "users", "SELECT users@remote_db")),
+            "SELECT * FROM users@remote_db",
+            expect("SELECT", "users", "SELECT", "users@remote_db", "SELECT users@remote_db")),
         Arguments.of(
             "SELECT * FROM schema.users@remote_db",
-            expect("SELECT", "schema.users", "SELECT schema.users@remote_db")),
+            expect(
+                "SELECT",
+                "schema.users",
+                "SELECT",
+                "schema.users@remote_db",
+                "SELECT schema.users@remote_db")),
 
         // SQL keywords used as column names
         Arguments.of(
@@ -999,32 +1189,36 @@ class SqlQueryAnalyzerTest {
         // CTEs (Common Table Expressions) - CTE names are filtered from query summary
         Arguments.of(
             "WITH cte AS (SELECT a FROM b) SELECT * FROM cte",
-            expect("SELECT", null, "SELECT b SELECT")),
+            expect("SELECT", null, "SELECT", "b", "SELECT b SELECT")),
         Arguments.of(
             "WITH cte AS (VALUES (1, 'a'), (2, 'b')) SELECT * FROM cte",
             expect(
                 "WITH cte AS (VALUES (?, ?), (?, ?)) SELECT * FROM cte",
                 "SELECT",
                 "cte",
+                "SELECT",
+                null,
                 "SELECT")),
         // Multiple CTEs - CTE references filtered in main query
         Arguments.of(
             "WITH a AS (SELECT * FROM t1), b AS (SELECT * FROM t2) SELECT * FROM a JOIN b ON a.id = b.id",
-            expect("SELECT", null, "SELECT t1 SELECT t2 SELECT")),
+            expect("SELECT", null, "SELECT", "t1", "SELECT t1 SELECT t2 SELECT")),
         // Recursive CTE - self-reference filtered in CTE body and main query
         Arguments.of(
             "WITH RECURSIVE cte AS (SELECT id FROM t WHERE parent IS NULL UNION ALL SELECT t.id FROM t JOIN cte ON t.parent = cte.id) SELECT * FROM cte",
-            expect("SELECT", null, "SELECT t SELECT t SELECT")));
+            expect("SELECT", null, "SELECT", "t", "SELECT t SELECT t SELECT")));
   }
 
   private static Stream<Arguments> ddlArgs() {
     return Stream.of(
         Arguments.of(
-            "CREATE TABLE `table`", expect("CREATE TABLE", "table", "CREATE TABLE `table`")),
+            "CREATE TABLE `table`",
+            expect("CREATE TABLE", "table", "CREATE TABLE", "`table`", "CREATE TABLE `table`")),
         Arguments.of(
             "CREATE TABLE IF NOT EXISTS table",
             expect("CREATE TABLE", "table", "CREATE TABLE table")),
-        Arguments.of("DROP TABLE `if`", expect("DROP TABLE", "if", "DROP TABLE `if`")),
+        Arguments.of(
+            "DROP TABLE `if`", expect("DROP TABLE", "if", "DROP TABLE", "`if`", "DROP TABLE `if`")),
         Arguments.of(
             "ALTER TABLE table ADD CONSTRAINT c FOREIGN KEY (foreign_id) REFERENCES ref (id)",
             expect("ALTER TABLE", "table", "ALTER TABLE table")),
@@ -1036,10 +1230,15 @@ class SqlQueryAnalyzerTest {
             expect("DROP INDEX", null, "DROP INDEX types_name")),
         Arguments.of(
             "CREATE VIEW tmp AS SELECT type FROM table WHERE id = ?",
-            expect("CREATE VIEW", null, "CREATE VIEW tmp SELECT table")),
+            expect("CREATE VIEW", null, "CREATE VIEW", "table", "CREATE VIEW tmp SELECT table")),
         Arguments.of(
             "CREATE PROCEDURE p AS SELECT * FROM table GO",
-            expect("CREATE PROCEDURE", null, "CREATE PROCEDURE p SELECT table")),
+            expect(
+                "CREATE PROCEDURE",
+                null,
+                "CREATE PROCEDURE",
+                "table",
+                "CREATE PROCEDURE p SELECT table")),
         // ALTER TABLE with DROP/ADD clauses
         Arguments.of(
             "ALTER TABLE t2 DROP COLUMN c, DROP COLUMN d",
@@ -1055,6 +1254,8 @@ class SqlQueryAnalyzerTest {
             "CREATE TABLE users (password VARCHAR(255))",
             expect(
                 "CREATE TABLE users (password VARCHAR(?))",
+                "CREATE TABLE",
+                "users",
                 "CREATE TABLE",
                 "users",
                 "CREATE TABLE users")),
@@ -1101,8 +1302,8 @@ class SqlQueryAnalyzerTest {
     SqlQuery expected = expectedFunction.apply(original);
     assertThat(result.getQueryText()).isEqualTo(expected.getQueryText());
     if (emitStableDatabaseSemconv()) {
-      assertThat(result.getOperationName()).isNull();
-      assertThat(result.getCollectionName()).isNull();
+      assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
+      assertThat(result.getCollectionName()).isEqualTo(expected.getCollectionName());
       assertThat(result.getQuerySummary()).isEqualTo(expected.getQuerySummary());
     } else {
       assertThat(result.getOperationName()).isEqualTo(expected.getOperationName());
@@ -1111,23 +1312,81 @@ class SqlQueryAnalyzerTest {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("stableMetadataArgs")
+  void stableOperationAndCollectionMetadata(
+      String sql,
+      String expectedOperationName,
+      String expectedCollectionName,
+      String expectedSummary) {
+    assumeTrue(emitStableDatabaseSemconv());
+
+    SqlQuery result = ANALYZER.analyzeWithSummary(sql, DOUBLE_QUOTES_ARE_IDENTIFIERS);
+
+    assertThat(result.getOperationName()).isEqualTo(expectedOperationName);
+    assertThat(result.getCollectionName()).isEqualTo(expectedCollectionName);
+    assertThat(result.getQuerySummary()).isEqualTo(expectedSummary);
+  }
+
+  private static Stream<Arguments> stableMetadataArgs() {
+    return Stream.of(
+        Arguments.of("SELECT * FROM users", "SELECT", "users", "SELECT users"),
+        Arguments.of(
+            "INSERT INTO ks.users (id, name) values (uuid(), 'alice')",
+            "INSERT",
+            "ks.users",
+            "INSERT ks.users"),
+        Arguments.of(
+            "CREATE TABLE ks.users ( id UUID PRIMARY KEY, name text )",
+            "CREATE TABLE",
+            "ks.users",
+            "CREATE TABLE ks.users"),
+        Arguments.of(
+            "create table ks.users ( id UUID PRIMARY KEY, name text )",
+            "CREATE table",
+            "ks.users",
+            "CREATE table ks.users"),
+        Arguments.of("CREATE KEYSPACE sync_test", "CREATE", null, "CREATE KEYSPACE"),
+        Arguments.of("USE sync_test", "USE", null, "USE sync_test"),
+        Arguments.of(
+            "SELECT * FROM users JOIN orders ON users.id = orders.user_id",
+            "SELECT",
+            "users",
+            "SELECT users orders"),
+        Arguments.of(
+            "SELECT * FROM users; SELECT * FROM orders",
+            "SELECT",
+            "users",
+            "SELECT users; SELECT orders"));
+  }
+
   private static Stream<Arguments> doubleQuotesAsIdentifiersArgs() {
     return Stream.of(
         // When dialect treats double quotes as identifiers, quoted text is preserved in query
-        Arguments.of("SELECT * FROM \"TABLE\"", expect("SELECT", "TABLE", "SELECT \"TABLE\"")),
+        Arguments.of(
+            "SELECT * FROM \"TABLE\"",
+            expect("SELECT", "TABLE", "SELECT", "\"TABLE\"", "SELECT \"TABLE\"")),
         Arguments.of(
             "SELECT x, y, z FROM \"schema table\"",
-            expect("SELECT", "schema table", "SELECT \"schema table\"")),
+            expect(
+                "SELECT", "schema table", "SELECT", "\"schema table\"", "SELECT \"schema table\"")),
         Arguments.of(
             "insert into \"db table\" where lalala",
-            expect("INSERT", "db table", "insert \"db table\"")),
+            expect("INSERT", "db table", "INSERT", "\"db table\"", "insert \"db table\"")),
         Arguments.of(
             "delete from \"my table\" where something something",
-            expect("DELETE", "my table", "delete \"my table\"")),
+            expect("DELETE", "my table", "DELETE", "\"my table\"", "delete \"my table\"")),
         Arguments.of(
             "update \"my table\" set answer=42",
             expect(
-                "update \"my table\" set answer=?", "UPDATE", "my table", "update \"my table\"")),
-        Arguments.of("merge into \"my table\"", expect("MERGE", "my table", "merge \"my table\"")));
+                "update \"my table\" set answer=?",
+                "UPDATE",
+                "my table",
+                "UPDATE",
+                "\"my table\"",
+                "update \"my table\"")),
+        Arguments.of(
+            "merge into \"my table\"",
+            expect("MERGE", "my table", "MERGE", "\"my table\"", "merge \"my table\"")));
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -566,10 +566,8 @@ class SqlQueryAnalyzerTest {
 
   private static Function<String, SqlQuery> expectStoredProcedure(
       String operation, String storedProcedureName, String querySummary) {
-    return sql ->
-        emitStableDatabaseSemconv()
-            ? SqlQuery.createWithSummary(sql, operation, null, storedProcedureName, querySummary)
-            : SqlQuery.create(sql, operation, storedProcedureName);
+    return expectStoredProcedureWithStableOperation(
+        operation, storedProcedureName, operation, querySummary);
   }
 
   private static Function<String, SqlQuery> expectStoredProcedure(
@@ -577,6 +575,18 @@ class SqlQueryAnalyzerTest {
     return ignored ->
         emitStableDatabaseSemconv()
             ? SqlQuery.createWithSummary(sql, operation, null, storedProcedureName, querySummary)
+            : SqlQuery.create(sql, operation, storedProcedureName);
+  }
+
+  private static Function<String, SqlQuery> expectStoredProcedureWithStableOperation(
+      String operation,
+      String storedProcedureName,
+      String stableOperationName,
+      String querySummary) {
+    return sql ->
+        emitStableDatabaseSemconv()
+            ? SqlQuery.createWithSummary(
+                sql, stableOperationName, null, storedProcedureName, querySummary)
             : SqlQuery.create(sql, operation, storedProcedureName);
   }
 
@@ -608,27 +618,28 @@ class SqlQueryAnalyzerTest {
             expect("SELECT", "\"schema\".\"table\"", "SELECT \"schema\".\"table\"")),
         Arguments.of(
             "WITH subquery as (select a from b) SELECT x, y, z FROM table",
-            expect("SELECT", null, "SELECT", "b", "select b SELECT table")),
+            expect("SELECT", null, "select", "b", "select b SELECT table")),
         Arguments.of(
             "SELECT x, y, (select a from b) as z FROM table",
             expect("SELECT", null, "SELECT", "b", "SELECT select b table")),
         Arguments.of(
             "select delete, insert into, merge, update from table", // invalid SQL
-            expect("SELECT", "table", "select table")),
+            expect("SELECT", "table", "select", "table", "select table")),
         Arguments.of(
-            "select col /* from table2 */ from table", expect("SELECT", "table", "select table")),
+            "select col /* from table2 */ from table",
+            expect("SELECT", "table", "select", "table", "select table")),
         Arguments.of(
             "select col from table join anotherTable",
-            expect("SELECT", null, "SELECT", "table", "select table anotherTable")),
+            expect("SELECT", null, "select", "table", "select table anotherTable")),
         Arguments.of(
             "SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id JOIN t3 ON t2.x = t3.x",
             expect("SELECT", null, "SELECT", "t1", "SELECT t1 t2 t3")),
         Arguments.of(
             "select col from (select * from anotherTable)",
-            expect("SELECT", null, "SELECT", "anotherTable", "select select anotherTable")),
+            expect("SELECT", null, "select", "anotherTable", "select select anotherTable")),
         Arguments.of(
             "select col from (select * from anotherTable) alias",
-            expect("SELECT", null, "SELECT", "anotherTable", "select select anotherTable")),
+            expect("SELECT", null, "select", "anotherTable", "select select anotherTable")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM t1) sub, t3",
             expect("SELECT", null, "SELECT", "t1", "SELECT SELECT t1 t3")),
@@ -640,7 +651,7 @@ class SqlQueryAnalyzerTest {
             expect("SELECT", null, "SELECT", "t1", "SELECT SELECT t1 t2 t3")),
         Arguments.of(
             "select col from table1 union select col from table2",
-            expect("SELECT", null, "SELECT", "table1", "select table1 select table2")),
+            expect("SELECT", null, "select", "table1", "select table1 select table2")),
         Arguments.of(
             "SELECT id, name FROM employees UNION ALL SELECT id, name FROM contractors UNION SELECT id, name FROM vendors",
             expect(
@@ -658,12 +669,12 @@ class SqlQueryAnalyzerTest {
             expect(
                 "SELECT",
                 null,
-                "SELECT",
+                "select",
                 "foos",
                 "select select select foos select bars main_table")),
         Arguments.of(
             "select col from table where col in (select * from anotherTable)",
-            expect("SELECT", null, "SELECT", "table", "select table select anotherTable")),
+            expect("SELECT", null, "select", "table", "select table select anotherTable")),
         Arguments.of(
             "SELECT * FROM (SELECT * FROM inner1 JOIN inner2 ON inner1.id = inner2.id) AS sub",
             expect("SELECT", null, "SELECT", "inner1", "SELECT SELECT inner1 inner2")),
@@ -679,35 +690,50 @@ class SqlQueryAnalyzerTest {
             expect("SELECT", null, "SELECT", "t1", "SELECT t1 SELECT t2")),
         Arguments.of(
             "select col from table1, table2",
-            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
+            expect("SELECT", null, "select", "table1", "select table1 table2")),
         Arguments.of(
             "select col from table1 t1, table2 t2",
-            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
+            expect("SELECT", null, "select", "table1", "select table1 table2")),
         Arguments.of(
             "select col from table1 as t1, table2 as t2",
-            expect("SELECT", null, "SELECT", "table1", "select table1 table2")),
+            expect("SELECT", null, "select", "table1", "select table1 table2")),
         Arguments.of(
             "select col from table where col in (1, 2, 3)",
-            expect("select col from table where col in (?)", "SELECT", "table", "select table")),
+            expect(
+                "select col from table where col in (?)",
+                "SELECT",
+                "table",
+                "select",
+                "table",
+                "select table")),
         Arguments.of(
             "select 'a' IN(x, 'b') from table where col in (1) and z IN( '3', '4' )",
             expect(
                 "select ? IN(x, ?) from table where col in (?) and z IN(?)",
                 "SELECT",
                 "table",
+                "select",
+                "table",
                 "select table")),
         Arguments.of(
-            "select col from table order by col, col2", expect("SELECT", "table", "select table")),
+            "select col from table order by col, col2",
+            expect("SELECT", "table", "select", "table", "select table")),
         Arguments.of(
             "select ąś∂ń© from źćļńĶ order by col, col2",
-            expect("SELECT", "źćļńĶ", "select źćļńĶ")),
-        Arguments.of("select 12345678", expect("select ?", "SELECT", null, "select")),
+            expect("SELECT", "źćļńĶ", "select", "źćļńĶ", "select źćļńĶ")),
+        Arguments.of(
+            "select 12345678", expect("select ?", "SELECT", null, "select", null, "select")),
         Arguments.of(
             "/* update comment */ select * from table1",
-            expect("SELECT", "table1", "select table1")),
-        Arguments.of("select /*((*/abc from table", expect("SELECT", "table", "select table")),
-        Arguments.of("SeLeCT * FrOm TAblE", expect("SELECT", "TAblE", "SeLeCT TAblE")),
-        Arguments.of("select next value in hibernate_sequence", expect("SELECT", null, "select")),
+            expect("SELECT", "table1", "select", "table1", "select table1")),
+        Arguments.of(
+            "select /*((*/abc from table",
+            expect("SELECT", "table", "select", "table", "select table")),
+        Arguments.of(
+            "SeLeCT * FrOm TAblE", expect("SELECT", "TAblE", "SeLeCT", "TAblE", "SeLeCT TAblE")),
+        Arguments.of(
+            "select next value in hibernate_sequence",
+            expect("SELECT", null, "select", null, "select")),
 
         // EXPLAIN - preserved as prefix command in summary
         Arguments.of(
@@ -715,74 +741,85 @@ class SqlQueryAnalyzerTest {
             expect("SELECT", "users", "EXPLAIN", "users", "EXPLAIN SELECT users")),
 
         // hibernate/jpa
-        Arguments.of("from schema.table", expect("SELECT", "schema.table", "select schema.table")),
+        Arguments.of(
+            "from schema.table",
+            expect("SELECT", "schema.table", "select", "schema.table", "select schema.table")),
         Arguments.of("FROM schema.table", expect("SELECT", "schema.table", "SELECT schema.table")),
         Arguments.of(
-            "/* update comment */ from table1", expect("SELECT", "table1", "select table1")),
+            "/* update comment */ from table1",
+            expect("SELECT", "table1", "select", "table1", "select table1")),
 
         // Insert
-        Arguments.of(" insert into table where lalala", expect("INSERT", "table", "insert table")),
+        Arguments.of(
+            " insert into table where lalala",
+            expect("INSERT", "table", "insert", "table", "insert table")),
         Arguments.of(
             "insert into metrics.users (id) values (1)",
             expect(
                 "insert into metrics.users (id) values (?)",
                 "INSERT",
                 "metrics.users",
-                "INSERT",
+                "insert",
                 "metrics.users",
                 "insert metrics.users")),
         Arguments.of(
             "insert insert into table where lalala", // invalid SQL
-            expect("INSERT", "table", "insert table")),
+            expect("INSERT", "table", "insert", "table", "insert table")),
         Arguments.of(
-            "insert into db.table where lalala", expect("INSERT", "db.table", "insert db.table")),
+            "insert into db.table where lalala",
+            expect("INSERT", "db.table", "insert", "db.table", "insert db.table")),
         Arguments.of(
             "insert into `db table` where lalala",
-            expect("INSERT", "db table", "INSERT", "`db table`", "insert `db table`")),
+            expect("INSERT", "db table", "insert", "`db table`", "insert `db table`")),
         Arguments.of(
             "insert into \"db table\" where lalala",
             expect(
                 "insert into ? where lalala",
                 "INSERT",
                 "db table",
-                "INSERT",
+                "insert",
                 "\"db table\"",
                 "insert \"db table\"")),
-        Arguments.of("insert without i-n-t-o", expect("INSERT", null, "insert")),
+        Arguments.of("insert without i-n-t-o", expect("INSERT", null, "insert", null, "insert")),
 
         // Delete
         Arguments.of(
             "delete from table where something something",
-            expect("DELETE", "table", "delete table")),
+            expect("DELETE", "table", "delete", "table", "delete table")),
         Arguments.of(
             "delete from `my table` where something something",
-            expect("DELETE", "my table", "DELETE", "`my table`", "delete `my table`")),
+            expect("DELETE", "my table", "delete", "`my table`", "delete `my table`")),
         Arguments.of(
             "delete from \"my table\" where something something",
             expect(
                 "delete from ? where something something",
                 "DELETE",
                 "my table",
-                "DELETE",
+                "delete",
                 "\"my table\"",
                 "delete \"my table\"")),
         Arguments.of(
             "delete from foo where x IN (1,2,3)",
-            expect("delete from foo where x IN (?)", "DELETE", "foo", "delete foo")),
-        Arguments.of("delete from 12345678", expect("delete from ?", "DELETE", null, "delete")),
-        Arguments.of("delete   (((", expect("delete (((", "DELETE", null, "delete")),
+            expect(
+                "delete from foo where x IN (?)", "DELETE", "foo", "delete", "foo", "delete foo")),
+        Arguments.of(
+            "delete from 12345678",
+            expect("delete from ?", "DELETE", null, "delete", null, "delete")),
+        Arguments.of(
+            "delete   (((", expect("delete (((", "DELETE", null, "delete", null, "delete")),
 
         // Update
         Arguments.of(
             "update table set answer=42",
-            expect("update table set answer=?", "UPDATE", "table", "update table")),
+            expect(
+                "update table set answer=?", "UPDATE", "table", "update", "table", "update table")),
         Arguments.of(
             "update `my table` set answer=42",
             expect(
                 "update `my table` set answer=?",
                 "UPDATE",
                 "my table",
-                "UPDATE",
+                "update",
                 "`my table`",
                 "update `my table`")),
         Arguments.of(
@@ -791,7 +828,7 @@ class SqlQueryAnalyzerTest {
                 "update `my table` set answer=? where x IN(?) AND y In (?)",
                 "UPDATE",
                 "my table",
-                "UPDATE",
+                "update",
                 "`my table`",
                 "update `my table`")),
         Arguments.of(
@@ -800,42 +837,48 @@ class SqlQueryAnalyzerTest {
                 "update ? set answer=?",
                 "UPDATE",
                 "my table",
-                "UPDATE",
+                "update",
                 "\"my table\"",
                 "update \"my table\"")),
-        Arguments.of("update /*table", expect("UPDATE", null, "update")),
+        Arguments.of("update /*table", expect("UPDATE", null, "update", null, "update")),
 
         // Call
         Arguments.of(
-            "call test_proc()", expectStoredProcedure("CALL", "test_proc", "call test_proc")),
+            "call test_proc()",
+            expectStoredProcedureWithStableOperation(
+                "CALL", "test_proc", "call", "call test_proc")),
         Arguments.of(
-            "call test_proc", expectStoredProcedure("CALL", "test_proc", "call test_proc")),
+            "call test_proc",
+            expectStoredProcedureWithStableOperation(
+                "CALL", "test_proc", "call", "call test_proc")),
         // Hibernate uses "call next value for sequence" on HSQLDB and H2 to get sequence values,
         // while it uses SELECT for this on most other databases.
         Arguments.of(
             "call next value for hibernate_sequence",
-            expect("CALL", null, "call hibernate_sequence")),
+            expect("CALL", null, "call", null, "call hibernate_sequence")),
         Arguments.of(
             "call db.test_proc",
-            expectStoredProcedure("CALL", "db.test_proc", "call db.test_proc")),
+            expectStoredProcedureWithStableOperation(
+                "CALL", "db.test_proc", "call", "call db.test_proc")),
 
         // Merge
-        Arguments.of("merge into table", expect("MERGE", "table", "merge table")),
+        Arguments.of("merge into table", expect("MERGE", "table", "merge", "table", "merge table")),
         Arguments.of(
             "merge into `my table`",
-            expect("MERGE", "my table", "MERGE", "`my table`", "merge `my table`")),
+            expect("MERGE", "my table", "merge", "`my table`", "merge `my table`")),
         Arguments.of(
             "merge into \"my table\"",
             expect(
                 "merge into ?",
                 "MERGE",
                 "my table",
-                "MERGE",
+                "merge",
                 "\"my table\"",
                 "merge \"my table\"")),
         Arguments.of(
-            "merge table (into is optional in some dbs)", expect("MERGE", "table", "merge table")),
-        Arguments.of("merge (into )))", expect("MERGE", null, "merge")),
+            "merge table (into is optional in some dbs)",
+            expect("MERGE", "table", "merge", "table", "merge table")),
+        Arguments.of("merge (into )))", expect("MERGE", null, "merge", null, "merge")),
 
         // Unknown operation
         Arguments.of("and now for something completely different", expect(null, null, null)),
@@ -1265,6 +1308,8 @@ class SqlQueryAnalyzerTest {
                 "create table users (password VARCHAR(?))",
                 "CREATE table",
                 "users",
+                "create table",
+                "users",
                 "create table users")),
         Arguments.of(
             "ALTER TABLE users ADD COLUMN password VARCHAR(255)",
@@ -1278,6 +1323,8 @@ class SqlQueryAnalyzerTest {
             expect(
                 "alter table users ADD COLUMN password VARCHAR(?)",
                 "ALTER table",
+                "users",
+                "alter table",
                 "users",
                 "alter table users")),
         Arguments.of(
@@ -1343,7 +1390,7 @@ class SqlQueryAnalyzerTest {
             "CREATE TABLE ks.users"),
         Arguments.of(
             "create table ks.users ( id UUID PRIMARY KEY, name text )",
-            "CREATE table",
+            "create table",
             "ks.users",
             "create table ks.users"),
         Arguments.of("CREATE KEYSPACE sync_test", "CREATE", null, "CREATE KEYSPACE"),
@@ -1372,21 +1419,21 @@ class SqlQueryAnalyzerTest {
                 "SELECT", "schema table", "SELECT", "\"schema table\"", "SELECT \"schema table\"")),
         Arguments.of(
             "insert into \"db table\" where lalala",
-            expect("INSERT", "db table", "INSERT", "\"db table\"", "insert \"db table\"")),
+            expect("INSERT", "db table", "insert", "\"db table\"", "insert \"db table\"")),
         Arguments.of(
             "delete from \"my table\" where something something",
-            expect("DELETE", "my table", "DELETE", "\"my table\"", "delete \"my table\"")),
+            expect("DELETE", "my table", "delete", "\"my table\"", "delete \"my table\"")),
         Arguments.of(
             "update \"my table\" set answer=42",
             expect(
                 "update \"my table\" set answer=?",
                 "UPDATE",
                 "my table",
-                "UPDATE",
+                "update",
                 "\"my table\"",
                 "update \"my table\"")),
         Arguments.of(
             "merge into \"my table\"",
-            expect("MERGE", "my table", "MERGE", "\"my table\"", "merge \"my table\"")));
+            expect("MERGE", "my table", "merge", "\"my table\"", "merge \"my table\"")));
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -1020,7 +1020,7 @@ class SqlQueryAnalyzerTest {
                 null,
                 null,
                 "TRUNCATE TABLE",
-                null,
+                "users",
                 "TRUNCATE TABLE users")),
         Arguments.of(
             "TRUNCATE users",
@@ -1032,7 +1032,7 @@ class SqlQueryAnalyzerTest {
                 null,
                 null,
                 "TRUNCATE TABLE",
-                null,
+                "schema.table",
                 "TRUNCATE TABLE schema.table")),
 
         // REPLACE statement (MySQL)

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
@@ -10,7 +10,9 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -145,6 +147,8 @@ class CassandraTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM_NAME, CASSANDRA),
                               equalTo(DB_NAMESPACE, "test"),
+                              equalTo(DB_OPERATION_NAME, "SELECT"),
+                              equalTo(DB_COLLECTION_NAME, "test.users"),
                               equalTo(
                                   DB_QUERY_TEXT,
                                   "select * from test.users where id=1 ALLOW FILTERING"),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
@@ -147,7 +147,7 @@ class CassandraTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
                               equalTo(NETWORK_PEER_PORT, cassandraPort),
                               equalTo(DB_SYSTEM_NAME, CASSANDRA),
                               equalTo(DB_NAMESPACE, "test"),
-                              equalTo(DB_OPERATION_NAME, "SELECT"),
+                              equalTo(DB_OPERATION_NAME, "select"),
                               equalTo(DB_COLLECTION_NAME, "test.users"),
                               equalTo(
                                   DB_QUERY_TEXT,

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -37,6 +37,7 @@ class CassandraSingletons {
             .addAttributesExtractor(
                 SqlClientAttributesExtractor.builder(attributesGetter)
                     .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setSingleOperationAndCollection(true)
                     .setQuerySanitizationEnabled(
                         DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
                     .build())

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -119,6 +121,9 @@ class CassandraClientTest {
                               equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                               equalTo(maybeStable(DB_STATEMENT), "USE " + parameter.keyspace),
                               equalTo(
+                                  maybeStable(DB_OPERATION),
+                                  emitStableDatabaseSemconv() ? "USE" : null),
+                              equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv()
                                       ? "USE " + parameter.keyspace
@@ -141,12 +146,8 @@ class CassandraClientTest {
                               equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
-                              equalTo(
-                                  maybeStable(DB_OPERATION),
-                                  emitStableDatabaseSemconv() ? null : parameter.operation),
-                              equalTo(
-                                  maybeStable(DB_CASSANDRA_TABLE),
-                                  emitStableDatabaseSemconv() ? null : parameter.table))));
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     } else {
       testing.waitAndAssertTraces(
           trace ->
@@ -166,12 +167,8 @@ class CassandraClientTest {
                               equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
-                              equalTo(
-                                  maybeStable(DB_OPERATION),
-                                  emitStableDatabaseSemconv() ? null : parameter.operation),
-                              equalTo(
-                                  maybeStable(DB_CASSANDRA_TABLE),
-                                  emitStableDatabaseSemconv() ? null : parameter.table))));
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     }
   }
 
@@ -208,6 +205,9 @@ class CassandraClientTest {
                               equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                               equalTo(maybeStable(DB_STATEMENT), "USE " + parameter.keyspace),
                               equalTo(
+                                  maybeStable(DB_OPERATION),
+                                  emitStableDatabaseSemconv() ? "USE" : null),
+                              equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv()
                                       ? "USE " + parameter.keyspace
@@ -231,12 +231,8 @@ class CassandraClientTest {
                               equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
-                              equalTo(
-                                  maybeStable(DB_OPERATION),
-                                  emitStableDatabaseSemconv() ? null : parameter.operation),
-                              equalTo(
-                                  maybeStable(DB_CASSANDRA_TABLE),
-                                  emitStableDatabaseSemconv() ? null : parameter.table)),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
                           .hasKind(SpanKind.INTERNAL)
@@ -261,12 +257,8 @@ class CassandraClientTest {
                               equalTo(
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
-                              equalTo(
-                                  maybeStable(DB_OPERATION),
-                                  emitStableDatabaseSemconv() ? null : parameter.operation),
-                              equalTo(
-                                  maybeStable(DB_CASSANDRA_TABLE),
-                                  emitStableDatabaseSemconv() ? null : parameter.table)),
+                              equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
                           .hasKind(SpanKind.INTERNAL)
@@ -279,12 +271,19 @@ class CassandraClientTest {
     Session session = cluster.connect();
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS non_existent");
+    session.execute("DROP KEYSPACE IF EXISTS metrics_test");
+    session.execute(
+        "CREATE KEYSPACE metrics_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    testing.clearData();
+
+    session.execute("CREATE TABLE metrics_test.users ( id UUID PRIMARY KEY, name text )");
 
     assertDurationMetric(
         testing,
         "io.opentelemetry.cassandra-3.0",
         DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
         DB_QUERY_SUMMARY,
         NETWORK_PEER_ADDRESS,
         NETWORK_PEER_PORT,

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
@@ -36,6 +36,7 @@ class CassandraSingletons {
             .addAttributesExtractor(
                 SqlClientAttributesExtractor.builder(attributesGetter)
                     .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setSingleOperationAndCollection(true)
                     .setQuerySanitizationEnabled(
                         DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "cassandra"))
                     .build())

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
@@ -67,6 +67,7 @@ public final class CassandraTelemetryBuilder {
             .addAttributesExtractor(
                 SqlClientAttributesExtractor.builder(attributesGetter)
                     .setTableAttribute(DB_CASSANDRA_TABLE)
+                    .setSingleOperationAndCollection(true)
                     .setQuerySanitizationEnabled(querySanitizationEnabled)
                     .build())
             .addAttributesExtractor(new CassandraAttributesExtractor())

--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -80,9 +80,7 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? parameter.spanName : null),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv() ? null : parameter.operation),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -93,9 +91,7 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
                                 equalTo(maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_TABLE),
-                                    emitStableDatabaseSemconv() ? null : parameter.table)),
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -100,12 +102,19 @@ public abstract class AbstractCassandraTest {
     CqlSession session = getSession(null);
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS non_existent");
+    session.execute("DROP KEYSPACE IF EXISTS metrics_test");
+    session.execute(
+        "CREATE KEYSPACE metrics_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    testing().clearData();
+
+    session.execute("CREATE TABLE metrics_test.users ( id UUID PRIMARY KEY, name text )");
 
     assertDurationMetric(
         testing(),
         getInstrumentationName(),
         DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
         DB_QUERY_SUMMARY,
         NETWORK_PEER_ADDRESS,
         NETWORK_PEER_PORT,
@@ -145,9 +154,7 @@ public abstract class AbstractCassandraTest {
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? parameter.spanName : null),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv() ? null : parameter.operation),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -158,9 +165,7 @@ public abstract class AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
                                 equalTo(maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_TABLE),
-                                    emitStableDatabaseSemconv() ? null : parameter.table))));
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
   }
 
   @ParameterizedTest(name = "{index}: {0}")
@@ -204,9 +209,7 @@ public abstract class AbstractCassandraTest {
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? parameter.spanName : null),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv() ? null : parameter.operation),
+                                equalTo(maybeStable(DB_OPERATION), parameter.operation),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -217,9 +220,7 @@ public abstract class AbstractCassandraTest {
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
                                 equalTo(maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_TABLE),
-                                    emitStableDatabaseSemconv() ? null : parameter.table)),
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -45,6 +45,7 @@ public abstract class CouchbaseRequestInfo {
     return new AutoValue_CouchbaseRequestInfo(bucket, null, null, operation, true);
   }
 
+  @SuppressWarnings("deprecation") // using deprecated old semconv operation
   public static CouchbaseRequestInfo create(@Nullable String bucket, Object query) {
     SqlQuery sqlQuery = emitOldDatabaseSemconv() ? CouchbaseQuerySanitizer.analyze(query) : null;
     SqlQuery sqlQueryWithSummary =

--- a/instrumentation/hibernate/hibernate-common-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/common/v3_3/OperationNameUtil.java
+++ b/instrumentation/hibernate/hibernate-common-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/common/v3_3/OperationNameUtil.java
@@ -39,6 +39,7 @@ public class OperationNameUtil {
     return getOperationNameForQueryOldSemconv(query);
   }
 
+  @SuppressWarnings("deprecation") // using deprecated old semconv operation
   private static String getOperationNameForQueryOldSemconv(@Nullable String query) {
     // set operation to default value that is used when sql sanitizer fails to extract
     // operation name


### PR DESCRIPTION
Cassandra CQL only supports a single operation and single collection per query, so should capture `db.operation.name` and `db.collection.name` under stable db semconv (e.g. similar to mongo).