### PR TITLE
Add async server instrumentation for Apache Thrift 0.13

### DIFF
--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
@@ -38,7 +38,7 @@ public final class ThriftAsyncProcessFunctionInstrumentation implements TypeInst
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static AsyncMethodCallback<?> methodExit(
         @Advice.Argument(value = 0) AbstractNonblockingServer.AsyncFrameBuffer fb,
-        @Advice.Return(readOnly = false) AsyncMethodCallback<?> callback) {
+        @Advice.Return AsyncMethodCallback<?> callback) {
       ServerInProtocolDecorator serverInProtocolDecorator =
           (ServerInProtocolDecorator) fb.getInputProtocol();
       ServerOutProtocolDecorator serverOutProtocolDecorator =

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.instrumentation.thrift.v0_13.internal.AsyncMethodCallbackUtil;
 import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerInProtocolDecorator;
@@ -27,11 +29,22 @@ public final class ThriftAsyncProcessFunctionInstrumentation implements TypeInst
   }
 
   @Override
-  public void transform(TypeTransformer transformer) {
-    transformer.applyAdviceToMethod(
-        named("getResultHandler"), getClass().getName() + "$GetResultHandlerAdvice");
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("org.apache.thrift.AsyncProcessFunction");
   }
 
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getResultHandler")
+            .and(
+                takesArgument(
+                    0,
+                    named("org.apache.thrift.server.AbstractNonblockingServer$AsyncFrameBuffer"))),
+        getClass().getName() + "$GetResultHandlerAdvice");
+  }
+
+  @SuppressWarnings("unused")
   public static class GetResultHandlerAdvice {
 
     @Advice.AssignReturned.ToReturned

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftAsyncProcessFunctionInstrumentation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.AsyncMethodCallbackUtil;
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerInProtocolDecorator;
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerOutProtocolDecorator;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.apache.thrift.server.AbstractNonblockingServer;
+
+public final class ThriftAsyncProcessFunctionInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return extendsClass(named("org.apache.thrift.AsyncProcessFunction"));
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getResultHandler"), getClass().getName() + "$GetResultHandlerAdvice");
+  }
+
+  public static class GetResultHandlerAdvice {
+
+    @Advice.AssignReturned.ToReturned
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static AsyncMethodCallback<?> methodExit(
+        @Advice.Argument(value = 0) AbstractNonblockingServer.AsyncFrameBuffer fb,
+        @Advice.Return(readOnly = false) AsyncMethodCallback<?> callback) {
+      ServerInProtocolDecorator serverInProtocolDecorator =
+          (ServerInProtocolDecorator) fb.getInputProtocol();
+      ServerOutProtocolDecorator serverOutProtocolDecorator =
+          (ServerOutProtocolDecorator) fb.getOutputProtocol();
+      return AsyncMethodCallbackUtil.wrap(
+          callback, serverInProtocolDecorator, serverOutProtocolDecorator);
+    }
+  }
+}

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftFrameBufferInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftFrameBufferInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
 
+import static io.opentelemetry.javaagent.instrumentation.thrift.v0_13.ThriftSingletons.getProtocolDecorator;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
@@ -14,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 
 class ThriftFrameBufferInstrumentation implements TypeInstrumentation {
@@ -29,6 +31,14 @@ class ThriftFrameBufferInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         namedOneOf("invoke").and(takesNoArguments()), getClass().getName() + "$InvokeAdvice");
+
+    transformer.applyAdviceToMethod(
+        namedOneOf("getInputProtocol").and(takesNoArguments()),
+        getClass().getName() + "$InputProtocolAdvice");
+
+    transformer.applyAdviceToMethod(
+        namedOneOf("getOutputProtocol").and(takesNoArguments()),
+        getClass().getName() + "$OutputProtocolAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -42,6 +52,24 @@ class ThriftFrameBufferInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void methodExit(@Advice.Enter ServerCallContext enter) {
       enter.end();
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class InputProtocolAdvice {
+    @Advice.AssignReturned.ToReturned
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static TProtocol methodExit(@Advice.Return TProtocol inProtocol) {
+      return getProtocolDecorator(inProtocol, false);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class OutputProtocolAdvice {
+    @Advice.AssignReturned.ToReturned
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static TProtocol methodExit(@Advice.Return TProtocol outProtocol) {
+      return getProtocolDecorator(outProtocol, true);
     }
   }
 }

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftInstrumentationModule.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftInstrumentationModule.java
@@ -34,6 +34,8 @@ public class ThriftInstrumentationModule extends InstrumentationModule {
         new ThriftServiceClientInstrumentation(),
         new ThriftAsyncClientInstrumentation(),
         new ThriftTBaseProcessorInstrumentation(),
+        new ThriftAsyncProcessFunctionInstrumentation(),
+        new ThriftTBaseAsyncProcessorInstrumentation(),
         new ThriftFrameBufferInstrumentation());
   }
 }

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
@@ -10,13 +10,19 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.instrumentation.thrift.v0_13.ThriftRequest;
 import io.opentelemetry.instrumentation.thrift.v0_13.ThriftResponse;
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerInProtocolDecorator;
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerOutProtocolDecorator;
 import io.opentelemetry.instrumentation.thrift.v0_13.internal.ThriftInstrumenterFactory;
 import java.util.function.UnaryOperator;
