### PR TITLE
Capture Cassandra batch queries

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -227,7 +227,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
             getter, request, batch ? "BATCH" : null, null, analyzedQuery.getStoredProcedureName());
       }
 
-      MultiQuery multiQuery = MultiQuery.analyzeWithSummary(rawQueryTexts, dialect, false);
+      MultiQuery multiQuery = MultiQuery.analyzeWithSummary(rawQueryTexts, dialect);
       String querySummary = multiQuery.getQuerySummary();
       if (querySummary != null) {
         return querySummary;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -23,23 +23,18 @@ class MultiQuery {
     this.querySummary = querySummary;
   }
 
-  static MultiQuery analyzeWithSummary(
-      Collection<String> rawQueryTexts, SqlDialect dialect, boolean querySanitizationEnabled) {
-    UniqueValue uniqueStoredProcedureName = new UniqueValue();
-    Set<String> uniqueQueryTexts = new LinkedHashSet<>();
-    UniqueValue uniqueQuerySummary = new UniqueValue();
+  static MultiQuery analyzeWithSummary(Collection<String> rawQueryTexts, SqlDialect dialect) {
+    Builder builder = builder();
     for (String rawQueryText : rawQueryTexts) {
       SqlQuery analyzedQuery = SqlQueryAnalyzerUtil.analyzeWithSummary(rawQueryText, dialect);
-      uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
-      uniqueQueryTexts.add(querySanitizationEnabled ? analyzedQuery.getQueryText() : rawQueryText);
-      uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
+      builder.add(analyzedQuery, rawQueryText);
     }
 
-    String querySummary = uniqueQuerySummary.getValue();
-    return new MultiQuery(
-        uniqueStoredProcedureName.getValue(),
-        uniqueQueryTexts,
-        querySummary == null ? "BATCH" : "BATCH " + querySummary);
+    return builder.build();
+  }
+
+  static Builder builder() {
+    return new Builder();
   }
 
   @Nullable
@@ -54,6 +49,26 @@ class MultiQuery {
 
   public Set<String> getQueryTexts() {
     return queryTexts;
+  }
+
+  static class Builder {
+    private final UniqueValue uniqueStoredProcedureName = new UniqueValue();
+    private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
+    private final UniqueValue uniqueQuerySummary = new UniqueValue();
+
+    void add(SqlQuery analyzedQuery, @Nullable String queryText) {
+      uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
+      uniqueQueryTexts.add(queryText);
+      uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
+    }
+
+    MultiQuery build() {
+      String querySummary = uniqueQuerySummary.getValue();
+      return new MultiQuery(
+          uniqueStoredProcedureName.getValue(),
+          uniqueQueryTexts,
+          querySummary == null ? "BATCH" : "BATCH " + querySummary);
+    }
   }
 
   private static class UniqueValue {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -56,7 +56,7 @@ class MultiQuery {
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
 
-    void add(SqlQuery analyzedQuery, @Nullable String queryText) {
+    void add(SqlQuery analyzedQuery, String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -56,7 +56,7 @@ class MultiQuery {
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
 
-    void add(SqlQuery analyzedQuery, String queryText) {
+    void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -109,11 +109,11 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
       if (isBatch) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
-      boolean parameterizedQuery = getter.isParameterizedQuery(request);
-      boolean shouldSanitize = querySanitizationEnabled && !parameterizedQuery;
       if (rawQueryTexts.size() == 1) {
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlQuery analyzedQuery = SqlQueryAnalyzerUtil.analyzeWithSummary(rawQueryText, dialect);
+        boolean shouldSanitize =
+            querySanitizationEnabled && !getter.isParameterizedQuery(request, 0);
         attributes.put(DB_QUERY_TEXT, shouldSanitize ? analyzedQuery.getQueryText() : rawQueryText);
         String querySummary = analyzedQuery.getQuerySummary();
         attributes.put(
@@ -125,9 +125,16 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         }
         attributes.put(DB_STORED_PROCEDURE_NAME, analyzedQuery.getStoredProcedureName());
       } else if (rawQueryTexts.size() > 1) {
-        MultiQuery multiQuery =
-            MultiQuery.analyzeWithSummary(
-                getter.getRawQueryTexts(request), dialect, shouldSanitize);
+        MultiQuery.Builder builder = MultiQuery.builder();
+        int queryIndex = 0;
+        for (String rawQueryText : rawQueryTexts) {
+          SqlQuery analyzedQuery = SqlQueryAnalyzerUtil.analyzeWithSummary(rawQueryText, dialect);
+          boolean shouldSanitize =
+              querySanitizationEnabled && !getter.isParameterizedQuery(request, queryIndex);
+          builder.add(analyzedQuery, shouldSanitize ? analyzedQuery.getQueryText() : rawQueryText);
+          queryIndex++;
+        }
+        MultiQuery multiQuery = builder.build();
         attributes.put(DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         attributes.put(DB_QUERY_SUMMARY, multiQuery.getQuerySummary());
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
@@ -71,9 +71,25 @@ public interface SqlClientAttributesGetter<REQUEST, RESPONSE>
    * query does not need to be sanitized. See <a
    * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sanitization-of-dbquerytext">sanitization
    * of db.query.text</a>.
+   *
+   * @deprecated use {@link #isParameterizedQuery(Object, int)} instead
    */
-  // TODO: make this required to implement
+  @Deprecated
   default boolean isParameterizedQuery(REQUEST request) {
     return false;
+  }
+
+  /**
+   * Returns whether the query at {@code queryIndex} in {@link #getRawQueryTexts(Object)} is
+   * parameterized.
+   *
+   * <p>The {@code queryIndex} is zero-based and follows the iteration order of {@link
+   * #getRawQueryTexts(Object)}. This supports batch operations where individual entries may have
+   * different parameterization.
+   */
+  // TODO: make this required to implement
+  @SuppressWarnings("deprecation")
+  default boolean isParameterizedQuery(REQUEST request, int queryIndex) {
+    return isParameterizedQuery(request);
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -369,7 +369,7 @@ class SqlClientAttributesExtractorTest {
     request.put("db.namespace", "potatoes");
     request.put(
         "db.query.texts",
-        asList("INSERT INTO potato VALUES(?)", "UPDATE potato SET name='bob' WHERE id=1"));
+        asList("INSERT INTO potato VALUES('alice', ?)", "UPDATE potato SET name='bob' WHERE id=1"));
     request.put("db.query.parameterized", asList(true, false));
     request.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
 
@@ -393,7 +393,7 @@ class SqlClientAttributesExtractorTest {
               entry(DB_NAMESPACE, "potatoes"),
               entry(
                   DB_QUERY_TEXT,
-                  "INSERT INTO potato VALUES(?); UPDATE potato SET name=? WHERE id=?"),
+                  "INSERT INTO potato VALUES('alice', ?); UPDATE potato SET name=? WHERE id=?"),
               entry(DB_QUERY_SUMMARY, "BATCH"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     } else if (emitOldDatabaseSemconv()) {
@@ -404,7 +404,7 @@ class SqlClientAttributesExtractorTest {
               entry(DB_NAMESPACE, "potatoes"),
               entry(
                   DB_QUERY_TEXT,
-                  "INSERT INTO potato VALUES(?); UPDATE potato SET name=? WHERE id=?"),
+                  "INSERT INTO potato VALUES('alice', ?); UPDATE potato SET name=? WHERE id=?"),
               entry(DB_QUERY_SUMMARY, "BATCH"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -36,6 +36,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -107,6 +108,16 @@ class SqlClientAttributesExtractorTest {
     @Override
     public Collection<String> getRawQueryTexts(Map<String, Object> map) {
       return (Collection<String>) map.get("db.query.texts");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean isParameterizedQuery(Map<String, Object> map, int queryIndex) {
+      List<Boolean> parameterizedQueries = (List<Boolean>) map.get("db.query.parameterized");
+      if (parameterizedQueries == null) {
+        return super.isParameterizedQuery(map, queryIndex);
+      }
+      return parameterizedQueries.get(queryIndex);
     }
   }
 
@@ -345,6 +356,56 @@ class SqlClientAttributesExtractorTest {
               entry(DB_NAMESPACE, "potatoes"),
               entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
               entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 2L));
+    }
+
+    assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldExtractMixedParameterizedMultiQueryBatchAttributes() {
+    // given
+    Map<String, Object> request = new HashMap<>();
+    request.put("db.namespace", "potatoes");
+    request.put(
+        "db.query.texts",
+        asList("INSERT INTO potato VALUES(?)", "UPDATE potato SET name='bob' WHERE id=1"));
+    request.put("db.query.parameterized", asList(true, false));
+    request.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.create(new TestMultiAttributesGetter());
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    underTest.onStart(startAttributes, context, request);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    underTest.onEnd(endAttributes, context, request, null, null);
+
+    // then
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(
+                  DB_QUERY_TEXT,
+                  "INSERT INTO potato VALUES(?); UPDATE potato SET name=? WHERE id=?"),
+              entry(DB_QUERY_SUMMARY, "BATCH"),
+              entry(DB_OPERATION_BATCH_SIZE, 2L));
+    } else if (emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build()).containsOnly(entry(DB_NAME, "potatoes"));
+    } else if (emitStableDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(
+                  DB_QUERY_TEXT,
+                  "INSERT INTO potato VALUES(?); UPDATE potato SET name=? WHERE id=?"),
+              entry(DB_QUERY_SUMMARY, "BATCH"),
               entry(DB_OPERATION_BATCH_SIZE, 2L));
     }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -39,49 +39,50 @@ abstract class CassandraRequest {
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {
     List<String> queryTexts = new ArrayList<>();
-    List<Boolean> parameterizedQueries = null;
-    boolean allParameterized = true;
+    List<Boolean> mixedParameterizedQueries = null;
+    boolean allQueriesParameterized = true;
     Boolean firstParameterizedQuery = null;
     int queryIndex = 0;
     for (Statement batchEntry : batchStatement.getStatements()) {
       queryTexts.add(getQuery(batchEntry));
       boolean parameterizedQuery = batchEntry instanceof BoundStatement;
       if (!parameterizedQuery) {
-        allParameterized = false;
+        allQueriesParameterized = false;
       }
       if (firstParameterizedQuery == null) {
         firstParameterizedQuery = parameterizedQuery;
-      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
-        parameterizedQueries = new ArrayList<>(batchStatement.size());
+      } else if (parameterizedQuery != firstParameterizedQuery
+          && mixedParameterizedQueries == null) {
+        mixedParameterizedQueries = new ArrayList<>(batchStatement.size());
         for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
-          parameterizedQueries.add(firstParameterizedQuery);
+          mixedParameterizedQueries.add(firstParameterizedQuery);
         }
       }
-      if (parameterizedQueries != null) {
-        parameterizedQueries.add(parameterizedQuery);
+      if (mixedParameterizedQueries != null) {
+        mixedParameterizedQueries.add(parameterizedQuery);
       }
       queryIndex++;
     }
-    boolean parameterizedQuery = allParameterized;
-    if (parameterizedQueries == null && firstParameterizedQuery != null) {
-      parameterizedQuery = firstParameterizedQuery;
+    boolean allQueriesParameterizedResult = allQueriesParameterized;
+    if (mixedParameterizedQueries == null && firstParameterizedQuery != null) {
+      allQueriesParameterizedResult = firstParameterizedQuery;
     }
     return create(
         session,
         queryTexts,
-        parameterizedQuery,
-        parameterizedQueries,
+        allQueriesParameterizedResult,
+        mixedParameterizedQueries,
         Long.valueOf(batchStatement.size()));
   }
 
   private static CassandraRequest create(
       Session session,
       Collection<String> queryTexts,
-      boolean parameterizedQuery,
-      @Nullable List<Boolean> parameterizedQueries,
+      boolean allQueriesParameterized,
+      @Nullable List<Boolean> mixedParameterizedQueries,
       @Nullable Long batchSize) {
     return new AutoValue_CassandraRequest(
-        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+        session, queryTexts, allQueriesParameterized, mixedParameterizedQueries, batchSize);
   }
 
   private static String getQuery(Statement statement) {
@@ -99,16 +100,16 @@ abstract class CassandraRequest {
 
   abstract Collection<String> getQueryTexts();
 
-  abstract boolean parameterizedQuery();
+  abstract boolean allQueriesParameterized();
 
   @Nullable
-  abstract List<Boolean> getParameterizedQueries();
+  abstract List<Boolean> mixedParameterizedQueries();
 
   boolean isParameterizedQuery(int queryIndex) {
-    List<Boolean> parameterizedQueries = getParameterizedQueries();
-    return parameterizedQueries == null
-        ? parameterizedQuery()
-        : parameterizedQueries.get(queryIndex);
+    List<Boolean> mixedParameterizedQueries = mixedParameterizedQueries();
+    return mixedParameterizedQueries == null
+        ? allQueriesParameterized()
+        : mixedParameterizedQueries.get(queryIndex);
   }
 
   @Nullable

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -5,20 +5,112 @@
 
 package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
+import static java.util.Collections.singleton;
+
+import com.datastax.driver.core.BatchStatement;
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
 import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 abstract class CassandraRequest {
 
-  public static CassandraRequest create(
-      Session session, String queryText, boolean parameterizedQuery) {
-    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
+  static CassandraRequest create(Session session, String queryText, boolean parameterizedQuery) {
+    return create(session, singleton(queryText), parameterizedQuery, null, null);
   }
 
-  public abstract Session getSession();
+  static CassandraRequest create(Session session, String queryText) {
+    return create(session, singleton(queryText), false, null, null);
+  }
 
-  public abstract String getQueryText();
+  static CassandraRequest create(Session session, Statement statement) {
+    if (statement instanceof BatchStatement) {
+      return create(session, (BatchStatement) statement);
+    }
+    return create(
+        session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
+  }
 
-  public abstract boolean isParameterizedQuery();
+  private static CassandraRequest create(Session session, BatchStatement batchStatement) {
+    List<String> queryTexts = new ArrayList<>();
+    List<Boolean> parameterizedQueries = null;
+    boolean allParameterized = true;
+    Boolean firstParameterizedQuery = null;
+    int queryIndex = 0;
+    for (Statement batchEntry : batchStatement.getStatements()) {
+      queryTexts.add(getQuery(batchEntry));
+      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      if (!parameterizedQuery) {
+        allParameterized = false;
+      }
+      if (firstParameterizedQuery == null) {
+        firstParameterizedQuery = parameterizedQuery;
+      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
+        parameterizedQueries = new ArrayList<>(batchStatement.size());
+        for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
+          parameterizedQueries.add(firstParameterizedQuery);
+        }
+      }
+      if (parameterizedQueries != null) {
+        parameterizedQueries.add(parameterizedQuery);
+      }
+      queryIndex++;
+    }
+    boolean parameterizedQuery = allParameterized;
+    if (parameterizedQueries == null && firstParameterizedQuery != null) {
+      parameterizedQuery = firstParameterizedQuery;
+    }
+    return create(
+        session,
+        queryTexts,
+        parameterizedQuery,
+        parameterizedQueries,
+        Long.valueOf(batchStatement.size()));
+  }
+
+  private static CassandraRequest create(
+      Session session,
+      Collection<String> queryTexts,
+      boolean parameterizedQuery,
+      @Nullable List<Boolean> parameterizedQueries,
+      @Nullable Long batchSize) {
+    return new AutoValue_CassandraRequest(
+        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+  }
+
+  private static String getQuery(Statement statement) {
+    String query = null;
+    if (statement instanceof BoundStatement) {
+      query = ((BoundStatement) statement).preparedStatement().getQueryString();
+    } else if (statement instanceof RegularStatement) {
+      query = ((RegularStatement) statement).getQueryString();
+    }
+
+    return query == null ? "" : query;
+  }
+
+  abstract Session getSession();
+
+  abstract Collection<String> getQueryTexts();
+
+  abstract boolean parameterizedQuery();
+
+  @Nullable
+  abstract List<Boolean> getParameterizedQueries();
+
+  boolean isParameterizedQuery(int queryIndex) {
+    List<Boolean> parameterizedQueries = getParameterizedQueries();
+    return parameterizedQueries == null
+        ? parameterizedQuery()
+        : parameterizedQueries.get(queryIndex);
+  }
+
+  @Nullable
+  abstract Long getBatchSize();
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
-import static java.util.Collections.singleton;
 
 import com.datastax.driver.core.ExecutionInfo;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
@@ -39,7 +38,13 @@ final class CassandraSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(CassandraRequest request) {
-    return singleton(request.getQueryText());
+    return request.getQueryTexts();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(CassandraRequest request) {
+    return request.getBatchSize();
   }
 
   @Nullable
@@ -50,7 +55,7 @@ final class CassandraSqlAttributesGetter
   }
 
   @Override
-  public boolean isParameterizedQuery(CassandraRequest request) {
-    return request.isParameterizedQuery();
+  public boolean isParameterizedQuery(CassandraRequest request, int queryIndex) {
+    return request.isParameterizedQuery(queryIndex);
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
 import static io.opentelemetry.javaagent.instrumentation.cassandra.v3_0.CassandraSingletons.instrumenter;
 
-import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CloseFuture;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.PreparedStatement;
@@ -48,7 +47,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSet execute(String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -93,9 +92,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSet execute(Statement statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -110,7 +107,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSetFuture executeAsync(String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(query);
@@ -152,9 +149,7 @@ public class TracingSession implements Session {
 
   @Override
   public ResultSetFuture executeAsync(Statement statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     Context context = instrumenter().start(Context.current(), request);
     try (Scope ignored = context.makeCurrent()) {
       ResultSetFuture future = session.executeAsync(statement);
@@ -209,17 +204,6 @@ public class TracingSession implements Session {
   @Override
   public State getState() {
     return session.getState();
-  }
-
-  private static String getQuery(Statement statement) {
-    String query = null;
-    if (statement instanceof BoundStatement) {
-      query = ((BoundStatement) statement).preparedStatement().getQueryString();
-    } else if (statement instanceof RegularStatement) {
-      query = ((RegularStatement) statement).getQueryString();
-    }
-
-    return query == null ? "" : query;
   }
 
   private static void addCallbackToEndSpan(

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -306,6 +306,7 @@ class CassandraClientTest {
     session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement preparedStatement =
         session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+    testing.waitForTraces(4);
     testing.clearData();
 
     BatchStatement batchStatement =
@@ -356,6 +357,7 @@ class CassandraClientTest {
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
         session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+    testing.waitForTraces(4);
     testing.clearData();
 
     BatchStatement batchStatement =

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -355,12 +355,12 @@ class CassandraClientTest {
         "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values (?, ?)");
+        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
     testing.clearData();
 
     BatchStatement batchStatement =
         new BatchStatement()
-            .add(insertStatement.bind("alice", 1))
+            .add(insertStatement.bind(1))
             .add(
                 new SimpleStatement(
                     "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
@@ -374,7 +374,7 @@ class CassandraClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
                             equalTo(SERVER_ADDRESS, cassandraHost),
                             equalTo(SERVER_PORT, cassandraPort),
                             equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
@@ -383,7 +383,7 @@ class CassandraClientTest {
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 emitStableDatabaseSemconv()
-                                    ? "INSERT INTO batch_mixed_test.users (name, age) values (?, ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
+                                    ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
                                     : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -306,7 +306,7 @@ class CassandraClientTest {
     session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement preparedStatement =
         session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
-    testing.waitForTraces(4);
+    testing.waitForTraces(3);
     testing.clearData();
 
     BatchStatement batchStatement =
@@ -357,7 +357,7 @@ class CassandraClientTest {
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
         session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing.waitForTraces(4);
+    testing.waitForTraces(3);
     testing.clearData();
 
     BatchStatement batchStatement =

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -325,7 +325,7 @@ class CassandraClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
                             equalTo(SERVER_ADDRESS, cassandraHost),
                             equalTo(SERVER_PORT, cassandraPort),
                             equalTo(NETWORK_PEER_ADDRESS, cassandraIp),

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -26,9 +27,12 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.CASSANDRA;
 import static org.junit.jupiter.api.Named.named;
 
+import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -289,6 +293,102 @@ class CassandraClientTest {
         NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @Test
+  void batchStatementWithSameQuery() {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute(
+        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
+    PreparedStatement preparedStatement =
+        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+    testing.clearData();
+
+    BatchStatement batchStatement =
+        new BatchStatement()
+            .add(preparedStatement.bind("alice", 1))
+            .add(preparedStatement.bind("bob", 2));
+    session.execute(batchStatement);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "BATCH INSERT batch_same_test.users"
+                                : "DB Query")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                emitStableDatabaseSemconv()
+                                    ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
+                                    : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv()
+                                    ? "BATCH INSERT batch_same_test.users"
+                                    : null))));
+  }
+
+  @Test
+  void batchStatementWithDifferentQueries() {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
+    session.execute(
+        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
+    PreparedStatement insertStatement =
+        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values (?, ?)");
+    testing.clearData();
+
+    BatchStatement batchStatement =
+        new BatchStatement()
+            .add(insertStatement.bind("alice", 1))
+            .add(
+                new SimpleStatement(
+                    "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+    session.execute(batchStatement);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                emitStableDatabaseSemconv()
+                                    ? "INSERT INTO batch_mixed_test.users (name, age) values (?, ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
+                                    : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(
+                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null))));
   }
 
   private static Stream<Arguments> provideSyncParameters() {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
@@ -30,55 +30,55 @@ abstract class CassandraRequest {
     if (statement instanceof BatchStatement) {
       return create(session, (BatchStatement) statement);
     }
-    return create(
-        session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
+    return create(session, singleton(getQuery(statement)), hasQueryValues(statement), null, null);
   }
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {
     List<String> queryTexts = new ArrayList<>();
-    List<Boolean> parameterizedQueries = null;
-    boolean allParameterized = true;
+    List<Boolean> mixedParameterizedQueries = null;
+    boolean allQueriesParameterized = true;
     Boolean firstParameterizedQuery = null;
     int queryIndex = 0;
     for (BatchableStatement<?> batchEntry : batchStatement) {
       queryTexts.add(getQuery(batchEntry));
-      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      boolean parameterizedQuery = hasQueryValues(batchEntry);
       if (!parameterizedQuery) {
-        allParameterized = false;
+        allQueriesParameterized = false;
       }
       if (firstParameterizedQuery == null) {
         firstParameterizedQuery = parameterizedQuery;
-      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
-        parameterizedQueries = new ArrayList<>(batchStatement.size());
+      } else if (parameterizedQuery != firstParameterizedQuery
+          && mixedParameterizedQueries == null) {
+        mixedParameterizedQueries = new ArrayList<>(batchStatement.size());
         for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
-          parameterizedQueries.add(firstParameterizedQuery);
+          mixedParameterizedQueries.add(firstParameterizedQuery);
         }
       }
-      if (parameterizedQueries != null) {
-        parameterizedQueries.add(parameterizedQuery);
+      if (mixedParameterizedQueries != null) {
+        mixedParameterizedQueries.add(parameterizedQuery);
       }
       queryIndex++;
     }
-    boolean parameterizedQuery = allParameterized;
-    if (parameterizedQueries == null && firstParameterizedQuery != null) {
-      parameterizedQuery = firstParameterizedQuery;
+    boolean allQueriesParameterizedResult = allQueriesParameterized;
+    if (mixedParameterizedQueries == null && firstParameterizedQuery != null) {
+      allQueriesParameterizedResult = firstParameterizedQuery;
     }
     return create(
         session,
         queryTexts,
-        parameterizedQuery,
-        parameterizedQueries,
+        allQueriesParameterizedResult,
+        mixedParameterizedQueries,
         Long.valueOf(batchStatement.size()));
   }
 
   private static CassandraRequest create(
       Session session,
       Collection<String> queryTexts,
-      boolean parameterizedQuery,
-      @Nullable List<Boolean> parameterizedQueries,
+      boolean allQueriesParameterized,
+      @Nullable List<Boolean> mixedParameterizedQueries,
       @Nullable Long batchSize) {
     return new AutoValue_CassandraRequest(
-        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+        session, queryTexts, allQueriesParameterized, mixedParameterizedQueries, batchSize);
   }
 
   private static String getQuery(Statement<?> statement) {
@@ -92,20 +92,32 @@ abstract class CassandraRequest {
     return query == null ? "" : query;
   }
 
+  private static boolean hasQueryValues(Statement<?> statement) {
+    if (statement instanceof BoundStatement) {
+      return true;
+    }
+    if (statement instanceof SimpleStatement) {
+      SimpleStatement simpleStatement = (SimpleStatement) statement;
+      return !simpleStatement.getPositionalValues().isEmpty()
+          || !simpleStatement.getNamedValues().isEmpty();
+    }
+    return false;
+  }
+
   abstract Session getSession();
 
   abstract Collection<String> getQueryTexts();
 
-  abstract boolean parameterizedQuery();
+  abstract boolean allQueriesParameterized();
 
   @Nullable
-  abstract List<Boolean> getParameterizedQueries();
+  abstract List<Boolean> mixedParameterizedQueries();
 
   boolean isParameterizedQuery(int queryIndex) {
-    List<Boolean> parameterizedQueries = getParameterizedQueries();
-    return parameterizedQueries == null
-        ? parameterizedQuery()
-        : parameterizedQueries.get(queryIndex);
+    List<Boolean> mixedParameterizedQueries = mixedParameterizedQueries();
+    return mixedParameterizedQueries == null
+        ? allQueriesParameterized()
+        : mixedParameterizedQueries.get(queryIndex);
   }
 
   @Nullable

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraRequest.java
@@ -5,19 +5,109 @@
 
 package io.opentelemetry.javaagent.instrumentation.cassandra.v4_0;
 
+import static java.util.Collections.singleton;
+
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 abstract class CassandraRequest {
 
-  static CassandraRequest create(Session session, String queryText, boolean parameterizedQuery) {
-    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
+  static CassandraRequest create(Session session, String queryText) {
+    return create(session, singleton(queryText), false, null, null);
+  }
+
+  static CassandraRequest create(Session session, Statement<?> statement) {
+    if (statement instanceof BatchStatement) {
+      return create(session, (BatchStatement) statement);
+    }
+    return create(
+        session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
+  }
+
+  private static CassandraRequest create(Session session, BatchStatement batchStatement) {
+    List<String> queryTexts = new ArrayList<>();
+    List<Boolean> parameterizedQueries = null;
+    boolean allParameterized = true;
+    Boolean firstParameterizedQuery = null;
+    int queryIndex = 0;
+    for (BatchableStatement<?> batchEntry : batchStatement) {
+      queryTexts.add(getQuery(batchEntry));
+      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      if (!parameterizedQuery) {
+        allParameterized = false;
+      }
+      if (firstParameterizedQuery == null) {
+        firstParameterizedQuery = parameterizedQuery;
+      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
+        parameterizedQueries = new ArrayList<>(batchStatement.size());
+        for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
+          parameterizedQueries.add(firstParameterizedQuery);
+        }
+      }
+      if (parameterizedQueries != null) {
+        parameterizedQueries.add(parameterizedQuery);
+      }
+      queryIndex++;
+    }
+    boolean parameterizedQuery = allParameterized;
+    if (parameterizedQueries == null && firstParameterizedQuery != null) {
+      parameterizedQuery = firstParameterizedQuery;
+    }
+    return create(
+        session,
+        queryTexts,
+        parameterizedQuery,
+        parameterizedQueries,
+        Long.valueOf(batchStatement.size()));
+  }
+
+  private static CassandraRequest create(
+      Session session,
+      Collection<String> queryTexts,
+      boolean parameterizedQuery,
+      @Nullable List<Boolean> parameterizedQueries,
+      @Nullable Long batchSize) {
+    return new AutoValue_CassandraRequest(
+        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+  }
+
+  private static String getQuery(Statement<?> statement) {
+    String query = null;
+    if (statement instanceof SimpleStatement) {
+      query = ((SimpleStatement) statement).getQuery();
+    } else if (statement instanceof BoundStatement) {
+      query = ((BoundStatement) statement).getPreparedStatement().getQuery();
+    }
+
+    return query == null ? "" : query;
   }
 
   abstract Session getSession();
 
-  abstract String getQueryText();
+  abstract Collection<String> getQueryTexts();
 
-  abstract boolean isParameterizedQuery();
+  abstract boolean parameterizedQuery();
+
+  @Nullable
+  abstract List<Boolean> getParameterizedQueries();
+
+  boolean isParameterizedQuery(int queryIndex) {
+    List<Boolean> parameterizedQueries = getParameterizedQueries();
+    return parameterizedQueries == null
+        ? parameterizedQuery()
+        : parameterizedQueries.get(queryIndex);
+  }
+
+  @Nullable
+  abstract Long getBatchSize();
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.cassandra.v4_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
-import static java.util.Collections.singleton;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -42,7 +41,13 @@ final class CassandraSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(CassandraRequest request) {
-    return singleton(request.getQueryText());
+    return request.getQueryTexts();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(CassandraRequest request) {
+    return request.getBatchSize();
   }
 
   @Nullable
@@ -63,7 +68,7 @@ final class CassandraSqlAttributesGetter
   }
 
   @Override
-  public boolean isParameterizedQuery(CassandraRequest request) {
-    return request.isParameterizedQuery();
+  public boolean isParameterizedQuery(CassandraRequest request, int queryIndex) {
+    return request.isParameterizedQuery(queryIndex);
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
@@ -11,10 +11,8 @@ import static java.util.Arrays.asList;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -67,7 +65,7 @@ final class TracingCqlSession {
   }
 
   private static ResultSet execute(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -81,9 +79,7 @@ final class TracingCqlSession {
   }
 
   private static ResultSet execute(CqlSession session, Statement<?> statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     Context context = instrumenter().start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -98,14 +94,12 @@ final class TracingCqlSession {
 
   private static CompletionStage<AsyncResultSet> executeAsync(
       CqlSession session, Statement<?> statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     return executeAsync(request, () -> session.executeAsync(statement));
   }
 
   private static CompletionStage<AsyncResultSet> executeAsync(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     return executeAsync(request, () -> session.executeAsync(query));
   }
 
@@ -142,17 +136,6 @@ final class TracingCqlSession {
         });
 
     return result;
-  }
-
-  private static String getQuery(Statement<?> statement) {
-    String query = null;
-    if (statement instanceof SimpleStatement) {
-      query = ((SimpleStatement) statement).getQuery();
-    } else if (statement instanceof BoundStatement) {
-      query = ((BoundStatement) statement).getPreparedStatement().getQuery();
-    }
-
-    return query == null ? "" : query;
   }
 
   @Nullable

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
@@ -110,6 +110,8 @@ final class CassandraAttributesExtractor
 
     Statement<?> statement = (Statement<?>) executionInfo.getRequest();
     String consistencyLevel;
+    // getSession() is deprecated only because its visibility will be reduced in the future.
+    @SuppressWarnings("deprecation")
     DriverExecutionProfile config =
         request.getSession().getContext().getConfig().getDefaultProfile();
     if (statement.getConsistencyLevel() != null) {

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -22,9 +22,6 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class CassandraRequest {
 
-  /**
-   * @deprecated use {@link #create(Session, String)} instead
-   */
   @Deprecated
   public static CassandraRequest create(
       Session session, String queryText, boolean parameterizedQuery) {

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -5,20 +5,141 @@
 
 package io.opentelemetry.instrumentation.cassandra.v4_4;
 
+import static java.util.Collections.singleton;
+
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class CassandraRequest {
 
+  /**
+   * @deprecated use {@link #create(Session, String)} instead
+   */
+  @Deprecated
   public static CassandraRequest create(
       Session session, String queryText, boolean parameterizedQuery) {
-    return new AutoValue_CassandraRequest(session, queryText, parameterizedQuery);
+    return create(session, singleton(queryText), parameterizedQuery, null, null);
   }
 
+  static CassandraRequest create(Session session, String queryText) {
+    return create(session, singleton(queryText), false, null, null);
+  }
+
+  static CassandraRequest create(Session session, Statement<?> statement) {
+    if (statement instanceof BatchStatement) {
+      return create(session, (BatchStatement) statement);
+    }
+    return create(session, getQuery(statement), statement instanceof BoundStatement);
+  }
+
+  private static CassandraRequest create(Session session, BatchStatement batchStatement) {
+    List<String> queryTexts = new ArrayList<>();
+    List<Boolean> parameterizedQueries = null;
+    boolean allParameterized = true;
+    Boolean firstParameterizedQuery = null;
+    int queryIndex = 0;
+    for (BatchableStatement<?> batchEntry : batchStatement) {
+      queryTexts.add(getQuery(batchEntry));
+      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      if (!parameterizedQuery) {
+        allParameterized = false;
+      }
+      if (firstParameterizedQuery == null) {
+        firstParameterizedQuery = parameterizedQuery;
+      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
+        parameterizedQueries = new ArrayList<>(batchStatement.size());
+        for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
+          parameterizedQueries.add(firstParameterizedQuery);
+        }
+      }
+      if (parameterizedQueries != null) {
+        parameterizedQueries.add(parameterizedQuery);
+      }
+      queryIndex++;
+    }
+    boolean parameterizedQuery = allParameterized;
+    if (parameterizedQueries == null && firstParameterizedQuery != null) {
+      parameterizedQuery = firstParameterizedQuery;
+    }
+    return create(
+        session,
+        queryTexts,
+        parameterizedQuery,
+        parameterizedQueries,
+        Long.valueOf(batchStatement.size()));
+  }
+
+  private static CassandraRequest create(
+      Session session,
+      Collection<String> queryTexts,
+      boolean parameterizedQuery,
+      @Nullable List<Boolean> parameterizedQueries,
+      @Nullable Long batchSize) {
+    return new AutoValue_CassandraRequest(
+        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+  }
+
+  private static String getQuery(Statement<?> statement) {
+    String query = null;
+    if (statement instanceof SimpleStatement) {
+      query = ((SimpleStatement) statement).getQuery();
+    } else if (statement instanceof BoundStatement) {
+      query = ((BoundStatement) statement).getPreparedStatement().getQuery();
+    }
+
+    return query == null ? "" : query;
+  }
+
+  /**
+   * @deprecated this method will be reduced to package-private visibility
+   */
+  @Deprecated
   public abstract Session getSession();
 
-  public abstract String getQueryText();
+  abstract Collection<String> getQueryTexts();
 
-  public abstract boolean isParameterizedQuery();
+  /**
+   * Returns the raw query text.
+   *
+   * @deprecated use {@link #getQueryTexts()} instead
+   */
+  @Deprecated
+  public String getQueryText() {
+    return getQueryTexts().isEmpty() ? "" : getQueryTexts().iterator().next();
+  }
+
+  abstract boolean parameterizedQuery();
+
+  @Nullable
+  abstract List<Boolean> getParameterizedQueries();
+
+  /**
+   * Returns whether all queries in this request are parameterized.
+   *
+   * @deprecated use {@link #isParameterizedQuery(int)} instead
+   */
+  @Deprecated
+  public boolean isParameterizedQuery() {
+    return parameterizedQuery();
+  }
+
+  boolean isParameterizedQuery(int queryIndex) {
+    List<Boolean> parameterizedQueries = getParameterizedQueries();
+    return parameterizedQueries == null
+        ? parameterizedQuery()
+        : parameterizedQueries.get(queryIndex);
+  }
+
+  @Nullable
+  abstract Long getBatchSize();
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -36,7 +36,7 @@ public abstract class CassandraRequest {
     if (statement instanceof BatchStatement) {
       return create(session, (BatchStatement) statement);
     }
-    return create(session, getQuery(statement), statement instanceof BoundStatement);
+    return create(session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
   }
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -36,54 +36,55 @@ public abstract class CassandraRequest {
     if (statement instanceof BatchStatement) {
       return create(session, (BatchStatement) statement);
     }
-    return create(session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
+    return create(session, singleton(getQuery(statement)), hasQueryValues(statement), null, null);
   }
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {
     List<String> queryTexts = new ArrayList<>();
-    List<Boolean> parameterizedQueries = null;
-    boolean allParameterized = true;
+    List<Boolean> mixedParameterizedQueries = null;
+    boolean allQueriesParameterized = true;
     Boolean firstParameterizedQuery = null;
     int queryIndex = 0;
     for (BatchableStatement<?> batchEntry : batchStatement) {
       queryTexts.add(getQuery(batchEntry));
-      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      boolean parameterizedQuery = hasQueryValues(batchEntry);
       if (!parameterizedQuery) {
-        allParameterized = false;
+        allQueriesParameterized = false;
       }
       if (firstParameterizedQuery == null) {
         firstParameterizedQuery = parameterizedQuery;
-      } else if (parameterizedQuery != firstParameterizedQuery && parameterizedQueries == null) {
-        parameterizedQueries = new ArrayList<>(batchStatement.size());
+      } else if (parameterizedQuery != firstParameterizedQuery
+          && mixedParameterizedQueries == null) {
+        mixedParameterizedQueries = new ArrayList<>(batchStatement.size());
         for (int previousQueryIndex = 0; previousQueryIndex < queryIndex; previousQueryIndex++) {
-          parameterizedQueries.add(firstParameterizedQuery);
+          mixedParameterizedQueries.add(firstParameterizedQuery);
         }
       }
-      if (parameterizedQueries != null) {
-        parameterizedQueries.add(parameterizedQuery);
+      if (mixedParameterizedQueries != null) {
+        mixedParameterizedQueries.add(parameterizedQuery);
       }
       queryIndex++;
     }
-    boolean parameterizedQuery = allParameterized;
-    if (parameterizedQueries == null && firstParameterizedQuery != null) {
-      parameterizedQuery = firstParameterizedQuery;
+    boolean allQueriesParameterizedResult = allQueriesParameterized;
+    if (mixedParameterizedQueries == null && firstParameterizedQuery != null) {
+      allQueriesParameterizedResult = firstParameterizedQuery;
     }
     return create(
         session,
         queryTexts,
-        parameterizedQuery,
-        parameterizedQueries,
+        allQueriesParameterizedResult,
+        mixedParameterizedQueries,
         Long.valueOf(batchStatement.size()));
   }
 
   private static CassandraRequest create(
       Session session,
       Collection<String> queryTexts,
-      boolean parameterizedQuery,
-      @Nullable List<Boolean> parameterizedQueries,
+      boolean allQueriesParameterized,
+      @Nullable List<Boolean> mixedParameterizedQueries,
       @Nullable Long batchSize) {
     return new AutoValue_CassandraRequest(
-        session, queryTexts, parameterizedQuery, parameterizedQueries, batchSize);
+        session, queryTexts, allQueriesParameterized, mixedParameterizedQueries, batchSize);
   }
 
   private static String getQuery(Statement<?> statement) {
@@ -95,6 +96,18 @@ public abstract class CassandraRequest {
     }
 
     return query == null ? "" : query;
+  }
+
+  private static boolean hasQueryValues(Statement<?> statement) {
+    if (statement instanceof BoundStatement) {
+      return true;
+    }
+    if (statement instanceof SimpleStatement) {
+      SimpleStatement simpleStatement = (SimpleStatement) statement;
+      return !simpleStatement.getPositionalValues().isEmpty()
+          || !simpleStatement.getNamedValues().isEmpty();
+    }
+    return false;
   }
 
   /**
@@ -112,13 +125,17 @@ public abstract class CassandraRequest {
    */
   @Deprecated
   public String getQueryText() {
-    return getQueryTexts().isEmpty() ? "" : getQueryTexts().iterator().next();
+    if (getBatchSize() != null) {
+      // Preserve previous public API behavior: BatchStatement query text was not captured.
+      return "";
+    }
+    return getQueryTexts().iterator().next();
   }
 
-  abstract boolean parameterizedQuery();
+  abstract boolean allQueriesParameterized();
 
   @Nullable
-  abstract List<Boolean> getParameterizedQueries();
+  abstract List<Boolean> mixedParameterizedQueries();
 
   /**
    * Returns whether all queries in this request are parameterized.
@@ -127,14 +144,14 @@ public abstract class CassandraRequest {
    */
   @Deprecated
   public boolean isParameterizedQuery() {
-    return parameterizedQuery();
+    return allQueriesParameterized();
   }
 
   boolean isParameterizedQuery(int queryIndex) {
-    List<Boolean> parameterizedQueries = getParameterizedQueries();
-    return parameterizedQueries == null
-        ? parameterizedQuery()
-        : parameterizedQueries.get(queryIndex);
+    List<Boolean> mixedParameterizedQueries = mixedParameterizedQueries();
+    return mixedParameterizedQueries == null
+        ? allQueriesParameterized()
+        : mixedParameterizedQueries.get(queryIndex);
   }
 
   @Nullable

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.cassandra.v4_4;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
-import static java.util.Collections.singleton;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -36,6 +35,8 @@ final class CassandraSqlAttributesGetter
     return DOUBLE_QUOTES_ARE_IDENTIFIERS;
   }
 
+  // getSession() is deprecated only because its visibility will be reduced in the future.
+  @SuppressWarnings("deprecation")
   @Override
   @Nullable
   public String getDbNamespace(CassandraRequest request) {
@@ -44,7 +45,13 @@ final class CassandraSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(CassandraRequest request) {
-    return singleton(request.getQueryText());
+    return request.getQueryTexts();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(CassandraRequest request) {
+    return request.getBatchSize();
   }
 
   @Nullable
@@ -67,7 +74,7 @@ final class CassandraSqlAttributesGetter
   }
 
   @Override
-  public boolean isParameterizedQuery(CassandraRequest request) {
-    return request.isParameterizedQuery();
+  public boolean isParameterizedQuery(CassandraRequest request, int queryIndex) {
+    return request.isParameterizedQuery(queryIndex);
   }
 }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/TracingCqlSession.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/TracingCqlSession.java
@@ -12,10 +12,8 @@ import com.datastax.dse.driver.internal.core.cql.reactive.DefaultReactiveResultS
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -83,7 +81,7 @@ final class TracingCqlSession {
   }
 
   private ResultSet execute(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     Context context = instrumenter.start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -97,9 +95,7 @@ final class TracingCqlSession {
   }
 
   private ResultSet execute(CqlSession session, Statement<?> statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     Context context = instrumenter.start(Context.current(), request);
     ResultSet resultSet;
     try (Scope ignored = context.makeCurrent()) {
@@ -113,14 +109,12 @@ final class TracingCqlSession {
   }
 
   private CompletionStage<AsyncResultSet> executeAsync(CqlSession session, Statement<?> statement) {
-    String query = getQuery(statement);
-    CassandraRequest request =
-        CassandraRequest.create(session, query, statement instanceof BoundStatement);
+    CassandraRequest request = CassandraRequest.create(session, statement);
     return executeAsync(request, () -> session.executeAsync(statement));
   }
 
   private CompletionStage<AsyncResultSet> executeAsync(CqlSession session, String query) {
-    CassandraRequest request = CassandraRequest.create(session, query, false);
+    CassandraRequest request = CassandraRequest.create(session, query);
     return executeAsync(request, () -> session.executeAsync(query));
   }
 
@@ -161,17 +155,6 @@ final class TracingCqlSession {
         });
 
     return result;
-  }
-
-  private static String getQuery(Statement<?> statement) {
-    String query = null;
-    if (statement instanceof SimpleStatement) {
-      query = ((SimpleStatement) statement).getQuery();
-    } else if (statement instanceof BoundStatement) {
-      query = ((BoundStatement) statement).getPreparedStatement().getQuery();
-    }
-
-    return query == null ? "" : query;
   }
 
   @Nullable

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -197,7 +197,7 @@ public abstract class AbstractCassandraTest {
     session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement preparedStatement =
         session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
-    testing().waitForTraces(4);
+    testing().waitForTraces(3);
     testing().clearData();
 
     BatchStatement batchStatement =
@@ -266,7 +266,7 @@ public abstract class AbstractCassandraTest {
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
         session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing().waitForTraces(4);
+    testing().waitForTraces(3);
     testing().clearData();
 
     BatchStatement batchStatement =

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -128,6 +128,67 @@ public abstract class AbstractCassandraTest {
   }
 
   @Test
+  void simpleStatementWithValues() {
+    CqlSession session = getSession(null);
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS simple_values_test");
+    session.execute(
+        "CREATE KEYSPACE simple_values_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE simple_values_test.users ( name text PRIMARY KEY, age int )");
+    testing().clearData();
+
+    session.execute(
+        SimpleStatement.newInstance(
+            "INSERT INTO simple_values_test.users (name, age) values ('alice', ?)", 1));
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("INSERT simple_values_test.users")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasAttributesSatisfyingExactly(
+                                satisfies(
+                                    NETWORK_TYPE,
+                                    emitStableDatabaseSemconv()
+                                        ? val -> val.isNull()
+                                        : val -> val.isIn("ipv4", "ipv6")),
+                                equalTo(SERVER_ADDRESS, cassandraHost),
+                                equalTo(SERVER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    emitStableDatabaseSemconv()
+                                        ? "INSERT INTO simple_values_test.users (name, age) values ('alice', ?)"
+                                        : "INSERT INTO simple_values_test.users (name, age) values (?, ?)"),
+                                equalTo(
+                                    DB_QUERY_SUMMARY,
+                                    emitStableDatabaseSemconv()
+                                        ? "INSERT simple_values_test.users"
+                                        : null),
+                                equalTo(maybeStable(DB_OPERATION), "INSERT"),
+                                equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                                equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                    val -> val.isInstanceOf(String.class)),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_IDEMPOTENCE),
+                                    val -> val.isInstanceOf(Boolean.class)),
+                                equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_TABLE),
+                                    "simple_values_test.users"))));
+  }
+
+  @Test
   void batchStatementWithSameQuery() {
     CqlSession session = getSession(null);
     cleanup.deferCleanup(session);
@@ -159,7 +220,11 @@ public abstract class AbstractCassandraTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
-                                satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")),
+                                satisfies(
+                                    NETWORK_TYPE,
+                                    emitStableDatabaseSemconv()
+                                        ? val -> val.isNull()
+                                        : val -> val.isIn("ipv4", "ipv6")),
                                 equalTo(SERVER_ADDRESS, cassandraHost),
                                 equalTo(SERVER_PORT, cassandraPort),
                                 equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
@@ -201,13 +266,13 @@ public abstract class AbstractCassandraTest {
         "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values (?, ?)");
+        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
     testing().clearData();
 
     BatchStatement batchStatement =
         BatchStatement.newInstance(
             DefaultBatchType.LOGGED,
-            insertStatement.bind("alice", 1),
+            insertStatement.bind(1),
             SimpleStatement.newInstance(
                 "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
     session.execute(batchStatement);
@@ -221,7 +286,11 @@ public abstract class AbstractCassandraTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
-                                satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")),
+                                satisfies(
+                                    NETWORK_TYPE,
+                                    emitStableDatabaseSemconv()
+                                        ? val -> val.isNull()
+                                        : val -> val.isIn("ipv4", "ipv6")),
                                 equalTo(SERVER_ADDRESS, cassandraHost),
                                 equalTo(SERVER_PORT, cassandraPort),
                                 equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
@@ -230,7 +299,7 @@ public abstract class AbstractCassandraTest {
                                 equalTo(
                                     maybeStable(DB_STATEMENT),
                                     emitStableDatabaseSemconv()
-                                        ? "INSERT INTO batch_mixed_test.users (name, age) values (?, ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
+                                        ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
                                         : null),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -197,6 +197,7 @@ public abstract class AbstractCassandraTest {
     session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement preparedStatement =
         session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+    testing().waitForTraces(4);
     testing().clearData();
 
     BatchStatement batchStatement =
@@ -265,6 +266,7 @@ public abstract class AbstractCassandraTest {
     session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
     PreparedStatement insertStatement =
         session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+    testing().waitForTraces(4);
     testing().clearData();
 
     BatchStatement batchStatement =

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -37,6 +38,10 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -120,6 +125,129 @@ public abstract class AbstractCassandraTest {
         NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @Test
+  void batchStatementWithSameQuery() {
+    CqlSession session = getSession(null);
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute(
+        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
+    PreparedStatement preparedStatement =
+        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+    testing().clearData();
+
+    BatchStatement batchStatement =
+        BatchStatement.newInstance(
+            DefaultBatchType.LOGGED,
+            preparedStatement.bind("alice", 1),
+            preparedStatement.bind("bob", 2));
+    session.execute(batchStatement);
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "BATCH INSERT batch_same_test.users"
+                                    : "DB Query")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasAttributesSatisfyingExactly(
+                                satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")),
+                                equalTo(SERVER_ADDRESS, cassandraHost),
+                                equalTo(SERVER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    emitStableDatabaseSemconv()
+                                        ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
+                                        : null),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? 2L : null),
+                                equalTo(
+                                    DB_QUERY_SUMMARY,
+                                    emitStableDatabaseSemconv()
+                                        ? "BATCH INSERT batch_same_test.users"
+                                        : null),
+                                equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                                equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                    val -> val.isInstanceOf(String.class)),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_IDEMPOTENCE),
+                                    val -> val.isInstanceOf(Boolean.class)),
+                                equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
+  }
+
+  @Test
+  void batchStatementWithDifferentQueries() {
+    CqlSession session = getSession(null);
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
+    session.execute(
+        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
+    PreparedStatement insertStatement =
+        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values (?, ?)");
+    testing().clearData();
+
+    BatchStatement batchStatement =
+        BatchStatement.newInstance(
+            DefaultBatchType.LOGGED,
+            insertStatement.bind("alice", 1),
+            SimpleStatement.newInstance(
+                "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+    session.execute(batchStatement);
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasAttributesSatisfyingExactly(
+                                satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")),
+                                equalTo(SERVER_ADDRESS, cassandraHost),
+                                equalTo(SERVER_PORT, cassandraPort),
+                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                                equalTo(NETWORK_PEER_PORT, cassandraPort),
+                                equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    emitStableDatabaseSemconv()
+                                        ? "INSERT INTO batch_mixed_test.users (name, age) values (?, ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
+                                        : null),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? 2L : null),
+                                equalTo(
+                                    DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
+                                equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                                equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                    val -> val.isInstanceOf(String.class)),
+                                satisfies(
+                                    maybeStable(DB_CASSANDRA_IDEMPOTENCE),
+                                    val -> val.isInstanceOf(Boolean.class)),
+                                equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -181,11 +181,9 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_IDEMPOTENCE),
                                     val -> val.isInstanceOf(Boolean.class)),
                                 equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                                equalTo(maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
                                 equalTo(
-                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_TABLE),
-                                    "simple_values_test.users"))));
+                                    maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -134,7 +134,8 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   }
 
   @Override
-  public boolean isParameterizedQuery(DbRequest request) {
+  public boolean isParameterizedQuery(DbRequest request, int queryIndex) {
+    // JDBC does not support mixed parameterization within a single request.
     return request.isParameterizedQuery();
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -6,25 +6,20 @@
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -593,79 +588,66 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     latch.await(1, MINUTES);
 
-    await()
-        .atMost(Duration.ofSeconds(20))
-        .untilAsserted(
-            () -> {
-              List<SpanData> spans = testing.spans();
-              SpanData topic1Producer = findSpan(spans, topic1 + " publish", SpanKind.PRODUCER);
-              SpanData topic2Producer = findSpan(spans, topic2 + " publish", SpanKind.PRODUCER);
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    AtomicReference<SpanData> producerSpan2 = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("parent1", topic1 + " receive", "parent2", topic2 + " receive"),
+        trace -> {
+          trace.hasSpansSatisfyingExactly(
+              span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
+              span ->
+                  span.hasName(topic1 + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          sendAttributes(topic1, msgId1.toString(), false)));
 
-              assertThat(topic1Producer)
-                  .hasAttributesSatisfyingExactly(sendAttributes(topic1, msgId1.toString(), false));
-              assertThat(topic2Producer)
-                  .hasAttributesSatisfyingExactly(sendAttributes(topic2, msgId2.toString(), false));
+          producerSpan.set(trace.getSpan(1));
+        },
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(topic1 + " receive")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            receiveAttributes(topic1, msgId1.toString(), false)),
+                span ->
+                    span.hasName(topic1 + " process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic1, msgId1.toString(), false))),
+        trace -> {
+          trace.hasSpansSatisfyingExactly(
+              span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
+              span ->
+                  span.hasName(topic2 + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          sendAttributes(topic2, msgId2.toString(), false)));
 
-              assertThat(spans)
-                  .filteredOn(span -> span.getName().equals(topic1 + " receive"))
-                  .anySatisfy(
-                      span -> assertReceiveSpan(span, topic1Producer, topic1, msgId1.toString()));
-              assertThat(spans)
-                  .filteredOn(span -> span.getName().equals(topic2 + " receive"))
-                  .anySatisfy(
-                      span -> assertReceiveSpan(span, topic2Producer, topic2, msgId2.toString()));
-
-              assertThat(spans)
-                  .filteredOn(span -> span.getName().equals(topic1 + " process"))
-                  .singleElement()
-                  .satisfies(
-                      span ->
-                          assertThat(span)
-                              .hasKind(SpanKind.CONSUMER)
-                              .hasLinks(LinkData.create(topic1Producer.getSpanContext()))
-                              .hasAttributesSatisfyingExactly(
-                                  processAttributes(topic1, msgId1.toString(), false)));
-              assertThat(spans)
-                  .filteredOn(span -> span.getName().equals(topic2 + " process"))
-                  .singleElement()
-                  .satisfies(
-                      span ->
-                          assertThat(span)
-                              .hasKind(SpanKind.CONSUMER)
-                              .hasLinks(LinkData.create(topic2Producer.getSpanContext()))
-                              .hasAttributesSatisfyingExactly(
-                                  processAttributes(topic2, msgId2.toString(), false)));
-            });
-  }
-
-  private static SpanData findSpan(List<SpanData> spans, String name, SpanKind kind) {
-    return spans.stream()
-        .filter(span -> span.getName().equals(name) && span.getKind() == kind)
-        .findFirst()
-        .orElseThrow(() -> new AssertionError("Could not find span " + name));
-  }
-
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  private static void assertReceiveSpan(
-      SpanData span, SpanData producerSpan, String topic, String messageId) {
-    assertThat(span)
-        .hasKind(SpanKind.CONSUMER)
-        .hasNoParent()
-        .hasLinks(LinkData.create(producerSpan.getSpanContext()));
-
-    Attributes attributes = span.getAttributes();
-    assertThat(attributes.get(MESSAGING_SYSTEM)).isEqualTo("pulsar");
-    assertThat(attributes.get(MESSAGING_DESTINATION_NAME)).isEqualTo(topic);
-    assertThat(attributes.get(MESSAGING_OPERATION)).isEqualTo("receive");
-    assertThat(attributes.get(SERVER_ADDRESS)).isEqualTo(brokerHost);
-    assertThat(attributes.get(SERVER_PORT)).isEqualTo(brokerPort);
-    assertThat(
-            attributes.get(MESSAGING_MESSAGE_ID) != null
-                || attributes.get(MESSAGING_BATCH_MESSAGE_COUNT) != null)
-        .isTrue();
-    if (attributes.get(MESSAGING_MESSAGE_ID) != null) {
-      assertThat(attributes.get(MESSAGING_MESSAGE_ID)).isEqualTo(messageId);
-    }
+          producerSpan2.set(trace.getSpan(1));
+        },
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(topic2 + " receive")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            receiveAttributes(topic2, msgId2.toString(), false)),
+                span ->
+                    span.hasName(topic2 + " process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic2, msgId2.toString(), false))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -6,20 +6,25 @@
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
-import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -588,66 +593,79 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     latch.await(1, MINUTES);
 
-    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
-    AtomicReference<SpanData> producerSpan2 = new AtomicReference<>();
-    testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("parent1", topic1 + " receive", "parent2", topic2 + " receive"),
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
-              span ->
-                  span.hasName(topic1 + " publish")
-                      .hasKind(SpanKind.PRODUCER)
-                      .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          sendAttributes(topic1, msgId1.toString(), false)));
+    await()
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              List<SpanData> spans = testing.spans();
+              SpanData topic1Producer = findSpan(spans, topic1 + " publish", SpanKind.PRODUCER);
+              SpanData topic2Producer = findSpan(spans, topic2 + " publish", SpanKind.PRODUCER);
 
-          producerSpan.set(trace.getSpan(1));
-        },
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(topic1 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasNoParent()
-                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
-                        .hasAttributesSatisfyingExactly(
-                            receiveAttributes(topic1, msgId1.toString(), false)),
-                span ->
-                    span.hasName(topic1 + " process")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(0))
-                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
-                        .hasAttributesSatisfyingExactly(
-                            processAttributes(topic1, msgId1.toString(), false))),
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
-              span ->
-                  span.hasName(topic2 + " publish")
-                      .hasKind(SpanKind.PRODUCER)
-                      .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          sendAttributes(topic2, msgId2.toString(), false)));
+              assertThat(topic1Producer)
+                  .hasAttributesSatisfyingExactly(sendAttributes(topic1, msgId1.toString(), false));
+              assertThat(topic2Producer)
+                  .hasAttributesSatisfyingExactly(sendAttributes(topic2, msgId2.toString(), false));
 
-          producerSpan2.set(trace.getSpan(1));
-        },
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(topic2 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasNoParent()
-                        .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
-                        .hasAttributesSatisfyingExactly(
-                            receiveAttributes(topic2, msgId2.toString(), false)),
-                span ->
-                    span.hasName(topic2 + " process")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(0))
-                        .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
-                        .hasAttributesSatisfyingExactly(
-                            processAttributes(topic2, msgId2.toString(), false))));
+              assertThat(spans)
+                  .filteredOn(span -> span.getName().equals(topic1 + " receive"))
+                  .anySatisfy(
+                      span -> assertReceiveSpan(span, topic1Producer, topic1, msgId1.toString()));
+              assertThat(spans)
+                  .filteredOn(span -> span.getName().equals(topic2 + " receive"))
+                  .anySatisfy(
+                      span -> assertReceiveSpan(span, topic2Producer, topic2, msgId2.toString()));
+
+              assertThat(spans)
+                  .filteredOn(span -> span.getName().equals(topic1 + " process"))
+                  .singleElement()
+                  .satisfies(
+                      span ->
+                          assertThat(span)
+                              .hasKind(SpanKind.CONSUMER)
+                              .hasLinks(LinkData.create(topic1Producer.getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  processAttributes(topic1, msgId1.toString(), false)));
+              assertThat(spans)
+                  .filteredOn(span -> span.getName().equals(topic2 + " process"))
+                  .singleElement()
+                  .satisfies(
+                      span ->
+                          assertThat(span)
+                              .hasKind(SpanKind.CONSUMER)
+                              .hasLinks(LinkData.create(topic2Producer.getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  processAttributes(topic2, msgId2.toString(), false)));
+            });
+  }
+
+  private static SpanData findSpan(List<SpanData> spans, String name, SpanKind kind) {
+    return spans.stream()
+        .filter(span -> span.getName().equals(name) && span.getKind() == kind)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Could not find span " + name));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  private static void assertReceiveSpan(
+      SpanData span, SpanData producerSpan, String topic, String messageId) {
+    assertThat(span)
+        .hasKind(SpanKind.CONSUMER)
+        .hasNoParent()
+        .hasLinks(LinkData.create(producerSpan.getSpanContext()));
+
+    Attributes attributes = span.getAttributes();
+    assertThat(attributes.get(MESSAGING_SYSTEM)).isEqualTo("pulsar");
+    assertThat(attributes.get(MESSAGING_DESTINATION_NAME)).isEqualTo(topic);
+    assertThat(attributes.get(MESSAGING_OPERATION)).isEqualTo("receive");
+    assertThat(attributes.get(SERVER_ADDRESS)).isEqualTo(brokerHost);
+    assertThat(attributes.get(SERVER_PORT)).isEqualTo(brokerPort);
+    assertThat(
+            attributes.get(MESSAGING_MESSAGE_ID) != null
+                || attributes.get(MESSAGING_BATCH_MESSAGE_COUNT) != null)
+        .isTrue();
+    if (attributes.get(MESSAGING_MESSAGE_ID) != null) {
+      assertThat(attributes.get(MESSAGING_MESSAGE_ID)).isEqualTo(messageId);
+    }
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -90,7 +90,8 @@ public final class R2dbcSqlAttributesGetter
   }
 
   @Override
-  public boolean isParameterizedQuery(DbExecution request) {
+  public boolean isParameterizedQuery(DbExecution request, int queryIndex) {
+    // R2DBC does not support mixed parameterization within a single request.
     return request.isParameterizedQuery();
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/common/v4_0/VertxSqlClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-common-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/common/v4_0/VertxSqlClientAttributesGetter.java
@@ -98,7 +98,8 @@ class VertxSqlClientAttributesGetter
   }
 
   @Override
-  public boolean isParameterizedQuery(VertxSqlClientRequest request) {
+  public boolean isParameterizedQuery(VertxSqlClientRequest request, int queryIndex) {
+    // Vert.x SQL client does not support mixed parameterization within a single request.
     return request.isParameterizedQuery();
   }
 


### PR DESCRIPTION
## Summary
- capture Cassandra batch query texts and batch size for 3.0, 4.0, and 4.4 instrumentation
- support per-query parameterization so mixed Cassandra batches preserve parameterized query text while sanitizing literal query text
