### PR TITLE
Recover pulsar wrapped message ids

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -10,11 +10,28 @@ import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.p
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.ProducerData;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 
 public class PulsarRequest extends BasePulsarRequest {
+  private static final ClassValue<Optional<Method>> INNER_MESSAGE_ID_METHOD =
+      new ClassValue<Optional<Method>>() {
+        @Override
+        protected Optional<Method> computeValue(Class<?> type) {
+          return findMethod(type, "getInnerMessageId");
+        }
+      };
+
+  private static final ClassValue<Optional<Method>> INNER_MESSAGE_METHOD =
+      new ClassValue<Optional<Method>>() {
+        @Override
+        protected Optional<Method> computeValue(Class<?> type) {
+          return findMethod(type, "getMessage");
+        }
+      };
+
   private final Message<?> message;
   private final String messageId;
 
@@ -78,8 +95,15 @@ public class PulsarRequest extends BasePulsarRequest {
   @Nullable
   private static MessageId invokeMessageIdMethod(Message<?> message, String methodName) {
     try {
-      Method method = message.getClass().getMethod(methodName);
-      Object result = method.invoke(message);
+      Optional<Method> method =
+          "getInnerMessageId".equals(methodName)
+              ? INNER_MESSAGE_ID_METHOD.get(message.getClass())
+              : findMethod(message.getClass(), methodName);
+      Method cachedMethod = method.orElse(null);
+      if (cachedMethod == null) {
+        return null;
+      }
+      Object result = cachedMethod.invoke(message);
       return result instanceof MessageId ? (MessageId) result : null;
     } catch (Throwable ignored) {
       return null;
@@ -92,11 +116,26 @@ public class PulsarRequest extends BasePulsarRequest {
   @Nullable
   private static Message<?> invokeMessageMethod(Message<?> message, String methodName) {
     try {
-      Method method = message.getClass().getMethod(methodName);
-      Object result = method.invoke(message);
+      Optional<Method> method =
+          "getMessage".equals(methodName)
+              ? INNER_MESSAGE_METHOD.get(message.getClass())
+              : findMethod(message.getClass(), methodName);
+      Method cachedMethod = method.orElse(null);
+      if (cachedMethod == null) {
+        return null;
+      }
+      Object result = cachedMethod.invoke(message);
       return result instanceof Message ? (Message<?>) result : null;
     } catch (Throwable ignored) {
       return null;
+    }
+  }
+
+  private static Optional<Method> findMethod(Class<?> type, String methodName) {
+    try {
+      return Optional.of(type.getMethod(methodName));
+    } catch (Throwable ignored) {
+      return Optional.empty();
     }
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -39,7 +39,8 @@ public class PulsarRequest extends BasePulsarRequest {
     this.message = message;
     // for producer spans message id is not available when the PulsarRequest is created, so we will
     // try to get it later when it's available
-    this.messageId = extractMessageId(message);
+    MessageId id = message.getMessageId();
+    this.messageId = id != null ? id.toString() : null;
   }
 
   public Message<?> getMessage() {
@@ -80,7 +81,7 @@ public class PulsarRequest extends BasePulsarRequest {
       Method method = message.getClass().getMethod(methodName);
       Object result = method.invoke(message);
       return result instanceof MessageId ? (MessageId) result : null;
-    } catch (ReflectiveOperationException ignored) {
+    } catch (Throwable ignored) {
       return null;
     }
   }
@@ -94,7 +95,7 @@ public class PulsarRequest extends BasePulsarRequest {
       Method method = message.getClass().getMethod(methodName);
       Object result = method.invoke(message);
       return result instanceof Message ? (Message<?>) result : null;
-    } catch (ReflectiveOperationException ignored) {
+    } catch (Throwable ignored) {
       return null;
     }
   }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.p
 
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.ProducerData;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
+import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -38,8 +39,7 @@ public class PulsarRequest extends BasePulsarRequest {
     this.message = message;
     // for producer spans message id is not available when the PulsarRequest is created, so we will
     // try to get it later when it's available
-    MessageId id = message.getMessageId();
-    this.messageId = id != null ? id.toString() : null;
+    this.messageId = extractMessageId(message);
   }
 
   public Message<?> getMessage() {
@@ -51,7 +51,51 @@ public class PulsarRequest extends BasePulsarRequest {
     if (messageId != null) {
       return messageId;
     }
+    return extractMessageId(message);
+  }
+
+  @Nullable
+  private static String extractMessageId(Message<?> message) {
     MessageId id = message.getMessageId();
-    return id != null ? id.toString() : null;
+    if (id != null) {
+      return id.toString();
+    }
+    id = invokeMessageIdMethod(message, "getInnerMessageId");
+    if (id != null) {
+      return id.toString();
+    }
+    Message<?> innerMessage = invokeMessageMethod(message, "getMessage");
+    if (innerMessage != null) {
+      MessageId innerId = innerMessage.getMessageId();
+      if (innerId != null) {
+        return innerId.toString();
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static MessageId invokeMessageIdMethod(Message<?> message, String methodName) {
+    try {
+      Method method = message.getClass().getMethod(methodName);
+      Object result = method.invoke(message);
+      return result instanceof MessageId ? (MessageId) result : null;
+    } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
+  }
+
+  // Reflection can only tell us this is some Message<?> implementation; erasing to Message<?> is
+  // safe because we only call getMessageId() on the returned value.
+  @SuppressWarnings("unchecked")
+  @Nullable
+  private static Message<?> invokeMessageMethod(Message<?> message, String methodName) {
+    try {
+      Method method = message.getClass().getMethod(methodName);
+      Object result = method.invoke(message);
+      return result instanceof Message ? (Message<?>) result : null;
+    } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Some `Message` implementations returned by pulsar-client (e.g. `TopicMessageImpl` from multi-topic consumers) wrap the underlying message and return `null` from `getMessageId()` on certain versions. Reflectively fall back to `getInnerMessageId()` or `getMessage().getMessageId()` on the wrapper to recover the id.
- Restores `messaging.message.id` attribute for `PulsarClientTest.testConsumeMultiTopics`.
- Main CI stays green because pinned pulsar-client 4.2.1 still returns a non-null id from the wrapper; the bug only surfaces on newer (unpinned) pulsar-client versions.

## Test plan
- [ ] CI green on pulsar-2.8 javaagent tests