### PR TITLE
Add Redisson batch size attribute

### DIFF
--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonDbAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonDbAttributesGetter.java
@@ -35,6 +35,12 @@ final class RedissonDbAttributesGetter implements DbClientAttributesGetter<Redis
     return request.getOperationName();
   }
 
+  @Nullable
+  @Override
+  public Long getDbOperationBatchSize(RedissonRequest request) {
+    return request.getOperationBatchSize();
+  }
+
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -100,6 +100,24 @@ public abstract class RedissonRequest {
   }
 
   @Nullable
+  public Long getOperationBatchSize() {
+    Object command = getCommand();
+    if (!(command instanceof CommandsData)) {
+      return null;
+    }
+    List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+    if (commands.isEmpty()) {
+      return null;
+    }
+    int batchSize = commands.size();
+    if (commands.get(0).getCommand().getName().equals(MULTI)) {
+      // MULTI is a transaction wrapper command, not a user operation in the batch.
+      batchSize--;
+    }
+    return batchSize > 1 ? (long) batchSize : null;
+  }
+
+  @Nullable
   private static String getBatchOperationName(List<CommandData<?, ?>> commands) {
     if (commands.size() < 2) {
       return null;

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -256,6 +256,9 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
+                            // db.operation.batch.size is not emitted because MULTI transaction
+                            // telemetry is split across wrapper and command spans, so this span
+                            // does not represent the full logical batch.
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -268,6 +269,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
                             equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
   }
 
@@ -297,6 +300,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(
                                 DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
                             equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
   }
 
@@ -330,6 +335,8 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 4L : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "SET " + bucketName + " ?;SET " + bucketName + " ?"))));
@@ -370,6 +377,9 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
+                            // db.operation.batch.size is not emitted because MULTI transaction
+                            // telemetry is split across wrapper and command spans, so this span
+                            // does not represent the full logical batch.
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
                         .hasParent(trace.getSpan(0)),
                 span ->


### PR DESCRIPTION
## Summary
- emit `db.operation.batch.size` for Redisson `CommandsData` pipeline spans in stable DB semantic convention mode
- exclude the `MULTI` transaction wrapper command from batch-size counting
- add stable-mode pipeline assertions and document why current `MULTI` wrapper spans omit batch size

## Testing
- `git diff --check -- instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonDbAttributesGetter.java instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java`
- `./gradlew :instrumentation:redisson:redisson-common-3.0:javaagent:spotlessCheck :instrumentation:redisson:redisson-common-3.0:testing:spotlessCheck :instrumentation:redisson:redisson-3.0:javaagent:compileTestJava :instrumentation:redisson:redisson-3.17:javaagent:compileTestJava`