### PR TITLE
Propagate Log4j appender context through async loggers

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -142,7 +142,15 @@ configuration:
 </Configuration>
 ```
 
-If your application already configures a custom `log4j2.ContextDataInjector`, it will need to be
-replaced or wrapped so that the OpenTelemetry `Context` is added to the Log4j event context data.
+If your application already configures a custom `log4j2.ContextDataInjector`, configure it as the
+OpenTelemetry injector's delegate:
+
+```properties
+log4j2.ContextDataInjector=io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppenderContextDataInjector
+otel.instrumentation.log4j-appender.context-data-injector.delegate=com.example.CustomContextDataInjector
+```
+
+The OpenTelemetry injector will call the delegate injector first, then add the OpenTelemetry
+`Context` to the Log4j event context data.
 
 [source code attributes]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -153,4 +153,8 @@ otel.instrumentation.log4j-appender.context-data-injector.delegate=com.example.C
 The OpenTelemetry injector will call the delegate injector first, then add the OpenTelemetry
 `Context` to the Log4j event context data.
 
+This adds an internal `otel.internal.context` context data entry to carry the OpenTelemetry `Context`.
+Applications that render all Log4j context data, for example with `%X` or JSON layouts, should
+exclude this key from log output because its value is not stable and may change without notice.
+
 [source code attributes]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -103,4 +103,46 @@ The available settings are:
 
 The `otel.event.name` key is supported in `MapMessage` entries and context data entries. When present, its value is used as the log event name and is not emitted as an attribute.
 
+#### Async Loggers
+
+When using Log4j async loggers, for example `AsyncRoot`, `AsyncLogger`, or Log4j's built-in
+`AsyncAppender`, Log4j creates the `LogEvent` on the application thread and later invokes appenders
+on a background thread. To make the `OpenTelemetryAppender` emit logs with the application thread's
+full OpenTelemetry `Context`, configure Log4j to use the OpenTelemetry appender context data
+injector:
+
+```properties
+log4j2.ContextDataInjector=io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppenderContextDataInjector
+```
+
+This is a Log4j component property and must be configured before Log4j initializes, for example via
+a JVM system property:
+
+```shell
+-Dlog4j2.ContextDataInjector=io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppenderContextDataInjector
+```
+
+or in a `log4j2.component.properties` file on the classpath. It cannot be configured reliably from
+`log4j2.xml`.
+
+With the component property set, the `log4j2.xml` configuration can use normal Log4j async logger
+configuration:
+
+```xml
+<Configuration status="WARN">
+  <Appenders>
+    <OpenTelemetry name="OpenTelemetryAppender"/>
+  </Appenders>
+
+  <Loggers>
+    <AsyncRoot level="info">
+      <AppenderRef ref="OpenTelemetryAppender"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>
+```
+
+If your application already configures a custom `log4j2.ContextDataInjector`, it will need to be
+replaced or wrapped so that the OpenTelemetry `Context` is added to the Log4j event context data.
+
 [source code attributes]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
   library("org.apache.logging.log4j:log4j-core:2.17.0")
   annotationProcessor("org.apache.logging.log4j:log4j-core:2.17.0")
 
+  // to be removed in 3.0
   implementation(project(":instrumentation:log4j:log4j-context-data:log4j-context-data-2.17:library-autoconfigure"))
 
   testImplementation(project(":instrumentation:log4j:log4j-appender-2.17:testing"))
@@ -26,7 +27,10 @@ tasks {
   val testAsyncLogger by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-DLog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
+    jvmArgs(
+      "-DLog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector",
+      "-Dlog4j2.ContextDataInjector=io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppenderContextDataInjector",
+    )
   }
 
   val testStableSemconv by registering(Test::class) {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
@@ -445,7 +445,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
     public void forEach(ReadOnlyStringMap contextData, BiConsumer<String, String> action) {
       contextData.forEach(
           (key, value) -> {
-            if (!OTEL_CONTEXT_DATA_KEY.equals(key) && value instanceof String) {
+            if (value instanceof String) {
               action.accept(key, (String) value);
             }
           });

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
@@ -377,35 +377,36 @@ public class OpenTelemetryAppender extends AbstractAppender {
       return (Context) context;
     }
     Context currentContext = Context.current();
-    if (v3Preview) {
+    if (currentContext != Context.root()) {
       return currentContext;
     }
 
-    // when using async logger we'll be executing on a different thread than what started logging
-    // reconstruct the context from context data
-    ContextDataAccessor<ReadOnlyStringMap> contextDataAccessor = ContextDataAccessorImpl.INSTANCE;
-    ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
-    String traceId = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceIdKey());
-    String spanId = contextDataAccessor.getValue(contextData, contextDataKeys.getSpanIdKey());
-    String traceFlags = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceFlags());
-    if (traceId != null && spanId != null && traceFlags != null) {
-      warnIfUsingLegacyContextDataForAsyncLoggers(event);
-      return Context.root()
-          .with(
-              Span.wrap(
-                  SpanContext.create(
-                      traceId,
-                      spanId,
-                      TraceFlags.fromHex(traceFlags, 0),
-                      TraceState.getDefault())));
+    if (!v3Preview) {
+      // when using async logger we'll be executing on a different thread than what started logging
+      // reconstruct the context from context data
+      ContextDataAccessor<ReadOnlyStringMap> contextDataAccessor = ContextDataAccessorImpl.INSTANCE;
+      ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
+      String traceId = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceIdKey());
+      String spanId = contextDataAccessor.getValue(contextData, contextDataKeys.getSpanIdKey());
+      String traceFlags =
+          contextDataAccessor.getValue(contextData, contextDataKeys.getTraceFlags());
+      if (traceId != null && spanId != null && traceFlags != null) {
+        warnIfUsingLegacyContextDataForAsyncLoggers(event);
+        return Context.root()
+            .with(
+                Span.wrap(
+                    SpanContext.create(
+                        traceId,
+                        spanId,
+                        TraceFlags.fromHex(traceFlags, 0),
+                        TraceState.getDefault())));
+      }
     }
     return currentContext;
   }
 
   private void warnIfUsingLegacyContextDataForAsyncLoggers(LogEvent event) {
-    long eventThreadId = event.getThreadId();
-    // Only warn when Log4j captured this event on a different thread from the appender thread.
-    if (eventThreadId <= 0 || eventThreadId == Thread.currentThread().getId()) {
+    if (!wasLoggedOnDifferentThread(event)) {
       return;
     }
     if (legacyContextDataWarningLogged.getAndSet(true)) {
@@ -419,6 +420,12 @@ public class OpenTelemetryAppender extends AbstractAppender {
                 + "log4j2.ContextDataInjector="
                 + OpenTelemetryAppenderContextDataInjector.class.getName()
                 + " to propagate the full OpenTelemetry Context for async loggers.");
+  }
+
+  private static boolean wasLoggedOnDifferentThread(LogEvent event) {
+    long eventThreadId = event.getThreadId();
+    // Only treat this as async handoff when Log4j captured a usable, different thread id.
+    return eventThreadId > 0 && eventThreadId != Thread.currentThread().getId();
   }
 
   private enum ContextDataAccessorImpl implements ContextDataAccessor<ReadOnlyStringMap> {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 
+import static io.opentelemetry.instrumentation.log4j.appender.v2_17.internal.ContextDataKeys.OTEL_CONTEXT_DATA_KEY;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -69,6 +70,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
   private final AtomicBoolean replayLimitWarningLogged = new AtomicBoolean();
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private final boolean captureCodeAttributes;
+  private final boolean v3Preview;
 
   /**
    * Installs the {@code openTelemetry} instance on any {@link OpenTelemetryAppender}s identified in
@@ -225,16 +227,16 @@ public class OpenTelemetryAppender extends AbstractAppender {
     boolean v3Preview = commonConfig.getBoolean("v3_preview", false);
 
     this.mapper =
-        new LogEventMapper<>(
-            ContextDataAccessorImpl.INSTANCE,
+        createMapper(
             captureExperimentalAttributes,
             captureCodeAttributes,
             captureMapMessageAttributes,
             captureMarkerAttribute,
-            splitAndFilterBlanksAndNulls(captureContextDataAttributes),
+            captureContextDataAttributes,
             v3Preview);
     this.openTelemetry = openTelemetry;
     this.captureCodeAttributes = captureCodeAttributes;
+    this.v3Preview = v3Preview;
     if (numLogsCapturedBeforeOtelInstall != 0) {
       this.eventsToReplay = new ArrayBlockingQueue<>(numLogsCapturedBeforeOtelInstall);
     } else {
@@ -250,6 +252,23 @@ public class OpenTelemetryAppender extends AbstractAppender {
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .collect(toList());
+  }
+
+  private static LogEventMapper<ReadOnlyStringMap> createMapper(
+      boolean captureExperimentalAttributes,
+      boolean captureCodeAttributes,
+      boolean captureMapMessageAttributes,
+      boolean captureMarkerAttribute,
+      @Nullable String captureContextDataAttributes,
+      boolean v3Preview) {
+    return new LogEventMapper<>(
+        ContextDataAccessorImpl.INSTANCE,
+        captureExperimentalAttributes,
+        captureCodeAttributes,
+        captureMapMessageAttributes,
+        captureMarkerAttribute,
+        splitAndFilterBlanksAndNulls(captureContextDataAttributes),
+        v3Preview);
   }
 
   /**
@@ -325,28 +344,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
     LogRecordBuilder builder =
         openTelemetry.getLogsBridge().loggerBuilder(instrumentationName).build().logRecordBuilder();
     ReadOnlyStringMap contextData = event.getContextData();
-    Context context = Context.current();
-    // when using async logger we'll be executing on a different thread than what started logging
-    // reconstruct the context from context data
-    if (context == Context.root()) {
-      ContextDataAccessor<ReadOnlyStringMap> contextDataAccessor = ContextDataAccessorImpl.INSTANCE;
-      ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
-      String traceId = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceIdKey());
-      String spanId = contextDataAccessor.getValue(contextData, contextDataKeys.getSpanIdKey());
-      String traceFlags =
-          contextDataAccessor.getValue(contextData, contextDataKeys.getTraceFlags());
-      if (traceId != null && spanId != null && traceFlags != null) {
-        context =
-            Context.root()
-                .with(
-                    Span.wrap(
-                        SpanContext.create(
-                            traceId,
-                            spanId,
-                            TraceFlags.fromHex(traceFlags, 0),
-                            TraceState.getDefault())));
-      }
-    }
+    Context context = getContext(openTelemetry, contextData);
 
     mapper.mapLogEvent(
         builder,
@@ -369,18 +367,57 @@ public class OpenTelemetryAppender extends AbstractAppender {
     builder.emit();
   }
 
+  private Context getContext(OpenTelemetry openTelemetry, ReadOnlyStringMap contextData) {
+    Object context = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
+    if (context instanceof Context) {
+      return (Context) context;
+    }
+    Context currentContext = Context.current();
+    if (v3Preview) {
+      return currentContext;
+    }
+
+    // when using async logger we'll be executing on a different thread than what started logging
+    // reconstruct the context from context data
+    ContextDataAccessor<ReadOnlyStringMap> contextDataAccessor = ContextDataAccessorImpl.INSTANCE;
+    ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
+    String traceId = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceIdKey());
+    String spanId = contextDataAccessor.getValue(contextData, contextDataKeys.getSpanIdKey());
+    String traceFlags = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceFlags());
+    if (traceId != null && spanId != null && traceFlags != null) {
+      return Context.root()
+          .with(
+              Span.wrap(
+                  SpanContext.create(
+                      traceId,
+                      spanId,
+                      TraceFlags.fromHex(traceFlags, 0),
+                      TraceState.getDefault())));
+    }
+    return currentContext;
+  }
+
   private enum ContextDataAccessorImpl implements ContextDataAccessor<ReadOnlyStringMap> {
     INSTANCE;
 
     @Override
     @Nullable
     public String getValue(ReadOnlyStringMap contextData, String key) {
-      return contextData.getValue(key);
+      Object value = contextData.getValue(key);
+      if (value instanceof String) {
+        return (String) value;
+      }
+      return null;
     }
 
     @Override
     public void forEach(ReadOnlyStringMap contextData, BiConsumer<String, String> action) {
-      contextData.forEach(action::accept);
+      contextData.forEach(
+          (key, value) -> {
+            if (!OTEL_CONTEXT_DATA_KEY.equals(key) && value instanceof String) {
+              action.accept(key, (String) value);
+            }
+          });
     }
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java
@@ -53,6 +53,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
 @Plugin(
@@ -68,6 +69,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
 
   private final BlockingQueue<LogEventToReplay> eventsToReplay;
   private final AtomicBoolean replayLimitWarningLogged = new AtomicBoolean();
+  private final AtomicBoolean legacyContextDataWarningLogged = new AtomicBoolean();
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private final boolean captureCodeAttributes;
   private final boolean v3Preview;
@@ -299,6 +301,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
       openTelemetry = null;
       eventsToReplay.clear();
       replayLimitWarningLogged.set(false);
+      legacyContextDataWarningLogged.set(false);
     } finally {
       writeLock.unlock();
     }
@@ -344,7 +347,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
     LogRecordBuilder builder =
         openTelemetry.getLogsBridge().loggerBuilder(instrumentationName).build().logRecordBuilder();
     ReadOnlyStringMap contextData = event.getContextData();
-    Context context = getContext(openTelemetry, contextData);
+    Context context = getContext(openTelemetry, event, contextData);
 
     mapper.mapLogEvent(
         builder,
@@ -367,7 +370,8 @@ public class OpenTelemetryAppender extends AbstractAppender {
     builder.emit();
   }
 
-  private Context getContext(OpenTelemetry openTelemetry, ReadOnlyStringMap contextData) {
+  private Context getContext(
+      OpenTelemetry openTelemetry, LogEvent event, ReadOnlyStringMap contextData) {
     Object context = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
     if (context instanceof Context) {
       return (Context) context;
@@ -385,6 +389,7 @@ public class OpenTelemetryAppender extends AbstractAppender {
     String spanId = contextDataAccessor.getValue(contextData, contextDataKeys.getSpanIdKey());
     String traceFlags = contextDataAccessor.getValue(contextData, contextDataKeys.getTraceFlags());
     if (traceId != null && spanId != null && traceFlags != null) {
+      warnIfUsingLegacyContextDataForAsyncLoggers(event);
       return Context.root()
           .with(
               Span.wrap(
@@ -395,6 +400,25 @@ public class OpenTelemetryAppender extends AbstractAppender {
                       TraceState.getDefault())));
     }
     return currentContext;
+  }
+
+  private void warnIfUsingLegacyContextDataForAsyncLoggers(LogEvent event) {
+    long eventThreadId = event.getThreadId();
+    // Only warn when Log4j captured this event on a different thread from the appender thread.
+    if (eventThreadId <= 0 || eventThreadId == Thread.currentThread().getId()) {
+      return;
+    }
+    if (legacyContextDataWarningLogged.getAndSet(true)) {
+      return;
+    }
+    StatusLogger.getLogger()
+        .warn(
+            "OpenTelemetry Log4j appender is recovering span context from Log4j context data "
+                + "for an event logged on another thread. This compatibility behavior only "
+                + "propagates span context and will be removed in 3.0. Configure "
+                + "log4j2.ContextDataInjector="
+                + OpenTelemetryAppenderContextDataInjector.class.getName()
+                + " to propagate the full OpenTelemetry Context for async loggers.");
   }
 
   private enum ContextDataAccessorImpl implements ContextDataAccessor<ReadOnlyStringMap> {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -88,6 +88,7 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
       }
     }
 
+    // Mirror Log4j's ContextDataInjectorFactory#createDefaultInjector() selection.
     ReadOnlyThreadContextMap threadContextMap = ThreadContext.getThreadContextMap();
     if (threadContextMap == null || threadContextMap instanceof DefaultThreadContextMap) {
       return new ThreadContextDataInjector.ForDefaultThreadContextMap();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -23,6 +23,21 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
 
+/**
+ * Injects the full OpenTelemetry {@link Context} into Log4j event context data for async logger
+ * handoff.
+ *
+ * <p>This uses Log4j's ContextDataInjector extension point instead of ContextDataProvider because
+ * the appender needs to carry the {@link Context} object itself, not only string key/value pairs.
+ * Although Log4j 2.17 added ContextDataProvider.supplyStringMap(), Log4j does not call it for every
+ * thread context map. In web-app mode, which is enabled by default when the Servlet API is on the
+ * classpath, Log4j disables thread locals and uses DefaultThreadContextMap. That path calls
+ * ContextDataProvider.supplyContextData(), which is limited to Map&lt;String, String&gt;.
+ *
+ * <p>By delegating to Log4j's selected injector first and then adding the {@link Context} object to
+ * the resulting {@link StringMap}, this works for DefaultThreadContextMap, copy-on-write, and
+ * garbage-free thread context maps.
+ */
 public final class OpenTelemetryAppenderContextDataInjector implements ContextDataInjector {
 
   static final String DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY =

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -42,7 +42,9 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
 
   @Override
   public ReadOnlyStringMap rawContextData() {
-    return delegate.rawContextData();
+    StringMap contextData = ContextDataFactory.createContextData(delegate.rawContextData());
+    contextData.putValue(OTEL_CONTEXT_DATA_KEY, Context.current());
+    return contextData;
   }
 
   private static ContextDataInjector createDelegateInjector() {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.appender.v2_17;
+
+import static io.opentelemetry.instrumentation.log4j.appender.v2_17.internal.ContextDataKeys.OTEL_CONTEXT_DATA_KEY;
+
+import io.opentelemetry.context.Context;
+import java.util.List;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.ContextDataInjector;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.impl.ContextDataFactory;
+import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
+import org.apache.logging.log4j.spi.CopyOnWrite;
+import org.apache.logging.log4j.spi.DefaultThreadContextMap;
+import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.StringMap;
+
+public final class OpenTelemetryAppenderContextDataInjector implements ContextDataInjector {
+
+  private final ContextDataInjector delegate = createDefaultInjector();
+
+  @Override
+  public StringMap injectContextData(List<Property> properties, StringMap reusable) {
+    StringMap contextData = delegate.injectContextData(properties, reusable);
+    if (contextData.isFrozen()) {
+      contextData = ContextDataFactory.createContextData(contextData);
+    }
+    contextData.putValue(OTEL_CONTEXT_DATA_KEY, Context.current());
+    return contextData;
+  }
+
+  @Override
+  public ReadOnlyStringMap rawContextData() {
+    return delegate.rawContextData();
+  }
+
+  private static ContextDataInjector createDefaultInjector() {
+    ReadOnlyThreadContextMap threadContextMap = ThreadContext.getThreadContextMap();
+    if (threadContextMap == null || threadContextMap instanceof DefaultThreadContextMap) {
+      return new ThreadContextDataInjector.ForDefaultThreadContextMap();
+    }
+    if (threadContextMap instanceof CopyOnWrite) {
+      return new ThreadContextDataInjector.ForCopyOnWriteThreadContextMap();
+    }
+    return new ThreadContextDataInjector.ForGarbageFreeThreadContextMap();
+  }
+}

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -47,11 +47,15 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
 
   @Override
   public StringMap injectContextData(List<Property> properties, StringMap reusable) {
+    Context context = Context.current();
+    if (context == Context.root()) {
+      return delegate.injectContextData(properties, reusable);
+    }
     StringMap contextData = delegate.injectContextData(properties, reusable);
     if (contextData.isFrozen()) {
       contextData = ContextDataFactory.createContextData(contextData);
     }
-    contextData.putValue(OTEL_CONTEXT_DATA_KEY, Context.current());
+    contextData.putValue(OTEL_CONTEXT_DATA_KEY, context);
     return contextData;
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -57,7 +57,7 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
       } catch (Exception e) {
         StatusLogger.getLogger()
             .warn(
-                "Could not create ContextDataInjector delegate for '{}', using default",
+                "Could not create configured ContextDataInjector delegate '{}'; ignoring delegate override",
                 className,
                 e);
       }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -14,15 +14,21 @@ import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
+import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.spi.CopyOnWrite;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
 
 public final class OpenTelemetryAppenderContextDataInjector implements ContextDataInjector {
 
-  private final ContextDataInjector delegate = createDefaultInjector();
+  static final String DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY =
+      "otel.instrumentation.log4j-appender.context-data-injector.delegate";
+
+  private final ContextDataInjector delegate = createDelegateInjector();
 
   @Override
   public StringMap injectContextData(List<Property> properties, StringMap reusable) {
@@ -39,7 +45,24 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
     return delegate.rawContextData();
   }
 
-  private static ContextDataInjector createDefaultInjector() {
+  private static ContextDataInjector createDelegateInjector() {
+    String className =
+        PropertiesUtil.getProperties().getStringProperty(DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY);
+    if (className != null) {
+      try {
+        if (className.equals(OpenTelemetryAppenderContextDataInjector.class.getName())) {
+          throw new IllegalArgumentException("Delegate injector cannot be this injector");
+        }
+        return Loader.newCheckedInstanceOf(className, ContextDataInjector.class);
+      } catch (Exception e) {
+        StatusLogger.getLogger()
+            .warn(
+                "Could not create ContextDataInjector delegate for '{}', using default: {}",
+                className,
+                e.toString());
+      }
+    }
+
     ReadOnlyThreadContextMap threadContextMap = ThreadContext.getThreadContextMap();
     if (threadContextMap == null || threadContextMap instanceof DefaultThreadContextMap) {
       return new ThreadContextDataInjector.ForDefaultThreadContextMap();

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -57,9 +57,9 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
       } catch (Exception e) {
         StatusLogger.getLogger()
             .warn(
-                "Could not create ContextDataInjector delegate for '{}', using default: {}",
+                "Could not create ContextDataInjector delegate for '{}', using default",
                 className,
-                e.toString());
+                e);
       }
     }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderContextDataInjector.java
@@ -61,8 +61,12 @@ public final class OpenTelemetryAppenderContextDataInjector implements ContextDa
 
   @Override
   public ReadOnlyStringMap rawContextData() {
+    Context context = Context.current();
+    if (context == Context.root()) {
+      return delegate.rawContextData();
+    }
     StringMap contextData = ContextDataFactory.createContextData(delegate.rawContextData());
-    contextData.putValue(OTEL_CONTEXT_DATA_KEY, Context.current());
+    contextData.putValue(OTEL_CONTEXT_DATA_KEY, context);
     return contextData;
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/ContextDataKeys.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/ContextDataKeys.java
@@ -11,7 +11,7 @@ package io.opentelemetry.instrumentation.log4j.appender.v2_17.internal;
  */
 public final class ContextDataKeys {
 
-  public static final String OTEL_CONTEXT_DATA_KEY = "otel.context";
+  public static final String OTEL_CONTEXT_DATA_KEY = "otel.internal.context";
 
   private ContextDataKeys() {}
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/ContextDataKeys.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/ContextDataKeys.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.appender.v2_17.internal;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class ContextDataKeys {
+
+  public static final String OTEL_CONTEXT_DATA_KEY = "otel.context";
+
+  private ContextDataKeys() {}
+}

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -211,6 +211,11 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
     assertThat(rootContextData).isSameAs(TestContextDataInjector.CONTEXT_DATA);
     assertThat(rootOtelContext).isNull();
 
+    ReadOnlyStringMap rootRawContextData = injector.rawContextData();
+    Object rootRawOtelContext = rootRawContextData.getValue(OTEL_CONTEXT_DATA_KEY);
+    assertThat(rootRawContextData).isSameAs(TestContextDataInjector.RAW_CONTEXT_DATA);
+    assertThat(rootRawOtelContext).isNull();
+
     Context context = Context.current().with(TEST_CONTEXT_KEY, "context-value");
     try (Scope ignored = context.makeCurrent()) {
       StringMap contextData =
@@ -276,10 +281,13 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   public static class TestContextDataInjector implements ContextDataInjector {
 
     private static final StringMap CONTEXT_DATA = ContextDataFactory.createContextData();
+    private static final StringMap RAW_CONTEXT_DATA = ContextDataFactory.createContextData();
 
     static {
       CONTEXT_DATA.putValue("delegate-key", "delegate-value");
       CONTEXT_DATA.freeze();
+      RAW_CONTEXT_DATA.putValue("raw-delegate-key", "raw-delegate-value");
+      RAW_CONTEXT_DATA.freeze();
     }
 
     @Override
@@ -289,9 +297,7 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
     @Override
     public ReadOnlyStringMap rawContextData() {
-      StringMap rawContextData = ContextDataFactory.createContextData();
-      rawContextData.putValue("raw-delegate-key", "raw-delegate-value");
-      return rawContextData;
+      return RAW_CONTEXT_DATA;
     }
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -167,7 +167,7 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
   private static class ContextCapturingLogRecordProcessor implements LogRecordProcessor {
 
-    private Context context = Context.root();
+    private volatile Context context = Context.root();
 
     @Override
     public void onEmit(Context context, ReadWriteLogRecord logRecord) {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -5,13 +5,39 @@
 
 package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.log4j.contextdata.v2_17.internal.ContextDataKeys;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.LogRecordProcessor;
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.impl.ContextDataFactory;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.FormattedMessage;
+import org.apache.logging.log4j.util.StringMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
+
+  private static final ContextKey<String> TEST_CONTEXT_KEY = ContextKey.named("test-context-key");
 
   @RegisterExtension
   private static final LibraryInstrumentationExtension testing =
@@ -31,5 +57,98 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   @Override
   protected InstrumentationExtension getTesting() {
     return testing;
+  }
+
+  @Test
+  void logWithFullContext() {
+    ContextCapturingLogRecordProcessor logRecordProcessor =
+        new ContextCapturingLogRecordProcessor();
+    InMemoryLogRecordExporter logRecordExporter = InMemoryLogRecordExporter.create();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder()
+            .setLoggerProvider(
+                SdkLoggerProvider.builder()
+                    .addLogRecordProcessor(logRecordProcessor)
+                    .addLogRecordProcessor(SimpleLogRecordProcessor.create(logRecordExporter))
+                    .build())
+            .build();
+    OpenTelemetryAppender.resetForTest();
+    OpenTelemetryAppender.install(openTelemetry);
+
+    try {
+      Context context = Context.current().with(TEST_CONTEXT_KEY, "context-value");
+      try (Scope ignored = context.makeCurrent()) {
+        logger.info("log message 1");
+      }
+
+      executeAfterLogsExecution();
+
+      await()
+          .untilAsserted(
+              () -> assertThat(logRecordExporter.getFinishedLogRecordItems()).hasSize(1));
+      assertThat(logRecordProcessor.getContext().get(TEST_CONTEXT_KEY)).isEqualTo("context-value");
+    } finally {
+      openTelemetry.close();
+    }
+  }
+
+  @Test
+  void logWithSpanContextFromContextData() {
+    assumeFalse(Boolean.getBoolean("otel.instrumentation.common.v3-preview"));
+
+    OpenTelemetryAppender.resetForTest();
+    OpenTelemetryAppender appender =
+        OpenTelemetryAppender.builder()
+            .setName("OpenTelemetryAppender")
+            .setOpenTelemetry(testing.getOpenTelemetry())
+            .build();
+    appender.start();
+
+    String traceId = "ff000000000000000000000000000041";
+    String spanId = "ff00000000000041";
+    String traceFlags = "01";
+    ContextDataKeys contextDataKeys = ContextDataKeys.create(testing.getOpenTelemetry());
+    StringMap contextData = ContextDataFactory.createContextData();
+    contextData.putValue(contextDataKeys.getTraceIdKey(), traceId);
+    contextData.putValue(contextDataKeys.getSpanIdKey(), spanId);
+    contextData.putValue(contextDataKeys.getTraceFlags(), traceFlags);
+
+    appender.append(
+        Log4jLogEvent.newBuilder()
+            .setLoggerName("TestLogger")
+            .setLevel(Level.INFO)
+            .setMessage(new FormattedMessage("log message 1", (Object) null))
+            .setContextData(contextData)
+            .build());
+
+    SpanContext spanContext =
+        SpanContext.create(
+            traceId, spanId, TraceFlags.fromHex(traceFlags, 0), TraceState.getDefault());
+    testing.waitAndAssertLogRecords(
+        logRecord -> logRecord.hasBody("log message 1").hasSpanContext(spanContext));
+  }
+
+  private static class ContextCapturingLogRecordProcessor implements LogRecordProcessor {
+
+    private Context context = Context.root();
+
+    @Override
+    public void onEmit(Context context, ReadWriteLogRecord logRecord) {
+      this.context = context;
+    }
+
+    @Override
+    public CompletableResultCode forceFlush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    private Context getContext() {
+      return context;
+    }
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -205,12 +205,20 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
     OpenTelemetryAppenderContextDataInjector injector =
         new OpenTelemetryAppenderContextDataInjector();
 
-    StringMap contextData =
-        injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
-    Object otelContext = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
+    Context context = Context.current().with(TEST_CONTEXT_KEY, "context-value");
+    try (Scope ignored = context.makeCurrent()) {
+      StringMap contextData =
+          injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
+      Context otelContext = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
+      ReadOnlyStringMap rawContextData = injector.rawContextData();
+      Context rawOtelContext = rawContextData.getValue(OTEL_CONTEXT_DATA_KEY);
 
-    assertThat((String) contextData.getValue("delegate-key")).isEqualTo("delegate-value");
-    assertThat(otelContext).isInstanceOf(Context.class);
+      assertThat((String) contextData.getValue("delegate-key")).isEqualTo("delegate-value");
+      assertThat(otelContext.get(TEST_CONTEXT_KEY)).isEqualTo("context-value");
+      assertThat((String) rawContextData.getValue("raw-delegate-key"))
+          .isEqualTo("raw-delegate-value");
+      assertThat(rawOtelContext.get(TEST_CONTEXT_KEY)).isEqualTo("context-value");
+    }
   }
 
   private static class ContextCapturingLogRecordProcessor implements LogRecordProcessor {
@@ -269,7 +277,9 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
     @Override
     public ReadOnlyStringMap rawContextData() {
-      return ContextDataFactory.createContextData();
+      StringMap rawContextData = ContextDataFactory.createContextData();
+      rawContextData.putValue("raw-delegate-key", "raw-delegate-value");
+      return rawContextData;
     }
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -34,12 +34,14 @@ import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
@@ -58,6 +60,7 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   @AfterEach
   void cleanup() {
     OpenTelemetryAppender.resetForTest();
+    StatusLogger.getLogger().clear();
   }
 
   @Override
@@ -118,6 +121,7 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
     contextData.putValue(contextDataKeys.getTraceIdKey(), traceId);
     contextData.putValue(contextDataKeys.getSpanIdKey(), spanId);
     contextData.putValue(contextDataKeys.getTraceFlags(), traceFlags);
+    StatusLogger.getLogger().clear();
 
     appender.append(
         Log4jLogEvent.newBuilder()
@@ -125,6 +129,8 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
             .setLevel(Level.INFO)
             .setMessage(new FormattedMessage("log message 1", (Object) null))
             .setContextData(contextData)
+            .setThreadId(Thread.currentThread().getId() + 1)
+            .setThreadName("application-thread")
             .build());
 
     SpanContext spanContext =
@@ -132,27 +138,31 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
             traceId, spanId, TraceFlags.fromHex(traceFlags, 0), TraceState.getDefault());
     testing.waitAndAssertLogRecords(
         logRecord -> logRecord.hasBody("log message 1").hasSpanContext(spanContext));
+    assertThat(StatusLogger.getLogger().getStatusData())
+        .extracting(statusData -> statusData.getMessage().getFormattedMessage())
+        .anySatisfy(
+            message ->
+                assertThat(message)
+                    .contains(
+                        "recovering span context from Log4j context data",
+                        OpenTelemetryAppenderContextDataInjector.class.getName()));
   }
 
   @Test
+  @SetSystemProperty(
+      key = OpenTelemetryAppenderContextDataInjector.DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY,
+      value =
+          "io.opentelemetry.instrumentation.log4j.appender.v2_17.OpenTelemetryAppenderTest$TestContextDataInjector")
   void contextDataInjectorDelegatesToConfiguredInjector() {
-    System.setProperty(
-        OpenTelemetryAppenderContextDataInjector.DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY,
-        TestContextDataInjector.class.getName());
-    try {
-      OpenTelemetryAppenderContextDataInjector injector =
-          new OpenTelemetryAppenderContextDataInjector();
+    OpenTelemetryAppenderContextDataInjector injector =
+        new OpenTelemetryAppenderContextDataInjector();
 
-      StringMap contextData =
-          injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
-      Object otelContext = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
+    StringMap contextData =
+        injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
+    Object otelContext = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
 
-      assertThat((String) contextData.getValue("delegate-key")).isEqualTo("delegate-value");
-      assertThat(otelContext).isInstanceOf(Context.class);
-    } finally {
-      System.clearProperty(
-          OpenTelemetryAppenderContextDataInjector.DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY);
-    }
+    assertThat((String) contextData.getValue("delegate-key")).isEqualTo("delegate-value");
+    assertThat(otelContext).isInstanceOf(Context.class);
   }
 
   private static class ContextCapturingLogRecordProcessor implements LogRecordProcessor {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.log4j.appender.v2_17;
 
+import static io.opentelemetry.instrumentation.log4j.appender.v2_17.internal.ContextDataKeys.OTEL_CONTEXT_DATA_KEY;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -25,10 +27,14 @@ import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.List;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.ContextDataInjector;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -128,6 +134,27 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
         logRecord -> logRecord.hasBody("log message 1").hasSpanContext(spanContext));
   }
 
+  @Test
+  void contextDataInjectorDelegatesToConfiguredInjector() {
+    System.setProperty(
+        OpenTelemetryAppenderContextDataInjector.DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY,
+        TestContextDataInjector.class.getName());
+    try {
+      OpenTelemetryAppenderContextDataInjector injector =
+          new OpenTelemetryAppenderContextDataInjector();
+
+      StringMap contextData =
+          injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
+      Object otelContext = contextData.getValue(OTEL_CONTEXT_DATA_KEY);
+
+      assertThat((String) contextData.getValue("delegate-key")).isEqualTo("delegate-value");
+      assertThat(otelContext).isInstanceOf(Context.class);
+    } finally {
+      System.clearProperty(
+          OpenTelemetryAppenderContextDataInjector.DELEGATE_CONTEXT_DATA_INJECTOR_PROPERTY);
+    }
+  }
+
   private static class ContextCapturingLogRecordProcessor implements LogRecordProcessor {
 
     private Context context = Context.root();
@@ -149,6 +176,20 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
     private Context getContext() {
       return context;
+    }
+  }
+
+  public static class TestContextDataInjector implements ContextDataInjector {
+
+    @Override
+    public StringMap injectContextData(List<Property> properties, StringMap reusable) {
+      reusable.putValue("delegate-key", "delegate-value");
+      return reusable;
+    }
+
+    @Override
+    public ReadOnlyStringMap rawContextData() {
+      return ContextDataFactory.createContextData();
     }
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -205,6 +205,12 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
     OpenTelemetryAppenderContextDataInjector injector =
         new OpenTelemetryAppenderContextDataInjector();
 
+    StringMap rootContextData =
+        injector.injectContextData(emptyList(), ContextDataFactory.createContextData());
+    Object rootOtelContext = rootContextData.getValue(OTEL_CONTEXT_DATA_KEY);
+    assertThat(rootContextData).isSameAs(TestContextDataInjector.CONTEXT_DATA);
+    assertThat(rootOtelContext).isNull();
+
     Context context = Context.current().with(TEST_CONTEXT_KEY, "context-value");
     try (Scope ignored = context.makeCurrent()) {
       StringMap contextData =
@@ -269,10 +275,16 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
   public static class TestContextDataInjector implements ContextDataInjector {
 
+    private static final StringMap CONTEXT_DATA = ContextDataFactory.createContextData();
+
+    static {
+      CONTEXT_DATA.putValue("delegate-key", "delegate-value");
+      CONTEXT_DATA.freeze();
+    }
+
     @Override
     public StringMap injectContextData(List<Property> properties, StringMap reusable) {
-      reusable.putValue("delegate-key", "delegate-value");
-      return reusable;
+      return CONTEXT_DATA;
     }
 
     @Override

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -28,12 +28,15 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
@@ -60,7 +63,6 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   @AfterEach
   void cleanup() {
     OpenTelemetryAppender.resetForTest();
-    StatusLogger.getLogger().clear();
   }
 
   @Override
@@ -163,31 +165,35 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
     contextData.putValue(contextDataKeys.getTraceIdKey(), traceId);
     contextData.putValue(contextDataKeys.getSpanIdKey(), spanId);
     contextData.putValue(contextDataKeys.getTraceFlags(), traceFlags);
-    StatusLogger.getLogger().clear();
 
-    appender.append(
-        Log4jLogEvent.newBuilder()
-            .setLoggerName("TestLogger")
-            .setLevel(Level.INFO)
-            .setMessage(new FormattedMessage("log message 1", (Object) null))
-            .setContextData(contextData)
-            .setThreadId(Thread.currentThread().getId() + 1)
-            .setThreadName("application-thread")
-            .build());
+    StatusMessageCollector statusMessages = new StatusMessageCollector();
+    StatusLogger.getLogger().registerListener(statusMessages);
+    try {
+      appender.append(
+          Log4jLogEvent.newBuilder()
+              .setLoggerName("TestLogger")
+              .setLevel(Level.INFO)
+              .setMessage(new FormattedMessage("log message 1", (Object) null))
+              .setContextData(contextData)
+              .setThreadId(Thread.currentThread().getId() + 1)
+              .setThreadName("application-thread")
+              .build());
 
-    SpanContext spanContext =
-        SpanContext.create(
-            traceId, spanId, TraceFlags.fromHex(traceFlags, 0), TraceState.getDefault());
-    testing.waitAndAssertLogRecords(
-        logRecord -> logRecord.hasBody("log message 1").hasSpanContext(spanContext));
-    assertThat(StatusLogger.getLogger().getStatusData())
-        .extracting(statusData -> statusData.getMessage().getFormattedMessage())
-        .anySatisfy(
-            message ->
-                assertThat(message)
-                    .contains(
-                        "recovering span context from Log4j context data",
-                        OpenTelemetryAppenderContextDataInjector.class.getName()));
+      SpanContext spanContext =
+          SpanContext.create(
+              traceId, spanId, TraceFlags.fromHex(traceFlags, 0), TraceState.getDefault());
+      testing.waitAndAssertLogRecords(
+          logRecord -> logRecord.hasBody("log message 1").hasSpanContext(spanContext));
+      assertThat(statusMessages.getMessages())
+          .anySatisfy(
+              message ->
+                  assertThat(message)
+                      .contains(
+                          "recovering span context from Log4j context data",
+                          OpenTelemetryAppenderContextDataInjector.class.getName()));
+    } finally {
+      StatusLogger.getLogger().removeListener(statusMessages);
+    }
   }
 
   @Test
@@ -228,6 +234,28 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
 
     private Context getContext() {
       return context;
+    }
+  }
+
+  private static class StatusMessageCollector implements StatusListener {
+
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void log(StatusData data) {
+      messages.add(data.getMessage().getFormattedMessage());
+    }
+
+    @Override
+    public Level getStatusLevel() {
+      return Level.WARN;
+    }
+
+    @Override
+    public void close() {}
+
+    private List<String> getMessages() {
+      return messages;
     }
   }
 

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderTest.java
@@ -102,6 +102,48 @@ class OpenTelemetryAppenderTest extends AbstractOpenTelemetryAppenderTest {
   }
 
   @Test
+  void logWithCarriedContextFromContextData() {
+    ContextCapturingLogRecordProcessor logRecordProcessor =
+        new ContextCapturingLogRecordProcessor();
+    InMemoryLogRecordExporter logRecordExporter = InMemoryLogRecordExporter.create();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder()
+            .setLoggerProvider(
+                SdkLoggerProvider.builder()
+                    .addLogRecordProcessor(logRecordProcessor)
+                    .addLogRecordProcessor(SimpleLogRecordProcessor.create(logRecordExporter))
+                    .build())
+            .build();
+    OpenTelemetryAppender appender =
+        OpenTelemetryAppender.builder()
+            .setName("OpenTelemetryAppender")
+            .setOpenTelemetry(openTelemetry)
+            .build();
+    appender.start();
+
+    try {
+      StringMap contextData = ContextDataFactory.createContextData();
+      contextData.putValue(
+          OTEL_CONTEXT_DATA_KEY, Context.current().with(TEST_CONTEXT_KEY, "context-value"));
+
+      appender.append(
+          Log4jLogEvent.newBuilder()
+              .setLoggerName("TestLogger")
+              .setLevel(Level.INFO)
+              .setMessage(new FormattedMessage("log message 1", (Object) null))
+              .setContextData(contextData)
+              .build());
+
+      await()
+          .untilAsserted(
+              () -> assertThat(logRecordExporter.getFinishedLogRecordItems()).hasSize(1));
+      assertThat(logRecordProcessor.getContext().get(TEST_CONTEXT_KEY)).isEqualTo("context-value");
+    } finally {
+      openTelemetry.close();
+    }
+  }
+
+  @Test
   void logWithSpanContextFromContextData() {
     assumeFalse(Boolean.getBoolean("otel.instrumentation.common.v3-preview"));
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
@@ -3,9 +3,6 @@
 This module provides a Log4j2 `ContextDataProvider` that injects trace context from active spans
 into log context.
 
-This module exposes trace context values such as `trace_id`, `span_id`, and `trace_flags` through
-Log4j context data so they can be referenced from Log4j layouts and appenders.
-
 ## Quickstart
 
 ### Add these dependencies to your project

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/README.md
@@ -3,6 +3,9 @@
 This module provides a Log4j2 `ContextDataProvider` that injects trace context from active spans
 into log context.
 
+This module exposes trace context values such as `trace_id`, `span_id`, and `trace_flags` through
+Log4j context data so they can be referenced from Log4j layouts and appenders.
+
 ## Quickstart
 
 ### Add these dependencies to your project


### PR DESCRIPTION
Propagate the full OpenTelemetry Context through Log4j async log events by adding an appender ContextDataInjector and teaching the Log4j appender to read the carried context when emitting OTel log records.