### PR TITLE
Add R2DBC batch size semconv attributes

### DIFF
--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -11,7 +11,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
-import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
@@ -19,6 +19,7 @@ import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -64,7 +65,8 @@ public final class DbExecution {
   @Nullable private final String serverAddress;
   @Nullable private final Integer serverPort;
   private final String connectionString;
-  private final String rawQueryText;
+  private final List<String> rawQueryTexts;
+  @Nullable private final Long batchSize;
   private final boolean parameterizedQuery;
 
   @Nullable private Context context;
@@ -100,13 +102,15 @@ public final class DbExecution {
             protocol != null ? ":" + protocol : "",
             serverAddress != null ? "//" + serverAddress : "",
             serverPort != null ? ":" + serverPort : "");
-    this.rawQueryText =
+    this.rawQueryTexts =
         queryInfo.getQueries().stream()
             .map(QueryInfo::getQuery)
             .map(
                 query ->
                     R2dbcSqlCommenterUtil.getOriginalQuery(queryInfo.getConnectionInfo(), query))
-            .collect(joining(";\n"));
+            .collect(toList());
+    int queryInfoBatchSize = queryInfo.getBatchSize();
+    this.batchSize = queryInfoBatchSize > 1 ? (long) queryInfoBatchSize : null;
     this.parameterizedQuery =
         queryInfo.getQueries().stream()
             .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());
@@ -146,8 +150,13 @@ public final class DbExecution {
     return connectionString;
   }
 
