### PR TITLE
Unify database batch tests into parameterized scenario tests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.AWS_DYNAMODB;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
@@ -39,7 +40,13 @@ import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTest {
 
@@ -82,10 +89,14 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         SERVER_PORT);
   }
 
+  // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
+  // BatchWriteItem): the request to send and the expected client span. batch attributes
+  // (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted under
+  // stable database semconv; the span and db.operation.name are emitted in both modes
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchGetItemWithMultipleItemsUsesStableBatchAttributes()
-      throws ReflectiveOperationException {
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchOperation(BatchScenario scenario) throws ReflectiveOperationException {
     AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
@@ -97,153 +108,160 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
                     maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
                 equalTo(
                     maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem"),
+                    emitStableDatabaseSemconv() ? scenario.stableOperation : scenario.awsOperation),
                 equalTo(
-                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
+                    DB_OPERATION_BATCH_SIZE,
+                    emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                equalTo(
+                    DB_COLLECTION_NAME,
+                    emitStableDatabaseSemconv() && scenario.hasCollection ? "sometable" : null)));
 
-    Object response =
-        client.batchGetItem(
-            new BatchGetItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable",
-                        new KeysAndAttributes()
-                            .withKeys(
-                                asList(
-                                    singletonMap("key", new AttributeValue().withS("value")),
-                                    singletonMap(
-                                        "key", new AttributeValue().withS("anotherValue")))))));
+    Object response = scenario.execute.apply(client);
     assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+        response, client, "DynamoDBv2", scenario.awsOperation, "POST", additionalAttributes);
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchGetItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "GetItem" : "BatchGetItem"),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchGetItem(
-            new BatchGetItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable",
-                        new KeysAndAttributes()
-                            .withKeys(
-                                singletonList(
-                                    singletonMap("key", new AttributeValue().withS("value")))))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // an empty batch keeps the raw batch operation name and emits no batch size or
+            // collection name
+            BatchScenario.builder("getItemEmpty")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(0)))
+                .stableOperation("BatchGetItem")
+                .build(),
+            // a single-item batch is not a batch, so it uses the singular item operation
+            BatchScenario.builder("getItemSingle")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(1)))
+                .stableOperation("GetItem")
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("getItemTwo")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(2)))
+                .stableOperation("BATCH GetItem")
+                .batchSize(2)
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("writeItemEmpty")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(0)))
+                .stableOperation("BatchWriteItem")
+                .build(),
+            BatchScenario.builder("writeItemSingle")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(1)))
+                .stableOperation("WriteItem")
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("writeItemTwo")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(2)))
+                .stableOperation("BATCH WriteItem")
+                .batchSize(2)
+                .hasCollection()
+                .build())
+        .map(Arguments::of);
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchWriteItemWithMultipleItemsUsesStableBatchAttributes()
-      throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "BATCH WriteItem" : "BatchWriteItem"),
-                equalTo(
-                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchWriteItem(
-            new BatchWriteItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable", asList(writeRequest("value"), writeRequest("anotherValue")))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static BatchGetItemRequest getItemRequest(int count) {
+    if (count == 0) {
+      return new BatchGetItemRequest().withRequestItems(emptyMap());
+    }
+    List<Map<String, AttributeValue>> keys = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      keys.add(singletonMap("key", new AttributeValue().withS("value" + i)));
+    }
+    return new BatchGetItemRequest()
+        .withRequestItems(singletonMap("sometable", new KeysAndAttributes().withKeys(keys)));
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchWriteItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "WriteItem" : "BatchWriteItem"),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchWriteItem(
-            new BatchWriteItemRequest()
-                .withRequestItems(singletonMap("sometable", singletonList(writeRequest("value")))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static BatchWriteItemRequest writeItemRequest(int count) {
+    if (count == 0) {
+      return new BatchWriteItemRequest().withRequestItems(emptyMap());
+    }
+    List<WriteRequest> writes = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      writes.add(writeRequest("value" + i));
+    }
+    return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
   }
 
   private static WriteRequest writeRequest(String value) {
     return new WriteRequest()
         .withPutRequest(
             new PutRequest().withItem(singletonMap("key", new AttributeValue().withS(value))));
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final String awsOperation;
+    final Function<AmazonDynamoDB, Object> execute;
+    final String stableOperation;
+    final Long batchSize;
+    final boolean hasCollection;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.awsOperation = builder.awsOperation;
+      this.execute = builder.execute;
+      this.stableOperation = builder.stableOperation;
+      this.batchSize = builder.batchSize;
+      this.hasCollection = builder.hasCollection;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String awsOperation;
+      private Function<AmazonDynamoDB, Object> execute;
+      private String stableOperation;
+      private Long batchSize;
+      private boolean hasCollection;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder awsOperation(String awsOperation) {
+        this.awsOperation = awsOperation;
+        return this;
+      }
+
+      Builder execute(Function<AmazonDynamoDB, Object> execute) {
+        this.execute = execute;
+        return this;
+      }
+
+      Builder stableOperation(String stableOperation) {
+        this.stableOperation = stableOperation;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder hasCollection() {
+        this.hasCollection = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private AmazonDynamoDB createClient() {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -566,9 +566,14 @@ public abstract class AbstractAws2ClientCoreTest {
                                         .doesNotContainKey(DB_COLLECTION_NAME))));
   }
 
-  @Test
+  // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
+  // BatchWriteItem): the request to send, the mocked response and the expected client span. batch
+  // attributes (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted
+  // under stable database semconv; the span and db.operation.name are emitted in both modes
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
   @SuppressWarnings("deprecation") // uses deprecated semconv
-  void testBatchGetItemWithMultipleItemsUsesStableBatchAttributes() {
+  void batchOperation(BatchScenario scenario) {
     DynamoDbClientBuilder builder = DynamoDbClient.builder();
     configureSdkClient(builder);
     DynamoDbClient client =
@@ -578,114 +583,260 @@ public abstract class AbstractAws2ClientCoreTest {
             .credentialsProvider(CREDENTIALS_PROVIDER)
             .build();
     server.enqueue(
-        HttpResponse.of(
-            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchGetItem")));
+        HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, scenario.responseContent));
 
-    client.batchGetItem(
-        b ->
-            b.requestItems(
-                ImmutableMap.of(
-                    "sometable",
-                    KeysAndAttributes.builder()
-                        .keys(
-                            asList(
-                                ImmutableMap.of("key", AttributeValue.builder().s("value").build()),
-                                ImmutableMap.of(
-                                    "key", AttributeValue.builder().s("anotherValue").build())))
-                        .build())));
+    Object response = scenario.execute.apply(client);
+    assertThat(response).isNotNull();
 
     getTesting()
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span ->
-                        assertDynamoDbRequest(
-                            span,
-                            "BatchGetItem",
-                            asList(
-                                equalTo(
-                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
-                                    singletonList(
-                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
-                            "BATCH GetItem")));
+                    span -> {
+                      List<AttributeAssertion> attributes =
+                          new ArrayList<>(
+                              asList(
+                                  equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                                  equalTo(SERVER_PORT, server.httpPort()),
+                                  equalTo(URL_FULL, server.httpUri() + "/"),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(RPC_SYSTEM, "aws-api"),
+                                  equalTo(RPC_SERVICE, "DynamoDb"),
+                                  equalTo(RPC_METHOD, scenario.awsOperation),
+                                  equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+                                  equalTo(AWS_REQUEST_ID, "UNKNOWN"),
+                                  equalTo(
+                                      maybeStable(DB_SYSTEM), maybeStableDbSystemName(DYNAMODB)),
+                                  equalTo(
+                                      maybeStable(DB_OPERATION),
+                                      emitStableDatabaseSemconv()
+                                          ? scenario.stableOperation
+                                          : scenario.awsOperation)));
+                      if (scenario.hasCollection) {
+                        attributes.add(
+                            equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")));
+                        if (emitStableDatabaseSemconv()) {
+                          attributes.add(equalTo(DB_COLLECTION_NAME, "sometable"));
+                        }
+                      }
+                      attributes.addAll(scenario.extraAttributes());
+                      span.hasName("DynamoDb." + scenario.awsOperation)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(attributes);
+                    }));
 
-    assertDurationMetric(
-        getTesting(),
-        "io.opentelemetry.aws-sdk-2.2",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME);
+    if (scenario.assertMetric) {
+      assertDurationMetric(
+          getTesting(),
+          "io.opentelemetry.aws-sdk-2.2",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_COLLECTION_NAME);
+    }
   }
 
-  @Test
   @SuppressWarnings("deprecation") // uses deprecated semconv
-  void testBatchWriteItemWithMultipleItemsUsesStableBatchAttributes() {
-    DynamoDbClientBuilder builder = DynamoDbClient.builder();
-    configureSdkClient(builder);
-    DynamoDbClient client =
-        builder
-            .endpointOverride(server.httpUri())
-            .region(Region.AP_NORTHEAST_1)
-            .credentialsProvider(CREDENTIALS_PROVIDER)
-            .build();
-    server.enqueue(
-        HttpResponse.of(
-            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchWriteItem")));
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // an empty batch still produces a span, but keeps the raw batch operation name and
+            // emits no db.operation.batch.size, db.collection.name or table-name attributes
+            BatchScenario.builder("getItemEmpty")
+                .awsOperation("BatchGetItem")
+                .responseContent("{\"ConsumedCapacity\":[]}")
+                .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
+                .stableOperation("BatchGetItem")
+                .build(),
+            BatchScenario.builder("getItemTwo")
+                .awsOperation("BatchGetItem")
+                .responseContent(getResponseContent("BatchGetItem"))
+                .execute(
+                    c ->
+                        c.batchGetItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        KeysAndAttributes.builder()
+                                            .keys(
+                                                asList(
+                                                    ImmutableMap.of(
+                                                        "key",
+                                                        AttributeValue.builder().s("value").build()),
+                                                    ImmutableMap.of(
+                                                        "key",
+                                                        AttributeValue.builder()
+                                                            .s("anotherValue")
+                                                            .build())))
+                                            .build()))))
+                .stableOperation("BATCH GetItem")
+                .hasCollection()
+                .batchSize(2)
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .assertMetric()
+                .build(),
+            BatchScenario.builder("writeItemTwo")
+                .awsOperation("BatchWriteItem")
+                .responseContent(getResponseContent("BatchWriteItem"))
+                .execute(
+                    c ->
+                        c.batchWriteItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        asList(
+                                            WriteRequest.builder()
+                                                .putRequest(
+                                                    PutRequest.builder()
+                                                        .item(
+                                                            ImmutableMap.of(
+                                                                "key",
+                                                                AttributeValue.builder()
+                                                                    .s("value")
+                                                                    .build()))
+                                                        .build())
+                                                .build(),
+                                            WriteRequest.builder()
+                                                .putRequest(
+                                                    PutRequest.builder()
+                                                        .item(
+                                                            ImmutableMap.of(
+                                                                "key",
+                                                                AttributeValue.builder()
+                                                                    .s("anotherValue")
+                                                                    .build()))
+                                                        .build())
+                                                .build()))))) 
+                .stableOperation("BATCH WriteItem")
+                .hasCollection()
+                .batchSize(2)
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+                .assertMetric()
+                .build())
+        .map(Arguments::of);
+  }
 
