### PR TITLE
Assert stable connection pool metric names in stable semconv mode

### DIFF
--- a/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
+++ b/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
@@ -88,15 +88,21 @@ public abstract class AbstractHikariInstrumentationTest {
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "db.client.connections.idle.min",
+            emitStableDatabaseSemconv()
+                ? "db.client.connection.idle.min"
+                : "db.client.connections.idle.min",
             AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME, "db.client.connections.max", AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME,
+            emitStableDatabaseSemconv() ? "db.client.connection.max" : "db.client.connections.max",
+            AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "db.client.connections.pending_requests",
+            emitStableDatabaseSemconv()
+                ? "db.client.connection.pending_requests"
+                : "db.client.connections.pending_requests",
             AbstractIterableAssert::isEmpty);
   }
 

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcInstrumentationTest.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcInstrumentationTest.java
@@ -78,19 +78,25 @@ class TomcatJdbcInstrumentationTest {
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connections.idle.min",
+        emitStableDatabaseSemconv()
+            ? "db.client.connection.idle.min"
+            : "db.client.connections.idle.min",
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connections.idle.max",
+        emitStableDatabaseSemconv()
+            ? "db.client.connection.idle.max"
+            : "db.client.connections.idle.max",
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connections.max",
+        emitStableDatabaseSemconv() ? "db.client.connection.max" : "db.client.connections.max",
         AbstractIterableAssert::isEmpty);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.tomcat-jdbc",
-        "db.client.connections.pending_requests",
+        emitStableDatabaseSemconv()
+            ? "db.client.connection.pending_requests"
+            : "db.client.connections.pending_requests",
         AbstractIterableAssert::isEmpty);
   }
 }

--- a/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
@@ -76,6 +76,8 @@ public abstract class AbstractViburInstrumentationTest {
             INSTRUMENTATION_NAME, countMetricName, AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME, "db.client.connections.max", AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME,
+            emitStableDatabaseSemconv() ? "db.client.connection.max" : "db.client.connections.max",
+            AbstractIterableAssert::isEmpty);
   }
 }


### PR DESCRIPTION
The HikariCP and Vibur connection-pool tests verify, after closing the data source, that pool metrics stop being emitted via `waitAndAssertMetrics(..., isEmpty)`. The `db.client.connection.count` check already switches between the stable and old metric name based on `emitStableDatabaseSemconv()`, but the remaining post-close absence checks hardcoded the old `db.client.connections.*` names:

- HikariCP: `idle.min`, `max`, `pending_requests`
- Vibur: `max`

In stable mode the old-named metrics are never emitted, so those `isEmpty` assertions passed vacuously and never verified that the stable-named metric (`db.client.connection.*`) was actually unregistered after close.

This wraps those names in the same `emitStableDatabaseSemconv()` conditional already used for the count metric, matching the existing pattern in the c3p0 test (`AbstractC3p0InstrumentationTest`).