+import org.apache.thrift.protocol.TProtocol;
 
 public final class ThriftSingletons {
 
+  private static final VirtualField<TProtocol, TProtocol> protocolVirtualField =
+      VirtualField.find(TProtocol.class, TProtocol.class);
   private static final Instrumenter<ThriftRequest, ThriftResponse> clientInstrumenter =
       ThriftInstrumenterFactory.createClientInstrumenter(
           GlobalOpenTelemetry.get(), UnaryOperator.identity(), emptyList(), emptyList());
@@ -35,6 +41,20 @@ public final class ThriftSingletons {
 
   public static ContextPropagators propagators() {
     return propagators;
+  }
+
+  public static TProtocol getProtocolDecorator(TProtocol protocol, boolean isOutput) {
+    TProtocol protocolDecorator = protocolVirtualField.get(protocol);
+    if (protocolDecorator != null) {
+      return protocolDecorator;
+    }
+
+    protocolDecorator =
+        isOutput
+            ? new ServerOutProtocolDecorator(protocol)
+            : new ServerInProtocolDecorator(protocol, null, serverInstrumenter());
+    protocolVirtualField.set(protocol, protocolDecorator);
+    return protocolDecorator;
   }
 
   private ThriftSingletons() {}

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerInProtocolDecorator;
+import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerOutProtocolDecorator;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.thrift.server.AbstractNonblockingServer;
+
+class ThriftTBaseAsyncProcessorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.apache.thrift.TBaseAsyncProcessor");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("process")
+            .and(
+                takesArgument(
+                    0,
+                    named("org.apache.thrift.server.AbstractNonblockingServer$AsyncFrameBuffer"))),
+        getClass().getName() + "$ProcessAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ProcessAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void methodEnter(
+        @Advice.Argument(0) AbstractNonblockingServer.AsyncFrameBuffer fb,
+        @Advice.FieldValue("iface") Object iface) {
+      String serviceName = iface.getClass().getName();
+      ((ServerInProtocolDecorator) fb.getInputProtocol()).setServiceName(serviceName);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void methodExit(
+        @Advice.Argument(0) AbstractNonblockingServer.AsyncFrameBuffer fb,
+        @Advice.Thrown Throwable throwable) {
+      ServerInProtocolDecorator serverInProtocolDecorator =
+          (ServerInProtocolDecorator) fb.getInputProtocol();
+      ServerOutProtocolDecorator serverOutProtocolDecorator =
+          (ServerOutProtocolDecorator) fb.getOutputProtocol();
+      if (serverInProtocolDecorator.isOneway()
+          || serverOutProtocolDecorator.hasException()
+          || throwable != null) {
+        serverInProtocolDecorator.endSpan(throwable, serverOutProtocolDecorator.hasException());
+      }
+    }
+  }
+}

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseProcessorInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseProcessorInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
 
 import static io.opentelemetry.javaagent.instrumentation.thrift.v0_13.ThriftSingletons.serverInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerInProtocolDecorator;
 import io.opentelemetry.instrumentation.thrift.v0_13.internal.ServerOutProtocolDecorator;
