### PR TITLE
Restore OpenTelemetry API 1.47 incubator log bridge

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.27/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_27/ApplicationOpenTelemetry127.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.27/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_27/ApplicationOpenTelemetry127.java
@@ -142,6 +142,12 @@ public class ApplicationOpenTelemetry127 implements application.io.opentelemetry
               "io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_50.logs.ApplicationLoggerFactory150");
     }
     if (loggerFactory == null) {
+      // this class is defined in opentelemetry-api-1.47
+      loggerFactory =
+          getLoggerFactory(
+              "io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs.ApplicationLoggerFactory147Incubator");
+    }
+    if (loggerFactory == null) {
       // this class is defined in opentelemetry-api-1.42
       loggerFactory =
           getLoggerFactory(

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/build.gradle.kts
@@ -19,6 +19,10 @@ configurations.configureEach {
     resolutionStrategy {
       force("io.opentelemetry:opentelemetry-api:1.47.0")
       force("io.opentelemetry:opentelemetry-api-incubator:1.47.0-alpha")
+      // use older SDK test artifacts that work with opentelemetry-api-incubator:1.47.0-alpha
+      force("io.opentelemetry:opentelemetry-sdk:1.47.0")
+      force("io.opentelemetry:opentelemetry-sdk-logs:1.47.0")
+      force("io.opentelemetry:opentelemetry-sdk-testing:1.47.0")
     }
   }
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/OpenTelemetryApiIncubatorInstrumentationModule.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/OpenTelemetryApiIncubatorInstrumentationModule.java
@@ -40,7 +40,10 @@ public class OpenTelemetryApiIncubatorInstrumentationModule
             // added in 1.50
             not(
                 hasClassesNamed(
-                    "application.io.opentelemetry.api.incubator.common.ExtendedAttributes")));
+                    "application.io.opentelemetry.api.incubator.common.ExtendedAttributes")))
+        .and(
+            // added in 1.63
+            not(hasClassesNamed("application.io.opentelemetry.api.impl.InstrumentationUtil")));
   }
 
   @Override

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/OpenTelemetryIncubatorInstrumentation.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/OpenTelemetryIncubatorInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_40.incubator.metrics.ApplicationMeterFactory140Incubator;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs.ApplicationLoggerFactory147Incubator;
 import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.trace.ApplicationTracerFactory147Incubator;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -33,6 +34,9 @@ class OpenTelemetryIncubatorInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(inline = false)
     @SuppressWarnings("ReturnValueIgnored")
     public static void init() {
+      // the sole purpose of this advice is to ensure that ApplicationLoggerFactory147Incubator is
+      // recognized as helper class and injected into class loader
+      ApplicationLoggerFactory147Incubator.class.getName();
       // 1.40 instrumentation does not apply on 1.47, we include only the metrics part here
       ApplicationMeterFactory140Incubator.class.getName();
       ApplicationTracerFactory147Incubator.class.getName();

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLogRecordBuilder147Incubator.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLogRecordBuilder147Incubator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_42.logs.ApplicationLogRecordBuilder142;
+
+public class ApplicationLogRecordBuilder147Incubator extends ApplicationLogRecordBuilder142
+    implements application.io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder {
+
+  private final LogRecordBuilder agentLogRecordBuilder;
+
+  ApplicationLogRecordBuilder147Incubator(LogRecordBuilder agentLogRecordBuilder) {
+    super(agentLogRecordBuilder);
+    this.agentLogRecordBuilder = agentLogRecordBuilder;
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public application.io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder setEventName(
+      String eventName) {
+    agentLogRecordBuilder.setEventName(eventName);
+    return this;
+  }
+}

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLogger147Incubator.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLogger147Incubator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs;
+
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_27.logs.ApplicationLogger;
+
+class ApplicationLogger147Incubator extends ApplicationLogger
+    implements application.io.opentelemetry.api.incubator.logs.ExtendedLogger {
+
+  private final Logger agentLogger;
+
+  ApplicationLogger147Incubator(Logger agentLogger) {
+    super(agentLogger);
+    this.agentLogger = agentLogger;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return agentLogger.isEnabled(Severity.UNDEFINED_SEVERITY_NUMBER);
+  }
+
+  @Override
+  public application.io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
+      logRecordBuilder() {
+    return new ApplicationLogRecordBuilder147Incubator(agentLogger.logRecordBuilder());
+  }
+}

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLoggerFactory147Incubator.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/ApplicationLoggerFactory147Incubator.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs;
+
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_27.logs.ApplicationLogger;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_27.logs.ApplicationLoggerFactory;
+
+// this class is used from opentelemetry-api-1.27.0 via reflection
+public class ApplicationLoggerFactory147Incubator implements ApplicationLoggerFactory {
+
+  @Override
+  public ApplicationLogger newLogger(Logger agentLogger) {
+    return new ApplicationLogger147Incubator(agentLogger);
+  }
+}

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/LoggerTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/LoggerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_50.incubator.logs;
+package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_47.incubator.logs;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -15,8 +15,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.common.ValueType;
-import io.opentelemetry.api.incubator.common.ExtendedAttributeKey;
-import io.opentelemetry.api.incubator.common.ExtendedAttributes;
 import io.opentelemetry.api.incubator.logs.ExtendedLogger;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.Severity;
@@ -38,11 +36,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@SuppressWarnings("deprecation") // testing deprecated EXTENDED_ATTRIBUTES feature
 class LoggerTest {
 
   @RegisterExtension
-  static final AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
+  private static final AgentInstrumentationExtension testing =
+      AgentInstrumentationExtension.create();
 
   private String instrumentationName;
   private Logger logger;
@@ -79,13 +77,8 @@ class LoggerTest {
         .setSeverity(Severity.DEBUG)
         .setSeverityText("debug")
         .setBody("body")
-        .setAttribute(stringKey("key1"), "value")
-        .setAttribute(ExtendedAttributeKey.stringKey("key2"), "value")
-        .setAllAttributes(Attributes.builder().put("key3", "value").build())
-        .setAllAttributes(ExtendedAttributes.builder().put("key4", "value").build())
-        .setAttribute(
-            ExtendedAttributeKey.extendedAttributesKey("key5"),
-            ExtendedAttributes.builder().put("key6", "value").build())
+        .setAttribute(stringKey("key"), "value")
+        .setAllAttributes(Attributes.builder().put("key", "value").build())
         .emit();
 
     await()
@@ -96,7 +89,8 @@ class LoggerTest {
                         logRecordData -> {
                           assertThat(logRecordData.getInstrumentationScopeInfo().getName())
                               .isEqualTo(instrumentationName);
-                          assertThat(logRecordData.getEventName()).isEqualTo("eventName");
+                          assertThat(((ExtendedLogRecordData) logRecordData).getEventName())
+                              .isEqualTo("eventName");
                           assertThat(logRecordData.getInstrumentationScopeInfo().getVersion())
                               .isEqualTo("1.2.3");
                           assertThat(logRecordData.getTimestampEpochNanos()).isGreaterThan(0);
@@ -106,18 +100,8 @@ class LoggerTest {
                           assertThat(logRecordData.getBodyValue().getType())
                               .isEqualTo(ValueType.STRING);
                           assertThat(logRecordData.getBodyValue().getValue()).isEqualTo("body");
-                          assertThat(
-                                  ((ExtendedLogRecordData) logRecordData).getExtendedAttributes())
-                              .isEqualTo(
-                                  ExtendedAttributes.builder()
-                                      .put("key1", "value")
-                                      .put("key2", "value")
-                                      .put("key3", "value")
-                                      .put("key4", "value")
-                                      .put(
-                                          "key5",
-                                          ExtendedAttributes.builder().put("key6", "value").build())
-                                      .build());
+                          assertThat(logRecordData.getAttributes())
+                              .isEqualTo(Attributes.builder().put("key", "value").build());
                         }));
   }
 

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/LoggerTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.47/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_47/incubator/logs/LoggerTest.java
@@ -89,8 +89,10 @@ class LoggerTest {
                         logRecordData -> {
                           assertThat(logRecordData.getInstrumentationScopeInfo().getName())
                               .isEqualTo(instrumentationName);
-                          assertThat(((ExtendedLogRecordData) logRecordData).getEventName())
-                              .isEqualTo("eventName");
+                          assertThat(logRecordData).isInstanceOf(ExtendedLogRecordData.class);
+                          ExtendedLogRecordData extendedLogRecordData =
+                              (ExtendedLogRecordData) logRecordData;
+                          assertThat(extendedLogRecordData.getEventName()).isEqualTo("eventName");
                           assertThat(logRecordData.getInstrumentationScopeInfo().getVersion())
                               .isEqualTo("1.2.3");
                           assertThat(logRecordData.getTimestampEpochNanos()).isGreaterThan(0);

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.50/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.50/javaagent/build.gradle.kts
@@ -20,6 +20,10 @@ configurations.configureEach {
     resolutionStrategy {
       force("io.opentelemetry:opentelemetry-api:1.50.0")
       force("io.opentelemetry:opentelemetry-api-incubator:1.50.0-alpha")
+      // use older SDK test artifacts that work with opentelemetry-api-incubator:1.50.0-alpha
+      force("io.opentelemetry:opentelemetry-sdk:1.50.0")
+      force("io.opentelemetry:opentelemetry-sdk-logs:1.50.0")
+      force("io.opentelemetry:opentelemetry-sdk-testing:1.50.0")
     }
   }
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.50/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_50/incubator/logs/LoggerTest.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.50/javaagent/src/incubatorTest/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/v1_50/incubator/logs/LoggerTest.java
@@ -106,8 +106,10 @@ class LoggerTest {
                           assertThat(logRecordData.getBodyValue().getType())
                               .isEqualTo(ValueType.STRING);
                           assertThat(logRecordData.getBodyValue().getValue()).isEqualTo("body");
-                          assertThat(
-                                  ((ExtendedLogRecordData) logRecordData).getExtendedAttributes())
+                          assertThat(logRecordData).isInstanceOf(ExtendedLogRecordData.class);
+                          ExtendedLogRecordData extendedLogRecordData =
+                              (ExtendedLogRecordData) logRecordData;
+                          assertThat(extendedLogRecordData.getExtendedAttributes())
                               .isEqualTo(
                                   ExtendedAttributes.builder()
                                       .put("key1", "value")

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/TelemetryConverter.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/TelemetryConverter.java
@@ -70,6 +70,7 @@ import io.opentelemetry.testing.internal.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.testing.internal.proto.trace.v1.Span;
 import io.opentelemetry.testing.internal.proto.trace.v1.Status;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -102,11 +103,21 @@ public class TelemetryConverter {
               "io.opentelemetry.sdk.testing.logs.TestLogRecordData$Builder",
               "setEventName",
               String.class);
-  // opentelemetry-api-1.50:javaagent tests use an older version where Value.empty() doesn't exist
-  private static final Value<?> EMPTY_VALUE = computeEmptyValue();
   private static final boolean hasExtendedLogRecordData =
       classAvailable("io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData")
           && classAvailable(TEST_EXTENDED_LOG_RECORD_DATA_CLASS_NAME);
+  private static final boolean canSetExtendedEventName =
+      hasExtendedLogRecordData
+          && canUseValue
+          && methodAvailable(
+              TEST_EXTENDED_LOG_RECORD_DATA_CLASS_NAME + "$Builder", "setEventName", String.class);
+  private static final boolean canSetExtendedBodyValue =
+      hasExtendedLogRecordData
+          && canUseValue
+          && methodAvailable(
+              TEST_EXTENDED_LOG_RECORD_DATA_CLASS_NAME + "$Builder", "setBodyValue", Value.class);
+  // opentelemetry-api-1.50:javaagent tests use an older version where Value.empty() doesn't exist
+  private static final Value<?> EMPTY_VALUE = computeEmptyValue();
   private static final boolean hasExtendedAttributes =
       classAvailable(EXTENDED_ATTRIBUTES_CLASS_NAME);
 
@@ -383,14 +394,25 @@ public class TelemetryConverter {
     builder =
         invoke(
             builder, "setSeverityText", new Class<?>[] {String.class}, logRecord.getSeverityText());
-    builder =
-        invoke(builder, "setEventName", new Class<?>[] {String.class}, logRecord.getEventName());
-    builder =
-        invoke(
-            builder,
-            "setBodyValue",
-            new Class<?>[] {Value.class},
-            getBodyValue(logRecord.getBody()));
+    if (canSetExtendedEventName) {
+      builder =
+          invoke(builder, "setEventName", new Class<?>[] {String.class}, logRecord.getEventName());
+    }
+    if (canSetExtendedBodyValue) {
+      builder =
+          invoke(
+              builder,
+              "setBodyValue",
+              new Class<?>[] {Value.class},
+              getBodyValue(logRecord.getBody()));
+    } else {
+      builder =
+          invoke(
+              builder,
+              "setBody",
+              new Class<?>[] {String.class},
+              logRecord.getBody().getStringValue());
+    }
     builder =
         invoke(
             builder,
@@ -893,7 +915,7 @@ public class TelemetryConverter {
     try {
       Class.forName(className);
       return true;
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException | LinkageError e) {
       return false;
     }
   }
@@ -908,7 +930,9 @@ public class TelemetryConverter {
 
   private static Object invokeStatic(String className, String methodName) {
     try {
-      return Class.forName(className).getMethod(methodName).invoke(null);
+      Method method = Class.forName(className).getMethod(methodName);
+      method.setAccessible(true);
+      return method.invoke(null);
     } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
       throw new IllegalStateException("Could not invoke " + className + "." + methodName, e);
     } catch (InvocationTargetException e) {
@@ -919,7 +943,9 @@ public class TelemetryConverter {
   private static Object invoke(
       Object target, String methodName, Class<?>[] parameterTypes, Object... args) {
     try {
-      return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+      Method method = target.getClass().getMethod(methodName, parameterTypes);
+      method.setAccessible(true);
+      return method.invoke(target, args);
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new IllegalStateException(
           "Could not invoke " + target.getClass().getName() + "." + methodName, e);
@@ -945,7 +971,7 @@ public class TelemetryConverter {
     try {
       Class.forName(className).getMethod(methodName, parameterTypes);
       return true;
-    } catch (ClassNotFoundException | NoSuchMethodException e) {
+    } catch (ClassNotFoundException | NoSuchMethodException | LinkageError e) {
       return false;
     }
   }


### PR DESCRIPTION
Follow-up from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18911/changes#r3380123612

Restore the OpenTelemetry API 1.47 incubator log bridge so applications using the post-EventLogger and pre-ExtendedAttributes incubator log API can still bridge ExtendedLogger#setEventName. The restored builder delegates event-name setting through the stable agent LogRecordBuilder API, brings back the original 1.47 incubator logger coverage, and hardens TelemetryConverter so old extended log testing builders can be used reflectively without requiring every modern builder method.