### PR TITLE
Fix Couchbase stable DB span names

### DIFF
--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSpanNameExtractor.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSpanNameExtractor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.javaagent.instrumentation.couchbase.common.v2_0.CouchbaseRequestInfo;
 
@@ -17,7 +19,7 @@ class CouchbaseSpanNameExtractor implements SpanNameExtractor<CouchbaseRequestIn
 
   @Override
   public String extract(CouchbaseRequestInfo couchbaseRequest) {
-    if (couchbaseRequest.isMethodCall()) {
+    if (!emitStableDatabaseSemconv() && couchbaseRequest.isMethodCall()) {
       return couchbaseRequest.getOperation();
     }
     return dbSpanNameExtractor.extract(couchbaseRequest);

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -171,7 +171,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
                             equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketSettings.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -230,7 +233,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
                             equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketSettings.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -245,7 +251,10 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.get")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.get " + bucketSettings.name()
+                                : "Bucket.get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(2))
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -152,7 +152,10 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketSettings.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -167,7 +170,10 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.get")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.get " + bucketSettings.name()
+                                : "Bucket.get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.couchbase.springdata;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -125,7 +126,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketCouchbase.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -160,7 +164,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketCouchbase.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -175,7 +182,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.get")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.get " + bucketCouchbase.name()
+                                : "Bucket.get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -208,7 +218,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketCouchbase.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -223,7 +236,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketCouchbase.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -258,7 +274,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketCouchbase.name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -273,7 +292,10 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.remove")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.remove " + bucketCouchbase.name()
+                                : "Bucket.remove")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.couchbase.springdata;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -106,7 +107,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + template.getCouchbaseBucket().name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -121,7 +125,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.get")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.get " + template.getCouchbaseBucket().name()
+                                : "Bucket.get")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -153,7 +160,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("Bucket.upsert")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + template.getCouchbaseBucket().name()
+                                : "Bucket.upsert")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -168,7 +178,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             satisfies(
                                 stringKey("couchbase.operation_id"), experimentalAttribute())),
                 span ->
-                    span.hasName("Bucket.remove")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.remove " + template.getCouchbaseBucket().name()
+                                : "Bucket.remove")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -192,7 +205,10 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("Bucket.get")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.get " + template.getCouchbaseBucket().name()
+                                : "Bucket.get")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(


### PR DESCRIPTION
Built on top of #18989. Updates Couchbase method-call span names so stable database semconv includes the bucket namespace while old semconv keeps the existing operation-only method-call names.