### PR TITLE
Prevent Lettuce Redis db.namespace being included in span names

### DIFF
--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -28,6 +28,8 @@ public class JedisSingletons {
 
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
+    // Redis semantic conventions don't follow the regular pattern of adding db.namespace to the
+    // span name.
     JedisDbAttributesGetter spanNameAttributesGetter =
         new JedisDbAttributesGetter() {
           @Override

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesGetter.java
@@ -9,7 +9,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class LettuceDbAttributesGetter
+class LettuceDbAttributesGetter
     implements DbClientAttributesGetter<LettuceRequest, LettuceResponse> {
 
   // copied from DbIncubatingAttributes.DbSystemIncubatingValues

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import javax.annotation.Nullable;
 
 /** A builder of {@link LettuceTelemetry}. */
 public final class LettuceTelemetryBuilder {
@@ -59,12 +60,22 @@ public final class LettuceTelemetryBuilder {
    */
   public LettuceTelemetry build() {
     LettuceDbAttributesGetter dbAttributesGetter = new LettuceDbAttributesGetter();
+    // Redis semantic conventions don't follow the regular pattern of adding db.namespace to the
+    // span name.
+    LettuceDbAttributesGetter spanNameAttributesGetter =
+        new LettuceDbAttributesGetter() {
+          @Override
+          @Nullable
+          public String getDbNamespace(LettuceRequest request) {
+            return null;
+          }
+        };
 
     InstrumenterBuilder<LettuceRequest, LettuceResponse> builder =
         Instrumenter.<LettuceRequest, LettuceResponse>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
+                DbClientSpanNameExtractor.create(spanNameAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
             .addOperationMetrics(DbClientMetrics.get())
             .setSpanStatusExtractor(


### PR DESCRIPTION
## Summary

This makes Lettuce 5.1 library span-name extraction ignore `db.namespace`. Redis stable semantic conventions do not use the Redis database index (`db.namespace`) as a span-name target.

Today Lettuce 5.1 does not appear to expose the selected Redis database index to command spans through its upstream tracing API. This is defensive for if/when upstream Lettuce starts emitting `db.namespace` as a command span tag.