### PR TITLE
Add back isMethod check in jedis instrumentation

### DIFF
--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -28,6 +29,7 @@ class JedisInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         isPublic()
+            .and(isMethod())
             .and(not(isStatic()))
             .and(
                 not(

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -28,6 +29,7 @@ class JedisInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         isPublic()
+            .and(isMethod())
             .and(not(isStatic()))
             .and(
                 not(

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -28,6 +29,7 @@ class JedisInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         isPublic()
+            .and(isMethod())
             .and(not(isStatic()))
             .and(
                 not(


### PR DESCRIPTION
`isMethod` got removed by automated review agent. Here instrumenting of constructors is not desired and also fails with
```
    [otel.javaagent 2026-06-15 11:56:57:707 +0000] [Test worker] ERROR io.opentelemetry.javaagent.testing.bytebuddy.TestAgentListener - Unexpected instrumentation error when instrumenting redis.clients.jedis.BinaryJedis on sun.misc.Launcher$AppClassLoader@df9a5aa0
    java.lang.IllegalStateException: Cannot catch exception during constructor call for public redis.clients.jedis.BinaryJedis()
    	at net.bytebuddy.asm.Advice.doWrap(Advice.java:632)
    	at net.bytebuddy.asm.Advice.wrap(Advice.java:587)
    	at net.bytebuddy.asm.AsmVisitorWrapper$ForDeclaredMethods$Entry.wrap(AsmVisitorWrapper.java:580)
    	at net.bytebuddy.asm.AsmVisitorWrapper$ForDeclaredMethods$DispatchingVisitor.visitMethod(AsmVisitorWrapper.java:662)
    	at org.objectweb.asm.ClassVisitor.visitMethod(ClassVisitor.java:384)
    	at net.bytebuddy.utility.visitor.MetadataAwareClassVisitor.onVisitMethod(MetadataAwareClassVisitor.java:429)
    	at net.bytebuddy.utility.visitor.MetadataAwareClassVisitor.visitMethod(MetadataAwareClassVisitor.java:414)
    	at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1354)
    	at org.objectweb.asm.ClassReader.accept(ClassReader.java:745)
    	at net.bytebuddy.utility.AsmClassReader$ForAsm.accept(AsmClassReader.java:290)
    	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:4199)
    	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2281)
    	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4889)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:12824)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:12759)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1800(AgentBuilder.java:12468)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:13168)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:13106)
    	at java.security.AccessController.doPrivileged(AccessController.java:725)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doPrivileged(AgentBuilder.java)
    	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:12668)
    	at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
    	at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:443)
    	at java.lang.ClassLoader.defineClassImpl(Native Method)
```
This stack trace doesn't seem to make tests fail.
