### PR TITLE
Fix DynamoDB batch attributes

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -98,12 +98,23 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
   private static String getStableOperationName(
       @Nullable String operation, @Nullable Long batchSize) {
     if ("BatchGetItem".equals(operation)) {
-      return isBatch(batchSize) ? "BATCH GetItem" : "GetItem";
+      return getStableBatchOperationName(batchSize, "GetItem", operation);
     }
     if ("BatchWriteItem".equals(operation)) {
-      return isBatch(batchSize) ? "BATCH WriteItem" : "WriteItem";
+      return getStableBatchOperationName(batchSize, "WriteItem", operation);
     }
     return operation;
+  }
+
+  private static String getStableBatchOperationName(
+      @Nullable Long batchSize, String itemOperation, String batchOperation) {
+    if (batchSize == null || batchSize == 0) {
+      return batchOperation;
+    }
+    if (batchSize == 1) {
+      return itemOperation;
+    }
+    return "BATCH " + itemOperation;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static java.util.Collections.singletonList;
@@ -18,6 +19,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -46,8 +48,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
     }
 
     String operation = getOperationName(request.getOriginalRequest());
+    Long batchSize = extractBatchSize(operation, request.getOriginalRequest());
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation));
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
+      if (isBatch(batchSize)) {
+        attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
+      }
     }
     if (emitOldDatabaseSemconv()) {
       attributes.put(DB_OPERATION, operation);
@@ -89,14 +95,58 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
   }
 
   @Nullable