-    client.batchWriteItem(
-        b ->
-            b.requestItems(
-                ImmutableMap.of(
-                    "sometable",
-                    asList(
-                        WriteRequest.builder()
-                            .putRequest(
-                                PutRequest.builder()
-                                    .item(
-                                        ImmutableMap.of(
-                                            "key", AttributeValue.builder().s("value").build()))
-                                    .build())
-                            .build(),
-                        WriteRequest.builder()
-                            .putRequest(
-                                PutRequest.builder()
-                                    .item(
-                                        ImmutableMap.of(
-                                            "key",
-                                            AttributeValue.builder().s("anotherValue").build()))
-                                    .build())
-                            .build()))));
+  private static final class BatchScenario {
+    final String name;
+    final String awsOperation;
+    final String responseContent;
+    final Function<DynamoDbClient, Object> execute;
+    final String stableOperation;
+    final boolean hasCollection;
+    final Long batchSize;
+    final String consumedCapacity;
+    final String itemCollectionMetrics;
+    final boolean assertMetric;
 
-    getTesting()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        assertDynamoDbRequest(
-                            span,
-                            "BatchWriteItem",
-                            asList(
-                                equalTo(
-                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
-                                    singletonList(
-                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
-                                equalTo(
-                                    AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
-                                    "[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]"),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
-                            "BATCH WriteItem")));
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.awsOperation = builder.awsOperation;
+      this.responseContent = builder.responseContent;
+      this.execute = builder.execute;
+      this.stableOperation = builder.stableOperation;
+      this.hasCollection = builder.hasCollection;
+      this.batchSize = builder.batchSize;
+      this.consumedCapacity = builder.consumedCapacity;
+      this.itemCollectionMetrics = builder.itemCollectionMetrics;
+      this.assertMetric = builder.assertMetric;
+    }
 
-    assertDurationMetric(
-        getTesting(),
-        "io.opentelemetry.aws-sdk-2.2",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME);
+    @SuppressWarnings("deprecation") // uses deprecated semconv
+    List<AttributeAssertion> extraAttributes() {
+      List<AttributeAssertion> attributes = new ArrayList<>();
+      if (consumedCapacity != null) {
+        attributes.add(
+            equalTo(AWS_DYNAMODB_CONSUMED_CAPACITY, singletonList(consumedCapacity)));
+      }
+      if (itemCollectionMetrics != null) {
+        attributes.add(equalTo(AWS_DYNAMODB_ITEM_COLLECTION_METRICS, itemCollectionMetrics));
+      }
+      if (batchSize != null) {
+        attributes.add(
+            equalTo(
+                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? batchSize : null));
+      }
+      return attributes;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String awsOperation;
+      private String responseContent;
+      private Function<DynamoDbClient, Object> execute;
+      private String stableOperation;
+      private boolean hasCollection;
+      private Long batchSize;
+      private String consumedCapacity;
+      private String itemCollectionMetrics;
+      private boolean assertMetric;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder awsOperation(String awsOperation) {
+        this.awsOperation = awsOperation;
+        return this;
+      }
+
+      Builder responseContent(String responseContent) {
+        this.responseContent = responseContent;
+        return this;
+      }
+
+      Builder execute(Function<DynamoDbClient, Object> execute) {
+        this.execute = execute;
+        return this;
+      }
+
+      Builder stableOperation(String stableOperation) {
+        this.stableOperation = stableOperation;
+        return this;
+      }
+
+      Builder hasCollection() {
+        this.hasCollection = true;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder consumedCapacity(String consumedCapacity) {
+        this.consumedCapacity = consumedCapacity;
+        return this;
+      }
+
+      Builder itemCollectionMetrics(String itemCollectionMetrics) {
+        this.itemCollectionMetrics = itemCollectionMetrics;
+        return this;
+      }
+
+      Builder assertMetric() {
+        this.assertMetric = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private static String expectedDbOperationNameForSingleItemRequest(String operation) {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -43,6 +43,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -295,34 +296,33 @@ class CassandraClientTest {
         SERVER_PORT);
   }
 
-  @Test
-  void batchStatementWithSameQuery() {
+  // describes the batch cases: two statements with the same query, and two statements with
+  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
+  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
+  // names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchStatement(BatchScenario scenario) {
     Session session = cluster.connect();
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
     session.execute(
-        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement preparedStatement =
-        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+        "CREATE KEYSPACE "
+            + scenario.keyspace
+            + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute(
+        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
     testing.waitForTraces(3);
     testing.clearData();
 
-    BatchStatement batchStatement =
-        new BatchStatement()
-            .add(preparedStatement.bind("alice", 1))
-            .add(preparedStatement.bind("bob", 2));
-    session.execute(batchStatement);
+    session.execute(scenario.buildBatch.apply(session));
 
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "BATCH INSERT batch_same_test.users"
-                                : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -334,63 +334,131 @@ class CassandraClientTest {
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
-                                    : null),
+                                emitStableDatabaseSemconv() ? scenario.statement : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT batch_same_test.users"
-                                    : null))));
+                                emitStableDatabaseSemconv() ? scenario.summary : null))));
   }
 
