### PR TITLE
Fix scope/telemetry attribution in metadata

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -64,21 +64,13 @@ jobs:
             echo "has_diff=false" >> $GITHUB_OUTPUT
           fi
 
-      # the CLA approved bot is only available on the upstream repo; forks fall back to the
-      # default github-actions bot and GITHUB_TOKEN
+      # we need to create the bot token after the workflow is completed to avoid 1 hour expiration
       - name: Use CLA approved github bot
-        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
+        if: steps.diffcheck.outputs.has_diff == 'true'
         run: .github/scripts/use-cla-approved-bot.sh
 
-      - name: Use default github-actions bot (fork)
-        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository != 'open-telemetry/opentelemetry-java-instrumentation'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      # we need to create the bot token after the workflow is completed to avoid 1 hour expiration
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
+        if: steps.diffcheck.outputs.has_diff == 'true'
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_APP_ID }}
@@ -95,7 +87,7 @@ jobs:
       - name: Commit and push changes
         if: steps.diffcheck.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
@@ -107,7 +99,7 @@ jobs:
         if: steps.diffcheck.outputs.has_diff == 'true'
         id: createpr
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           PR_EXISTS=$(gh pr list --state open --head "$BRANCH_NAME" --label automation --json url -q '.[0].url')
@@ -126,18 +118,12 @@ jobs:
       - name: Add label to PR
         if: steps.createpr.outputs.new_pr == 'true'
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
-          IS_UPSTREAM: ${{ github.repository == 'open-telemetry/opentelemetry-java-instrumentation' }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           PR_URL=$(gh pr list --state open --head "$BRANCH_NAME" --json url -q '.[0].url')
           if [ -n "$PR_URL" ]; then
-            # jaydeluca is only assignable on the upstream repo
-            if [ "$IS_UPSTREAM" = "true" ]; then
-              gh pr edit "$PR_URL" --add-label "automation" --add-assignee jaydeluca
-            else
-              gh pr edit "$PR_URL" --add-label "automation"
-            fi
+            gh pr edit "$PR_URL" --add-label "automation" --add-assignee jaydeluca
           else
             echo "No open PR found for branch $BRANCH_NAME."
           fi

--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -64,13 +64,21 @@ jobs:
             echo "has_diff=false" >> $GITHUB_OUTPUT
           fi
 
-      # we need to create the bot token after the workflow is completed to avoid 1 hour expiration
+      # the CLA approved bot is only available on the upstream repo; forks fall back to the
+      # default github-actions bot and GITHUB_TOKEN
       - name: Use CLA approved github bot
-        if: steps.diffcheck.outputs.has_diff == 'true'
+        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
         run: .github/scripts/use-cla-approved-bot.sh
 
+      - name: Use default github-actions bot (fork)
+        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository != 'open-telemetry/opentelemetry-java-instrumentation'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # we need to create the bot token after the workflow is completed to avoid 1 hour expiration
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        if: steps.diffcheck.outputs.has_diff == 'true'
+        if: steps.diffcheck.outputs.has_diff == 'true' && github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_APP_ID }}
@@ -87,7 +95,7 @@ jobs:
       - name: Commit and push changes
         if: steps.diffcheck.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
@@ -99,7 +107,7 @@ jobs:
         if: steps.diffcheck.outputs.has_diff == 'true'
         id: createpr
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           PR_EXISTS=$(gh pr list --state open --head "$BRANCH_NAME" --label automation --json url -q '.[0].url')
@@ -118,12 +126,18 @@ jobs:
       - name: Add label to PR
         if: steps.createpr.outputs.new_pr == 'true'
         env:
-          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token || github.token }}
+          IS_UPSTREAM: ${{ github.repository == 'open-telemetry/opentelemetry-java-instrumentation' }}
         run: |
           BRANCH_NAME="${{ steps.findbranch.outputs.branch }}"
           PR_URL=$(gh pr list --state open --head "$BRANCH_NAME" --json url -q '.[0].url')
           if [ -n "$PR_URL" ]; then
