### PR TITLE
Fix logback MDC declarative config keys

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
@@ -169,11 +169,9 @@ class LogbackAppenderInstaller {
     }
 
     String mdcAttributeProperty =
-        applicationEnvironmentPreparedEvent
-            .getEnvironment()
-            .getProperty(
-                "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes",
-                String.class);
+        getLoggingProperty(
+            applicationEnvironmentPreparedEvent.getEnvironment(),
+            "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes");
     if (mdcAttributeProperty != null) {
       openTelemetryAppender.setCaptureMdcAttributes(mdcAttributeProperty);
     }
@@ -260,16 +258,35 @@ class LogbackAppenderInstaller {
       ConfigurableEnvironment environment, String property) {
     if (EarlyConfig.isDeclarativeConfig(environment)) {
       if (property.startsWith("otel.instrumentation.")) {
-        return String.format(
-                "otel.instrumentation/development.java.%s",
-                property.substring("otel.instrumentation.".length()))
-            .replace('-', '_');
+        return "otel.instrumentation/development.java."
+            + toDeclarativeInstrumentationPropertyName(
+                property.substring("otel.instrumentation.".length()));
       } else {
         throw new IllegalStateException(
             "No mapping found for property name: " + property + ". Please report this bug.");
       }
     }
     return property;
+  }
+
+  private static String toDeclarativeInstrumentationPropertyName(String instrumentationProperty) {
+    StringBuilder declarativeProperty = new StringBuilder();
+    boolean nextSegmentIsDevelopment = false;
+    for (String segment : instrumentationProperty.split("\\.")) {
+      if (segment.equals("experimental")) {
+        nextSegmentIsDevelopment = true;
+        continue;
+      }
+      if (declarativeProperty.length() > 0) {
+        declarativeProperty.append('.');
+      }
+      declarativeProperty.append(segment.replace('-', '_'));
+      if (nextSegmentIsDevelopment || segment.startsWith("experimental-")) {
+        declarativeProperty.append("/development");
+        nextSegmentIsDevelopment = false;
+      }
+    }
+    return declarativeProperty.toString();
   }
 
   private static <T> Optional<T> findAppender(Class<T> appenderClass) {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderInstaller.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppen
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.EarlyConfig;
 import java.util.Iterator;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -217,48 +218,58 @@ class LogbackAppenderInstaller {
     }
 
     String traceIdKey =
-        applicationEnvironmentPreparedEvent
-            .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.trace-id", String.class);
+        getLoggingProperty(
+            applicationEnvironmentPreparedEvent.getEnvironment(),
+            "otel.instrumentation.common.logging.trace-id");
     if (traceIdKey != null) {
       openTelemetryAppender.setTraceIdKey(traceIdKey);
     }
 
     String spanIdKey =
-        applicationEnvironmentPreparedEvent
-            .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.span-id", String.class);
+        getLoggingProperty(
+            applicationEnvironmentPreparedEvent.getEnvironment(),
+            "otel.instrumentation.common.logging.span-id");
     if (spanIdKey != null) {
       openTelemetryAppender.setSpanIdKey(spanIdKey);
     }
 
     String traceFlagsKey =
-        applicationEnvironmentPreparedEvent
-            .getEnvironment()
-            .getProperty("otel.instrumentation.common.logging.trace-flags", String.class);
+        getLoggingProperty(
+            applicationEnvironmentPreparedEvent.getEnvironment(),
+            "otel.instrumentation.common.logging.trace-flags");
     if (traceFlagsKey != null) {
       openTelemetryAppender.setTraceFlagsKey(traceFlagsKey);
     }
   }
 
+  @Nullable
+  private static String getLoggingProperty(ConfigurableEnvironment environment, String property) {
+    return environment.getProperty(getEnvironmentPropertyName(environment, property), String.class);
+  }
+
   /** Evaluates a boolean property, taking into account whether declarative config is in use. */