-  @Test
-  void batchStatementWithDifferentQueries() {
-    Session session = cluster.connect();
-    cleanup.deferCleanup(session);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            BatchScenario.builder("twoSameOperation")
+                .keyspace("batch_same_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                      return new BatchStatement()
+                          .add(insert.bind("alice", 1))
+                          .add(insert.bind("bob", 2));
+                    })
+                .spanName("BATCH INSERT batch_same_test.users")
+                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+                .summary("BATCH INSERT batch_same_test.users")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder("twoDifferentOperations")
+                .keyspace("batch_mixed_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      return new BatchStatement()
+                          .add(insert.bind(1))
+                          .add(
+                              new SimpleStatement(
+                                  "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                    })
+                .spanName("BATCH")
+                .statement(
+                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
-    session.execute(
-        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing.waitForTraces(3);
-    testing.clearData();
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<Session, BatchStatement> buildBatch;
+    final String spanName;
+    final String statement;
+    final String summary;
+    final Long batchSize;
 
-    BatchStatement batchStatement =
-        new BatchStatement()
-            .add(insertStatement.bind(1))
-            .add(
-                new SimpleStatement(
-                    "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-    session.execute(batchStatement);
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.statement = builder.statement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
-                            equalTo(SERVER_ADDRESS, cassandraHost),
-                            equalTo(SERVER_PORT, cassandraPort),
-                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
-                            equalTo(NETWORK_PEER_PORT, cassandraPort),
-                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
-                            equalTo(
-                                maybeStable(DB_STATEMENT),
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
-                                    : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(
-                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null))));
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<Session, BatchStatement> buildBatch;
+      private String spanName;
+      private String statement;
+      private String summary;
+      private Long batchSize;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<Session, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private static Stream<Arguments> provideSyncParameters() {

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -50,6 +50,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeAll;
@@ -186,26 +187,27 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
   }
 
-  @Test
-  void batchStatementWithSameQuery() {
+  // describes the batch cases: two statements with the same query, and two statements with
+  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
+  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
+  // names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchStatement(BatchScenario scenario) {
     CqlSession session = getSession(null);
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
     session.execute(
-        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement preparedStatement =
-        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+        "CREATE KEYSPACE "
+            + scenario.keyspace
+            + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute(
+        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
     testing().waitForTraces(3);
     testing().clearData();
 
-    BatchStatement batchStatement =
-        BatchStatement.newInstance(
-            DefaultBatchType.LOGGED,
-            preparedStatement.bind("alice", 1),
-            preparedStatement.bind("bob", 2));
-    session.execute(batchStatement);
+    session.execute(scenario.buildBatch.apply(session));
 
     testing()
         .waitAndAssertTraces(
@@ -213,9 +215,7 @@ public abstract class AbstractCassandraTest {
                 trace.hasSpansSatisfyingExactly(
                     span ->
                         span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT batch_same_test.users"
-                                    : "DB Query")
+                                emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
@@ -231,17 +231,13 @@ public abstract class AbstractCassandraTest {
                                 equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                                 equalTo(
                                     maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
-                                        : null),
+                                    emitStableDatabaseSemconv() ? scenario.statement : null),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null),
+                                    emitStableDatabaseSemconv() ? scenario.batchSize : null),
                                 equalTo(
                                     DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv()
-                                        ? "BATCH INSERT batch_same_test.users"
-                                        : null),
+                                    emitStableDatabaseSemconv() ? scenario.summary : null),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -255,68 +251,121 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
   }
 
-  @Test
-  void batchStatementWithDifferentQueries() {
-    CqlSession session = getSession(null);
-    cleanup.deferCleanup(session);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            BatchScenario.builder("twoSameOperation")
+                .keyspace("batch_same_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                      return BatchStatement.newInstance(
+                          DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
+                    })
+                .spanName("BATCH INSERT batch_same_test.users")
+                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+                .summary("BATCH INSERT batch_same_test.users")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder("twoDifferentOperations")
+                .keyspace("batch_mixed_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      return BatchStatement.newInstance(
+                          DefaultBatchType.LOGGED,
+                          insert.bind(1),
+                          SimpleStatement.newInstance(
+                              "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                    })
+                .spanName("BATCH")
+                .statement(
+                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
-    session.execute(
-        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing().waitForTraces(3);
-    testing().clearData();
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<CqlSession, BatchStatement> buildBatch;
+    final String spanName;
+    final String statement;
+    final String summary;
+    final Long batchSize;
 
-    BatchStatement batchStatement =
-        BatchStatement.newInstance(
-            DefaultBatchType.LOGGED,
-            insertStatement.bind(1),
-            SimpleStatement.newInstance(
-                "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-    session.execute(batchStatement);
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.statement = builder.statement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
 
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasNoParent()
-                            .hasAttributesSatisfyingExactly(
-                                satisfies(
-                                    NETWORK_TYPE,
-                                    emitStableDatabaseSemconv()
-                                        ? val -> val.isNull()
-                                        : val -> val.isIn("ipv4", "ipv6")),
-                                equalTo(SERVER_ADDRESS, cassandraHost),
-                                equalTo(SERVER_PORT, cassandraPort),
-                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
-                                equalTo(NETWORK_PEER_PORT, cassandraPort),
-                                equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
-                                        : null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
-                                equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
-                                equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
-                                satisfies(
-                                    maybeStable(DB_CASSANDRA_COORDINATOR_ID),
-                                    val -> val.isInstanceOf(String.class)),
-                                satisfies(
-                                    maybeStable(DB_CASSANDRA_IDEMPOTENCE),
-                                    val -> val.isInstanceOf(Boolean.class)),
-                                equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<CqlSession, BatchStatement> buildBatch;
+      private String spanName;
+      private String statement;
+      private String summary;
+      private Long batchSize;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<CqlSession, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -18,6 +18,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -1879,6 +1880,101 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasParent(trace.getSpan(0))));
   }
 
+  // describes the four batch cases: the tables to create, the statements added to the batch, the
+  // expected executeBatch() result, and the expected client span. batch telemetry comes from the
+  // shared SQL extractors and is database-agnostic, so a single (in-memory) database is enough to
+  // lock down its shape
+  static Stream<Arguments> batchCasesStream() {
+    return Stream.of(
+            // an empty batch still produces a client span, but with no query text or batch size;
+            // the span name falls back to the database namespace
+            BatchScenario.builder().name("empty").spanName(DATABASE_NAME_LOWER).build(),
+            // a single-statement batch is not a batch (size 1), so it looks like a normal statement
+            BatchScenario.builder()
+                .name("single")
+                .createTable("stmt_batch_single")
+                .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
+                .expectedResult(1)
+                .spanName("INSERT stmt_batch_single")
+                .queryText("INSERT INTO stmt_batch_single VALUES(?)")
+                .summary("INSERT stmt_batch_single")
+                .build(),
+            BatchScenario.builder()
+                .name("twoSameOperation")
+                .createTable("stmt_batch_same")
+                .addQuery("INSERT INTO stmt_batch_same VALUES(1)")
+                .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
+                .expectedResult(1, 1)
+                .spanName("BATCH INSERT stmt_batch_same")
+                .queryText("INSERT INTO stmt_batch_same VALUES(?)")
+                .summary("BATCH INSERT stmt_batch_same")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder()
+                .name("twoDifferentOperations")
+                .createTable("stmt_batch_diff_1")
+                .createTable("stmt_batch_diff_2")
+                .addQuery("INSERT INTO stmt_batch_diff_1 VALUES(1)")
+                .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
+                .expectedResult(1, 1)
+                .spanName("BATCH")
+                .queryText(
+                    "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
+                        + " VALUES(?)")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("batchCasesStream")
+  void testStatementBatch(BatchScenario scenario) throws SQLException {
+    // batch telemetry (db.operation.batch.size, BATCH span names and summaries) is only emitted
+    // under stable database semconv
+    Assumptions.assumeTrue(emitStableDatabaseSemconv());
+
+    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+    cleanup.deferCleanup(connection);
+
+    for (String table : scenario.tablesToCreate) {
+      Statement createTable = connection.createStatement();
+      createTable.execute("CREATE TABLE " + table + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+      cleanup.deferCleanup(createTable);
+    }
+    if (!scenario.tablesToCreate.isEmpty()) {
+      testing().waitForTraces(scenario.tablesToCreate.size());
+      testing().clearData();
+    }
+
+    Statement statement = connection.createStatement();
+    cleanup.deferCleanup(statement);
+    for (String sql : scenario.statementsToAdd) {
+      statement.addBatch(sql);
+    }
+
+    testing()
+        .runWithSpan(
+            "parent",
+            () -> assertThat(statement.executeBatch()).isEqualTo(scenario.expectedResult));
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasName(scenario.spanName)
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(DB_SYSTEM_NAME, maybeStableDbSystemName("h2")),
+                                equalTo(DB_NAMESPACE, DATABASE_NAME_LOWER),
+                                equalTo(DB_QUERY_TEXT, scenario.queryText),
+                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
+                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize))));
+  }
+
   static Stream<Arguments> batchStream() throws SQLException {
     return Stream.of(
         Arguments.of("h2", new org.h2.Driver().connect(JDBC_URLS.get("h2"), null), null, "h2:mem:"),
@@ -1894,19 +1990,6 @@ public abstract class AbstractJdbcInstrumentationTest {
             new JDBC().connect(JDBC_URLS.get("sqlite"), new Properties()),
             null,
             "sqlite:memory:"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testBatch(String system, Connection connection, String username, String url)
-      throws SQLException {
-    testBatchImpl(
-        system,
-        wrap(connection),
-        username,
-        url,
-        "simple_batch_test",
-        statement -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1, 1}));
   }
 
   @ParameterizedTest
@@ -1931,170 +2014,6 @@ public abstract class AbstractJdbcInstrumentationTest {
       assertThatThrownBy(statement::executeLargeBatch)
           .isInstanceOf(UnsupportedOperationException.class);
     }
-  }
-
-  private void testBatchImpl(
-      String system,
-      Connection connection,
-      String username,
-      String url,
-      String tableName,
-      ThrowingConsumer<Statement> action)
-      throws SQLException {
-    Statement createTable = connection.createStatement();
-    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable);
-
-    testing().waitForTraces(1);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO non_existent_table VALUES(1)");
-    statement.clearBatch();
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(1)");
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(2)");
-    testing().runWithSpan("parent", () -> action.accept(statement));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT " + tableName
-                                    : "jdbcunittest")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO " + tableName + " VALUES(?)"
-                                        : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv()
-                                        ? "BATCH INSERT " + tableName
-                                        : null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null))));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testMultiBatch(String system, Connection conn, String username, String url)
-      throws SQLException {
-    Connection connection = wrap(conn);
-    String tableName1 = "multi_batch_test_1";
-    String tableName2 = "multi_batch_test_2";
-    Statement createTable1 = connection.createStatement();
-    createTable1.execute(
-        "CREATE TABLE " + tableName1 + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable1);
-    Statement createTable2 = connection.createStatement();
-    createTable2.execute(
-        "CREATE TABLE " + tableName2 + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable2);
-
-    testing().waitForTraces(2);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO " + tableName1 + " VALUES(1)");
-    statement.addBatch("INSERT INTO " + tableName2 + " VALUES(2)");
-    testing()
-        .runWithSpan(
-            "parent", () -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1, 1}));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "jdbcunittest")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO "
-                                            + tableName1
-                                            + " VALUES(?); INSERT INTO multi_batch_test_2 VALUES(?)"
-                                        : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
-                                equalTo(maybeStable(DB_OPERATION), null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null))));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testSingleItemBatch(String system, Connection conn, String username, String url)
-      throws SQLException {
-    Connection connection = wrap(conn);
-    String tableName = "single_item_batch_test";
-    Statement createTable = connection.createStatement();
-    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable);
-
-    testing().waitForTraces(1);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(1)");
-    testing()
-        .runWithSpan("parent", () -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1}));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT " + tableName
-                                    : "INSERT jdbcunittest." + tableName)
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "INSERT INTO " + tableName + " VALUES(?)"),
-                                equalTo(
-                                    DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv() ? "INSERT " + tableName : null),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv() ? null : "INSERT"),
-                                equalTo(
-                                    maybeStable(DB_SQL_TABLE),
-                                    emitStableDatabaseSemconv() ? null : tableName))));
   }
 
   @ParameterizedTest
