### PR TITLE
Add v3 preview config fallback

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -43,7 +43,7 @@ public final class SemconvStability {
 
   static {
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.getOrNoop();
-    v3Preview = getInstrumentationConfig(openTelemetry, "common").getBoolean("v3_preview", false);
+    v3Preview = resolveV3Preview(openTelemetry);
     Set<String> optInValues = resolveOptInValues(openTelemetry, "opt_in");
     Set<String> previewValues = resolveOptInValues(openTelemetry, "preview");
 
@@ -62,6 +62,15 @@ public final class SemconvStability {
 
     emitOldMessagingSemconv = shouldEmitOld("messaging", false, previewValues);
     emitStableMessagingSemconv = shouldEmitStable("messaging", false, previewValues);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated config property fallback
+  static boolean resolveV3Preview(OpenTelemetry openTelemetry) {
+    Boolean value = getInstrumentationConfig(openTelemetry, "common").getBoolean("v3_preview");
+    if (value != null) {
+      return value;
+    }
+    return ConfigPropertiesUtil.getBoolean("otel.semconv-stability.v3-preview", false);
   }
 
   @SuppressWarnings("deprecation") // using deprecated config property fallback

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -65,7 +65,7 @@ public final class SemconvStability {
   }
 
   @SuppressWarnings("deprecation") // using deprecated config property fallback
-  static boolean resolveV3Preview(OpenTelemetry openTelemetry) {
+  private static boolean resolveV3Preview(OpenTelemetry openTelemetry) {
     Boolean value = getInstrumentationConfig(openTelemetry, "common").getBoolean("v3_preview");
     if (value != null) {
       return value;


### PR DESCRIPTION
Make `common.v3_preview` fall back to `otel.semconv-stability.v3-preview` via `ConfigPropertiesUtil` when declarative config does not provide a value. This keeps v3 preview resolution consistent with the existing semconv stability `opt_in` and `preview` flags, which read declarative config first and fall back to system properties/environment variables.

Motivated by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18934/changes#r3373093942