### PR TITLE
Harden workflow input handling

### DIFF
--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   crawl:
     runs-on: ubuntu-latest
-    outputs:
-      audit-output: ${{ steps.audit.outputs.AUDIT_OUTPUT }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -27,20 +25,7 @@ jobs:
         run: ./gradlew :instrumentation-docs:runAnalysis
 
       - name: Run doc site audit
-        id: audit
-        run: |
-          if ! output=$(./gradlew :instrumentation-docs:docSiteAudit 2>&1); then
-            echo "AUDIT_FAILED=true" >> $GITHUB_OUTPUT
-            echo "AUDIT_OUTPUT<<EOF" >> $GITHUB_OUTPUT
-            # Extract only the content between our custom markers
-            echo "$output" | sed -n '/=== AUDIT_FAILURE_START ===/,/=== AUDIT_FAILURE_END ===/p' | \
-              sed '/=== AUDIT_FAILURE_START ===/d' | \
-              sed '/=== AUDIT_FAILURE_END ===/d' >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            exit 1
-          else
-            echo "AUDIT_FAILED=false" >> $GITHUB_OUTPUT
-          fi
+        run: ./gradlew :instrumentation-docs:docSiteAudit
 
   workflow-notification:
     permissions:
@@ -52,5 +37,4 @@ jobs:
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.crawl.result == 'success' }}
-      failure-details: ${{ needs.crawl.outputs.audit-output }}
       title: "Documentation sync needed: opentelemetry.io site out of sync"

--- a/.github/workflows/reusable-pr-smoke-test-images.yml
+++ b/.github/workflows/reusable-pr-smoke-test-images.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LATEST_JAVA_VERSION: 25 # renovate(java-version)
+      PROJECT: ${{ inputs.project }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -53,17 +54,17 @@ jobs:
 
       - name: Build Java 8 Docker image
         if: "!inputs.skip-java-8"
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jibDockerBuild" -Ptag="$TAG" -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 11 Docker image
         if: "!inputs.skip-java-11"
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jibDockerBuild" -Ptag="$TAG" -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 17 Docker image
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jibDockerBuild" -Ptag="$TAG" -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 21 Docker image
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jibDockerBuild" -Ptag="$TAG" -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java ${{ env.LATEST_JAVA_VERSION }} Docker image
-        run: ./gradlew ${{ inputs.project }}:jibDockerBuild -Ptag=${{ env.TAG }} -PtargetJDK=${{ env.LATEST_JAVA_VERSION }} -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jibDockerBuild" -Ptag="$TAG" -PtargetJDK="$LATEST_JAVA_VERSION" -Djib.httpTimeout=120000 -Djib.console=plain

--- a/.github/workflows/reusable-publish-smoke-test-images.yml
+++ b/.github/workflows/reusable-publish-smoke-test-images.yml
@@ -34,6 +34,7 @@ jobs:
       packages: write
     env:
       LATEST_JAVA_VERSION: 25 # renovate(java-version)
+      PROJECT: ${{ inputs.project }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -63,17 +64,17 @@ jobs:
 
       - name: Build Java 8 Docker image
         if: "!inputs.skip-java-8"
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jib" -Ptag="$TAG" -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 11 Docker image
         if: "!inputs.skip-java-11"
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jib" -Ptag="$TAG" -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 17 Docker image
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jib" -Ptag="$TAG" -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 21 Docker image
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jib" -Ptag="$TAG" -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java ${{ env.LATEST_JAVA_VERSION }} Docker image
-        run: ./gradlew ${{ inputs.project }}:jib -Ptag=${{ env.TAG }} -PtargetJDK=${{ env.LATEST_JAVA_VERSION }} -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew "$PROJECT:jib" -Ptag="$TAG" -PtargetJDK="$LATEST_JAVA_VERSION" -Djib.httpTimeout=120000 -Djib.console=plain

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -8,9 +8,6 @@ on:
       success:
         type: boolean
         required: true
-      failure-details:
-        type: string
-        required: false
       title:
         type: string
         required: false
@@ -37,10 +34,12 @@ jobs:
       - name: Open issue or add comment if issue already open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SUCCESS: ${{ inputs.success }}
+          INPUT_TITLE: ${{ inputs.title }}
         run: |
           # Use custom title if provided, otherwise use default
-          if [[ -n "${{ inputs.title }}" ]]; then
-            issue_title="${{ inputs.title }}"
+          if [[ -n "$INPUT_TITLE" ]]; then
+            issue_title="$INPUT_TITLE"
           else
             issue_title="Workflow failed: $GITHUB_WORKFLOW"
           fi
@@ -48,22 +47,17 @@ jobs:
           # TODO (trask) search doesn't support exact phrases, so it's possible that this could grab the wrong issue
           number=$(gh issue list --search "in:title $issue_title" --limit 1 --json number -q .[].number)
 
-          echo $number
-          echo ${{ inputs.success }}
+          echo "$number"
+          echo "$INPUT_SUCCESS"
 
-          # Prepare the issue body with failure details if available
-          if [[ -n "${{ inputs.failure-details }}" ]]; then
-            issue_body="See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."$'\n\n'"## Failure Details"$'\n\n'"${{ inputs.failure-details }}"
-          else
-            issue_body="See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
-          fi
+          issue_body="See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
 
           if [[ $number ]]; then
-            if [[ "${{ inputs.success }}" == "true" ]]; then
-              gh issue close $number
+            if [[ "$INPUT_SUCCESS" == "true" ]]; then
+              gh issue close "$number"
             else
-              gh issue comment $number --body "$issue_body"
+              gh issue comment "$number" --body "$issue_body"
             fi
-          elif [[ "${{ inputs.success }}" == "false" ]]; then
+          elif [[ "$INPUT_SUCCESS" == "false" ]]; then
             gh issue create --title "$issue_title (#$GITHUB_RUN_NUMBER)" --body "$issue_body"
           fi


### PR DESCRIPTION
## Summary

- remove multiline audit details from the docs synchronization workflow output path
- simplify the reusable notification issue body to link to the failed run
- pass reusable workflow string inputs through environment variables before using them in shell commands
