### PR TITLE
Remove deprecated db config names when v3 preview is enabled

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.config.internal;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -98,24 +99,26 @@ public final class DbConfig {
       return value;
     }
 
-    // this variant was never a regular (non-declarative) configuration property name
-    Boolean deprecatedStatementSanitizerValue =
-        commonConfig.get("database").get("statement_sanitizer").getBoolean("enabled");
-    if (deprecatedStatementSanitizerValue != null) {
-      warnIfDeprecatedDeclarativeConfigurationUsed(
-          "instrumentation/development: java: common: database: statement_sanitizer: enabled",
-          "instrumentation/development: java: common: db: query_sanitization: enabled");
-      return deprecatedStatementSanitizerValue;
-    }
+    if (!SemconvStability.v3Preview()) {
+      // this variant was never a regular (non-declarative) configuration property name
+      Boolean deprecatedStatementSanitizerValue =
+          commonConfig.get("database").get("statement_sanitizer").getBoolean("enabled");
+      if (deprecatedStatementSanitizerValue != null) {
+        warnIfDeprecatedDeclarativeConfigurationUsed(
+            "instrumentation/development: java: common: database: statement_sanitizer: enabled",
+            "instrumentation/development: java: common: db: query_sanitization: enabled");
+        return deprecatedStatementSanitizerValue;
+      }
 
-    // this variant was never a declarative configuration property name
-    Boolean deprecatedStatementSanitizerPropertyValue =
-        commonConfig.get("db_statement_sanitizer").getBoolean("enabled");
-    if (deprecatedStatementSanitizerPropertyValue != null) {
-      warnIfDeprecatedSystemPropertyUsed(
-          "otel.instrumentation.common.db-statement-sanitizer.enabled",
-          "otel.instrumentation.common.db.query-sanitization.enabled");
-      return deprecatedStatementSanitizerPropertyValue;
+      // this variant was never a declarative configuration property name
+      Boolean deprecatedStatementSanitizerPropertyValue =
+          commonConfig.get("db_statement_sanitizer").getBoolean("enabled");
+      if (deprecatedStatementSanitizerPropertyValue != null) {
+        warnIfDeprecatedSystemPropertyUsed(
+            "otel.instrumentation.common.db-statement-sanitizer.enabled",
+            "otel.instrumentation.common.db.query-sanitization.enabled");
+        return deprecatedStatementSanitizerPropertyValue;
+      }
     }
 
     return null;
@@ -129,10 +132,12 @@ public final class DbConfig {
       return value;
     }
 
-    Boolean deprecatedValue = config.get("statement_sanitizer").getBoolean("enabled");
-    if (deprecatedValue != null) {
-      warnIfDeprecatedSettingOrEquivalentUsed(deprecatedProperty, replacementProperty);
-      return deprecatedValue;
+    if (!SemconvStability.v3Preview()) {
+      Boolean deprecatedValue = config.get("statement_sanitizer").getBoolean("enabled");
+      if (deprecatedValue != null) {
+        warnIfDeprecatedSettingOrEquivalentUsed(deprecatedProperty, replacementProperty);
+        return deprecatedValue;
+      }
     }
 
     return null;

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.util.List;
 import javax.sql.DataSource;
@@ -52,8 +53,10 @@ public final class JdbcInstrumenterFactory {
             openTelemetry,
             ConfigPropertiesUtil.getBoolean(
                 "otel.instrumentation.common.db.query-sanitization.enabled",
-                ConfigPropertiesUtil.getBoolean(
-                    "otel.instrumentation.common.db-statement-sanitizer.enabled", true)));
+                SemconvStability.v3Preview()
+                    ? true
+                    : ConfigPropertiesUtil.getBoolean(
+                        "otel.instrumentation.common.db-statement-sanitizer.enabled", true)));
     return createStatementInstrumenter(
         openTelemetry, emptyList(), true, querySanitizationEnabled, captureQueryParameters);
   }


### PR DESCRIPTION
## Summary

- In `DbConfig`, skips reading deprecated config aliases (`database.statement_sanitizer`, `db_statement_sanitizer` / `otel.instrumentation.common.db-statement-sanitizer.enabled`) when `otel.instrumentation.common.v3-preview` is true
- In `JdbcInstrumenterFactory`, skips the deprecated `otel.instrumentation.common.db-statement-sanitizer.enabled` flat-property fallback under the same flag
- These aliases will be unconditionally removed in 3.0; this change lets users opt in early to verify they've migrated

## Related

Closes part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15810 (old deprecated config-name cleanup bucket)

## Test plan

- [ ] Existing JDBC tests pass
- [ ] Manual: set `otel.instrumentation.common.v3-preview=true` and verify deprecated property is ignored