### PR TITLE
Fix Elasticsearch REST stable DB operation names

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -5,17 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
@@ -99,11 +102,14 @@ class ElasticsearchRest5Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),
@@ -125,6 +131,7 @@ class ElasticsearchRest5Test {
         testing,
         "io.opentelemetry.elasticsearch-rest-5.0",
         DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -174,11 +181,14 @@ class ElasticsearchRest5Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -5,16 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
@@ -93,11 +96,14 @@ class ElasticsearchRest6Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),
@@ -119,6 +125,7 @@ class ElasticsearchRest6Test {
         testing,
         "io.opentelemetry.elasticsearch-rest-6.4",
         DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -168,11 +175,14 @@ class ElasticsearchRest6Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -5,17 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
@@ -90,11 +93,14 @@ class ElasticsearchRest7Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),
@@ -116,6 +122,7 @@ class ElasticsearchRest7Test {
         testing,
         "io.opentelemetry.elasticsearch-rest-7.0",
         DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -166,11 +173,14 @@ class ElasticsearchRest7Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.elasticsearch.rest.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -87,11 +89,14 @@ class ElasticsearchRest7Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),
@@ -143,11 +148,14 @@ class ElasticsearchRest7Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "cluster.health" : null),
                             equalTo(HTTP_REQUEST_METHOD, "GET"),
                             equalTo(SERVER_ADDRESS, httpHost.getHostName()),
                             equalTo(SERVER_PORT, httpHost.getPort()),

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
@@ -149,7 +149,10 @@ final class ElasticsearchDbAttributesGetter
     if (documentOperation != null) {
       return documentOperation;
     }
