### PR TITLE
Close BufferedWriter in code

### DIFF
--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -77,41 +77,42 @@ class YamlHelperTest {
             .build());
 
     StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
+    try (BufferedWriter writer = new BufferedWriter(stringWriter)) {
 
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
+        YamlHelper.generateInstrumentationYaml(modules, writer);
+        writer.flush();
 
-    String expectedYaml =
-        """
-        libraries:
-        - name: spring-web-6.0
-          display_name: Spring Web
-          description: Spring Web 6.0 instrumentation
-          semantic_conventions:
-          - DATABASE_CLIENT_METRICS
-          - DATABASE_CLIENT_SPANS
-          disabled_by_default: true
-          source_path: instrumentation/spring/spring-web/spring-web-6.0
-          minimum_java_version: 11
-          scope:
-            name: io.opentelemetry.spring-web-6.0
-            schema_url: http:://www.schema.org
-            attributes:
-              instrumentation.type: library
-              version.major: 6
-          javaagent_target_versions:
-          - org.springframework:spring-web:[6.0.0,)
-        - name: struts-2.3
-          source_path: instrumentation/struts/struts-2.3
-          scope:
-            name: io.opentelemetry.struts-2.3
-          has_standalone_library: true
-          javaagent_target_versions:
-          - org.apache.struts:struts2-core:2.1.0
-        """;
+        String expectedYaml =
+            """
+            libraries:
+            - name: spring-web-6.0
+              display_name: Spring Web
+              description: Spring Web 6.0 instrumentation
+              semantic_conventions:
+              - DATABASE_CLIENT_METRICS
+              - DATABASE_CLIENT_SPANS
+              disabled_by_default: true
+              source_path: instrumentation/spring/spring-web/spring-web-6.0
+              minimum_java_version: 11
+              scope:
+                name: io.opentelemetry.spring-web-6.0
+                schema_url: http:://www.schema.org
+                attributes:
+                  instrumentation.type: library
+                  version.major: 6
+              javaagent_target_versions:
+              - org.springframework:spring-web:[6.0.0,)
+            - name: struts-2.3
+              source_path: instrumentation/struts/struts-2.3
+              scope:
+                name: io.opentelemetry.struts-2.3
+              has_standalone_library: true
+              javaagent_target_versions:
+              - org.apache.struts:struts2-core:2.1.0
+            """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+        assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    }
   }
 
   @Test

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -76,43 +77,37 @@ class YamlHelperTest {
             .group("struts")
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    try (BufferedWriter writer = new BufferedWriter(stringWriter)) {
+    String result = generateInstrumentationYaml(modules);
+    String expectedYaml =
+        """
+        libraries:
+        - name: spring-web-6.0
+          display_name: Spring Web
+          description: Spring Web 6.0 instrumentation
+          semantic_conventions:
+          - DATABASE_CLIENT_METRICS
+          - DATABASE_CLIENT_SPANS
+          disabled_by_default: true
+          source_path: instrumentation/spring/spring-web/spring-web-6.0
+          minimum_java_version: 11
+          scope:
+            name: io.opentelemetry.spring-web-6.0
+            schema_url: http:://www.schema.org
+            attributes:
+              instrumentation.type: library
+              version.major: 6
+          javaagent_target_versions:
+          - org.springframework:spring-web:[6.0.0,)
+        - name: struts-2.3
+          source_path: instrumentation/struts/struts-2.3
+          scope:
+            name: io.opentelemetry.struts-2.3
+          has_standalone_library: true
+          javaagent_target_versions:
+          - org.apache.struts:struts2-core:2.1.0
+        """;
 
-        YamlHelper.generateInstrumentationYaml(modules, writer);
-        writer.flush();
-
-        String expectedYaml =
-            """
-            libraries:
-            - name: spring-web-6.0
-              display_name: Spring Web
-              description: Spring Web 6.0 instrumentation
-              semantic_conventions:
-              - DATABASE_CLIENT_METRICS
-              - DATABASE_CLIENT_SPANS
-              disabled_by_default: true
-              source_path: instrumentation/spring/spring-web/spring-web-6.0
-              minimum_java_version: 11
-              scope:
-                name: io.opentelemetry.spring-web-6.0
-                schema_url: http:://www.schema.org
-                attributes:
-                  instrumentation.type: library
-                  version.major: 6
-              javaagent_target_versions:
-              - org.springframework:spring-web:[6.0.0,)
-            - name: struts-2.3
-              source_path: instrumentation/struts/struts-2.3
-              scope:
-                name: io.opentelemetry.struts-2.3
-              has_standalone_library: true
-              javaagent_target_versions:
-              - org.apache.struts:struts2-core:2.1.0
-            """;
-
-        assertThat(expectedYaml).isEqualTo(stringWriter.toString());
-    }
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -176,12 +171,7 @@ class YamlHelperTest {
                 Set.of("io.opentelemetry:opentelemetry-extension-annotations:[0.16.0,)"))
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
             libraries:
@@ -213,7 +203,7 @@ class YamlHelperTest {
               - io.opentelemetry:opentelemetry-extension-annotations:[0.16.0,)
             """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -238,12 +228,7 @@ class YamlHelperTest {
                     "org.springframework.data:spring-data-commons:[1.8.0.RELEASE,)"))
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
         libraries:
@@ -263,7 +248,7 @@ class YamlHelperTest {
           - org.springframework:spring-aop:[1.2,)
         """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -409,12 +394,7 @@ class YamlHelperTest {
             .metrics(Map.of("default", List.of(metric)))
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
         libraries:
@@ -445,7 +425,7 @@ class YamlHelperTest {
                 type: LONG
         """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -469,12 +449,7 @@ class YamlHelperTest {
             .metrics(Map.of("default", metrics))
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
         libraries:
@@ -511,7 +486,7 @@ class YamlHelperTest {
               attributes: []
         """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -538,12 +513,7 @@ class YamlHelperTest {
             .spans(Map.of("default", List.of(span)))
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
         libraries:
@@ -569,7 +539,7 @@ class YamlHelperTest {
                 type: LONG
         """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -599,11 +569,7 @@ class YamlHelperTest {
             .spans(spans1)
             .build());
 
-    StringWriter stringWriter1 = new StringWriter();
-    BufferedWriter writer1 = new BufferedWriter(stringWriter1);
-    YamlHelper.generateInstrumentationYaml(modules1, writer1);
-    writer1.flush();
-    String yaml1 = stringWriter1.toString();
+    String yaml1 = generateInstrumentationYaml(modules1);
 
     // Different ordering
     Map<String, List<EmittedMetrics.Metric>> metrics2 = new LinkedHashMap<>();
@@ -626,11 +592,7 @@ class YamlHelperTest {
             .spans(spans2)
             .build());
 
-    StringWriter stringWriter2 = new StringWriter();
-    BufferedWriter writer2 = new BufferedWriter(stringWriter2);
-    YamlHelper.generateInstrumentationYaml(modules2, writer2);
-    writer2.flush();
-    String yaml2 = stringWriter2.toString();
+    String yaml2 = generateInstrumentationYaml(modules2);
 
     assertThat(yaml1).isEqualTo(yaml2);
   }
@@ -676,12 +638,7 @@ class YamlHelperTest {
             .metadata(metadataWithoutLink)
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
             libraries:
@@ -702,7 +659,7 @@ class YamlHelperTest {
               - com.example:test-library:[1.0.0,)
             """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -727,12 +684,7 @@ class YamlHelperTest {
             .hasStandaloneLibrary(true)
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
         libraries:
@@ -748,7 +700,7 @@ class YamlHelperTest {
           has_javaagent: true
         """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
   }
 
   @Test
@@ -794,12 +746,7 @@ class YamlHelperTest {
             .metadata(metadata)
             .build());
 
-    StringWriter stringWriter = new StringWriter();
-    BufferedWriter writer = new BufferedWriter(stringWriter);
-
-    YamlHelper.generateInstrumentationYaml(modules, writer);
-    writer.flush();
-
+    String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
             libraries:
@@ -825,6 +772,15 @@ class YamlHelperTest {
                 name: io.opentelemetry.opentelemetry-api-2.0
             """;
 
-    assertThat(expectedYaml).isEqualTo(stringWriter.toString());
+    assertThat(result).isEqualTo(expectedYaml);
+  }
+
+  private static String generateInstrumentationYaml(List<InstrumentationModule> modules)
+      throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    try (BufferedWriter writer = new BufferedWriter(stringWriter)) {
+      YamlHelper.generateInstrumentationYaml(modules, writer);
+    }
+    return stringWriter.toString();
   }
 }


### PR DESCRIPTION
Not sure how often code hits the edge case, but The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Close this if it’s not worth the noise.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.