-            gh pr edit "$PR_URL" --add-label "automation" --add-assignee jaydeluca
+            # jaydeluca is only assignable on the upstream repo
+            if [ "$IS_UPSTREAM" = "true" ]; then
+              gh pr edit "$PR_URL" --add-label "automation" --add-assignee jaydeluca
+            else
+              gh pr edit "$PR_URL" --add-label "automation"
+            fi
           else
             echo "No open PR found for branch $BRANCH_NAME."
           fi

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -9,8 +9,6 @@ import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.groupingBy;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -74,41 +72,34 @@ public class EmittedScopeParser {
   @Nullable
   private static EmittedScope.Scope getMatchingScope(
       Set<EmittedScope.Scope> scopes, String defaultScopeName) {
-    EmittedScope.Scope exactMatch =
-        scopes.stream()
-            .filter(scope -> defaultScopeName.equals(scope.getName()))
-            .min(Comparator.comparing(scope -> scope.getSchemaUrl() == null ? 1 : 0))
-            .orElse(null);
+    EmittedScope.Scope exactMatch = findScopeByName(scopes, defaultScopeName);
     if (exactMatch != null) {
       return exactMatch;
     }
 
-    Map<String, List<EmittedScope.Scope>> nonSdkScopes =
-        scopes.stream()
-            .filter(scope -> isInstrumentationScope(scope.getName()))
-            .collect(groupingBy(scope -> requireNonNull(scope.getName())));
-
-    if (nonSdkScopes.size() == 1) {
-      return nonSdkScopes.values().stream()
-          .flatMap(List::stream)
-          .min(Comparator.comparing(scope -> scope.getSchemaUrl() == null ? 1 : 0))
-          .orElse(null);
+    String baseScopeName = stripTrailingVersion(defaultScopeName);
+    if (!baseScopeName.equals(defaultScopeName)) {
+      return findScopeByName(scopes, baseScopeName);
     }
 
-    if (nonSdkScopes.size() > 1) {
-      logger.warning(
-          "Unable to choose instrumentation scope for "
-              + defaultScopeName
-              + ". Candidates: "
-              + nonSdkScopes.keySet());
-    }
     return null;
   }
 
-  private static boolean isInstrumentationScope(@Nullable String scopeName) {
-    return scopeName != null
-        && scopeName.startsWith("io.opentelemetry.")
-        && !scopeName.startsWith("io.opentelemetry.sdk.");
+  @Nullable
+  private static EmittedScope.Scope findScopeByName(
+      Set<EmittedScope.Scope> scopes, String scopeName) {
+    return scopes.stream()
+        .filter(scope -> scopeName.equals(scope.getName()))
+        .min(Comparator.comparing(scope -> scope.getSchemaUrl() == null ? 1 : 0))
+        .orElse(null);
+  }
+
+  /**
+   * Removes a trailing version suffix (e.g. {@code -5.0}, {@code -8.5}, {@code -3.1.6}) from a
+   * scope name. Returns the input unchanged if it has no such suffix.
+   */
+  private static String stripTrailingVersion(String scopeName) {
+    return scopeName.replaceFirst("-\\d+(\\.\\d+)*$", "");
   }
 
   /**

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -232,8 +232,7 @@ class EmittedScopeParserTest {
   }
 
   @Test
-  void testGetScopeUsesSingleNonSdkScopeWhenDefaultDoesNotMatch(@TempDir Path tempDir)
-      throws IOException {
+  void testGetScopeMatchesVersionStrippedModuleName(@TempDir Path tempDir) throws IOException {
     Path instrumentationDir = tempDir.resolve("test-instrumentation");
     Path telemetryDir = instrumentationDir.resolve(".telemetry");
     Files.createDirectories(telemetryDir);
@@ -259,6 +258,38 @@ class EmittedScopeParserTest {
 
     assertThat(scopeInfo).isNotNull();
     assertThat(scopeInfo.getName()).isEqualTo("io.opentelemetry.oshi");
+  }
+
+  @Test
+  void testGetScopeIgnoresBorrowedScopeFromAnotherInstrumentation(@TempDir Path tempDir)
+      throws IOException {
+    // reactor-netty-0.9 emits no telemetry of its own; its tests exercise netty-4.1.
+    Path instrumentationDir = tempDir.resolve("test-instrumentation");
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    String scopeContent =
+        """
+        scopes:
+          - name: io.opentelemetry.sdk.metrics
+            version: null
+            schemaUrl: null
+          - name: io.opentelemetry.netty-4.1
+            version: 2.14.0
+            schemaUrl: null
+        """;
+
+    Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
+
+    FileManager fileManager = new FileManager(tempDir + "/");
+    InstrumentationModule module =
+        new InstrumentationModule.Builder("reactor-netty-0.9")
+            .srcPath("test-instrumentation")
+            .build();
+
+    InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
+
+    assertThat(scopeInfo).isNull();
   }
 
   @Test


### PR DESCRIPTION
#18901 fixed things for jdbc and oshi, but introduced problems where it was over-attributing telemetry /scope to other scopes emitted in the tests. For example for reactor-netty it was matching on the underlying netty telemetry scope.

This replaces the previous fallback we added in EmittedScopeParser with a more precise version-stripped base-name match:                                                                                                  
                                                                                                                                                                                                                       
1. Exact match on `io.opentelemetry.<module> (unchanged)`. 
2. Otherwise, strip the trailing `-<version>` from the module name and match that scope exactly (oshi-5.0 -> io.opentelemetry.oshi, tomcat-jdbc-8.5 -> io.opentelemetry.tomcat-jdbc)
3. Otherwise, no scope (the module keeps its default scope name)

Tested on my fork and the [instrumentation-list](https://github.com/jaydeluca/opentelemetry-java-instrumentation/pull/30/files#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1) has the expected changes