-    if (isGroupedApi(apiSegment) && nextSegment != null && !nextSegment.startsWith("_")) {
+    if (isGroupedApi(apiSegment)
+        && nextSegment != null
+        && !nextSegment.isEmpty()
+        && !nextSegment.startsWith("_")) {
       return apiSegment + "." + nextSegment;
     }
     return apiSegment;

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
@@ -90,32 +90,58 @@ final class ElasticsearchDbAttributesGetter
 
   @Nullable
   static String inferOperationName(String method, String endpoint) {
-    int queryStart = endpoint.indexOf('?');
-    if (queryStart >= 0) {
-      endpoint = endpoint.substring(0, queryStart);
+    int end = endpoint.indexOf('?');
+    if (end < 0) {
+      end = endpoint.length();
     }
 
-    while (endpoint.startsWith("/")) {
-      endpoint = endpoint.substring(1);
+    int start = 0;
+    if (start < end && endpoint.charAt(start) == '/') {
+      // low-level REST client endpoints conventionally start with a single leading slash
+      start++;
     }
-    if (endpoint.isEmpty()) {
+
+    // Only the first three path segments are needed to infer the operation name, so extract them
+    // in a single pass instead of allocating an array for the whole path on this hot path.
+    String segment0 = null;
+    String segment1 = null;
+    String segment2 = null;
+    int segmentStart = start;
+    int found = 0;
+    for (int i = start; i <= end && found < 3; i++) {
+      if (i == end || endpoint.charAt(i) == '/') {
+        String segment = endpoint.substring(segmentStart, i);
+        switch (found++) {
+          case 0:
+            segment0 = segment;
+            break;
+          case 1:
+            segment1 = segment;
+            break;
+          default:
+            segment2 = segment;
+            break;
+        }
+        segmentStart = i + 1;
+      }
+    }
+
+    if (segment0 == null || segment0.isEmpty()) {
       return null;
     }
-
-    String[] segments = endpoint.split("/");
-    if (segments[0].startsWith("_")) {
-      return inferOperationNameFromApiSegments(method, segments, 0);
+    if (segment0.startsWith("_")) {
+      return inferOperationNameFromApiSegments(method, segment0, segment1);
     }
-    if (segments.length > 1 && segments[1].startsWith("_")) {
-      return inferOperationNameFromApiSegments(method, segments, 1);
+    if (segment1 != null && segment1.startsWith("_")) {
+      return inferOperationNameFromApiSegments(method, segment1, segment2);
     }
     return null;
   }
 
   @Nullable
   private static String inferOperationNameFromApiSegments(
-      String method, String[] segments, int apiSegmentIndex) {
-    String apiSegment = stripLeadingUnderscores(segments[apiSegmentIndex]);
+      String method, String apiSegmentRaw, @Nullable String nextSegment) {
+    String apiSegment = stripLeadingUnderscores(apiSegmentRaw);
     if (apiSegment.isEmpty()) {
       return null;
     }
@@ -123,10 +149,8 @@ final class ElasticsearchDbAttributesGetter
     if (documentOperation != null) {
       return documentOperation;
     }
-    if (isGroupedApi(apiSegment)
-        && segments.length > apiSegmentIndex + 1
-        && !segments[apiSegmentIndex + 1].startsWith("_")) {
-      return apiSegment + "." + segments[apiSegmentIndex + 1];
+    if (isGroupedApi(apiSegment) && nextSegment != null && !nextSegment.startsWith("_")) {
+      return apiSegment + "." + nextSegment;
     }
     return apiSegment;
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetter.java
@@ -74,7 +74,109 @@ final class ElasticsearchDbAttributesGetter
   @Nullable
   public String getDbOperationName(ElasticsearchRestRequest request) {
     ElasticsearchEndpointDefinition endpointDefinition = request.getEndpointDefinition();
+    if (endpointDefinition != null) {
+      return endpointDefinition.getEndpointName();
+    }
+    return inferOperationName(request.getMethod(), request.getEndpoint());
+  }
+
+  @Deprecated // to be removed in 3.0
+  @Override
+  @Nullable
+  public String getDbOperation(ElasticsearchRestRequest request) {
+    ElasticsearchEndpointDefinition endpointDefinition = request.getEndpointDefinition();
     return endpointDefinition != null ? endpointDefinition.getEndpointName() : null;
+  }
+
+  @Nullable
+  static String inferOperationName(String method, String endpoint) {
+    int queryStart = endpoint.indexOf('?');
+    if (queryStart >= 0) {
+      endpoint = endpoint.substring(0, queryStart);
+    }
+
+    while (endpoint.startsWith("/")) {
+      endpoint = endpoint.substring(1);
+    }
+    if (endpoint.isEmpty()) {
+      return null;
+    }
+
+    String[] segments = endpoint.split("/");
+    if (segments[0].startsWith("_")) {
+      return inferOperationNameFromApiSegments(method, segments, 0);
+    }
+    if (segments.length > 1 && segments[1].startsWith("_")) {
+      return inferOperationNameFromApiSegments(method, segments, 1);
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String inferOperationNameFromApiSegments(
+      String method, String[] segments, int apiSegmentIndex) {
+    String apiSegment = stripLeadingUnderscores(segments[apiSegmentIndex]);
+    if (apiSegment.isEmpty()) {
+      return null;
+    }
+    String documentOperation = inferDocumentOperationName(method, apiSegment);
+    if (documentOperation != null) {
+      return documentOperation;
+    }
+    if (isGroupedApi(apiSegment)
+        && segments.length > apiSegmentIndex + 1
+        && !segments[apiSegmentIndex + 1].startsWith("_")) {
+      return apiSegment + "." + segments[apiSegmentIndex + 1];
+    }
+    return apiSegment;
+  }
+
+  @Nullable
+  private static String inferDocumentOperationName(String method, String apiSegment) {
+    switch (apiSegment) {
+      case "create":
+      case "update":
+        return apiSegment;
+      case "doc":
+        return inferDocOperationName(method);
+      default:
+        return null;
+    }
+  }
+
+  @Nullable
+  private static String inferDocOperationName(String method) {
+    switch (method) {
+      case "DELETE":
+        return "delete";
+      case "GET":
+        return "get";
+      case "POST":
+      case "PUT":
+        return "index";
+      default:
+        return null;
+    }
+  }
+
+  private static boolean isGroupedApi(String apiSegment) {
+    switch (apiSegment) {
+      case "cat":
+      case "cluster":
+      case "nodes":
+      case "snapshot":
+      case "tasks":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private static String stripLeadingUnderscores(String value) {
+    while (value.startsWith("_")) {
+      value = value.substring(1);
+    }
+    return value;
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchSpanNameExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchSpanNameExtractor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 /**
@@ -19,9 +21,13 @@ final class ElasticsearchSpanNameExtractor implements SpanNameExtractor<Elastics
     this.dbAttributesGetter = dbAttributesGetter;
   }
 
+  @SuppressWarnings("deprecation") // getDbOperation is used for old semconv span names
   @Override
   public String extract(ElasticsearchRestRequest elasticsearchRestRequest) {
-    String name = dbAttributesGetter.getDbOperationName(elasticsearchRestRequest);
+    String name =
+        emitStableDatabaseSemconv()
+            ? dbAttributesGetter.getDbOperationName(elasticsearchRestRequest)
+            : dbAttributesGetter.getDbOperation(elasticsearchRestRequest);
     return name != null ? name : elasticsearchRestRequest.getMethod();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchDbAttributesGetterTest {
+
+  private final ElasticsearchDbAttributesGetter underTest =
+      new ElasticsearchDbAttributesGetter(false);
+
+  @Test
+  void shouldInferLowCardinalityOperationNameFromApiPath() {
+    assertThat(
+            underTest.getDbOperationName(ElasticsearchRestRequest.create("GET", "_cluster/health")))
+        .isEqualTo("cluster.health");
+    assertThat(
+            underTest.getDbOperationName(ElasticsearchRestRequest.create("GET", "/_cat/indices?v")))
+        .isEqualTo("cat.indices");
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("POST", "test-index/_search")))
+        .isEqualTo("search");
+  }
+
+  @Test
+  void shouldInferDocumentOperationNameFromMethodAndApiPath() {
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("GET", "test-index/_doc/document-id")))
+        .isEqualTo("get");
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("PUT", "test-index/_doc/document-id")))
+        .isEqualTo("index");
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("DELETE", "test-index/_doc/document-id")))
+        .isEqualTo("delete");
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("POST", "test-index/_create/document-id")))
+        .isEqualTo("create");
+    assertThat(
+            underTest.getDbOperationName(
+                ElasticsearchRestRequest.create("POST", "test-index/_update/document-id")))
+        .isEqualTo("update");
+  }
+
+  @SuppressWarnings("deprecation") // getDbOperation is used for old semconv
+  @Test
+  void shouldKeepOldLowLevelOperationUnavailable() {
+    assertThat(underTest.getDbOperation(ElasticsearchRestRequest.create("GET", "_cluster/health")))
+        .isNull();
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
@@ -58,4 +58,39 @@ class ElasticsearchDbAttributesGetterTest {
     assertThat(underTest.getDbOperation(ElasticsearchRestRequest.create("GET", "_cluster/health")))
         .isNull();
   }
+
+  @Test
+  void shouldStripLeadingSlashAndQueryString() {
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "/_cat/indices"))
+        .isEqualTo("cat.indices");
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "_search?size=10"))
+        .isEqualTo("search");
+    assertThat(
+            ElasticsearchDbAttributesGetter.inferOperationName(
+                "GET", "/test-index/_search?from=0&size=10"))
+        .isEqualTo("search");
+  }
+
+  @Test
+  void shouldInferGroupedApiNameWithAndWithoutSubcommand() {
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "_nodes/stats"))
+        .isEqualTo("nodes.stats");
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "_nodes"))
+        .isEqualTo("nodes");
+    // a following underscore segment is not treated as a subcommand
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("POST", "_tasks/_cancel"))
+        .isEqualTo("tasks");
+    // a non-grouped api keeps just the api segment
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("POST", "_search/scroll"))
+        .isEqualTo("search");
+  }
+
+  @Test
+  void shouldReturnNullWhenNoApiSegmentPresent() {
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "")).isNull();
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "/")).isNull();
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "test-index")).isNull();
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "test-index/doc-id"))
+        .isNull();
+  }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchDbAttributesGetterTest.java
@@ -83,6 +83,9 @@ class ElasticsearchDbAttributesGetterTest {
     // a non-grouped api keeps just the api segment
     assertThat(ElasticsearchDbAttributesGetter.inferOperationName("POST", "_search/scroll"))
         .isEqualTo("search");
+    // a trailing slash does not produce a trailing dot
+    assertThat(ElasticsearchDbAttributesGetter.inferOperationName("GET", "_nodes/"))
+        .isEqualTo("nodes");
   }
 
   @Test


### PR DESCRIPTION
Built on top of #18989. Updates Elasticsearch REST low-level client instrumentation to infer stable low-cardinality database operation names from REST API paths while preserving old semconv operation names for legacy span naming.