### PR TITLE
Fix HBase stable DB semconv attributes

### DIFF
--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
@@ -9,6 +9,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
+import org.apache.hadoop.hbase.TableName;
 
 final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseRequest, Void> {
 
@@ -21,7 +22,24 @@ final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseReque
   @Nullable
   @Override
   public String getDbNamespace(HbaseRequest hbaseRequest) {
-    return hbaseRequest.getTable();
+    TableName tableName = hbaseRequest.getTableName();
+    return tableName == null ? null : tableName.getNamespaceAsString();
+  }
+
+  @Nullable
+  @Override
+  public String getDbCollectionName(HbaseRequest hbaseRequest) {
+    TableName tableName = hbaseRequest.getTableName();
+    return tableName == null ? null : tableName.getNameAsString();
+  }
+
+  @Nullable
+  @Override
+  // Old database semconv still use db.name, so we must implement the deprecated hook.
+  @SuppressWarnings("deprecation")
+  public String getDbName(HbaseRequest hbaseRequest) {
+    TableName tableName = hbaseRequest.getTableName();
+    return tableName == null ? null : tableName.getNameAsString();
   }
 
   @Nullable

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
@@ -35,7 +35,7 @@ final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseReque
 
   @Nullable
   @Override
-  // Old database semconv still use db.name, so we must implement the deprecated hook.
+  // Old database semconv still uses db.name, so we must implement the deprecated hook.
   @SuppressWarnings("deprecation")
   public String getDbName(HbaseRequest hbaseRequest) {
     TableName tableName = hbaseRequest.getTableName();
@@ -44,7 +44,7 @@ final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseReque
 
   @Nullable
   @Override
-  // Old database semconv still use db.user, so we must implement the deprecated hook.
+  // Old database semconv still uses db.user, so we must implement the deprecated hook.
   @SuppressWarnings("deprecation")
   public String getUser(HbaseRequest hbaseRequest) {
     return hbaseRequest.getUser();

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseRequest.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseRequest.java
@@ -7,24 +7,25 @@ package io.opentelemetry.javaagent.instrumentation.hbase.client.v2_0;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
+import org.apache.hadoop.hbase.TableName;
 
 @AutoValue
 public abstract class HbaseRequest {
 
   public static HbaseRequest create(
       @Nullable String operation,
-      @Nullable String table,
+      @Nullable TableName tableName,
       @Nullable String user,
       @Nullable String host,
       @Nullable Integer port) {
-    return new AutoValue_HbaseRequest(operation, table, user, host, port);
+    return new AutoValue_HbaseRequest(operation, tableName, user, host, port);
   }
 
   @Nullable
   public abstract String getOperation();
 
   @Nullable
-  public abstract String getTable();
+  public abstract TableName getTableName();
 
   @Nullable
   public abstract String getUser();

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseSingletons.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseSingletons.java
@@ -12,21 +12,22 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import javax.annotation.Nullable;
+import org.apache.hadoop.hbase.TableName;
 
 public class HbaseSingletons {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.hbase-client-2.0";
-  private static final ThreadLocal<String> tableNameThreadLocal = new ThreadLocal<>();
+  private static final ThreadLocal<TableName> tableNameThreadLocal = new ThreadLocal<>();
   private static final ThreadLocal<RequestAndContext> requestAndContextThreadLocal =
       new ThreadLocal<>();
   private static final Instrumenter<HbaseRequest, Void> instrumenter = createInstrumenter();
 
-  public static void setTableName(String tableName) {
+  public static void setTableName(TableName tableName) {
     tableNameThreadLocal.set(tableName);
   }
 
   @Nullable
-  public static String getTableName() {
+  public static TableName getTableName() {
     return tableNameThreadLocal.get();
   }
 

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/RegionServerCallableInstrumentation.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/RegionServerCallableInstrumentation.java
@@ -34,9 +34,9 @@ class RegionServerCallableInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class RpcCallAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.FieldValue(value = "tableName") TableName table) {
-      if (table != null) {
-        setTableName(table.getNameAsString());
+    public static void onEnter(@Advice.FieldValue(value = "tableName") TableName tableName) {
+      if (tableName != null) {
+        setTableName(tableName);
       }
     }
 

--- a/instrumentation/hbase-client-2.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
+++ b/instrumentation/hbase-client-2.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStableDbSystemName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
@@ -273,7 +274,16 @@ public abstract class AbstractHbaseTest {
                                     maybeStable(DB_SYSTEM),
                                     maybeStableDbSystemName(DB_SYSTEM_VALUE)),
                                 equalTo(maybeStable(DB_OPERATION), GET),
-                                equalTo(maybeStable(DB_NAME), TABLE_NAME.getNameAsString()),
+                                equalTo(
+                                    maybeStable(DB_NAME),
+                                    emitStableDatabaseSemconv()
+                                        ? TABLE_NAME.getNamespaceAsString()
+                                        : TABLE_NAME.getNameAsString()),
+                                equalTo(
+                                    DB_COLLECTION_NAME,
+                                    emitStableDatabaseSemconv()
+                                        ? TABLE_NAME.getNameAsString()
+                                        : null),
                                 equalTo(SERVER_ADDRESS, hostname),
                                 equalTo(SERVER_PORT, REGION_SERVER_PORT),
                                 equalTo(
@@ -509,6 +519,7 @@ public abstract class AbstractHbaseTest {
         DB_SYSTEM_NAME,
         maybeStable(DB_OPERATION),
         maybeStable(DB_NAME),
+        DB_COLLECTION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -531,7 +542,8 @@ public abstract class AbstractHbaseTest {
                     .hasAttributesSatisfyingExactly(
                         equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(DB_SYSTEM_VALUE)),
                         equalTo(maybeStable(DB_OPERATION), operation),
-                        equalTo(maybeStable(DB_NAME), hasTable ? table.getNameAsString() : null),
+                        equalTo(maybeStable(DB_NAME), dbNamespace(table, hasTable)),
+                        equalTo(DB_COLLECTION_NAME, dbCollectionName(table, hasTable)),
                         equalTo(SERVER_ADDRESS, hostname),
                         equalTo(SERVER_PORT, port),
                         satisfies(
@@ -539,5 +551,22 @@ public abstract class AbstractHbaseTest {
                             emitStableDatabaseSemconv()
                                 ? AbstractAssert::isNull
                                 : AbstractAssert::isNotNull)));
+  }
+
+  private static String dbNamespace(TableName table, boolean hasTable) {
+    if (!hasTable) {
+      return null;
+    }
+    if (emitStableDatabaseSemconv()) {
+      return table.getNamespaceAsString();
+    }
+    return table.getNameAsString();
+  }
+
+  private static String dbCollectionName(TableName table, boolean hasTable) {
+    if (hasTable && emitStableDatabaseSemconv()) {
+      return table.getNameAsString();
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Built on top of #18989. Updates HBase to preserve the HBase `TableName` through request creation so stable database semconv can emit namespace and collection separately while old semconv keeps the previous `db.name` value.