### PR TITLE
Support Redisson batch operations

### DIFF
--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.logging.Level.FINE;
@@ -31,6 +32,9 @@ import org.redisson.client.protocol.CommandsData;
 public abstract class RedissonRequest {
 
   private static final Logger logger = Logger.getLogger(RedissonRequest.class.getName());
+
+  private static final String MULTI = "MULTI";
+  private static final String PIPELINE = "PIPELINE";
 
   private static final RedisCommandSanitizer sanitizer =
       RedisCommandSanitizer.create(
@@ -86,11 +90,28 @@ public abstract class RedissonRequest {
       return ((CommandData<?, ?>) command).getCommand().getName();
     } else if (command instanceof CommandsData) {
       CommandsData commandsData = (CommandsData) command;
-      if (commandsData.getCommands().size() == 1) {
-        return commandsData.getCommands().get(0).getCommand().getName();
+      List<CommandData<?, ?>> commands = commandsData.getCommands();
+      if (commands.size() == 1) {
+        return commands.get(0).getCommand().getName();
       }
+      return emitStableDatabaseSemconv() ? getBatchOperationName(commands) : null;
     }
     return null;
+  }
+
+  @Nullable
+  private static String getBatchOperationName(List<CommandData<?, ?>> commands) {
+    if (commands.size() < 2) {
+      return null;
+    }
+
+    String firstCommandName = commands.get(0).getCommand().getName();
+    String batchOperationName = firstCommandName.equals(MULTI) ? MULTI : PIPELINE;
+    int firstBatchCommandIndex = firstCommandName.equals(MULTI) ? 1 : 0;
+    String commonCommandName = getCommonCommandName(commands, firstBatchCommandIndex);
+    return commonCommandName == null
+        ? batchOperationName
+        : batchOperationName + " " + commonCommandName;
   }
 
   @Nullable
@@ -127,6 +148,23 @@ public abstract class RedissonRequest {
       return singletonList(normalizeSingleCommand((CommandData<?, ?>) command));
     }
     return emptyList();
+  }
+
+  @Nullable
+  private static String getCommonCommandName(
+      List<CommandData<?, ?>> commands, int firstBatchCommandIndex) {
+    if (firstBatchCommandIndex >= commands.size()) {
+      return null;
+    }
+
+    String commonCommandName = commands.get(firstBatchCommandIndex).getCommand().getName();
+    for (int i = firstBatchCommandIndex + 1; i < commands.size(); i++) {
+      String commandName = commands.get(i).getCommand().getName();
+      if (!commandName.equals(commonCommandName)) {
+        return null;
+      }
+    }
+    return commonCommandName;
   }
 
   private static String normalizeSingleCommand(CommandData<?, ?> command) {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -19,6 +19,7 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
@@ -245,13 +246,16 @@ public abstract class AbstractRedissonAsyncClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "redis" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? "MULTI SET" : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(
+                                DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() ? "MULTI SET" : null),
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -276,6 +276,31 @@ public abstract class AbstractRedissonClientTest {
   }
 
   @Test
+  void mixedBatchCommand() throws ReflectiveOperationException {
+    RBatch batch = createBatch(redisson);
+    assertThat(batch).isNotNull();
+    batch.getBucket("batch1").setAsync("v1");
+    batch.getBucket("batch1").getAsync();
+    // Adapt different method signature:
+    // `BatchResult<?> execute()` and `List<?> execute()`
+    invokeExecute(batch);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE" : "DB Query")
+                        .hasKind(CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(
+                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
+                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
+  }
+
+  @Test
   void largeBatchCommand() throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -258,13 +258,16 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "redis" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(
+                                DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
                             equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
   }
 
@@ -292,13 +295,16 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "redis" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(
+                                DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "SET " + bucketName + " ?;SET " + bucketName + " ?"))));
@@ -324,18 +330,21 @@ public abstract class AbstractRedissonClientTest {
           batch.execute();
         });
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("redis", "DB Query", "SET", "EXEC"),
+        orderByRootSpanName("MULTI SET", "DB Query", "SET", "EXEC"),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasKind(INTERNAL),
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "redis" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? "MULTI SET" : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(
+                                DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() ? "MULTI SET" : null),
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->


### PR DESCRIPTION
## Summary
- derive stable Redisson multi-command operation names as `PIPELINE <command>` or `MULTI <command>`