-  private static String getStableOperationName(@Nullable String operation) {
+  private static String getStableOperationName(
+      @Nullable String operation, @Nullable Long batchSize) {
     if ("BatchGetItem".equals(operation)) {
-      return "BATCH GetItem";
+      return isBatch(batchSize) ? "BATCH GetItem" : "GetItem";
     }
     if ("BatchWriteItem".equals(operation)) {
-      return "BATCH WriteItem";
+      return isBatch(batchSize) ? "BATCH WriteItem" : "WriteItem";
     }
     return operation;
+  }
+
+  @Nullable
+  private static Long extractBatchSize(@Nullable String operation, Object request) {
+    if (!"BatchGetItem".equals(operation) && !"BatchWriteItem".equals(operation)) {
+      return null;
+    }
+
+    Map<?, ?> requestItems = RequestAccess.getRequestItems(request);
+    if (requestItems == null) {
+      return null;
+    }
+
+    long batchSize =
+        "BatchGetItem".equals(operation)
+            ? countBatchGetItems(requestItems)
+            : countBatchWriteItems(requestItems);
+    return batchSize == 0 ? null : batchSize;
+  }
+
+  private static long countBatchGetItems(Map<?, ?> requestItems) {
+    long count = 0;
+    for (Object keysAndAttributes : requestItems.values()) {
+      List<?> keys = RequestAccess.getKeys(keysAndAttributes);
+      if (keys != null) {
+        count += keys.size();
+      }
+    }
+    return count;
+  }
+
+  private static long countBatchWriteItems(Map<?, ?> requestItems) {
+    long count = 0;
+    for (Object writeRequests : requestItems.values()) {
+      if (writeRequests instanceof Collection) {
+        count += ((Collection<?>) writeRequests).size();
+      }
+    }
+    return count;
+  }
+
+  private static boolean isBatch(@Nullable Long batchSize) {
+    return batchSize != null && batchSize > 1;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -105,6 +106,12 @@ final class RequestAccess {
   }
 
   @Nullable
+  static List<?> getKeys(Object request) {
+    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
+    return invokeOrNull(access.getKeys, request, List.class);
+  }
+
+  @Nullable
   static String getSnsTopicArn(Object request) {
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
     return invokeOrNull(access.getTopicArn, request);
@@ -135,6 +142,7 @@ final class RequestAccess {
   }
 
   @Nullable private final MethodHandle getBucketName;
+  @Nullable private final MethodHandle getKeys;
   @Nullable private final MethodHandle getLambdaConfiguration;
   @Nullable private final MethodHandle getLambdaName;
   @Nullable private final MethodHandle getLambdaResourceMappingId;
@@ -155,6 +163,7 @@ final class RequestAccess {
     getQueueName = findAccessorOrNull(clz, "getQueueName");
     getStreamName = findAccessorOrNull(clz, "getStreamName");
     getTableName = findAccessorOrNull(clz, "getTableName");
+    getKeys = findAccessorOrNull(clz, "getKeys", List.class);
     getRequestItems = findAccessorOrNull(clz, "getRequestItems", Map.class);
     getTopicArn = findAccessorOrNull(clz, "getTopicArn");
     getTargetArn = findAccessorOrNull(clz, "getTargetArn");

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -28,8 +28,11 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+import com.amazonaws.services.dynamodbv2.model.PutRequest;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
@@ -81,8 +84,8 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
-    void batchGetItemWithMultipleItemsUsesStableBatchAttributes()
-            throws ReflectiveOperationException {
+  void batchGetItemWithMultipleItemsUsesStableBatchAttributes()
+      throws ReflectiveOperationException {
     AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
@@ -96,8 +99,7 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
                     maybeStable(DB_OPERATION),
                     emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem"),
                 equalTo(
-                    DB_OPERATION_BATCH_SIZE,
-                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
+                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
                 equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
 
     Object response =
@@ -127,8 +129,7 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
-    void batchGetItemWithSingleItemUsesStableItemOperation()
-      throws ReflectiveOperationException {
+  void batchGetItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
     AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
@@ -164,6 +165,85 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         DB_COLLECTION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+  void batchWriteItemWithMultipleItemsUsesStableBatchAttributes()
+      throws ReflectiveOperationException {
+    AmazonDynamoDB client = createClient();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
+
+    List<AttributeAssertion> additionalAttributes =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? "BATCH WriteItem" : "BatchWriteItem"),
+                equalTo(
+                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
+                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
+
+    Object response =
+        client.batchWriteItem(
+            new BatchWriteItemRequest()
+                .withRequestItems(
+                    singletonMap(
+                        "sometable", asList(writeRequest("value"), writeRequest("anotherValue")))));
+    assertRequestWithMockedResponse(
+        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
+
+    assertDurationMetric(
+        testing(),
+        "io.opentelemetry.aws-sdk-1.11",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+  void batchWriteItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
+    AmazonDynamoDB client = createClient();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
+
+    List<AttributeAssertion> additionalAttributes =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? "WriteItem" : "BatchWriteItem"),
+                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
+
+    Object response =
+        client.batchWriteItem(
+            new BatchWriteItemRequest()
+                .withRequestItems(singletonMap("sometable", singletonList(writeRequest("value")))));
+    assertRequestWithMockedResponse(
+        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
+
+    assertDurationMetric(
+        testing(),
+        "io.opentelemetry.aws-sdk-1.11",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
+  }
+
+  private static WriteRequest writeRequest(String value) {
+    return new WriteRequest()
+        .withPutRequest(
+            new PutRequest().withItem(singletonMap("key", new AttributeValue().withS(value))));
   }
 
   private AmazonDynamoDB createClient() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -80,7 +81,8 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
-  void batchGetItemWithSingleTableUsesStableBatchAttributes() throws ReflectiveOperationException {
+    void batchGetItemWithMultipleItemsUsesStableBatchAttributes()
+            throws ReflectiveOperationException {
     AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
@@ -92,10 +94,54 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
                     maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
                 equalTo(
                     maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem")));
-    if (emitStableDatabaseSemconv()) {
-      additionalAttributes.add(equalTo(DB_COLLECTION_NAME, "sometable"));
-    }
+                    emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem"),
+                equalTo(
+                    DB_OPERATION_BATCH_SIZE,
+                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
+                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
+
+    Object response =
+        client.batchGetItem(
+            new BatchGetItemRequest()
+                .withRequestItems(
+                    singletonMap(
+                        "sometable",
+                        new KeysAndAttributes()
+                            .withKeys(
+                                asList(
+                                    singletonMap("key", new AttributeValue().withS("value")),
+                                    singletonMap(
+                                        "key", new AttributeValue().withS("anotherValue")))))));
+    assertRequestWithMockedResponse(
+        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
+
+    assertDurationMetric(
+        testing(),
+        "io.opentelemetry.aws-sdk-1.11",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+    void batchGetItemWithSingleItemUsesStableItemOperation()
+      throws ReflectiveOperationException {
+    AmazonDynamoDB client = createClient();
+
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
+
+    List<AttributeAssertion> additionalAttributes =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? "GetItem" : "BatchGetItem"),
+                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
 
     Object response =
         client.batchGetItem(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -49,7 +49,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
       attributes.put(DB_SYSTEM, DYNAMODB);
     }
     String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
-    long batchSize = extractBatchSize(operation, executionAttributes);
+    Long batchSize = extractBatchSize(operation, executionAttributes);
     if (emitStableDatabaseSemconv()) {
       attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
       if (isBatch(batchSize)) {
@@ -68,7 +68,8 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   }
 
   @Nullable
-  private static String getStableOperationName(@Nullable String operation, long batchSize) {
+  private static String getStableOperationName(
+      @Nullable String operation, @Nullable Long batchSize) {
     if ("BatchGetItem".equals(operation)) {
       return isBatch(batchSize) ? "BATCH GetItem" : "GetItem";
     }
@@ -78,20 +79,21 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     return operation;
   }
 
-  private long extractBatchSize(
+  @Nullable
+  private Long extractBatchSize(
       @Nullable String operation, ExecutionAttributes executionAttributes) {
     if (!"BatchGetItem".equals(operation) && !"BatchWriteItem".equals(operation)) {
-      return 0;
+      return null;
     }
 
     SdkRequest request =
         executionAttributes.getAttribute(TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE);
     if (request == null) {
-      return 0;
+      return null;
     }
     Optional<?> requestItems = request.getValueForField("RequestItems", Object.class);
     if (!requestItems.isPresent() || !(requestItems.get() instanceof Map)) {
-      return 0;
+      return null;
     }
 
     Map<?, ?> requestItemsMap = (Map<?, ?>) requestItems.get();
@@ -121,8 +123,8 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     return count;
   }
 
-  private static boolean isBatch(long batchSize) {
-    return batchSize > 1;
+  private static boolean isBatch(@Nullable Long batchSize) {
+    return batchSize != null && batchSize > 1;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -71,12 +71,23 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   private static String getStableOperationName(
       @Nullable String operation, @Nullable Long batchSize) {
     if ("BatchGetItem".equals(operation)) {
-      return isBatch(batchSize) ? "BATCH GetItem" : "GetItem";
+      return getStableBatchOperationName(batchSize, "GetItem", operation);
     }
     if ("BatchWriteItem".equals(operation)) {
-      return isBatch(batchSize) ? "BATCH WriteItem" : "WriteItem";
+      return getStableBatchOperationName(batchSize, "WriteItem", operation);
     }
     return operation;
+  }
+
+  private static String getStableBatchOperationName(
+      @Nullable Long batchSize, String itemOperation, String batchOperation) {
+    if (batchSize == null || batchSize == 0) {
+      return batchOperation;
+    }
+    if (batchSize == 1) {
+      return itemOperation;
+    }
+    return "BATCH " + itemOperation;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 
@@ -15,6 +16,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -33,6 +35,8 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
   private static final String AWS_DYNAMODB = "aws.dynamodb";
 
+  private final MethodHandleFactory methodHandleFactory = new MethodHandleFactory();
+
   @Override
   public void onStart(
       AttributesBuilder attributes,
@@ -45,8 +49,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
       attributes.put(DB_SYSTEM, DYNAMODB);
     }
     String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
+    long batchSize = extractBatchSize(operation, executionAttributes);
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation));
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
+      if (isBatch(batchSize)) {
+        attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
+      }
     }
     if (emitOldDatabaseSemconv()) {
       attributes.put(DB_OPERATION, operation);
@@ -60,14 +68,70 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   }
 
   @Nullable
-  private static String getStableOperationName(@Nullable String operation) {
+  private static String getStableOperationName(@Nullable String operation, long batchSize) {
     if ("BatchGetItem".equals(operation)) {
-      return "BATCH GetItem";
+      return isBatch(batchSize) ? "BATCH GetItem" : "GetItem";
     }
     if ("BatchWriteItem".equals(operation)) {
-      return "BATCH WriteItem";
+      return isBatch(batchSize) ? "BATCH WriteItem" : "WriteItem";
     }
     return operation;
+  }
+
+  private long extractBatchSize(
+      @Nullable String operation, ExecutionAttributes executionAttributes) {
+    if (!"BatchGetItem".equals(operation) && !"BatchWriteItem".equals(operation)) {
+      return 0;
+    }
+
+    SdkRequest request =
+        executionAttributes.getAttribute(TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE);
+    if (request == null) {
+      return 0;
+    }
+    Optional<?> requestItems = request.getValueForField("RequestItems", Object.class);
+    if (!requestItems.isPresent() || !(requestItems.get() instanceof Map)) {
+      return 0;
+    }
+
+    Map<?, ?> requestItemsMap = (Map<?, ?>) requestItems.get();
+    return "BatchGetItem".equals(operation)
+        ? countBatchGetItems(requestItemsMap)
+        : countBatchWriteItems(requestItemsMap);
+  }
+
+  private long countBatchGetItems(Map<?, ?> requestItems) {
+    long count = 0;
+    for (Object keysAndAttributes : requestItems.values()) {
+      Object keys = next(keysAndAttributes, "Keys");
+      if (keys instanceof Collection) {
+        count += ((Collection<?>) keys).size();
+      }
+    }
+    return count;
+  }
+
+  private static long countBatchWriteItems(Map<?, ?> requestItems) {
+    long count = 0;
+    for (Object writeRequests : requestItems.values()) {
+      if (writeRequests instanceof Collection) {
+        count += ((Collection<?>) writeRequests).size();
+      }
+    }
+    return count;
+  }
+
+  private static boolean isBatch(long batchSize) {
+    return batchSize > 1;
+  }
+
+  @Nullable
+  private Object next(Object current, String fieldName) {
+    try {
+      return methodHandleFactory.forField(current.getClass(), fieldName).invoke(current);
+    } catch (Throwable ignored) {
+      return null;
+    }
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStableDbSystemName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -293,6 +294,16 @@ public abstract class AbstractAws2ClientCoreTest {
   @SuppressWarnings("deprecation") // uses deprecated semconv
   private static void assertDynamoDbRequest(
       SpanDataAssert span, String operation, List<AttributeAssertion> extraAttributes) {
+        assertDynamoDbRequest(
+                span, operation, extraAttributes, expectedDbOperationNameForSingleItemRequest(operation));
+  }
+
+  @SuppressWarnings("deprecation") // uses deprecated semconv
+  private static void assertDynamoDbRequest(
+      SpanDataAssert span,
+      String operation,
+      List<AttributeAssertion> extraAttributes,
+      String expectedStableOperationName) {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
@@ -308,7 +319,9 @@ public abstract class AbstractAws2ClientCoreTest {
                 equalTo(AWS_REQUEST_ID, "UNKNOWN"),
                 equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")),
                 equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(DYNAMODB)),
-                equalTo(maybeStable(DB_OPERATION), expectedDbOperationName(operation))));
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? expectedStableOperationName : operation)));
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(DB_COLLECTION_NAME, "sometable"));
     }
@@ -553,18 +566,144 @@ public abstract class AbstractAws2ClientCoreTest {
                                         .doesNotContainKey(DB_COLLECTION_NAME))));
   }
 
-  private static String expectedDbOperationName(String operation) {
-    if (!emitStableDatabaseSemconv()) {
-      return operation;
-    }
-    switch (operation) {
-      case "BatchGetItem":
-        return "BATCH GetItem";
-      case "BatchWriteItem":
-        return "BATCH WriteItem";
-      default:
-        return operation;
-    }
+  @Test
+  @SuppressWarnings("deprecation") // uses deprecated semconv
+  void testBatchGetItemWithMultipleItemsUsesStableBatchAttributes() {
+    DynamoDbClientBuilder builder = DynamoDbClient.builder();
+    configureSdkClient(builder);
+    DynamoDbClient client =
+        builder
+            .endpointOverride(server.httpUri())
+            .region(Region.AP_NORTHEAST_1)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+    server.enqueue(
+        HttpResponse.of(
+            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchGetItem")));
+
+    client.batchGetItem(
+        b ->
+            b.requestItems(
+                ImmutableMap.of(
+                    "sometable",
+                    KeysAndAttributes.builder()
+                        .keys(
+                            asList(
+                                ImmutableMap.of(
+                                    "key", AttributeValue.builder().s("value").build()),
+                                ImmutableMap.of(
+                                    "key", AttributeValue.builder().s("anotherValue").build())))
+                        .build())));
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertDynamoDbRequest(
+                            span,
+                            "BatchGetItem",
+                            asList(
+                                equalTo(
+                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
+                                    singletonList(
+                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
+                            "BATCH GetItem")));
+
+    assertDurationMetric(
+        getTesting(),
+        "io.opentelemetry.aws-sdk-2.2",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // uses deprecated semconv
+  void testBatchWriteItemWithMultipleItemsUsesStableBatchAttributes() {
+    DynamoDbClientBuilder builder = DynamoDbClient.builder();
+    configureSdkClient(builder);
+    DynamoDbClient client =
+        builder
+            .endpointOverride(server.httpUri())
+            .region(Region.AP_NORTHEAST_1)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+    server.enqueue(
+        HttpResponse.of(
+            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchWriteItem")));
+
+    client.batchWriteItem(
+        b ->
+            b.requestItems(
+                ImmutableMap.of(
+                    "sometable",
+                    asList(
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder()
+                                    .item(
+                                        ImmutableMap.of(
+                                            "key",
+                                            AttributeValue.builder().s("value").build()))
+                                    .build())
+                            .build(),
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder()
+                                    .item(
+                                        ImmutableMap.of(
+                                            "key",
+                                            AttributeValue.builder().s("anotherValue").build()))
+                                    .build())
+                            .build()))));
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertDynamoDbRequest(
+                            span,
+                            "BatchWriteItem",
+                            asList(
+                                equalTo(
+                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
+                                    singletonList(
+                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
+                                equalTo(
+                                    AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+                                    "[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]"),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
+                            "BATCH WriteItem")));
+
+    assertDurationMetric(
+        getTesting(),
+        "io.opentelemetry.aws-sdk-2.2",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME);
+  }
+
+    private static String expectedDbOperationNameForSingleItemRequest(String operation) {
+        if (!emitStableDatabaseSemconv()) {
+            return operation;
+        }
+        // The parameterized Batch* requests contain one item. Stable DB semconv treats those as
+        // logical item operations; dedicated multi-item tests pass the BATCH operation name directly.
+        switch (operation) {
+            case "BatchGetItem":
+                return "GetItem";
+            case "BatchWriteItem":
+                return "WriteItem";
+            default:
+                return operation;
+        }
   }
 
   private static String getResponseContent(String operation) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -294,8 +294,8 @@ public abstract class AbstractAws2ClientCoreTest {
   @SuppressWarnings("deprecation") // uses deprecated semconv
   private static void assertDynamoDbRequest(
       SpanDataAssert span, String operation, List<AttributeAssertion> extraAttributes) {
-        assertDynamoDbRequest(
-                span, operation, extraAttributes, expectedDbOperationNameForSingleItemRequest(operation));
+    assertDynamoDbRequest(
+        span, operation, extraAttributes, expectedDbOperationNameForSingleItemRequest(operation));
   }
 
   @SuppressWarnings("deprecation") // uses deprecated semconv
@@ -589,8 +589,7 @@ public abstract class AbstractAws2ClientCoreTest {
                     KeysAndAttributes.builder()
                         .keys(
                             asList(
-                                ImmutableMap.of(
-                                    "key", AttributeValue.builder().s("value").build()),
+                                ImmutableMap.of("key", AttributeValue.builder().s("value").build()),
                                 ImmutableMap.of(
                                     "key", AttributeValue.builder().s("anotherValue").build())))
                         .build())));
@@ -647,8 +646,7 @@ public abstract class AbstractAws2ClientCoreTest {
                                 PutRequest.builder()
                                     .item(
                                         ImmutableMap.of(
-                                            "key",
-                                            AttributeValue.builder().s("value").build()))
+                                            "key", AttributeValue.builder().s("value").build()))
                                     .build())
                             .build(),
                         WriteRequest.builder()
@@ -690,20 +688,20 @@ public abstract class AbstractAws2ClientCoreTest {
         DB_COLLECTION_NAME);
   }
 
-    private static String expectedDbOperationNameForSingleItemRequest(String operation) {
-        if (!emitStableDatabaseSemconv()) {
-            return operation;
-        }
-        // The parameterized Batch* requests contain one item. Stable DB semconv treats those as
-        // logical item operations; dedicated multi-item tests pass the BATCH operation name directly.
-        switch (operation) {
-            case "BatchGetItem":
-                return "GetItem";
-            case "BatchWriteItem":
-                return "WriteItem";
-            default:
-                return operation;
-        }
+  private static String expectedDbOperationNameForSingleItemRequest(String operation) {
+    if (!emitStableDatabaseSemconv()) {
+      return operation;
+    }
+    // The parameterized Batch* requests contain one item. Stable DB semconv treats those as
+    // logical item operations; dedicated multi-item tests pass the BATCH operation name directly.
+    switch (operation) {
+      case "BatchGetItem":
+        return "GetItem";
+      case "BatchWriteItem":
+        return "WriteItem";
+      default:
+        return operation;
+    }
   }
 
   private static String getResponseContent(String operation) {


### PR DESCRIPTION
## Summary

Fixes DynamoDB stable database semconv batch handling for AWS SDK 1.11 and 2.2 instrumentation.

Previously, `BatchGetItem` and `BatchWriteItem` stable operation names were based only on the AWS operation name. This PR counts the actual request items so that:

- single-item `BatchGetItem` / `BatchWriteItem` requests emit logical stable item operations (`GetItem` / `WriteItem`)
- multi-item batch requests emit `BATCH GetItem` / `BATCH WriteItem`
- true batch requests emit `db.operation.batch.size`