@@ -28,7 +29,11 @@ class ThriftTBaseProcessorInstrumentation implements TypeInstrumentation {
 
   @Override
   public void transform(TypeTransformer transformer) {
-    transformer.applyAdviceToMethod(named("process"), getClass().getName() + "$ProcessAdvice");
+    transformer.applyAdviceToMethod(
+        named("process")
+            .and(takesArgument(0, named("org.apache.thrift.protocol.TProtocol")))
+            .and(takesArgument(1, named("org.apache.thrift.protocol.TProtocol"))),
+        getClass().getName() + "$ProcessAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/thrift-0.13/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTest.java
+++ b/instrumentation/thrift-0.13/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTest.java
@@ -109,11 +109,8 @@ class ThriftTest extends AbstractThriftTest {
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                     span -> assertClientSpan(span, "say", port).hasParent(trace.getSpan(0)),
                     span ->
-                        (hasAsyncServerNetworkAttributes()
-                                ? assertServerSpan(
-                                    span, CustomAsyncHandler.class.getName(), "say", port, null)
-                                : assertServerSpan(
-                                    span, CustomAsyncHandler.class.getName(), "say", null))
+                        assertServerSpan(
+                                span, CustomAsyncHandler.class.getName(), "say", port, null)
                             .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("callback")
@@ -163,11 +160,8 @@ class ThriftTest extends AbstractThriftTest {
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span -> assertClientSpan(span, "withDelay", port).hasParent(trace.getSpan(0)),
                 span ->
-                    (hasAsyncServerNetworkAttributes()
-                            ? assertServerSpan(
-                                span, CustomAsyncHandler.class.getName(), "withDelay", port, null)
-                            : assertServerSpan(
-                                span, CustomAsyncHandler.class.getName(), "withDelay", null))
+                    assertServerSpan(
+                            span, CustomAsyncHandler.class.getName(), "withDelay", port, null)
                         .hasParent(trace.getSpan(1)),
                 span ->
                     span.hasName("callback")
@@ -209,11 +203,8 @@ class ThriftTest extends AbstractThriftTest {
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                     span -> assertClientSpan(span, "oneWay", port).hasParent(trace.getSpan(0)),
                     span ->
-                        (hasAsyncServerNetworkAttributes()
-                                ? assertServerSpan(
-                                    span, CustomAsyncHandler.class.getName(), "oneWay", port, null)
-                                : assertServerSpan(
-                                    span, CustomAsyncHandler.class.getName(), "oneWay", null))
+                        assertServerSpan(
+                                span, CustomAsyncHandler.class.getName(), "oneWay", port, null)
                             .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("callback")
@@ -264,18 +255,12 @@ class ThriftTest extends AbstractThriftTest {
                             .hasParent(trace.getSpan(0))
                             .hasStatus(StatusData.error()),
                     span ->
-                        (hasAsyncServerNetworkAttributes()
-                                ? assertServerSpan(
-                                    span,
-                                    CustomAsyncHandler.class.getName(),
-                                    "withError",
-                                    port,
-                                    IllegalStateException.class.getName())
-                                : assertServerSpan(
-                                    span,
-                                    CustomAsyncHandler.class.getName(),
-                                    "withError",
-                                    IllegalStateException.class.getName()))
+                        assertServerSpan(
+                                span,
+                                CustomAsyncHandler.class.getName(),
+                                "withError",
+                                port,
+                                IllegalStateException.class.getName())
                             .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("callback")

--- a/instrumentation/thrift-0.13/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTest.java
+++ b/instrumentation/thrift-0.13/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTest.java
@@ -5,13 +5,30 @@
 
 package io.opentelemetry.javaagent.instrumentation.thrift.v0_13;
 
+import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import custom.CustomService;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.thrift.v0_13.AbstractThriftTest;
+import io.opentelemetry.instrumentation.thrift.v0_13.CustomAsyncHandler;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TProcessor;
+import org.apache.thrift.async.AsyncMethodCallback;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ThriftTest extends AbstractThriftTest {
@@ -51,5 +68,218 @@ class ThriftTest extends AbstractThriftTest {
   @Override
   protected boolean hasAsyncServerNetworkAttributes() {
     return true;
+  }
+
+  @Test
+  void async() throws Exception {
+    // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
+    // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
+    assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
+
+    int port = startAsyncServer();
+    CustomService.AsyncIface asyncClient = createAsyncClient(port);
+
+    CompletableFuture<String> completableFuture = new CompletableFuture<>();
+    getTesting()
+        .runWithSpan(
+            "parent",
+            () ->
+                asyncClient.say(
+                    "Async",
+                    "World",
+                    new AsyncMethodCallback<String>() {
+                      @Override
+                      public void onComplete(String response) {
+                        getTesting()
+                            .runWithSpan("callback", () -> completableFuture.complete(response));
+                      }
+
+                      @Override
+                      public void onError(Exception exception) {
+                        completableFuture.completeExceptionally(exception);
+                      }
+                    }));
+
+    assertThat(completableFuture.get(15, SECONDS)).isEqualTo("Say Async World");
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span -> assertClientSpan(span, "say", port).hasParent(trace.getSpan(0)),
+                    span ->
+                        (hasAsyncServerNetworkAttributes()
+                                ? assertServerSpan(
+                                    span, CustomAsyncHandler.class.getName(), "say", port, null)
+                                : assertServerSpan(
+                                    span, CustomAsyncHandler.class.getName(), "say", null))
+                            .hasParent(trace.getSpan(1)),
+                    span ->
+                        span.hasName("callback")
+                            .hasKind(SpanKind.INTERNAL)
+                            .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void asyncMany() throws Exception {
+    // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
+    // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
+    assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
+
+    int port = startAsyncServer();
+
+    List<CompletableFuture<String>> results = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      CustomService.AsyncIface asyncClient = createAsyncClient(port);
+      CompletableFuture<String> completableFuture = new CompletableFuture<>();
+      results.add(completableFuture);
+      getTesting()
+          .runWithSpan(
+              "parent",
+              () ->
+                  asyncClient.withDelay(
+                      1,
+                      new AsyncMethodCallback<String>() {
+                        @Override
+                        public void onComplete(String response) {
+                          getTesting()
+                              .runWithSpan("callback", () -> completableFuture.complete(response));
+                        }
+
+                        @Override
+                        public void onError(Exception exception) {
+                          completableFuture.completeExceptionally(exception);
+                        }
+                      }));
+    }
+    for (CompletableFuture<String> completableFuture : results) {
+      assertThat(completableFuture.get(15, SECONDS)).isEqualTo("delay 1");
+    }
+
+    Consumer<TraceAssert> traceAssert =
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertClientSpan(span, "withDelay", port).hasParent(trace.getSpan(0)),
+                span ->
+                    (hasAsyncServerNetworkAttributes()
+                            ? assertServerSpan(
+                                span, CustomAsyncHandler.class.getName(), "withDelay", port, null)
+                            : assertServerSpan(
+                                span, CustomAsyncHandler.class.getName(), "withDelay", null))
+                        .hasParent(trace.getSpan(1)),
+                span ->
+                    span.hasName("callback")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0)));
+    getTesting().waitAndAssertTraces(traceAssert, traceAssert, traceAssert, traceAssert);
+  }
+
+  @Test
+  void oneWayAsync() throws Exception {
+    int port = startAsyncServer();
+    CustomService.AsyncIface asyncClient = createAsyncClient(port);
+
+    CompletableFuture<String> completableFuture = new CompletableFuture<>();
+    getTesting()
+        .runWithSpan(
+            "parent",
+            () ->
+                asyncClient.oneWay(
+                    new AsyncMethodCallback<Void>() {
+                      @Override
+                      public void onComplete(Void response) {
+                        getTesting()
+                            .runWithSpan("callback", () -> completableFuture.complete("ok"));
+                      }
+
+                      @Override
+                      public void onError(Exception exception) {
+                        completableFuture.completeExceptionally(exception);
+                      }
+                    }));
+
+    assertThat(completableFuture.get(15, SECONDS)).isEqualTo("ok");
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span -> assertClientSpan(span, "oneWay", port).hasParent(trace.getSpan(0)),
+                    span ->
+                        (hasAsyncServerNetworkAttributes()
+                                ? assertServerSpan(
+                                    span, CustomAsyncHandler.class.getName(), "oneWay", port, null)
+                                : assertServerSpan(
+                                    span, CustomAsyncHandler.class.getName(), "oneWay", null))
+                            .hasParent(trace.getSpan(1)),
+                    span ->
+                        span.hasName("callback")
+                            .hasKind(SpanKind.INTERNAL)
+                            .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void asyncWithError() throws Exception {
+    // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
+    // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
+    assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
+
+    int port = startAsyncServer();
+    CustomService.AsyncIface asyncClient = createAsyncClient(port);
+
+    CompletableFuture<String> completableFuture = new CompletableFuture<>();
+    getTesting()
+        .runWithSpan(
+            "parent",
+            () ->
+                asyncClient.withError(
+                    new AsyncMethodCallback<String>() {
+                      @Override
+                      public void onComplete(String response) {
+                        completableFuture.complete(response);
+                      }
+
+                      @Override
+                      public void onError(Exception exception) {
+                        getTesting()
+                            .runWithSpan(
+                                "callback",
+                                () -> completableFuture.completeExceptionally(exception));
+                      }
+                    }));
+
+    assertThatThrownBy(() -> completableFuture.get(15, SECONDS))
+        .hasRootCauseInstanceOf(TApplicationException.class);
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertClientSpan(span, "withError", port, true)
+                            .hasParent(trace.getSpan(0))
+                            .hasStatus(StatusData.error()),
+                    span ->
+                        (hasAsyncServerNetworkAttributes()
+                                ? assertServerSpan(
+                                    span,
+                                    CustomAsyncHandler.class.getName(),
+                                    "withError",
+                                    port,
+                                    IllegalStateException.class.getName())
+                                : assertServerSpan(
+                                    span,
+                                    CustomAsyncHandler.class.getName(),
+                                    "withError",
+                                    IllegalStateException.class.getName()))
+                            .hasParent(trace.getSpan(1)),
+                    span ->
+                        span.hasName("callback")
+                            .hasKind(SpanKind.INTERNAL)
+                            .hasParent(trace.getSpan(0))));
   }
 }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
@@ -47,17 +47,21 @@ public final class AsyncMethodCallbackUtil {
 
       @Override
       public void onComplete(T response) {
-        serverInProtocolDecorator.endSpan(null, serverOutProtocolDecorator.hasException());
+        Throwable error = null;
         try (Scope ignore = context.makeCurrent()) {
           callback.onComplete(response);
+        } catch (Throwable e) {
+          error = e;
         }
+        serverInProtocolDecorator.endSpan(error, serverOutProtocolDecorator.hasException());
       }
 
       @Override
       public void onError(Exception exception) {
-        serverInProtocolDecorator.endSpan(exception, serverOutProtocolDecorator.hasException());
         try (Scope ignore = context.makeCurrent()) {
           callback.onError(exception);
+        } finally {
+          serverInProtocolDecorator.endSpan(exception, serverOutProtocolDecorator.hasException());
         }
       }
     };

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/AsyncMethodCallbackUtil.java
@@ -38,5 +38,30 @@ public final class AsyncMethodCallbackUtil {
     };
   }
 
+  public static <T> AsyncMethodCallback<T> wrap(
+      AsyncMethodCallback<T> callback,
+      ServerInProtocolDecorator serverInProtocolDecorator,
+      ServerOutProtocolDecorator serverOutProtocolDecorator) {
+    Context context = Context.current();
+    return new AsyncMethodCallback<T>() {
+
+      @Override
+      public void onComplete(T response) {
+        serverInProtocolDecorator.endSpan(null, serverOutProtocolDecorator.hasException());
+        try (Scope ignore = context.makeCurrent()) {
+          callback.onComplete(response);
+        }
+      }
+
+      @Override
+      public void onError(Exception exception) {
+        serverInProtocolDecorator.endSpan(exception, serverOutProtocolDecorator.hasException());
+        try (Scope ignore = context.makeCurrent()) {
+          callback.onError(exception);
+        }
+      }
+    };
+  }
+
   private AsyncMethodCallbackUtil() {}
 }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TField;
 import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolDecorator;
 import org.apache.thrift.protocol.TStruct;
@@ -29,8 +30,8 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
 
   private final TProtocol protocol;
   private final Instrumenter<ThriftRequest, ThriftResponse> instrumenter;
-  private final String serviceName;
-
+  private boolean isOneway;
+  @Nullable private String serviceName;
   @Nullable private String methodName;
   @Nullable private ThriftRequest currentRequest;
   @Nullable private Context currentContext;
@@ -51,6 +52,7 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
   public TMessage readMessageBegin() throws TException {
     TMessage message = super.readMessageBegin();
     this.methodName = message.name;
+    this.isOneway = message.type == TMessageType.ONEWAY;
     structDepth = 0;
     return message;
   }
@@ -132,11 +134,23 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
     }
     instrumenter.end(
         currentContext, currentRequest, failed ? ThriftResponse.FAILED : null, throwable);
+    // Avoid duplicate end invocations from exceptions in asynchronous workflows
+    currentContext = null;
+    currentRequest = null;
+    currentScope = null;
   }
 
   private boolean isContextPropagationField(TField field) {
     return structDepth == 1
         && field.id == ContextPropagationUtil.TRACE_CONTEXT_FIELD_ID
         && field.type == TType.MAP;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  public boolean isOneway() {
+    return isOneway;
   }
 }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
