### PR TITLE
Fix DynamoDB stable database semconv

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -37,6 +37,19 @@ tasks {
     include("**/SqsSuppressReceiveSpansTest.*")
   }
 
+  val testStableSemconv by registering(Test::class) {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      excludeTestsMatching("SqsSuppressReceiveSpansTest")
+    }
+    jvmArgs(
+      "-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true",
+      "-Dotel.semconv-stability.opt-in=database",
+    )
+  }
+
   test {
     filter {
       excludeTestsMatching("SqsSuppressReceiveSpansTest")
@@ -45,7 +58,7 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpansDisabled)
+    dependsOn(testReceiveSpansDisabled, testStableSemconv)
   }
 }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Response<?>> {
@@ -46,7 +47,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
 
     String operation = getOperationName(request.getOriginalRequest());
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, operation);
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation));
     }
     if (emitOldDatabaseSemconv()) {
       attributes.put(DB_OPERATION, operation);
@@ -56,9 +57,46 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
     if (tableName != null) {
       attributes.put(AWS_DYNAMODB_TABLE_NAMES, singletonList(tableName));
     }
-    if (emitStableDatabaseSemconv() && tableName != null) {
-      attributes.put(DB_COLLECTION_NAME, tableName);
+    if (emitStableDatabaseSemconv()) {
+      attributes.put(
+          DB_COLLECTION_NAME, getCollectionName(request.getOriginalRequest(), tableName));
     }
+  }
+
+  @Nullable
+  private static String getCollectionName(Object request, @Nullable String tableName) {
+    if (tableName != null) {
+      return tableName;
+    }
+
+    Map<?, ?> requestItems = RequestAccess.getRequestItems(request);
+    return requestItems != null ? getSingleCollectionName(requestItems) : null;
+  }
+
+  @Nullable
+  private static String getSingleCollectionName(Map<?, ?> requestItems) {
+    String collectionName = null;
+    for (Object candidate : requestItems.keySet()) {
+      if (!(candidate instanceof String)) {
+        return null;
+      }
+      if (collectionName != null && !collectionName.equals(candidate)) {
+        return null;
+      }
+      collectionName = (String) candidate;
+    }
+    return collectionName;
+  }
+
+  @Nullable
+  private static String getStableOperationName(@Nullable String operation) {
+    if ("BatchGetItem".equals(operation)) {
+      return "BATCH GetItem";
+    }
+    if ("BatchWriteItem".equals(operation)) {
+      return "BATCH WriteItem";
+    }
+    return operation;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 final class RequestAccess {
@@ -98,6 +99,12 @@ final class RequestAccess {
   }
 
   @Nullable
+  static Map<?, ?> getRequestItems(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getRequestItems, request, Map.class);
+  }
+
+  @Nullable
   static String getSnsTopicArn(Object request) {
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getTopicArn, request);
@@ -133,6 +140,7 @@ final class RequestAccess {
   @Nullable private final MethodHandle getLambdaResourceMappingId;
   @Nullable private final MethodHandle getQueueUrl;
   @Nullable private final MethodHandle getQueueName;
+  @Nullable private final MethodHandle getRequestItems;
   @Nullable private final MethodHandle getSecretArn;
   @Nullable private final MethodHandle getStreamName;
   @Nullable private final MethodHandle getTableName;
@@ -147,6 +155,7 @@ final class RequestAccess {
     getQueueName = findAccessorOrNull(clz, "getQueueName");
     getStreamName = findAccessorOrNull(clz, "getStreamName");
     getTableName = findAccessorOrNull(clz, "getTableName");
+    getRequestItems = findAccessorOrNull(clz, "getRequestItems", Map.class);
     getTopicArn = findAccessorOrNull(clz, "getTopicArn");
     getTargetArn = findAccessorOrNull(clz, "getTargetArn");
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -21,10 +21,14 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.AWS_DYNAMODB;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
@@ -45,12 +49,7 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
   void sendRequestWithMockedResponse() throws ReflectiveOperationException {
-    AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
-    AmazonDynamoDB client =
-        configureClient(clientBuilder)
-            .withEndpointConfiguration(endpoint)
-            .withCredentials(credentialsProvider)
-            .build();
+    AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
 
@@ -77,5 +76,55 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         DB_COLLECTION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+  void batchGetItemWithSingleTableUsesStableBatchAttributes() throws ReflectiveOperationException {
+    AmazonDynamoDB client = createClient();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
+
+    List<AttributeAssertion> additionalAttributes =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem")));
+    if (emitStableDatabaseSemconv()) {
+      additionalAttributes.add(equalTo(DB_COLLECTION_NAME, "sometable"));
+    }
+
+    Object response =
+        client.batchGetItem(
+            new BatchGetItemRequest()
+                .withRequestItems(
+                    singletonMap(
+                        "sometable",
+                        new KeysAndAttributes()
+                            .withKeys(
+                                singletonList(
+                                    singletonMap("key", new AttributeValue().withS("value")))))));
+    assertRequestWithMockedResponse(
+        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
+
+    assertDurationMetric(
+        testing(),
+        "io.opentelemetry.aws-sdk-1.11",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
+  }
+
+  private AmazonDynamoDB createClient() {
+    AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
+    return configureClient(clientBuilder)
+        .withEndpointConfiguration(endpoint)
+        .withCredentials(credentialsProvider)
+        .build();
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -82,6 +82,14 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testCoreOnlyStableSemconv by registering(Test::class) {
+    val testCoreOnlySourceSet = sourceSets["testCoreOnly"]
+    testClassesDirs = testCoreOnlySourceSet.output.classesDirs
+    classpath = testCoreOnlySourceSet.runtimeClasspath
+
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
   val testExceptionSignalLogs by registering(Test::class) {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -90,6 +98,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
+    dependsOn(testing.suites, testStableSemconv, testCoreOnlyStableSemconv, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -17,7 +17,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -47,7 +46,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     }
     String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, operation);
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation));
     }
     if (emitOldDatabaseSemconv()) {
       attributes.put(DB_OPERATION, operation);
@@ -58,6 +57,17 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
         attributes.put(DB_COLLECTION_NAME, tableName);
       }
     }
+  }
+
+  @Nullable
+  private static String getStableOperationName(@Nullable String operation) {
+    if ("BatchGetItem".equals(operation)) {
+      return "BATCH GetItem";
+    }
+    if ("BatchWriteItem".equals(operation)) {
+      return "BATCH WriteItem";
+    }
+    return operation;
   }
 
   @Nullable
@@ -77,14 +87,24 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     // as the attribute is defined as a single collection identifier.
     Optional<?> requestItems = request.getValueForField("RequestItems", Object.class);
     if (requestItems.isPresent() && requestItems.get() instanceof Map) {
-      // The instanceof check above guarantees Map, only the generic parameters are unchecked.
-      @SuppressWarnings("unchecked")
-      Set<String> tables = ((Map<String, ?>) requestItems.get()).keySet();
-      if (tables.size() == 1) {
-        return tables.iterator().next();
-      }
+      return getSingleCollectionName((Map<?, ?>) requestItems.get());
     }
     return null;
+  }
+
+  @Nullable
+  private static String getSingleCollectionName(Map<?, ?> requestItems) {
+    String collectionName = null;
+    for (Object candidate : requestItems.keySet()) {
+      if (!(candidate instanceof String)) {
+        return null;
+      }
+      if (collectionName != null && !collectionName.equals(candidate)) {
+        return null;
+      }
+      collectionName = (String) candidate;
+    }
+    return collectionName;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -308,7 +308,7 @@ public abstract class AbstractAws2ClientCoreTest {
                 equalTo(AWS_REQUEST_ID, "UNKNOWN"),
                 equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")),
                 equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(DYNAMODB)),
-                equalTo(maybeStable(DB_OPERATION), operation)));
+                equalTo(maybeStable(DB_OPERATION), expectedDbOperationName(operation))));
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(DB_COLLECTION_NAME, "sometable"));
     }
@@ -551,6 +551,20 @@ public abstract class AbstractAws2ClientCoreTest {
                                     assertThat(s.getAttributes().asMap())
                                         .containsKey(stringArrayKey("aws.dynamodb.table_names"))
                                         .doesNotContainKey(DB_COLLECTION_NAME))));
+  }
+
+  private static String expectedDbOperationName(String operation) {
+    if (!emitStableDatabaseSemconv()) {
+      return operation;
+    }
+    switch (operation) {
+      case "BatchGetItem":
+        return "BATCH GetItem";
+      case "BatchWriteItem":
+        return "BATCH WriteItem";
+      default:
+        return operation;
+    }
   }
 
   private static String getResponseContent(String operation) {


### PR DESCRIPTION
## Summary

- emit stable DynamoDB batch operation names as `BATCH GetItem` and `BATCH WriteItem`
- set `db.collection.name` for AWS SDK v1 single-table DynamoDB batch requests
- add stable semconv test coverage for AWS SDK v1 autoconfigure and AWS SDK v2 DynamoDB core tests

cc @chlos 