-  public String getRawQueryText() {
-    return rawQueryText;
+  public List<String> getRawQueryTexts() {
+    return rawQueryTexts;
+  }
+
+  @Nullable
+  public Long getBatchSize() {
+    return batchSize;
   }
 
   public boolean isParameterizedQuery() {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -66,6 +66,9 @@ public final class R2dbcSqlAttributesGetter
   @Override
   public Collection<String> getRawQueryTexts(DbExecution request) {
     Collection<String> rawQueryTexts = request.getRawQueryTexts();
+    // In old-only mode, return a single joined query to preserve the legacy db.statement and
+    // db.operation extraction behavior. In database/dup mode, favor stable multi-query batch
+    // attributes because the shared SQL extractor can only use one raw query collection.
     return emitStableDatabaseSemconv() ? rawQueryTexts : singleton(join("; ", rawQueryTexts));
   }
 
@@ -83,7 +86,9 @@ public final class R2dbcSqlAttributesGetter
   @Override
   @Nullable
   public Long getDbOperationBatchSize(DbExecution request) {
-    return request.getBatchSize();
+    // Batch size is a stable database semconv signal. Keep it hidden from old-only mode so legacy
+    // extraction does not start treating existing requests as batches.
+    return emitStableDatabaseSemconv() ? request.getBatchSize() : null;
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -66,10 +66,13 @@ public final class R2dbcSqlAttributesGetter
   @Override
   public Collection<String> getRawQueryTexts(DbExecution request) {
     Collection<String> rawQueryTexts = request.getRawQueryTexts();
-    // In old-only mode, return a single joined query to preserve the legacy db.statement and
-    // db.operation extraction behavior. In database/dup mode, favor stable multi-query batch
-    // attributes because the shared SQL extractor can only use one raw query collection.
-    return emitStableDatabaseSemconv() ? rawQueryTexts : singleton(join("; ", rawQueryTexts));
+    // In old-only mode, join multi-query batches into a single query to preserve the legacy
+    // db.statement and db.operation extraction behavior. In database/dup mode, favor stable
+    // multi-query batch attributes because the shared SQL extractor can only use one raw query
+    // collection.
+    return emitStableDatabaseSemconv() || rawQueryTexts.size() == 1
+        ? rawQueryTexts
+        : singleton(join("; ", rawQueryTexts));
   }
 
   private static String join(String delimiter, Collection<String> collection) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static java.util.Collections.singleton;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
@@ -63,7 +65,19 @@ public final class R2dbcSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(DbExecution request) {
-    return request.getRawQueryTexts();
+    Collection<String> rawQueryTexts = request.getRawQueryTexts();
+    return emitStableDatabaseSemconv() ? rawQueryTexts : singleton(join("; ", rawQueryTexts));
+  }
+
+  private static String join(String delimiter, Collection<String> collection) {
+    StringBuilder builder = new StringBuilder();
+    for (String string : collection) {
+      if (builder.length() != 0) {
+        builder.append(delimiter);
+      }
+      builder.append(string);
+    }
+    return builder.toString();
   }
 
   @Override

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -72,7 +72,7 @@ public final class R2dbcSqlAttributesGetter
     // collection.
     return emitStableDatabaseSemconv() || rawQueryTexts.size() == 1
         ? rawQueryTexts
-        : singleton(join("; ", rawQueryTexts));
+        : singleton(join(";\n", rawQueryTexts));
   }
 
   private static String join(String delimiter, Collection<String> collection) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
-import static java.util.Collections.singleton;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
@@ -64,7 +63,13 @@ public final class R2dbcSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(DbExecution request) {
-    return singleton(request.getRawQueryText());
+    return request.getRawQueryTexts();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(DbExecution request) {
+    return request.getBatchSize();
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -49,8 +49,45 @@ class DbExecutionTest {
     assertThat(dbExecution.getServerAddress()).isEqualTo("localhost");
     assertThat(dbExecution.getServerPort()).isEqualTo(3306);
     assertThat(dbExecution.getConnectionString()).isEqualTo("mariadb://localhost:3306");
-    assertThat(dbExecution.getRawQueryText())
-        .isEqualTo("SELECT * from person where last_name = 'tom'");
+    assertThat(dbExecution.getRawQueryTexts())
+        .containsExactly("SELECT * from person where last_name = 'tom'");
+    assertThat(dbExecution.getBatchSize()).isNull();
+  }
+
+  @Test
+  void dbExecutionWithBatch() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
+            .batchSize(2)
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    assertThat(dbExecution.getRawQueryTexts())
+        .containsExactly("INSERT INTO person VALUES(1)", "INSERT INTO person VALUES(2)");
+    assertThat(dbExecution.getBatchSize()).isEqualTo(2);
+  }
+
+  @Test
+  void dbExecutionWithBatchSizeOne() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
+            .batchSize(1)
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    assertThat(dbExecution.getRawQueryTexts()).containsExactly("INSERT INTO person VALUES(1)");
+    assertThat(dbExecution.getBatchSize()).isNull();
   }
 
   @SuppressWarnings("deprecation") // testing deprecated semconv

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -40,9 +40,11 @@ class R2dbcSqlAttributesGetterTest {
     if (emitStableDatabaseSemconv()) {
       assertThat(rawQueryTexts)
           .containsExactly("INSERT INTO person VALUES(1)", "INSERT INTO person VALUES(2)");
+      assertThat(getter.getDbOperationBatchSize(dbExecution)).isEqualTo(2);
     } else {
       assertThat(rawQueryTexts)
           .containsExactly("INSERT INTO person VALUES(1); INSERT INTO person VALUES(2)");
+      assertThat(getter.getDbOperationBatchSize(dbExecution)).isNull();
     }
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -23,6 +23,23 @@ class R2dbcSqlAttributesGetterTest {
   private final R2dbcSqlAttributesGetter getter = new R2dbcSqlAttributesGetter();
 
   @Test
+  void rawQueryTextsForSingleQuery() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    Collection<String> rawQueryTexts = getter.getRawQueryTexts(dbExecution);
+
+    assertThat(rawQueryTexts).isSameAs(dbExecution.getRawQueryTexts());
+    assertThat(rawQueryTexts).containsExactly("INSERT INTO person VALUES(1)");
+  }
+
+  @Test
   void rawQueryTextsForBatch() {
     QueryExecutionInfo queryExecutionInfo =
         MockQueryExecutionInfo.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.r2dbc.v1_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
+import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.R2dbcSqlAttributesGetter;
+import io.r2dbc.proxy.core.QueryExecutionInfo;
+import io.r2dbc.proxy.core.QueryInfo;
+import io.r2dbc.proxy.test.MockConnectionInfo;
+import io.r2dbc.proxy.test.MockQueryExecutionInfo;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+
+class R2dbcSqlAttributesGetterTest {
+
+  private final R2dbcSqlAttributesGetter getter = new R2dbcSqlAttributesGetter();
+
+  @Test
+  void rawQueryTextsForBatch() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
+            .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
+            .batchSize(2)
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    Collection<String> rawQueryTexts = getter.getRawQueryTexts(dbExecution);
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(rawQueryTexts)
+          .containsExactly("INSERT INTO person VALUES(1)", "INSERT INTO person VALUES(2)");
+    } else {
+      assertThat(rawQueryTexts)
+          .containsExactly("INSERT INTO person VALUES(1); INSERT INTO person VALUES(2)");
+    }
+  }
+}

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -60,7 +60,7 @@ class R2dbcSqlAttributesGetterTest {
       assertThat(getter.getDbOperationBatchSize(dbExecution)).isEqualTo(2);
     } else {
       assertThat(rawQueryTexts)
-          .containsExactly("INSERT INTO person VALUES(1); INSERT INTO person VALUES(2)");
+          .containsExactly("INSERT INTO person VALUES(1);\nINSERT INTO person VALUES(2)");
       assertThat(getter.getDbOperationBatchSize(dbExecution)).isNull();
     }
   }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -11,8 +11,10 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
@@ -30,6 +32,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -54,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -292,6 +296,62 @@ public abstract class AbstractR2dbcStatementTest {
         emitStableDatabaseSemconv() ? DB_QUERY_SUMMARY : DB_OPERATION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @Test
+  void testBatchQueries() {
+    assumeTrue(emitStableDatabaseSemconv());
+
+    DbSystemProps props = systems.get(MARIADB.system);
+    startContainer(props);
+    ConnectionFactory connectionFactory =
+        createProxyConnectionFactory(
+            ConnectionFactoryOptions.builder()
+                .option(DRIVER, props.system)
+                .option(HOST, container.getHost())
+                .option(PORT, port)
+                .option(USER, USER_DB)
+                .option(PASSWORD, PW_DB)
+                .option(DATABASE, DB)
+                .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
+                .build());
+
+    getTesting()
+        .runWithSpan(
+            "parent",
+            () -> {
+              Mono.from(connectionFactory.create())
+                  .flatMapMany(
+                      connection ->
+                          Flux.from(
+                                  connection
+                                      .createBatch()
+                                      .add("SELECT 1")
+                                      .add("SELECT 2")
+                                      .execute())
+                              .flatMap(result -> result.map((row, metadata) -> ""))
+                              .concatWith(Mono.from(connection.close()).cast(String.class)))
+                  .blockLast(Duration.ofMinutes(1));
+            });
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
+                    span ->
+                        span.hasName("BATCH SELECT")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(DB_SYSTEM_NAME, MARIADB.system),
+                                equalTo(DB_NAMESPACE, DB),
+                                equalTo(DB_QUERY_TEXT, "SELECT ?"),
+                                equalTo(DB_QUERY_SUMMARY, "BATCH SELECT"),
+                                equalTo(DB_OPERATION_BATCH_SIZE, 2),
+                                equalTo(maybeStablePeerService(), "test-peer-service"),
+                                equalTo(SERVER_ADDRESS, container.getHost()),
+                                equalTo(SERVER_PORT, port))));
   }
 
   private static class Parameter {


### PR DESCRIPTION
## Summary
- preserve individual R2DBC batch query texts instead of joining them into one string
- expose multi-query batch size to the shared SQL semconv extractor