+  @Nullable
   private static Boolean evaluateBooleanProperty(
       ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent, String property) {
     ConfigurableEnvironment environment = applicationEnvironmentPreparedEvent.getEnvironment();
-    String key = property;
+    return environment.getProperty(
+        getEnvironmentPropertyName(environment, property), Boolean.class);
+  }
+
+  private static String getEnvironmentPropertyName(
+      ConfigurableEnvironment environment, String property) {
     if (EarlyConfig.isDeclarativeConfig(environment)) {
       if (property.startsWith("otel.instrumentation.")) {
-        key =
-            String.format(
-                    "otel.instrumentation/development.java.%s",
-                    property.substring("otel.instrumentation.".length()))
-                .replace('-', '_');
+        return String.format(
+                "otel.instrumentation/development.java.%s",
+                property.substring("otel.instrumentation.".length()))
+            .replace('-', '_');
       } else {
         throw new IllegalStateException(
             "No mapping found for property name: " + property + ". Please report this bug.");
       }
     }
-    return environment.getProperty(key, Boolean.class);
+    return property;
   }
 
   private static <T> Optional<T> findAppender(Class<T> appenderClass) {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
@@ -149,15 +149,27 @@ class LogbackAppenderTest {
     assertThat(testing.logRecords()).isEmpty();
   }
 
-  @Test
-  void mdcAppender() {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void mdcAppender(boolean declarativeConfig) {
     Map<String, Object> properties = new HashMap<>();
     properties.put("logging.config", "classpath:logback-test.xml");
-    properties.put("otel.instrumentation.logback-appender.enabled", "false");
-    properties.put("otel.instrumentation.logback-mdc.add-baggage", "true");
-    properties.put("otel.instrumentation.common.logging.trace-id", "traceid");
-    properties.put("otel.instrumentation.common.logging.span-id", "spanid");
-    properties.put("otel.instrumentation.common.logging.trace-flags", "traceflags");
+    if (declarativeConfig) {
+      properties.put("otel.file_format", "1.0");
+      properties.put(
+          "otel.distribution.spring_starter.instrumentation.disabled[0]", "logback_appender");
+      properties.put("otel.instrumentation/development.java.logback_mdc.add_baggage", "true");
+      properties.put("otel.instrumentation/development.java.common.logging.trace_id", "traceid");
+      properties.put("otel.instrumentation/development.java.common.logging.span_id", "spanid");
+      properties.put(
+          "otel.instrumentation/development.java.common.logging.trace_flags", "traceflags");
+    } else {
+      properties.put("otel.instrumentation.logback-appender.enabled", "false");
+      properties.put("otel.instrumentation.logback-mdc.add-baggage", "true");
+      properties.put("otel.instrumentation.common.logging.trace-id", "traceid");
+      properties.put("otel.instrumentation.common.logging.span-id", "spanid");
+      properties.put("otel.instrumentation.common.logging.trace-flags", "traceflags");
+    }
 
     SpringApplication app =
         new SpringApplication(

--- a/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testLogbackAppender/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/logging/LogbackAppenderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
@@ -69,15 +70,33 @@ class LogbackAppenderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"logback-test.xml", "logback-test-no-mdc.xml"})
-  void shouldInitializeAppender(String configurationFile) {
+  @CsvSource({
+    "logback-test.xml, false",
+    "logback-test-no-mdc.xml, false",
+    "logback-test.xml, true",
+    "logback-test-no-mdc.xml, true"
+  })
+  void shouldInitializeAppender(String configurationFile, boolean declarativeConfig) {
     Map<String, Object> properties = new HashMap<>();
     properties.put("logging.config", "classpath:" + configurationFile);
-    properties.put(
-        "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes", "*");
-    properties.put(
-        "otel.instrumentation.logback-appender.experimental.capture-code-attributes", false);
-    properties.put("otel.instrumentation.logback-appender.experimental.capture-template", true);
+    if (declarativeConfig) {
+      properties.put("otel.file_format", "1.0");
+      properties.put(
+          "otel.instrumentation/development.java.logback_appender.capture_mdc_attributes/development",
+          "*");
+      properties.put(
+          "otel.instrumentation/development.java.logback_appender.capture_code_attributes/development",
+          false);
+      properties.put(
+          "otel.instrumentation/development.java.logback_appender.capture_template/development",
+          true);
+    } else {
+      properties.put(
+          "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes", "*");
+      properties.put(
+          "otel.instrumentation.logback-appender.experimental.capture-code-attributes", false);
+      properties.put("otel.instrumentation.logback-appender.experimental.capture-template", true);
+    }
 
     SpringApplication app =
         new SpringApplication(


### PR DESCRIPTION
Fix Spring starter Logback declarative config handling during early logging initialization. The Logback appenders are configured from Spring's `ApplicationEnvironmentPreparedEvent`, before the normal declarative config bridge is available, so their early `Environment` reads need to translate flat `otel.instrumentation.*` property names to declarative Spring Environment names.

This applies that mapping to the MDC key-name settings and updates the mapper to handle experimental Logback appender keys such as `capture_code_attributes/development` and `capture_mdc_attributes/development`, with coverage for both flat and declarative property forms.