@@ -40,7 +40,7 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
 
   public ServerInProtocolDecorator(
       TProtocol protocol,
-      String serviceName,
+      @Nullable String serviceName,
       Instrumenter<ThriftRequest, ThriftResponse> instrumenter) {
     super(protocol);
     this.protocol = protocol;

--- a/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/AbstractThriftTest.java
+++ b/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/AbstractThriftTest.java
@@ -170,15 +170,37 @@ public abstract class AbstractThriftTest {
     return transport.getServerSocket().getLocalPort();
   }
 
+  protected int startNonblockingSyncServer() throws Exception {
+    return startNonblockingSyncServer(true);
+  }
+
+  protected int startNonblockingSyncServer(boolean configure) throws Exception {
+    CustomHandler handler = new CustomHandler();
+    TProcessor processor = new CustomService.Processor<CustomService.Iface>(handler);
+    if (configure) {
+      processor = configure(processor, CustomHandler.class.getName());
+    }
+
+    TNonblockingServerSocket transport = new TNonblockingServerSocket(0, 30000);
+    TNonblockingServer.Args tnbArgs = new TNonblockingServer.Args(transport);
+    tnbArgs.processor(processor);
+
+    TServer server = new TNonblockingServer(tnbArgs);
+    new Thread(server::serve).start();
+    cleanup.deferCleanup(server::stop);
+
+    return transport.getPort();
+  }
+
   protected int startAsyncServer() throws Exception {
     return startAsyncServer(true);
   }
 
   protected int startAsyncServer(boolean configure) throws Exception {
-    CustomHandler handler = new CustomHandler();
-    TProcessor processor = new CustomService.Processor<CustomService.Iface>(handler);
+    CustomAsyncHandler handler = new CustomAsyncHandler();
+    TProcessor processor = new CustomService.AsyncProcessor<CustomService.AsyncIface>(handler);
     if (configure) {
-      processor = configure(processor, CustomHandler.class.getName());
+      processor = configure(processor, CustomAsyncHandler.class.getName());
     }
 
     TNonblockingServerSocket transport = new TNonblockingServerSocket(0, 30000);
@@ -276,14 +298,13 @@ public abstract class AbstractThriftTest {
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
-  protected SpanDataAssert assertServerSpan(SpanDataAssert span, String method, int port) {
-    return span.hasName(CustomHandler.class.getName() + "/" + method)
+  protected SpanDataAssert assertServerSpan(
+      SpanDataAssert span, String className, String method, int port, String errorType) {
+    return span.hasName(className + "/" + method)
         .hasKind(SpanKind.SERVER)
         .hasAttributesSatisfyingExactly(
-            equalTo(
-                RPC_METHOD,
-                emitStableRpcSemconv() ? CustomHandler.class.getName() + "/" + method : method),
-            equalTo(RPC_SERVICE, emitOldRpcSemconv() ? CustomHandler.class.getName() : null),
+            equalTo(RPC_METHOD, emitStableRpcSemconv() ? className + "/" + method : method),
+            equalTo(RPC_SERVICE, emitOldRpcSemconv() ? className : null),
             equalTo(RPC_SYSTEM, emitOldRpcSemconv() ? "apache_thrift" : null),
             equalTo(RPC_SYSTEM_NAME, emitStableRpcSemconv() ? "apache_thrift" : null),
             equalTo(SERVER_PORT, port),
@@ -292,20 +313,31 @@ public abstract class AbstractThriftTest {
             equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
             satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative),
             equalTo(NETWORK_LOCAL_ADDRESS, "127.0.0.1"),
-            equalTo(NETWORK_LOCAL_PORT, port));
+            equalTo(NETWORK_LOCAL_PORT, port),
+            equalTo(ERROR_TYPE, emitStableRpcSemconv() ? errorType : null));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected SpanDataAssert assertServerSpan(SpanDataAssert span, String method, int port) {
+    return assertServerSpan(span, CustomHandler.class.getName(), method, port, null);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected SpanDataAssert assertServerSpan(
+      SpanDataAssert span, String className, String method, String errorType) {
+    return span.hasName(className + "/" + method)
+        .hasKind(SpanKind.SERVER)
+        .hasAttributesSatisfyingExactly(
+            equalTo(RPC_METHOD, emitStableRpcSemconv() ? className + "/" + method : method),
+            equalTo(RPC_SERVICE, emitOldRpcSemconv() ? className : null),
+            equalTo(RPC_SYSTEM, emitOldRpcSemconv() ? "apache_thrift" : null),
+            equalTo(RPC_SYSTEM_NAME, emitStableRpcSemconv() ? "apache_thrift" : null),
+            equalTo(ERROR_TYPE, emitStableRpcSemconv() ? errorType : null));
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   protected SpanDataAssert assertServerSpan(SpanDataAssert span, String method) {
-    return span.hasName(CustomHandler.class.getName() + "/" + method)
-        .hasKind(SpanKind.SERVER)
-        .hasAttributesSatisfyingExactly(
-            equalTo(
-                RPC_METHOD,
-                emitStableRpcSemconv() ? CustomHandler.class.getName() + "/" + method : method),
-            equalTo(RPC_SERVICE, emitOldRpcSemconv() ? CustomHandler.class.getName() : null),
-            equalTo(RPC_SYSTEM, emitOldRpcSemconv() ? "apache_thrift" : null),
-            equalTo(RPC_SYSTEM_NAME, emitStableRpcSemconv() ? "apache_thrift" : null));
+    return assertServerSpan(span, CustomHandler.class.getName(), method, null);
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
@@ -532,12 +564,12 @@ public abstract class AbstractThriftTest {
   }
 
   @Test
-  void async() throws Exception {
+  void clientAsync() throws Exception {
     // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
     // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
     assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
 
-    int port = startAsyncServer();
+    int port = startNonblockingSyncServer();
     CustomService.AsyncIface asyncClient = createAsyncClient(port);
 
     CompletableFuture<String> completableFuture = new CompletableFuture<>();
@@ -581,12 +613,12 @@ public abstract class AbstractThriftTest {
   }
 
   @Test
-  void asyncMany() throws Exception {
+  void clientAsyncMany() throws Exception {
     // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
     // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
     assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
 
-    int port = startAsyncServer();
+    int port = startNonblockingSyncServer();
 
     List<CompletableFuture<String>> results = new ArrayList<>();
     for (int i = 0; i < 4; i++) {
@@ -634,12 +666,12 @@ public abstract class AbstractThriftTest {
   }
 
   @Test
-  void asyncWithError() throws Exception {
+  void clientAsyncWithError() throws Exception {
     // with thrift 0.13 fails on Java 8 due to java.lang.NoSuchMethodError:
     // java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
     assumeTrue(!"1.8".equals(System.getProperty("java.specification.version")) || testLatestDeps());
 
-    int port = startAsyncServer();
+    int port = startNonblockingSyncServer();
     CustomService.AsyncIface asyncClient = createAsyncClient(port);
 
     CompletableFuture<String> completableFuture = new CompletableFuture<>();
@@ -702,8 +734,8 @@ public abstract class AbstractThriftTest {
   }
 
   @Test
-  void oneWayAsync() throws Exception {
-    int port = startAsyncServer();
+  void clientOneWayAsync() throws Exception {
+    int port = startNonblockingSyncServer();
     CustomService.AsyncIface asyncClient = createAsyncClient(port);
 
     CompletableFuture<String> completableFuture = new CompletableFuture<>();

--- a/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/CustomAsyncHandler.java
+++ b/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/CustomAsyncHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+/*
+ * Thrift Opentracing Component
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.thrift.v0_13;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import custom.Address;
+import custom.CustomService;
+import custom.User;
+import custom.UserWithAddress;
+import org.apache.thrift.TException;
+import org.apache.thrift.async.AsyncMethodCallback;
+
+public class CustomAsyncHandler implements CustomService.AsyncIface {
+
+  @Override
+  public void say(String text, String text2, AsyncMethodCallback<String> resultHandler)
+      throws TException {
+    resultHandler.onComplete("Say " + text + " " + text2);
+  }
+
+  @Override
+  public void withDelay(int seconds, AsyncMethodCallback<String> resultHandler) throws TException {
+    try {
+      SECONDS.sleep(seconds);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    resultHandler.onComplete("delay " + seconds);
+  }
+
+  @Override
+  public void withoutArgs(AsyncMethodCallback<String> resultHandler) throws TException {
+    resultHandler.onComplete("no args");
+  }
+
+  @Override
+  public void withError(AsyncMethodCallback<String> resultHandler) throws TException {
+    resultHandler.onError(new IllegalStateException("fail"));
+  }
+
+  @Override
+  public void withCollision(String input, AsyncMethodCallback<String> resultHandler)
+      throws TException {
+    resultHandler.onComplete(input);
+  }
+
+  @Override
+  public void oneWay(AsyncMethodCallback<Void> resultHandler) throws TException {}
+
+  @Override
+  public void oneWayWithError(AsyncMethodCallback<Void> resultHandler) throws TException {
+    resultHandler.onError(new IllegalStateException("fail"));
+  }
+
+  @Override
+  public void save(User user, Address address, AsyncMethodCallback<UserWithAddress> resultHandler)
+      throws TException {
+    resultHandler.onComplete(new UserWithAddress(user, address));
+  }
+}

--- a/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/CustomAsyncHandler.java
+++ b/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/CustomAsyncHandler.java
@@ -29,19 +29,17 @@ import custom.Address;
 import custom.CustomService;
 import custom.User;
 import custom.UserWithAddress;
-import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 public class CustomAsyncHandler implements CustomService.AsyncIface {
 
   @Override
-  public void say(String text, String text2, AsyncMethodCallback<String> resultHandler)
-      throws TException {
+  public void say(String text, String text2, AsyncMethodCallback<String> resultHandler) {
     resultHandler.onComplete("Say " + text + " " + text2);
   }
 
   @Override
-  public void withDelay(int seconds, AsyncMethodCallback<String> resultHandler) throws TException {
+  public void withDelay(int seconds, AsyncMethodCallback<String> resultHandler) {
     try {
       SECONDS.sleep(seconds);
     } catch (InterruptedException e) {
@@ -51,32 +49,30 @@ public class CustomAsyncHandler implements CustomService.AsyncIface {
   }
 
   @Override
-  public void withoutArgs(AsyncMethodCallback<String> resultHandler) throws TException {
+  public void withoutArgs(AsyncMethodCallback<String> resultHandler) {
     resultHandler.onComplete("no args");
   }
 
   @Override
-  public void withError(AsyncMethodCallback<String> resultHandler) throws TException {
+  public void withError(AsyncMethodCallback<String> resultHandler) {
     resultHandler.onError(new IllegalStateException("fail"));
   }
 
   @Override
-  public void withCollision(String input, AsyncMethodCallback<String> resultHandler)
-      throws TException {
+  public void withCollision(String input, AsyncMethodCallback<String> resultHandler) {
     resultHandler.onComplete(input);
   }
 
   @Override
-  public void oneWay(AsyncMethodCallback<Void> resultHandler) throws TException {}
+  public void oneWay(AsyncMethodCallback<Void> resultHandler) {}
 
   @Override
-  public void oneWayWithError(AsyncMethodCallback<Void> resultHandler) throws TException {
+  public void oneWayWithError(AsyncMethodCallback<Void> resultHandler) {
     resultHandler.onError(new IllegalStateException("fail"));
   }
 
   @Override
-  public void save(User user, Address address, AsyncMethodCallback<UserWithAddress> resultHandler)
-      throws TException {
+  public void save(User user, Address address, AsyncMethodCallback<UserWithAddress> resultHandler) {
     resultHandler.onComplete(new UserWithAddress(user, address));
   }
 }


### PR DESCRIPTION
  Previously the Thrift 0.13 instrumentation covered async clients and nonblocking sync server processing, but async server handlers using `CustomService.AsyncProcessor` were not
  covered as a server-side async workflow.

  This PR adds instrumentation for:
  - `org.apache.thrift.TBaseAsyncProcessor#process`
  - `org.apache.thrift.AsyncProcessFunction#getResultHandler`
  - async frame buffer input/output protocol accessors

  The test fixture now separates nonblocking sync server startup from true async server startup and adds a `CustomAsyncHandler` for async server test coverage.