@@ -2445,5 +2364,92 @@ public abstract class AbstractJdbcInstrumentationTest {
                                     : "SELECT " + DATABASE_NAME_LOWER)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(1))));
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<String> tablesToCreate;
+    final List<String> statementsToAdd;
+    final int[] expectedResult;
+    final String spanName;
+    final String queryText;
+    final String summary;
+    final Long batchSize;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.tablesToCreate = builder.tablesToCreate;
+      this.statementsToAdd = builder.statementsToAdd;
+      this.expectedResult = builder.expectedResult;
+      this.spanName = builder.spanName;
+      this.queryText = builder.queryText;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+      private String name;
+      private final List<String> tablesToCreate = new ArrayList<>();
+      private final List<String> statementsToAdd = new ArrayList<>();
+      private int[] expectedResult = new int[] {};
+      private String spanName;
+      private String queryText;
+      private String summary;
+      private Long batchSize;
+
+      Builder name(String name) {
+        this.name = name;
+        return this;
+      }
+
+      Builder createTable(String table) {
+        this.tablesToCreate.add(table);
+        return this;
+      }
+
+      Builder addQuery(String query) {
+        this.statementsToAdd.add(query);
+        return this;
+      }
+
+      Builder expectedResult(int... result) {
+        this.expectedResult = result;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -32,18 +32,22 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -298,8 +302,12 @@ public abstract class AbstractR2dbcStatementTest {
         SERVER_PORT);
   }
 
-  @Test
-  void testBatchQueries() {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements with the same operation. batch telemetry (db.operation.batch.size, BATCH
+  // span names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchQueries(BatchScenario scenario) {
     assumeTrue(emitStableDatabaseSemconv());
 
     DbSystemProps props = systems.get(MARIADB.system);
@@ -322,15 +330,15 @@ public abstract class AbstractR2dbcStatementTest {
             () -> {
               Mono.from(connectionFactory.create())
                   .flatMapMany(
-                      connection ->
-                          Flux.from(
-                                  connection
-                                      .createBatch()
-                                      .add("SELECT 1")
-                                      .add("SELECT 2")
-                                      .execute())
-                              .flatMap(result -> result.map((row, metadata) -> ""))
-                              .concatWith(Mono.from(connection.close()).cast(String.class)))
+                      connection -> {
+                        Batch batch = connection.createBatch();
+                        for (String query : scenario.queries) {
+                          batch.add(query);
+                        }
+                        return Flux.from(batch.execute())
+                            .flatMap(result -> result.map((row, metadata) -> ""))
+                            .concatWith(Mono.from(connection.close()).cast(String.class));
+                      })
                   .blockLast(Duration.ofMinutes(1));
             });
 
@@ -340,18 +348,55 @@ public abstract class AbstractR2dbcStatementTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("BATCH SELECT")
+                        span.hasName(scenario.spanName)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(DB_SYSTEM_NAME, MARIADB.system),
                                 equalTo(DB_NAMESPACE, DB),
                                 equalTo(DB_QUERY_TEXT, "SELECT ?"),
-                                equalTo(DB_QUERY_SUMMARY, "BATCH SELECT"),
-                                equalTo(DB_OPERATION_BATCH_SIZE, 2),
+                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
+                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize),
                                 equalTo(maybeStablePeerService(), "test-peer-service"),
                                 equalTo(SERVER_ADDRESS, container.getHost()),
                                 equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario("single", singletonList("SELECT 1"), "SELECT", "SELECT", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList("SELECT 1", "SELECT 2"),
+                "BATCH SELECT",
+                "BATCH SELECT",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<String> queries;
+    final String spanName;
+    final String summary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name, List<String> queries, String spanName, String summary, Long batchSize) {
+      this.name = name;
+      this.queries = queries;
+      this.spanName = spanName;
+      this.summary = summary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   private static class Parameter {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -52,6 +53,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.RAtomicLong;
@@ -246,12 +250,16 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
-  @Test
-  void batchCommand() throws ReflectiveOperationException {
+  // describes the batch cases: two commands with the same operation, and two commands with
+  // different operations. (a single-command batch is executed as a normal command rather than a
+  // pipeline.) batch telemetry (db.operation.batch.size, PIPELINE operation name) is only emitted
+  // under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchCommand(BatchScenario scenario) throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch2").setAsync("v2");
+    scenario.commands.accept(batch);
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
     invokeExecute(batch);
@@ -259,7 +267,7 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? scenario.operationName : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
@@ -268,41 +276,65 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(
                                 DB_OPERATION_NAME,
-                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                                emitStableDatabaseSemconv() ? scenario.operationName : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                            equalTo(maybeStable(DB_STATEMENT), scenario.statement))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            new BatchScenario(
+                "twoSameOperation",
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch2").setAsync("v2");
+                },
+                "PIPELINE SET",
+                2L,
+                "SET batch1 ?;SET batch2 ?"),
+            new BatchScenario(
+                "twoDifferentOperations",
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch1").getAsync();
+                },
+                "PIPELINE",
+                2L,
+                "SET batch1 ?;GET batch1"))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final Consumer<RBatch> commands;
+    final String operationName;
+    final Long batchSize;
+    final String statement;
+
+    BatchScenario(
+        String name,
+        Consumer<RBatch> commands,
+        String operationName,
+        Long batchSize,
+        String statement) {
+      this.name = name;
+      this.commands = commands;
+      this.operationName = operationName;
+      this.batchSize = batchSize;
+      this.statement = statement;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {
     batch.getClass().getMethod("execute").invoke(batch);
-  }
-
-  @Test
-  void mixedBatchCommand() throws ReflectiveOperationException {
-    RBatch batch = createBatch(redisson);
-    assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch1").getAsync();
-    // Adapt different method signature:
-    // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE" : "DB Query")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(
-                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,9 +54,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -280,14 +285,18 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  @Test
-  void testBatch() throws Exception {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements. batch telemetry (db.operation.batch.size, BATCH span names and summaries)
+  // is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void testBatch(BatchScenario scenario) throws Exception {
     testing
         .runWithSpan(
             "parent",
             () ->
                 pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(asList(Tuple.of(3, "Three"), Tuple.of(4, "Four"))))
+                    .executeBatch(scenario.tuples))
         .toCompletionStage()
         .toCompletableFuture()
         .get(30, SECONDS);
@@ -299,7 +308,7 @@ class VertxSqlClientTest {
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
-                                ? "BATCH insert test"
+                                ? scenario.stableSpanName
                                 : "INSERT tempdb.test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
@@ -314,9 +323,10 @@ class VertxSqlClientTest {
                                 "insert into test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv() ? "BATCH insert test" : null),
+                                emitStableDatabaseSemconv() ? scenario.stableSummary : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
@@ -326,6 +336,48 @@ class VertxSqlClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario(
+                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
+                "BATCH insert test",
+                "BATCH insert test",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name,
+        List<Tuple> tuples,
+        String stableSpanName,
+        String stableSummary,
+        Long batchSize) {
+      this.name = name;
+      this.tuples = tuples;
+      this.stableSpanName = stableSpanName;
+      this.stableSummary = stableSummary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,9 +54,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -281,14 +286,18 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  @Test
-  void testBatch() throws Exception {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements. batch telemetry (db.operation.batch.size, BATCH span names and summaries)
+  // is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void testBatch(BatchScenario scenario) throws Exception {
     testing
         .runWithSpan(
             "parent",
             () ->
                 pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(asList(Tuple.of(3, "Three"), Tuple.of(4, "Four"))))
+                    .executeBatch(scenario.tuples))
         .toCompletionStage()
         .toCompletableFuture()
         .get(30, SECONDS);
@@ -300,7 +309,7 @@ class VertxSqlClientTest {
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
-                                ? "BATCH insert test"
+                                ? scenario.stableSpanName
                                 : "INSERT tempdb.test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
@@ -315,9 +324,10 @@ class VertxSqlClientTest {
                                 "insert into test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv() ? "BATCH insert test" : null),
+                                emitStableDatabaseSemconv() ? scenario.stableSummary : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
@@ -327,6 +337,48 @@ class VertxSqlClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario(
+                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
+                "BATCH insert test",
+                "BATCH insert test",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name,
+        List<Tuple> tuples,
+        String stableSpanName,
+        String stableSummary,
+        Long batchSize) {
+      this.name = name;
+      this.tuples = tuples;
+      this.stableSpanName = stableSpanName;
+      this.stableSummary = stableSummary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

Consolidates the per-case batch tests across the database instrumentations that emit `db.operation.batch.size` into a single `@ParameterizedTest` driven by a small `BatchScenario` holder, locking down the shape of batch telemetry (BATCH-prefixed span names/summaries, `db.operation.batch.size`, joined `db.query.text`).

Each unified test covers the relevant cases:

- **empty** — only where the driver allows it and it produces telemetry
- **single** — a size-1 batch (verifies it is *not* treated as a batch: no `db.operation.batch.size`)
- **two, same operation** — `BATCH <op>` span/summary, `db.operation.batch.size = 2`
- **two, different operations** — `BATCH` span/summary, joined query text

Modules updated:

| Module | Cases | Notes |
|---|---|---|
| JDBC (`Statement`) | empty / single / two-same / two-different | stable-only, h2 |
| DynamoDB aws-sdk 1.11 | GetItem & WriteItem × empty / single / two | dual-mode |
| DynamoDB aws-sdk 2.2 | empty / two-get / two-write | dual-mode |
| Cassandra 3.0 / 4.0 / 4.4 | two-same / two-different | dual-mode |
| R2DBC 1.0 | single / two-same | stable-only |
| Vert.x SQL client 4.0 / 5.0 | single / two-same | dual-mode |
| Redisson | two-same / two-different | dual-mode |

### Notes

- Batch telemetry is database-agnostic (it comes from the shared SQL extractors), so JDBC locks the shape against a single in-memory database rather than the full driver cross-product.
- A size-1 batch is executed as a normal single statement/command (e.g. Cassandra `INSERT ks.users`, Redisson `SET`), not a batch — so the `single` case is dropped where that path diverges and kept where the size-1 span still looks batch-shaped.
- Alternate-API batch tests that exercise genuinely different behavior (JDBC `executeLargeBatch`/prepared batch, Redisson large/atomic batch) are left as separate tests.

Opening as a draft to run CI across the Docker-based integration suites.
