### PR TITLE
Unify database batch tests into parameterized scenario tests

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -94,10 +94,10 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       boolean captureQueryParameters) {
     Long batchSize = getter.getDbOperationBatchSize(request);
-    boolean isBatch = batchSize != null && batchSize > 1;
     // db.operation.batch.size is captured for every batch execution (including an empty batch with
     // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
     boolean emitBatchSize = batchSize != null && batchSize != 1;
+    boolean isBatch = emitBatchSize;
 
     if (emitStableDatabaseSemconv()) {
       attributes.put(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -95,6 +95,9 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       boolean captureQueryParameters) {
     Long batchSize = getter.getDbOperationBatchSize(request);
     boolean isBatch = batchSize != null && batchSize > 1;
+    // db.operation.batch.size is captured for every batch execution (including an empty batch with
+    // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
+    boolean emitBatchSize = batchSize != null && batchSize != 1;
 
     if (emitStableDatabaseSemconv()) {
       attributes.put(
@@ -104,7 +107,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       attributes.put(DB_QUERY_TEXT, getter.getDbQueryText(request));
       attributes.put(DB_OPERATION_NAME, getter.getDbOperationName(request));
       attributes.put(DB_QUERY_SUMMARY, getter.getDbQuerySummary(request));
-      if (isBatch) {
+      if (emitBatchSize) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -193,6 +193,9 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
       if (rawQueryTexts.isEmpty()) {
         if (emitStableDatabaseSemconv()) {
+          if (isBatch(request)) {
+            return "BATCH";
+          }
           return computeSpanNameStable(getter, request, null, null, null);
         }
         String dbName = getter.getDbName(request);
@@ -240,7 +243,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     private boolean isBatch(REQUEST request) {
       Long batchSize = getter.getDbOperationBatchSize(request);
-      return batchSize != null && batchSize > 1;
+      return batchSize != null && batchSize != 1;
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -15,12 +15,20 @@ class MultiQuery {
   @Nullable private final String storedProcedureName;
   private final Set<String> queryTexts;
   @Nullable private final String querySummary;
+  @Nullable private final String operationName;
+  @Nullable private final String collectionName;
 
   private MultiQuery(
-      @Nullable String storedProcedureName, Set<String> queryTexts, @Nullable String querySummary) {
+      @Nullable String storedProcedureName,
+      Set<String> queryTexts,
+      @Nullable String querySummary,
+      @Nullable String operationName,
+      @Nullable String collectionName) {
     this.storedProcedureName = storedProcedureName;
     this.queryTexts = queryTexts;
     this.querySummary = querySummary;
+    this.operationName = operationName;
+    this.collectionName = collectionName;
   }
 
   static MultiQuery analyzeWithSummary(Collection<String> rawQueryTexts, SqlDialect dialect) {
@@ -47,6 +55,16 @@ class MultiQuery {
     return querySummary;
   }
 
+  @Nullable
+  public String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  public String getCollectionName() {
+    return collectionName;
+  }
+
   public Set<String> getQueryTexts() {
     return queryTexts;
   }
@@ -55,19 +73,27 @@ class MultiQuery {
     private final UniqueValue uniqueStoredProcedureName = new UniqueValue();
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
+    private final UniqueValue uniqueOperationName = new UniqueValue();
+    private final UniqueValue uniqueCollectionName = new UniqueValue();
 
+    @SuppressWarnings("deprecation") // getOperationName()/getCollectionName() package-private in 3.0
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
+      uniqueOperationName.set(analyzedQuery.getOperationName());
+      uniqueCollectionName.set(analyzedQuery.getCollectionName());
     }
 
     MultiQuery build() {
       String querySummary = uniqueQuerySummary.getValue();
+      String operationName = uniqueOperationName.getValue();
       return new MultiQuery(
           uniqueStoredProcedureName.getValue(),
           uniqueQueryTexts,
-          querySummary == null ? "BATCH" : "BATCH " + querySummary);
+          querySummary == null ? "BATCH" : "BATCH " + querySummary,
+          operationName == null ? "BATCH" : "BATCH " + operationName,
+          uniqueCollectionName.getValue());
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -76,7 +76,8 @@ class MultiQuery {
     private final UniqueValue uniqueOperationName = new UniqueValue();
     private final UniqueValue uniqueCollectionName = new UniqueValue();
 
-    @SuppressWarnings("deprecation") // getOperationName()/getCollectionName() package-private in 3.0
+    @SuppressWarnings(
+        "deprecation") // getOperationName()/getCollectionName() package-private in 3.0
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -101,10 +101,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     SqlDialect dialect = getter.getSqlDialect(request);
 
     Long batchSize = getter.getDbOperationBatchSize(request);
-    boolean isBatch = batchSize != null && batchSize > 1;
     // db.operation.batch.size is captured for every batch execution (including an empty batch with
     // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
     boolean emitBatchSize = batchSize != null && batchSize != 1;
+    boolean isBatch = emitBatchSize;
 
     if (emitOldDatabaseSemconv()) {
       if (rawQueryTexts.size() == 1) { // for backcompat(?)

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -102,6 +102,9 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
 
     Long batchSize = getter.getDbOperationBatchSize(request);
     boolean isBatch = batchSize != null && batchSize > 1;
+    // db.operation.batch.size is captured for every batch execution (including an empty batch with
+    // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
+    boolean emitBatchSize = batchSize != null && batchSize != 1;
 
     if (emitOldDatabaseSemconv()) {
       if (rawQueryTexts.size() == 1) { // for backcompat(?)
@@ -118,7 +121,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     }
 
     if (emitStableDatabaseSemconv()) {
-      if (isBatch) {
+      if (emitBatchSize) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
       if (rawQueryTexts.size() == 1) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -149,6 +149,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         MultiQuery multiQuery = builder.build();
         attributes.put(DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         attributes.put(DB_QUERY_SUMMARY, multiQuery.getQuerySummary());
+        if (singleOperationAndCollection) {
+          attributes.put(DB_OPERATION_NAME, multiQuery.getOperationName());
+          attributes.put(DB_COLLECTION_NAME, multiQuery.getCollectionName());
+        }
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
       }
     }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -35,6 +35,7 @@ class DbClientSpanNameExtractorTest {
     lenient()
         .when(sqlAttributesGetter.getSqlDialect(any()))
         .thenReturn(DOUBLE_QUOTES_ARE_STRING_LITERALS);
+    lenient().when(sqlAttributesGetter.getDbOperationBatchSize(any())).thenReturn(null);
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -267,6 +267,30 @@ class DbClientSpanNameExtractorTest {
   }
 
   @Test
+  void shouldExtractFullSpanNameForSingleQueryEmptyBatch() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest))
+        .thenReturn(singleton("INSERT INTO table VALUES(?)"));
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("database");
+    }
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+
+    SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName)
+        .isEqualTo(emitStableDatabaseSemconv() ? "BATCH INSERT table" : "INSERT database.table");
+  }
+
+  @Test
   void shouldFallBackToNamespaceForEmptySqlQuery() {
     // given
     DbRequest dbRequest = new DbRequest();
@@ -286,6 +310,28 @@ class DbClientSpanNameExtractorTest {
 
     // then
     assertThat(spanName).isEqualTo("mydb");
+  }
+
+  @Test
+  void shouldExtractBatchSpanNameForEmptySqlQueryBatch() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest)).thenReturn(emptyList());
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("mydb");
+    }
+
+    SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName).isEqualTo(emitStableDatabaseSemconv() ? "BATCH" : "mydb");
   }
 
   @Test
@@ -333,6 +379,30 @@ class DbClientSpanNameExtractorTest {
 
     // then
     assertThat(spanName).isEqualTo("mydb");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // testing deprecated method
+  void shouldExtractBatchSpanNameForEmptySqlQueryBatchInMigration() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest)).thenReturn(emptyList());
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("mydb");
+    }
+
+    SpanNameExtractor<DbRequest> underTest =
+        DbClientSpanNameExtractor.createWithGenericOldSpanName(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName).isEqualTo(emitStableDatabaseSemconv() ? "BATCH" : "mydb");
   }
 
   static class DbRequest {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -9,8 +9,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDiale
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -410,6 +412,67 @@ class SqlClientAttributesExtractorTest {
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
+    // given
+    Map<String, Object> sameOperation = new HashMap<>();
+    sameOperation.put("db.namespace", "potatoes");
+    sameOperation.put(
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
+    sameOperation.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedOperations = new HashMap<>();
+    mixedOperations.put("db.namespace", "potatoes");
+    mixedOperations.put(
+        "db.query.texts",
+        asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
+    mixedOperations.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedCollections = new HashMap<>();
+    mixedCollections.put("db.namespace", "potatoes");
+    mixedCollections.put(
+        "db.query.texts",
+        asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
+    mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
+            .setSingleOperationAndCollection(true)
+            .build();
+
+    // when
+    AttributesBuilder sameOperationAttributes = Attributes.builder();
+    underTest.onStart(sameOperationAttributes, context, sameOperation);
+
+    AttributesBuilder mixedOperationsAttributes = Attributes.builder();
+    underTest.onStart(mixedOperationsAttributes, context, mixedOperations);
+
+    AttributesBuilder mixedCollectionsAttributes = Attributes.builder();
+    underTest.onStart(mixedCollectionsAttributes, context, mixedCollections);
+
+    // then
+    if (emitStableDatabaseSemconv()) {
+      assertThat(sameOperationAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
+      assertThat(mixedOperationsAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH");
+      // different collections -> db.collection.name is omitted, db.operation.name is BATCH INSERT
+      assertThat(mixedCollectionsAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .doesNotContainKey(DB_COLLECTION_NAME);
+    } else {
+      assertThat(sameOperationAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedOperationsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedCollectionsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+    }
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -433,8 +433,7 @@ class SqlClientAttributesExtractorTest {
     Map<String, Object> mixedCollections = new HashMap<>();
     mixedCollections.put("db.namespace", "potatoes");
     mixedCollections.put(
-        "db.query.texts",
-        asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
     mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
 
     Context context = Context.root();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -321,6 +321,57 @@ class SqlClientAttributesExtractorTest {
   }
 
   @Test
+  void shouldExtractSingleQueryEmptyBatchAttributes() {
+    // given
+    Map<String, Object> request = new HashMap<>();
+    request.put("db.namespace", "potatoes");
+    request.put("db.query.texts", singleton("INSERT INTO potato VALUES(?)"));
+    request.put(DB_OPERATION_BATCH_SIZE.getKey(), 0L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.create(new TestMultiAttributesGetter());
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    underTest.onStart(startAttributes, context, request);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    underTest.onEnd(endAttributes, context, request, null, null);
+
+    // then
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    } else if (emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"));
+    } else if (emitStableDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    }
+
+    assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
   void shouldExtractMultiQueryBatchAttributes() {
     // given
     Map<String, Object> request = new HashMap<>();

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -107,9 +107,6 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
   @Nullable
   private static String getStableOperationName(
       @Nullable String operation, @Nullable Long batchSize, int writeOpType) {
-    if ("BatchGetItem".equals(operation)) {
-      return getStableBatchOperationName(batchSize, "GetItem", operation);
-    }
     if ("BatchWriteItem".equals(operation)) {
       return getStableWriteOperationName(batchSize, writeOpType);
     }
@@ -131,20 +128,9 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
     return "BATCH " + itemOp;
   }
 
-  private static String getStableBatchOperationName(
-      @Nullable Long batchSize, String itemOperation, String batchOperation) {
-    if (batchSize == null || batchSize == 0) {
-      return batchOperation;
-    }
-    if (batchSize == 1) {
-      return itemOperation;
-    }
-    return "BATCH " + itemOperation;
-  }
-
   @Nullable
   private static Long extractBatchSize(@Nullable String operation, Object request) {
-    if (!"BatchGetItem".equals(operation) && !"BatchWriteItem".equals(operation)) {
+    if (!"BatchWriteItem".equals(operation)) {
       return null;
     }
 
@@ -153,23 +139,9 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
       return null;
     }
 
-    long batchSize =
-        "BatchGetItem".equals(operation)
-            ? countBatchGetItems(requestItems)
-            : countBatchWriteItems(requestItems);
+    long batchSize = countBatchWriteItems(requestItems);
     // return the size for every batch request, including an empty batch with size 0
     return batchSize;
-  }
-
-  private static long countBatchGetItems(Map<?, ?> requestItems) {
-    long count = 0;
-    for (Object keysAndAttributes : requestItems.values()) {
-      List<?> keys = RequestAccess.getKeys(keysAndAttributes);
-      if (keys != null) {
-        count += keys.size();
-      }
-    }
-    return count;
   }
 
   private static long countBatchWriteItems(Map<?, ?> requestItems) {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -51,7 +51,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
     Long batchSize = extractBatchSize(operation, request.getOriginalRequest());
     if (emitStableDatabaseSemconv()) {
       attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
-      if (isBatch(batchSize)) {
+      if (shouldEmitBatchSize(batchSize)) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
     }
@@ -132,7 +132,8 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
         "BatchGetItem".equals(operation)
             ? countBatchGetItems(requestItems)
             : countBatchWriteItems(requestItems);
-    return batchSize == 0 ? null : batchSize;
+    // return the size for every batch request, including an empty batch with size 0
+    return batchSize;
   }
 
   private static long countBatchGetItems(Map<?, ?> requestItems) {
@@ -156,8 +157,10 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
     return count;
   }
 
-  private static boolean isBatch(@Nullable Long batchSize) {
-    return batchSize != null && batchSize > 1;
+  // db.operation.batch.size is captured for every batch request (including an empty batch with
+  // size 0); it is only omitted for a single-item batch, which is reported as a non-batch operation
+  private static boolean shouldEmitBatchSize(@Nullable Long batchSize) {
+    return batchSize != null && batchSize != 1;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/DynamoDbAttributesExtractor.java
@@ -38,6 +38,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
   // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
   private static final String AWS_DYNAMODB = "aws.dynamodb";
 
+  // write operation type classification
+  private static final int WRITE_OP_NONE = 0;
+  private static final int WRITE_OP_PUT = 1;
+  private static final int WRITE_OP_DELETE = 2;
+  private static final int WRITE_OP_MIXED = 3;
+
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
     if (emitStableDatabaseSemconv()) {
@@ -49,8 +55,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
 
     String operation = getOperationName(request.getOriginalRequest());
     Long batchSize = extractBatchSize(operation, request.getOriginalRequest());
+    int writeOpType =
+        "BatchWriteItem".equals(operation)
+            ? extractWriteOperationType(request.getOriginalRequest())
+            : WRITE_OP_NONE;
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize, writeOpType));
       if (shouldEmitBatchSize(batchSize)) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
@@ -96,14 +106,29 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
 
   @Nullable
   private static String getStableOperationName(
-      @Nullable String operation, @Nullable Long batchSize) {
+      @Nullable String operation, @Nullable Long batchSize, int writeOpType) {
     if ("BatchGetItem".equals(operation)) {
       return getStableBatchOperationName(batchSize, "GetItem", operation);
     }
     if ("BatchWriteItem".equals(operation)) {
-      return getStableBatchOperationName(batchSize, "WriteItem", operation);
+      return getStableWriteOperationName(batchSize, writeOpType);
     }
     return operation;
+  }
+
+  private static String getStableWriteOperationName(@Nullable Long batchSize, int writeOpType) {
+    if (batchSize == null || batchSize == 0) {
+      return "BatchWriteItem";
+    }
+    String itemOp = writeOpType == WRITE_OP_PUT ? "PutItem" : "DeleteItem";
+    if (batchSize == 1) {
+      return itemOp;
+    }
+    // mixed operations collapse to bare BATCH (consistent with SQL/Cassandra)
+    if (writeOpType == WRITE_OP_MIXED) {
+      return "BATCH";
+    }
+    return "BATCH " + itemOp;
   }
 
   private static String getStableBatchOperationName(
@@ -155,6 +180,47 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<Request<?>, Res
       }
     }
     return count;
+  }
+
+  /**
+   * Extracts the write operation type from a BatchWriteItem request. Returns WRITE_OP_PUT if all
+   * requests are PutRequests, WRITE_OP_DELETE if all are DeleteRequests, WRITE_OP_MIXED if both
+   * types are present, or WRITE_OP_NONE if the request is empty or cannot be inspected.
+   */
+  private static int extractWriteOperationType(Object request) {
+    Map<?, ?> requestItems = RequestAccess.getRequestItems(request);
+    if (requestItems == null) {
+      return WRITE_OP_NONE;
+    }
+
+    int result = WRITE_OP_NONE;
+    for (Object writeRequests : requestItems.values()) {
+      if (writeRequests instanceof Collection) {
+        for (Object writeRequest : (Collection<?>) writeRequests) {
+          int opType = classifyWriteRequest(writeRequest);
+          if (opType == WRITE_OP_NONE) {
+            continue;
+          }
+          if (result == WRITE_OP_NONE) {
+            result = opType;
+          } else if (result != opType) {
+            return WRITE_OP_MIXED;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static int classifyWriteRequest(Object writeRequest) {
+    // WriteRequest has getPutRequest() and getDeleteRequest() methods; exactly one returns non-null
+    if (RequestAccess.hasPutRequest(writeRequest)) {
+      return WRITE_OP_PUT;
+    }
+    if (RequestAccess.hasDeleteRequest(writeRequest)) {
+      return WRITE_OP_DELETE;
+    }
+    return WRITE_OP_NONE;
   }
 
   // db.operation.batch.size is captured for every batch request (including an empty batch with

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
@@ -111,6 +111,24 @@ final class RequestAccess {
     return invokeOrNull(access.getKeys, request, List.class);
   }
 
+  /**
+   * Returns true if the given WriteRequest contains a PutRequest, false otherwise. Uses reflection
+   * to call getPutRequest() on the WriteRequest object.
+   */
+  static boolean hasPutRequest(Object writeRequest) {
+    WriteRequestAccess access = WriteRequestAccess.ACCESSORS.get(writeRequest.getClass());
+    return invokeOrNull(access.getPutRequest, writeRequest, Object.class) != null;
+  }
+
+  /**
+   * Returns true if the given WriteRequest contains a DeleteRequest, false otherwise. Uses
+   * reflection to call getDeleteRequest() on the WriteRequest object.
+   */
+  static boolean hasDeleteRequest(Object writeRequest) {
+    WriteRequestAccess access = WriteRequestAccess.ACCESSORS.get(writeRequest.getClass());
+    return invokeOrNull(access.getDeleteRequest, writeRequest, Object.class) != null;
+  }
+
   @Nullable
   static String getSnsTopicArn(Object request) {
     RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
@@ -218,6 +236,24 @@ final class RequestAccess {
       } catch (Throwable ignored) {
         return null;
       }
+    }
+  }
+
+  private static class WriteRequestAccess {
+    private static final ClassValue<WriteRequestAccess> ACCESSORS =
+        new ClassValue<WriteRequestAccess>() {
+          @Override
+          protected WriteRequestAccess computeValue(Class<?> type) {
+            return new WriteRequestAccess(type);
+          }
+        };
+
+    @Nullable private final MethodHandle getPutRequest;
+    @Nullable private final MethodHandle getDeleteRequest;
+
+    private WriteRequestAccess(Class<?> clz) {
+      getPutRequest = findAccessorOrNull(clz, "getPutRequest", Object.class);
+      getDeleteRequest = findAccessorOrNull(clz, "getDeleteRequest", Object.class);
     }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/RequestAccess.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -117,7 +118,7 @@ final class RequestAccess {
    */
   static boolean hasPutRequest(Object writeRequest) {
     WriteRequestAccess access = WriteRequestAccess.ACCESSORS.get(writeRequest.getClass());
-    return invokeOrNull(access.getPutRequest, writeRequest, Object.class) != null;
+    return access.invokeGetPutRequest(writeRequest) != null;
   }
 
   /**
@@ -126,7 +127,7 @@ final class RequestAccess {
    */
   static boolean hasDeleteRequest(Object writeRequest) {
     WriteRequestAccess access = WriteRequestAccess.ACCESSORS.get(writeRequest.getClass());
-    return invokeOrNull(access.getDeleteRequest, writeRequest, Object.class) != null;
+    return access.invokeGetDeleteRequest(writeRequest) != null;
   }
 
   @Nullable
@@ -248,12 +249,43 @@ final class RequestAccess {
           }
         };
 
-    @Nullable private final MethodHandle getPutRequest;
-    @Nullable private final MethodHandle getDeleteRequest;
+    @Nullable private final Method getPutRequest;
+    @Nullable private final Method getDeleteRequest;
 
     private WriteRequestAccess(Class<?> clz) {
-      getPutRequest = findAccessorOrNull(clz, "getPutRequest", Object.class);
-      getDeleteRequest = findAccessorOrNull(clz, "getDeleteRequest", Object.class);
+      getPutRequest = findMethodOrNull(clz, "getPutRequest");
+      getDeleteRequest = findMethodOrNull(clz, "getDeleteRequest");
+    }
+
+    @Nullable
+    Object invokeGetPutRequest(Object obj) {
+      return invokeMethod(getPutRequest, obj);
+    }
+
+    @Nullable
+    Object invokeGetDeleteRequest(Object obj) {
+      return invokeMethod(getDeleteRequest, obj);
+    }
+
+    @Nullable
+    private static Object invokeMethod(@Nullable Method method, Object obj) {
+      if (method == null) {
+        return null;
+      }
+      try {
+        return method.invoke(obj);
+      } catch (Throwable ignored) {
+        return null;
+      }
+    }
+
+    @Nullable
+    private static Method findMethodOrNull(Class<?> clz, String methodName) {
+      try {
+        return clz.getMethod(methodName);
+      } catch (Throwable ignored) {
+        return null;
+      }
     }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -123,12 +123,13 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
 
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch keeps the raw batch operation name and emits no batch size or
-        // collection name
+        // an empty batch keeps the raw batch operation name and carries db.operation.batch.size 0,
+        // but no collection name
         BatchScenario.builder("getItemEmpty")
             .awsOperation("BatchGetItem")
             .execute(client -> client.batchGetItem(getItemRequest(0)))
             .stableOperation("BatchGetItem")
+            .batchSize(0)
             .build(),
         // a single-item batch is not a batch, so it uses the singular item operation
         BatchScenario.builder("getItemSingle")
@@ -148,6 +149,7 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
             .awsOperation("BatchWriteItem")
             .execute(client -> client.batchWriteItem(writeItemRequest(0)))
             .stableOperation("BatchWriteItem")
+            .batchSize(0)
             .build(),
         BatchScenario.builder("writeItemSingle")
             .awsOperation("BatchWriteItem")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.AWS_DYNAMODB;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
@@ -39,7 +40,13 @@ import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTest {
 
@@ -82,10 +89,14 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         SERVER_PORT);
   }
 
+  // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
+  // BatchWriteItem): the request to send and the expected client span. batch attributes
+  // (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted under
+  // stable database semconv; the span and db.operation.name are emitted in both modes
   @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchGetItemWithMultipleItemsUsesStableBatchAttributes()
-      throws ReflectiveOperationException {
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchOperation(BatchScenario scenario) throws ReflectiveOperationException {
     AmazonDynamoDB client = createClient();
 
     server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
@@ -97,153 +108,160 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
                     maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
                 equalTo(
                     maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "BATCH GetItem" : "BatchGetItem"),
+                    emitStableDatabaseSemconv() ? scenario.stableOperation : scenario.awsOperation),
                 equalTo(
-                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
+                    DB_OPERATION_BATCH_SIZE,
+                    emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                equalTo(
+                    DB_COLLECTION_NAME,
+                    emitStableDatabaseSemconv() && scenario.hasCollection ? "sometable" : null)));
 
-    Object response =
-        client.batchGetItem(
-            new BatchGetItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable",
-                        new KeysAndAttributes()
-                            .withKeys(
-                                asList(
-                                    singletonMap("key", new AttributeValue().withS("value")),
-                                    singletonMap(
-                                        "key", new AttributeValue().withS("anotherValue")))))));
+    Object response = scenario.execute.apply(client);
     assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+        response, client, "DynamoDBv2", scenario.awsOperation, "POST", additionalAttributes);
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchGetItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "GetItem" : "BatchGetItem"),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchGetItem(
-            new BatchGetItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable",
-                        new KeysAndAttributes()
-                            .withKeys(
-                                singletonList(
-                                    singletonMap("key", new AttributeValue().withS("value")))))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchGetItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // an empty batch keeps the raw batch operation name and emits no batch size or
+            // collection name
+            BatchScenario.builder("getItemEmpty")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(0)))
+                .stableOperation("BatchGetItem")
+                .build(),
+            // a single-item batch is not a batch, so it uses the singular item operation
+            BatchScenario.builder("getItemSingle")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(1)))
+                .stableOperation("GetItem")
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("getItemTwo")
+                .awsOperation("BatchGetItem")
+                .execute(client -> client.batchGetItem(getItemRequest(2)))
+                .stableOperation("BATCH GetItem")
+                .batchSize(2)
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("writeItemEmpty")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(0)))
+                .stableOperation("BatchWriteItem")
+                .build(),
+            BatchScenario.builder("writeItemSingle")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(1)))
+                .stableOperation("WriteItem")
+                .hasCollection()
+                .build(),
+            BatchScenario.builder("writeItemTwo")
+                .awsOperation("BatchWriteItem")
+                .execute(client -> client.batchWriteItem(writeItemRequest(2)))
+                .stableOperation("BATCH WriteItem")
+                .batchSize(2)
+                .hasCollection()
+                .build())
+        .map(Arguments::of);
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchWriteItemWithMultipleItemsUsesStableBatchAttributes()
-      throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "BATCH WriteItem" : "BatchWriteItem"),
-                equalTo(
-                    DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? Long.valueOf(2) : null),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchWriteItem(
-            new BatchWriteItemRequest()
-                .withRequestItems(
-                    singletonMap(
-                        "sometable", asList(writeRequest("value"), writeRequest("anotherValue")))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static BatchGetItemRequest getItemRequest(int count) {
+    if (count == 0) {
+      return new BatchGetItemRequest().withRequestItems(emptyMap());
+    }
+    List<Map<String, AttributeValue>> keys = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      keys.add(singletonMap("key", new AttributeValue().withS("value" + i)));
+    }
+    return new BatchGetItemRequest()
+        .withRequestItems(singletonMap("sometable", new KeysAndAttributes().withKeys(keys)));
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
-  @Test
-  void batchWriteItemWithSingleItemUsesStableItemOperation() throws ReflectiveOperationException {
-    AmazonDynamoDB client = createClient();
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "{}"));
-
-    List<AttributeAssertion> additionalAttributes =
-        new ArrayList<>(
-            asList(
-                equalTo(
-                    maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? AWS_DYNAMODB : DYNAMODB),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "WriteItem" : "BatchWriteItem"),
-                equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "sometable" : null)));
-
-    Object response =
-        client.batchWriteItem(
-            new BatchWriteItemRequest()
-                .withRequestItems(singletonMap("sometable", singletonList(writeRequest("value")))));
-    assertRequestWithMockedResponse(
-        response, client, "DynamoDBv2", "BatchWriteItem", "POST", additionalAttributes);
-
-    assertDurationMetric(
-        testing(),
-        "io.opentelemetry.aws-sdk-1.11",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+  private static BatchWriteItemRequest writeItemRequest(int count) {
+    if (count == 0) {
+      return new BatchWriteItemRequest().withRequestItems(emptyMap());
+    }
+    List<WriteRequest> writes = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      writes.add(writeRequest("value" + i));
+    }
+    return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
   }
 
   private static WriteRequest writeRequest(String value) {
     return new WriteRequest()
         .withPutRequest(
             new PutRequest().withItem(singletonMap("key", new AttributeValue().withS(value))));
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final String awsOperation;
+    final Function<AmazonDynamoDB, Object> execute;
+    final String stableOperation;
+    final Long batchSize;
+    final boolean hasCollection;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.awsOperation = builder.awsOperation;
+      this.execute = builder.execute;
+      this.stableOperation = builder.stableOperation;
+      this.batchSize = builder.batchSize;
+      this.hasCollection = builder.hasCollection;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String awsOperation;
+      private Function<AmazonDynamoDB, Object> execute;
+      private String stableOperation;
+      private Long batchSize;
+      private boolean hasCollection;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder awsOperation(String awsOperation) {
+        this.awsOperation = awsOperation;
+        return this;
+      }
+
+      Builder execute(Function<AmazonDynamoDB, Object> execute) {
+        this.execute = execute;
+        return this;
+      }
+
+      Builder stableOperation(String stableOperation) {
+        this.stableOperation = stableOperation;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder hasCollection() {
+        this.hasCollection = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private AmazonDynamoDB createClient() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -151,27 +151,42 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
             .stableOperation("BatchWriteItem")
             .batchSize(0)
             .build(),
-        BatchScenario.builder("writeItemSingle")
+        // a single put request is reported as PutItem
+        BatchScenario.builder("writeItemSinglePut")
             .awsOperation("BatchWriteItem")
-            .execute(client -> client.batchWriteItem(writeItemRequest(1)))
-            .stableOperation("WriteItem")
+            .execute(client -> client.batchWriteItem(putItemsRequest(1)))
+            .stableOperation("PutItem")
             .hasCollection()
             .build(),
-        BatchScenario.builder("writeItemTwo")
+        // a single delete request is reported as DeleteItem
+        BatchScenario.builder("writeItemSingleDelete")
             .awsOperation("BatchWriteItem")
-            .execute(client -> client.batchWriteItem(writeItemRequest(2)))
-            .stableOperation("BATCH WriteItem")
+            .execute(client -> client.batchWriteItem(deleteItemsRequest(1)))
+            .stableOperation("DeleteItem")
+            .hasCollection()
+            .build(),
+        // two put requests are reported as BATCH PutItem
+        BatchScenario.builder("writeItemTwoPuts")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(putItemsRequest(2)))
+            .stableOperation("BATCH PutItem")
             .batchSize(2)
             .hasCollection()
             .build(),
-        // a batch mixing a put and a delete in one table: unlike the SQL/Cassandra matrices where
-        // a batch with differing operations collapses to just "BATCH", DynamoDB derives the
-        // operation name from the item count alone, so a put+delete write batch still reports the
-        // shared "BATCH WriteItem" operation (and the single collection)
+        // two delete requests are reported as BATCH DeleteItem
+        BatchScenario.builder("writeItemTwoDeletes")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(deleteItemsRequest(2)))
+            .stableOperation("BATCH DeleteItem")
+            .batchSize(2)
+            .hasCollection()
+            .build(),
+        // a batch mixing a put and a delete collapses to bare "BATCH"
+        // (consistent with SQL/Cassandra mixed-operation batches)
         BatchScenario.builder("writeItemMixed")
             .awsOperation("BatchWriteItem")
             .execute(client -> client.batchWriteItem(mixedWriteItemRequest()))
-            .stableOperation("BATCH WriteItem")
+            .stableOperation("BATCH")
             .batchSize(2)
             .hasCollection()
             .build());
@@ -195,15 +210,37 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
     }
     List<WriteRequest> writes = new ArrayList<>();
     for (int i = 0; i < count; i++) {
-      writes.add(writeRequest("value" + i));
+      writes.add(putRequest("value" + i));
     }
     return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
   }
 
-  private static WriteRequest writeRequest(String value) {
+  private static BatchWriteItemRequest putItemsRequest(int count) {
+    List<WriteRequest> writes = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      writes.add(putRequest("value" + i));
+    }
+    return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
+  }
+
+  private static BatchWriteItemRequest deleteItemsRequest(int count) {
+    List<WriteRequest> writes = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      writes.add(deleteRequest("value" + i));
+    }
+    return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
+  }
+
+  private static WriteRequest putRequest(String value) {
     return new WriteRequest()
         .withPutRequest(
             new PutRequest().withItem(singletonMap("key", new AttributeValue().withS(value))));
+  }
+
+  private static WriteRequest deleteRequest(String value) {
+    return new WriteRequest()
+        .withDeleteRequest(
+            new DeleteRequest().withKey(singletonMap("key", new AttributeValue().withS(value))));
   }
 
   private static BatchWriteItemRequest mixedWriteItemRequest() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -31,6 +31,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteRequest;
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 import com.amazonaws.services.dynamodbv2.model.PutRequest;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
@@ -160,6 +161,17 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
             .stableOperation("BATCH WriteItem")
             .batchSize(2)
             .hasCollection()
+            .build(),
+        // a batch mixing a put and a delete in one table: unlike the SQL/Cassandra matrices where
+        // a batch with differing operations collapses to just "BATCH", DynamoDB derives the
+        // operation name from the item count alone, so a put+delete write batch still reports the
+        // shared "BATCH WriteItem" operation (and the single collection)
+        BatchScenario.builder("writeItemMixed")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(mixedWriteItemRequest()))
+            .stableOperation("BATCH WriteItem")
+            .batchSize(2)
+            .hasCollection()
             .build());
   }
 
@@ -190,6 +202,20 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
     return new WriteRequest()
         .withPutRequest(
             new PutRequest().withItem(singletonMap("key", new AttributeValue().withS(value))));
+  }
+
+  private static BatchWriteItemRequest mixedWriteItemRequest() {
+    List<WriteRequest> writes =
+        asList(
+            new WriteRequest()
+                .withPutRequest(
+                    new PutRequest()
+                        .withItem(singletonMap("key", new AttributeValue().withS("value")))),
+            new WriteRequest()
+                .withDeleteRequest(
+                    new DeleteRequest()
+                        .withKey(singletonMap("key", new AttributeValue().withS("anotherValue")))));
+    return new BatchWriteItemRequest().withRequestItems(singletonMap("sometable", writes));
   }
 
   private static final class BatchScenario {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -92,7 +92,8 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
   // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
   // BatchWriteItem): the request to send and the expected client span. batch attributes
   // (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted under
-  // stable database semconv; the span and db.operation.name are emitted in both modes
+  // stable database semconv for BatchWriteItem, whose request entries represent explicit write
+  // operations. BatchGetItem request entries are keys, so they do not produce batch telemetry.
   @SuppressWarnings("deprecation") // using deprecated semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
@@ -123,26 +124,23 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
 
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch keeps the raw batch operation name and carries db.operation.batch.size 0,
-        // but no collection name
+        // BatchGetItem entries are keys, not explicit operations, so the stable operation name
+        // remains the raw batch operation and db.operation.batch.size is not emitted.
         BatchScenario.builder("getItemEmpty")
             .awsOperation("BatchGetItem")
             .execute(client -> client.batchGetItem(getItemRequest(0)))
             .stableOperation("BatchGetItem")
-            .batchSize(0)
             .build(),
-        // a single-item batch is not a batch, so it uses the singular item operation
         BatchScenario.builder("getItemSingle")
             .awsOperation("BatchGetItem")
             .execute(client -> client.batchGetItem(getItemRequest(1)))
-            .stableOperation("GetItem")
+            .stableOperation("BatchGetItem")
             .hasCollection()
             .build(),
         BatchScenario.builder("getItemTwo")
             .awsOperation("BatchGetItem")
             .execute(client -> client.batchGetItem(getItemRequest(2)))
-            .stableOperation("BATCH GetItem")
-            .batchSize(2)
+            .stableOperation("BatchGetItem")
             .hasCollection()
             .build(),
         BatchScenario.builder("writeItemEmpty")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTest {
@@ -121,48 +120,47 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
         response, client, "DynamoDBv2", scenario.awsOperation, "POST", additionalAttributes);
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch keeps the raw batch operation name and emits no batch size or
-            // collection name
-            BatchScenario.builder("getItemEmpty")
-                .awsOperation("BatchGetItem")
-                .execute(client -> client.batchGetItem(getItemRequest(0)))
-                .stableOperation("BatchGetItem")
-                .build(),
-            // a single-item batch is not a batch, so it uses the singular item operation
-            BatchScenario.builder("getItemSingle")
-                .awsOperation("BatchGetItem")
-                .execute(client -> client.batchGetItem(getItemRequest(1)))
-                .stableOperation("GetItem")
-                .hasCollection()
-                .build(),
-            BatchScenario.builder("getItemTwo")
-                .awsOperation("BatchGetItem")
-                .execute(client -> client.batchGetItem(getItemRequest(2)))
-                .stableOperation("BATCH GetItem")
-                .batchSize(2)
-                .hasCollection()
-                .build(),
-            BatchScenario.builder("writeItemEmpty")
-                .awsOperation("BatchWriteItem")
-                .execute(client -> client.batchWriteItem(writeItemRequest(0)))
-                .stableOperation("BatchWriteItem")
-                .build(),
-            BatchScenario.builder("writeItemSingle")
-                .awsOperation("BatchWriteItem")
-                .execute(client -> client.batchWriteItem(writeItemRequest(1)))
-                .stableOperation("WriteItem")
-                .hasCollection()
-                .build(),
-            BatchScenario.builder("writeItemTwo")
-                .awsOperation("BatchWriteItem")
-                .execute(client -> client.batchWriteItem(writeItemRequest(2)))
-                .stableOperation("BATCH WriteItem")
-                .batchSize(2)
-                .hasCollection()
-                .build())
-        .map(Arguments::of);
+        // an empty batch keeps the raw batch operation name and emits no batch size or
+        // collection name
+        BatchScenario.builder("getItemEmpty")
+            .awsOperation("BatchGetItem")
+            .execute(client -> client.batchGetItem(getItemRequest(0)))
+            .stableOperation("BatchGetItem")
+            .build(),
+        // a single-item batch is not a batch, so it uses the singular item operation
+        BatchScenario.builder("getItemSingle")
+            .awsOperation("BatchGetItem")
+            .execute(client -> client.batchGetItem(getItemRequest(1)))
+            .stableOperation("GetItem")
+            .hasCollection()
+            .build(),
+        BatchScenario.builder("getItemTwo")
+            .awsOperation("BatchGetItem")
+            .execute(client -> client.batchGetItem(getItemRequest(2)))
+            .stableOperation("BATCH GetItem")
+            .batchSize(2)
+            .hasCollection()
+            .build(),
+        BatchScenario.builder("writeItemEmpty")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(writeItemRequest(0)))
+            .stableOperation("BatchWriteItem")
+            .build(),
+        BatchScenario.builder("writeItemSingle")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(writeItemRequest(1)))
+            .stableOperation("WriteItem")
+            .hasCollection()
+            .build(),
+        BatchScenario.builder("writeItemTwo")
+            .awsOperation("BatchWriteItem")
+            .execute(client -> client.batchWriteItem(writeItemRequest(2)))
+            .stableOperation("BATCH WriteItem")
+            .batchSize(2)
+            .hasCollection()
+            .build());
   }
 
   private static BatchGetItemRequest getItemRequest(int count) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -80,9 +80,6 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   @Nullable
   private static String getStableOperationName(
       @Nullable String operation, @Nullable Long batchSize, int writeOpType) {
-    if ("BatchGetItem".equals(operation)) {
-      return getStableBatchOperationName(batchSize, "GetItem", operation);
-    }
     if ("BatchWriteItem".equals(operation)) {
       return getStableWriteOperationName(batchSize, writeOpType);
     }
@@ -104,21 +101,10 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     return "BATCH " + itemOp;
   }
 
-  private static String getStableBatchOperationName(
-      @Nullable Long batchSize, String itemOperation, String batchOperation) {
-    if (batchSize == null || batchSize == 0) {
-      return batchOperation;
-    }
-    if (batchSize == 1) {
-      return itemOperation;
-    }
-    return "BATCH " + itemOperation;
-  }
-
   @Nullable
-  private Long extractBatchSize(
+  private static Long extractBatchSize(
       @Nullable String operation, ExecutionAttributes executionAttributes) {
-    if (!"BatchGetItem".equals(operation) && !"BatchWriteItem".equals(operation)) {
+    if (!"BatchWriteItem".equals(operation)) {
       return null;
     }
 
@@ -133,20 +119,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     }
 
     Map<?, ?> requestItemsMap = (Map<?, ?>) requestItems.get();
-    return "BatchGetItem".equals(operation)
-        ? countBatchGetItems(requestItemsMap)
-        : countBatchWriteItems(requestItemsMap);
-  }
-
-  private long countBatchGetItems(Map<?, ?> requestItems) {
-    long count = 0;
-    for (Object keysAndAttributes : requestItems.values()) {
-      Object keys = next(keysAndAttributes, "Keys");
-      if (keys instanceof Collection) {
-        count += ((Collection<?>) keys).size();
-      }
-    }
-    return count;
+    return countBatchWriteItems(requestItemsMap);
   }
 
   private static long countBatchWriteItems(Map<?, ?> requestItems) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -52,7 +52,7 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     Long batchSize = extractBatchSize(operation, executionAttributes);
     if (emitStableDatabaseSemconv()) {
       attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
-      if (isBatch(batchSize)) {
+      if (shouldEmitBatchSize(batchSize)) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
     }
@@ -134,8 +134,10 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     return count;
   }
 
-  private static boolean isBatch(@Nullable Long batchSize) {
-    return batchSize != null && batchSize > 1;
+  // db.operation.batch.size is captured for every batch request (including an empty batch with
+  // size 0); it is only omitted for a single-item batch, which is reported as a non-batch operation
+  private static boolean shouldEmitBatchSize(@Nullable Long batchSize) {
+    return batchSize != null && batchSize != 1;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/DynamoDbAttributesExtractor.java
@@ -35,6 +35,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
   // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
   private static final String AWS_DYNAMODB = "aws.dynamodb";
 
+  // write operation type classification
+  private static final int WRITE_OP_NONE = 0;
+  private static final int WRITE_OP_PUT = 1;
+  private static final int WRITE_OP_DELETE = 2;
+  private static final int WRITE_OP_MIXED = 3;
+
   private final MethodHandleFactory methodHandleFactory = new MethodHandleFactory();
 
   @Override
@@ -50,8 +56,12 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
     }
     String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
     Long batchSize = extractBatchSize(operation, executionAttributes);
+    int writeOpType =
+        "BatchWriteItem".equals(operation)
+            ? extractWriteOperationType(executionAttributes)
+            : WRITE_OP_NONE;
     if (emitStableDatabaseSemconv()) {
-      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize));
+      attributes.put(DB_OPERATION_NAME, getStableOperationName(operation, batchSize, writeOpType));
       if (shouldEmitBatchSize(batchSize)) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
@@ -69,14 +79,29 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
 
   @Nullable
   private static String getStableOperationName(
-      @Nullable String operation, @Nullable Long batchSize) {
+      @Nullable String operation, @Nullable Long batchSize, int writeOpType) {
     if ("BatchGetItem".equals(operation)) {
       return getStableBatchOperationName(batchSize, "GetItem", operation);
     }
     if ("BatchWriteItem".equals(operation)) {
-      return getStableBatchOperationName(batchSize, "WriteItem", operation);
+      return getStableWriteOperationName(batchSize, writeOpType);
     }
     return operation;
+  }
+
+  private static String getStableWriteOperationName(@Nullable Long batchSize, int writeOpType) {
+    if (batchSize == null || batchSize == 0) {
+      return "BatchWriteItem";
+    }
+    String itemOp = writeOpType == WRITE_OP_PUT ? "PutItem" : "DeleteItem";
+    if (batchSize == 1) {
+      return itemOp;
+    }
+    // mixed operations collapse to bare BATCH (consistent with SQL/Cassandra)
+    if (writeOpType == WRITE_OP_MIXED) {
+      return "BATCH";
+    }
+    return "BATCH " + itemOp;
   }
 
   private static String getStableBatchOperationName(
@@ -132,6 +157,54 @@ class DynamoDbAttributesExtractor implements AttributesExtractor<ExecutionAttrib
       }
     }
     return count;
+  }
+
+  /**
+   * Extracts the write operation type from a BatchWriteItem request. Returns WRITE_OP_PUT if all
+   * requests are PutRequests, WRITE_OP_DELETE if all are DeleteRequests, WRITE_OP_MIXED if both
+   * types are present, or WRITE_OP_NONE if the request is empty or cannot be inspected.
+   */
+  private int extractWriteOperationType(ExecutionAttributes executionAttributes) {
+    SdkRequest request =
+        executionAttributes.getAttribute(TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE);
+    if (request == null) {
+      return WRITE_OP_NONE;
+    }
+    Optional<?> requestItems = request.getValueForField("RequestItems", Object.class);
+    if (!requestItems.isPresent() || !(requestItems.get() instanceof Map)) {
+      return WRITE_OP_NONE;
+    }
+
+    int result = WRITE_OP_NONE;
+    for (Object writeRequests : ((Map<?, ?>) requestItems.get()).values()) {
+      if (writeRequests instanceof Collection) {
+        for (Object writeRequest : (Collection<?>) writeRequests) {
+          int opType = classifyWriteRequest(writeRequest);
+          if (opType == WRITE_OP_NONE) {
+            continue;
+          }
+          if (result == WRITE_OP_NONE) {
+            result = opType;
+          } else if (result != opType) {
+            return WRITE_OP_MIXED;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private int classifyWriteRequest(Object writeRequest) {
+    // WriteRequest has putRequest() and deleteRequest() methods; exactly one returns non-null
+    Object putRequest = next(writeRequest, "PutRequest");
+    if (putRequest != null) {
+      return WRITE_OP_PUT;
+    }
+    Object deleteRequest = next(writeRequest, "DeleteRequest");
+    if (deleteRequest != null) {
+      return WRITE_OP_DELETE;
+    }
+    return WRITE_OP_NONE;
   }
 
   // db.operation.batch.size is captured for every batch request (including an empty batch with

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -80,6 +80,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
@@ -687,6 +688,50 @@ public abstract class AbstractAws2ClientCoreTest {
                                             .putRequest(
                                                 PutRequest.builder()
                                                     .item(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("anotherValue")
+                                                                .build()))
+                                                    .build())
+                                            .build())))))
+            .stableOperation("BATCH WriteItem")
+            .hasCollection()
+            .batchSize(2)
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+            .assertMetric()
+            .build(),
+        // a batch mixing a put and a delete in one table: unlike the SQL/Cassandra matrices where
+        // a batch with differing operations collapses to just "BATCH", DynamoDB derives the
+        // operation name from the item count alone, so a put+delete write batch still reports the
+        // shared "BATCH WriteItem" operation (and the single collection)
+        BatchScenario.builder("writeItemMixed")
+            .awsOperation("BatchWriteItem")
+            .responseContent(getResponseContent("BatchWriteItem"))
+            .execute(
+                c ->
+                    c.batchWriteItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    asList(
+                                        WriteRequest.builder()
+                                            .putRequest(
+                                                PutRequest.builder()
+                                                    .item(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("value")
+                                                                .build()))
+                                                    .build())
+                                            .build(),
+                                        WriteRequest.builder()
+                                            .deleteRequest(
+                                                DeleteRequest.builder()
+                                                    .key(
                                                         ImmutableMap.of(
                                                             "key",
                                                             AttributeValue.builder()

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -566,13 +566,14 @@ public abstract class AbstractAws2ClientCoreTest {
   @SuppressWarnings("deprecation") // uses deprecated semconv
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch still produces a span, but keeps the raw batch operation name and
-        // emits no db.operation.batch.size, db.collection.name or table-name attributes
+        // an empty batch still produces a span with the raw batch operation name and
+        // db.operation.batch.size 0, but no db.collection.name or table-name attributes
         BatchScenario.builder("getItemEmpty")
             .awsOperation("BatchGetItem")
             .responseContent("{\"ConsumedCapacity\":[]}")
             .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
             .stableOperation("BatchGetItem")
+            .batchSize(0)
             .build(),
         // a single-item batch is not a batch, so it uses the singular item operation and emits
         // no db.operation.batch.size
@@ -631,6 +632,7 @@ public abstract class AbstractAws2ClientCoreTest {
             .responseContent("{\"ConsumedCapacity\":[]}")
             .execute(c -> c.batchWriteItem(b -> b.requestItems(ImmutableMap.of())))
             .stableOperation("BatchWriteItem")
+            .batchSize(0)
             .build(),
         // a single-item batch is not a batch, so it uses the singular item operation and emits
         // no db.operation.batch.size

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -563,149 +563,144 @@ public abstract class AbstractAws2ClientCoreTest {
   }
 
   @SuppressWarnings("deprecation") // uses deprecated semconv
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch still produces a span, but keeps the raw batch operation name and
-            // emits no db.operation.batch.size, db.collection.name or table-name attributes
-            BatchScenario.builder("getItemEmpty")
-                .awsOperation("BatchGetItem")
-                .responseContent("{\"ConsumedCapacity\":[]}")
-                .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
-                .stableOperation("BatchGetItem")
-                .build(),
-            // a single-item batch is not a batch, so it uses the singular item operation and emits
-            // no db.operation.batch.size
-            BatchScenario.builder("getItemSingle")
-                .awsOperation("BatchGetItem")
-                .responseContent(getResponseContent("BatchGetItem"))
-                .execute(
-                    c ->
-                        c.batchGetItem(
-                            b ->
-                                b.requestItems(
-                                    ImmutableMap.of(
-                                        "sometable",
-                                        KeysAndAttributes.builder()
-                                            .keys(
-                                                singletonList(
-                                                    ImmutableMap.of(
-                                                        "key",
-                                                        AttributeValue.builder()
-                                                            .s("value")
-                                                            .build())))
-                                            .build()))))
-                .stableOperation("GetItem")
-                .hasCollection()
-                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
-                .assertMetric()
-                .build(),
-            BatchScenario.builder("getItemTwo")
-                .awsOperation("BatchGetItem")
-                .responseContent(getResponseContent("BatchGetItem"))
-                .execute(
-                    c ->
-                        c.batchGetItem(
-                            b ->
-                                b.requestItems(
-                                    ImmutableMap.of(
-                                        "sometable",
-                                        KeysAndAttributes.builder()
-                                            .keys(
-                                                asList(
-                                                    ImmutableMap.of(
-                                                        "key",
-                                                        AttributeValue.builder()
-                                                            .s("value")
-                                                            .build()),
-                                                    ImmutableMap.of(
-                                                        "key",
-                                                        AttributeValue.builder()
-                                                            .s("anotherValue")
-                                                            .build())))
-                                            .build()))))
-                .stableOperation("BATCH GetItem")
-                .hasCollection()
-                .batchSize(2)
-                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
-                .assertMetric()
-                .build(),
-            BatchScenario.builder("writeItemEmpty")
-                .awsOperation("BatchWriteItem")
-                .responseContent("{\"ConsumedCapacity\":[]}")
-                .execute(c -> c.batchWriteItem(b -> b.requestItems(ImmutableMap.of())))
-                .stableOperation("BatchWriteItem")
-                .build(),
-            // a single-item batch is not a batch, so it uses the singular item operation and emits
-            // no db.operation.batch.size
-            BatchScenario.builder("writeItemSingle")
-                .awsOperation("BatchWriteItem")
-                .responseContent(getResponseContent("BatchWriteItem"))
-                .execute(
-                    c ->
-                        c.batchWriteItem(
-                            b ->
-                                b.requestItems(
-                                    ImmutableMap.of(
-                                        "sometable",
-                                        singletonList(
-                                            WriteRequest.builder()
-                                                .putRequest(
-                                                    PutRequest.builder()
-                                                        .item(
-                                                            ImmutableMap.of(
-                                                                "key",
-                                                                AttributeValue.builder()
-                                                                    .s("value")
-                                                                    .build()))
-                                                        .build())
-                                                .build())))))
-                .stableOperation("WriteItem")
-                .hasCollection()
-                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
-                .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
-                .assertMetric()
-                .build(),
-            BatchScenario.builder("writeItemTwo")
-                .awsOperation("BatchWriteItem")
-                .responseContent(getResponseContent("BatchWriteItem"))
-                .execute(
-                    c ->
-                        c.batchWriteItem(
-                            b ->
-                                b.requestItems(
-                                    ImmutableMap.of(
-                                        "sometable",
-                                        asList(
-                                            WriteRequest.builder()
-                                                .putRequest(
-                                                    PutRequest.builder()
-                                                        .item(
-                                                            ImmutableMap.of(
-                                                                "key",
-                                                                AttributeValue.builder()
-                                                                    .s("value")
-                                                                    .build()))
-                                                        .build())
-                                                .build(),
-                                            WriteRequest.builder()
-                                                .putRequest(
-                                                    PutRequest.builder()
-                                                        .item(
-                                                            ImmutableMap.of(
-                                                                "key",
-                                                                AttributeValue.builder()
-                                                                    .s("anotherValue")
-                                                                    .build()))
-                                                        .build())
-                                                .build())))))
-                .stableOperation("BATCH WriteItem")
-                .hasCollection()
-                .batchSize(2)
-                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
-                .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
-                .assertMetric()
-                .build())
-        .map(Arguments::of);
+        // an empty batch still produces a span, but keeps the raw batch operation name and
+        // emits no db.operation.batch.size, db.collection.name or table-name attributes
+        BatchScenario.builder("getItemEmpty")
+            .awsOperation("BatchGetItem")
+            .responseContent("{\"ConsumedCapacity\":[]}")
+            .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
+            .stableOperation("BatchGetItem")
+            .build(),
+        // a single-item batch is not a batch, so it uses the singular item operation and emits
+        // no db.operation.batch.size
+        BatchScenario.builder("getItemSingle")
+            .awsOperation("BatchGetItem")
+            .responseContent(getResponseContent("BatchGetItem"))
+            .execute(
+                c ->
+                    c.batchGetItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    KeysAndAttributes.builder()
+                                        .keys(
+                                            singletonList(
+                                                ImmutableMap.of(
+                                                    "key",
+                                                    AttributeValue.builder().s("value").build())))
+                                        .build()))))
+            .stableOperation("GetItem")
+            .hasCollection()
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .assertMetric()
+            .build(),
+        BatchScenario.builder("getItemTwo")
+            .awsOperation("BatchGetItem")
+            .responseContent(getResponseContent("BatchGetItem"))
+            .execute(
+                c ->
+                    c.batchGetItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    KeysAndAttributes.builder()
+                                        .keys(
+                                            asList(
+                                                ImmutableMap.of(
+                                                    "key",
+                                                    AttributeValue.builder().s("value").build()),
+                                                ImmutableMap.of(
+                                                    "key",
+                                                    AttributeValue.builder()
+                                                        .s("anotherValue")
+                                                        .build())))
+                                        .build()))))
+            .stableOperation("BATCH GetItem")
+            .hasCollection()
+            .batchSize(2)
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .assertMetric()
+            .build(),
+        BatchScenario.builder("writeItemEmpty")
+            .awsOperation("BatchWriteItem")
+            .responseContent("{\"ConsumedCapacity\":[]}")
+            .execute(c -> c.batchWriteItem(b -> b.requestItems(ImmutableMap.of())))
+            .stableOperation("BatchWriteItem")
+            .build(),
+        // a single-item batch is not a batch, so it uses the singular item operation and emits
+        // no db.operation.batch.size
+        BatchScenario.builder("writeItemSingle")
+            .awsOperation("BatchWriteItem")
+            .responseContent(getResponseContent("BatchWriteItem"))
+            .execute(
+                c ->
+                    c.batchWriteItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    singletonList(
+                                        WriteRequest.builder()
+                                            .putRequest(
+                                                PutRequest.builder()
+                                                    .item(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("value")
+                                                                .build()))
+                                                    .build())
+                                            .build())))))
+            .stableOperation("WriteItem")
+            .hasCollection()
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+            .assertMetric()
+            .build(),
+        BatchScenario.builder("writeItemTwo")
+            .awsOperation("BatchWriteItem")
+            .responseContent(getResponseContent("BatchWriteItem"))
+            .execute(
+                c ->
+                    c.batchWriteItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    asList(
+                                        WriteRequest.builder()
+                                            .putRequest(
+                                                PutRequest.builder()
+                                                    .item(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("value")
+                                                                .build()))
+                                                    .build())
+                                            .build(),
+                                        WriteRequest.builder()
+                                            .putRequest(
+                                                PutRequest.builder()
+                                                    .item(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("anotherValue")
+                                                                .build()))
+                                                    .build())
+                                            .build())))))
+            .stableOperation("BATCH WriteItem")
+            .hasCollection()
+            .batchSize(2)
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+            .assertMetric()
+            .build());
   }
 
   private static String getResponseContent(String operation) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -566,9 +566,14 @@ public abstract class AbstractAws2ClientCoreTest {
                                         .doesNotContainKey(DB_COLLECTION_NAME))));
   }
 
-  @Test
+  // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
+  // BatchWriteItem): the request to send, the mocked response and the expected client span. batch
+  // attributes (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted
+  // under stable database semconv; the span and db.operation.name are emitted in both modes
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
   @SuppressWarnings("deprecation") // uses deprecated semconv
-  void testBatchGetItemWithMultipleItemsUsesStableBatchAttributes() {
+  void batchOperation(BatchScenario scenario) {
     DynamoDbClientBuilder builder = DynamoDbClient.builder();
     configureSdkClient(builder);
     DynamoDbClient client =
@@ -578,114 +583,260 @@ public abstract class AbstractAws2ClientCoreTest {
             .credentialsProvider(CREDENTIALS_PROVIDER)
             .build();
     server.enqueue(
-        HttpResponse.of(
-            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchGetItem")));
+        HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, scenario.responseContent));
 
-    client.batchGetItem(
-        b ->
-            b.requestItems(
-                ImmutableMap.of(
-                    "sometable",
-                    KeysAndAttributes.builder()
-                        .keys(
-                            asList(
-                                ImmutableMap.of("key", AttributeValue.builder().s("value").build()),
-                                ImmutableMap.of(
-                                    "key", AttributeValue.builder().s("anotherValue").build())))
-                        .build())));
+    Object response = scenario.execute.apply(client);
+    assertThat(response).isNotNull();
 
     getTesting()
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span ->
-                        assertDynamoDbRequest(
-                            span,
-                            "BatchGetItem",
-                            asList(
-                                equalTo(
-                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
-                                    singletonList(
-                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
-                            "BATCH GetItem")));
+                    span -> {
+                      List<AttributeAssertion> attributes =
+                          new ArrayList<>(
+                              asList(
+                                  equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                                  equalTo(SERVER_PORT, server.httpPort()),
+                                  equalTo(URL_FULL, server.httpUri() + "/"),
+                                  equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                  equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                  equalTo(RPC_SYSTEM, "aws-api"),
+                                  equalTo(RPC_SERVICE, "DynamoDb"),
+                                  equalTo(RPC_METHOD, scenario.awsOperation),
+                                  equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+                                  equalTo(AWS_REQUEST_ID, "UNKNOWN"),
+                                  equalTo(
+                                      maybeStable(DB_SYSTEM), maybeStableDbSystemName(DYNAMODB)),
+                                  equalTo(
+                                      maybeStable(DB_OPERATION),
+                                      emitStableDatabaseSemconv()
+                                          ? scenario.stableOperation
+                                          : scenario.awsOperation)));
+                      if (scenario.hasCollection) {
+                        attributes.add(
+                            equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")));
+                        if (emitStableDatabaseSemconv()) {
+                          attributes.add(equalTo(DB_COLLECTION_NAME, "sometable"));
+                        }
+                      }
+                      attributes.addAll(scenario.extraAttributes());
+                      span.hasName("DynamoDb." + scenario.awsOperation)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(attributes);
+                    }));
 
-    assertDurationMetric(
-        getTesting(),
-        "io.opentelemetry.aws-sdk-2.2",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME);
+    if (scenario.assertMetric) {
+      assertDurationMetric(
+          getTesting(),
+          "io.opentelemetry.aws-sdk-2.2",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_COLLECTION_NAME);
+    }
   }
 
-  @Test
   @SuppressWarnings("deprecation") // uses deprecated semconv
-  void testBatchWriteItemWithMultipleItemsUsesStableBatchAttributes() {
-    DynamoDbClientBuilder builder = DynamoDbClient.builder();
-    configureSdkClient(builder);
-    DynamoDbClient client =
-        builder
-            .endpointOverride(server.httpUri())
-            .region(Region.AP_NORTHEAST_1)
-            .credentialsProvider(CREDENTIALS_PROVIDER)
-            .build();
-    server.enqueue(
-        HttpResponse.of(
-            HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, getResponseContent("BatchWriteItem")));
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // an empty batch still produces a span, but keeps the raw batch operation name and
+            // emits no db.operation.batch.size, db.collection.name or table-name attributes
+            BatchScenario.builder("getItemEmpty")
+                .awsOperation("BatchGetItem")
+                .responseContent("{\"ConsumedCapacity\":[]}")
+                .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
+                .stableOperation("BatchGetItem")
+                .build(),
+            BatchScenario.builder("getItemTwo")
+                .awsOperation("BatchGetItem")
+                .responseContent(getResponseContent("BatchGetItem"))
+                .execute(
+                    c ->
+                        c.batchGetItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        KeysAndAttributes.builder()
+                                            .keys(
+                                                asList(
+                                                    ImmutableMap.of(
+                                                        "key",
+                                                        AttributeValue.builder()
+                                                            .s("value")
+                                                            .build()),
+                                                    ImmutableMap.of(
+                                                        "key",
+                                                        AttributeValue.builder()
+                                                            .s("anotherValue")
+                                                            .build())))
+                                            .build()))))
+                .stableOperation("BATCH GetItem")
+                .hasCollection()
+                .batchSize(2)
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .assertMetric()
+                .build(),
+            BatchScenario.builder("writeItemTwo")
+                .awsOperation("BatchWriteItem")
+                .responseContent(getResponseContent("BatchWriteItem"))
+                .execute(
+                    c ->
+                        c.batchWriteItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        asList(
+                                            WriteRequest.builder()
+                                                .putRequest(
+                                                    PutRequest.builder()
+                                                        .item(
+                                                            ImmutableMap.of(
+                                                                "key",
+                                                                AttributeValue.builder()
+                                                                    .s("value")
+                                                                    .build()))
+                                                        .build())
+                                                .build(),
+                                            WriteRequest.builder()
+                                                .putRequest(
+                                                    PutRequest.builder()
+                                                        .item(
+                                                            ImmutableMap.of(
+                                                                "key",
+                                                                AttributeValue.builder()
+                                                                    .s("anotherValue")
+                                                                    .build()))
+                                                        .build())
+                                                .build())))))
+                .stableOperation("BATCH WriteItem")
+                .hasCollection()
+                .batchSize(2)
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+                .assertMetric()
+                .build())
+        .map(Arguments::of);
+  }
 
-    client.batchWriteItem(
-        b ->
-            b.requestItems(
-                ImmutableMap.of(
-                    "sometable",
-                    asList(
-                        WriteRequest.builder()
-                            .putRequest(
-                                PutRequest.builder()
-                                    .item(
-                                        ImmutableMap.of(
-                                            "key", AttributeValue.builder().s("value").build()))
-                                    .build())
-                            .build(),
-                        WriteRequest.builder()
-                            .putRequest(
-                                PutRequest.builder()
-                                    .item(
-                                        ImmutableMap.of(
-                                            "key",
-                                            AttributeValue.builder().s("anotherValue").build()))
-                                    .build())
-                            .build()))));
+  private static final class BatchScenario {
+    final String name;
+    final String awsOperation;
+    final String responseContent;
+    final Function<DynamoDbClient, Object> execute;
+    final String stableOperation;
+    final boolean hasCollection;
+    final Long batchSize;
+    final String consumedCapacity;
+    final String itemCollectionMetrics;
+    final boolean assertMetric;
 
-    getTesting()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        assertDynamoDbRequest(
-                            span,
-                            "BatchWriteItem",
-                            asList(
-                                equalTo(
-                                    AWS_DYNAMODB_CONSUMED_CAPACITY,
-                                    singletonList(
-                                        "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
-                                equalTo(
-                                    AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
-                                    "[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]"),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? Long.valueOf(2) : null)),
-                            "BATCH WriteItem")));
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.awsOperation = builder.awsOperation;
+      this.responseContent = builder.responseContent;
+      this.execute = builder.execute;
+      this.stableOperation = builder.stableOperation;
+      this.hasCollection = builder.hasCollection;
+      this.batchSize = builder.batchSize;
+      this.consumedCapacity = builder.consumedCapacity;
+      this.itemCollectionMetrics = builder.itemCollectionMetrics;
+      this.assertMetric = builder.assertMetric;
+    }
 
-    assertDurationMetric(
-        getTesting(),
-        "io.opentelemetry.aws-sdk-2.2",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_COLLECTION_NAME);
+    @SuppressWarnings("deprecation") // uses deprecated semconv
+    List<AttributeAssertion> extraAttributes() {
+      List<AttributeAssertion> attributes = new ArrayList<>();
+      if (consumedCapacity != null) {
+        attributes.add(equalTo(AWS_DYNAMODB_CONSUMED_CAPACITY, singletonList(consumedCapacity)));
+      }
+      if (itemCollectionMetrics != null) {
+        attributes.add(equalTo(AWS_DYNAMODB_ITEM_COLLECTION_METRICS, itemCollectionMetrics));
+      }
+      if (batchSize != null) {
+        attributes.add(
+            equalTo(DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? batchSize : null));
+      }
+      return attributes;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String awsOperation;
+      private String responseContent;
+      private Function<DynamoDbClient, Object> execute;
+      private String stableOperation;
+      private boolean hasCollection;
+      private Long batchSize;
+      private String consumedCapacity;
+      private String itemCollectionMetrics;
+      private boolean assertMetric;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder awsOperation(String awsOperation) {
+        this.awsOperation = awsOperation;
+        return this;
+      }
+
+      Builder responseContent(String responseContent) {
+        this.responseContent = responseContent;
+        return this;
+      }
+
+      Builder execute(Function<DynamoDbClient, Object> execute) {
+        this.execute = execute;
+        return this;
+      }
+
+      Builder stableOperation(String stableOperation) {
+        this.stableOperation = stableOperation;
+        return this;
+      }
+
+      Builder hasCollection() {
+        this.hasCollection = true;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder consumedCapacity(String consumedCapacity) {
+        this.consumedCapacity = consumedCapacity;
+        return this;
+      }
+
+      Builder itemCollectionMetrics(String itemCollectionMetrics) {
+        this.itemCollectionMetrics = itemCollectionMetrics;
+        return this;
+      }
+
+      Builder assertMetric() {
+        this.assertMetric = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private static String expectedDbOperationNameForSingleItemRequest(String operation) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -172,7 +172,6 @@ public abstract class AbstractAws2ClientCoreTest {
                         case "ListTables":
                           assertListTablesRequest(span);
                           return;
-                        case "BatchGetItem":
                         case "GetItem":
                           assertDynamoDbRequest(
                               span,
@@ -182,19 +181,6 @@ public abstract class AbstractAws2ClientCoreTest {
                                       AWS_DYNAMODB_CONSUMED_CAPACITY,
                                       singletonList(
                                           "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}"))));
-                          return;
-                        case "BatchWriteItem":
-                          assertDynamoDbRequest(
-                              span,
-                              operation,
-                              asList(
-                                  equalTo(
-                                      AWS_DYNAMODB_CONSUMED_CAPACITY,
-                                      singletonList(
-                                          "{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")),
-                                  equalTo(
-                                      AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
-                                      "[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")));
                           return;
                         case "DeleteItem":
                         case "PutItem":
@@ -294,16 +280,6 @@ public abstract class AbstractAws2ClientCoreTest {
   @SuppressWarnings("deprecation") // uses deprecated semconv
   private static void assertDynamoDbRequest(
       SpanDataAssert span, String operation, List<AttributeAssertion> extraAttributes) {
-    assertDynamoDbRequest(
-        span, operation, extraAttributes, expectedDbOperationNameForSingleItemRequest(operation));
-  }
-
-  @SuppressWarnings("deprecation") // uses deprecated semconv
-  private static void assertDynamoDbRequest(
-      SpanDataAssert span,
-      String operation,
-      List<AttributeAssertion> extraAttributes,
-      String expectedStableOperationName) {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
@@ -319,9 +295,7 @@ public abstract class AbstractAws2ClientCoreTest {
                 equalTo(AWS_REQUEST_ID, "UNKNOWN"),
                 equalTo(AWS_DYNAMODB_TABLE_NAMES, singletonList("sometable")),
                 equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(DYNAMODB)),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? expectedStableOperationName : operation)));
+                equalTo(maybeStable(DB_OPERATION), operation)));
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(DB_COLLECTION_NAME, "sometable"));
     }
@@ -433,56 +407,7 @@ public abstract class AbstractAws2ClientCoreTest {
             "UpdateTable",
             (Function<DynamoDbClient, Object>) c -> c.updateTable(b -> b.tableName("sometable"))),
         Arguments.of(
-            "Scan", (Function<DynamoDbClient, Object>) c -> c.scan(b -> b.tableName("sometable"))),
-        Arguments.of(
-            "BatchGetItem",
-            (Function<DynamoDbClient, Object>)
-                c ->
-                    c.batchGetItem(
-                        b ->
-                            b.requestItems(
-                                ImmutableMap.of(
-                                    "sometable",
-                                    KeysAndAttributes.builder()
-                                        .keys(
-                                            singletonList(
-                                                ImmutableMap.of(
-                                                    "keyOne",
-                                                        AttributeValue.builder().s("value").build(),
-                                                    "keyTwo",
-                                                        AttributeValue.builder()
-                                                            .s("differentValue")
-                                                            .build())))
-                                        .build())))),
-        Arguments.of(
-            "BatchWriteItem",
-            (Function<DynamoDbClient, Object>)
-                c ->
-                    c.batchWriteItem(
-                        b ->
-                            b.requestItems(
-                                ImmutableMap.of(
-                                    "sometable",
-                                    singletonList(
-                                        WriteRequest.builder()
-                                            .putRequest(
-                                                PutRequest.builder()
-                                                    .item(
-                                                        ImmutableMap.of(
-                                                            "key",
-                                                                AttributeValue.builder()
-                                                                    .s("value")
-                                                                    .build(),
-                                                            "attributeOne",
-                                                                AttributeValue.builder()
-                                                                    .s("one")
-                                                                    .build(),
-                                                            "attributeTwo",
-                                                                AttributeValue.builder()
-                                                                    .s("two")
-                                                                    .build()))
-                                                    .build())
-                                            .build()))))));
+            "Scan", (Function<DynamoDbClient, Object>) c -> c.scan(b -> b.tableName("sometable"))));
   }
 
   @ParameterizedTest
@@ -648,6 +573,32 @@ public abstract class AbstractAws2ClientCoreTest {
                 .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
                 .stableOperation("BatchGetItem")
                 .build(),
+            // a single-item batch is not a batch, so it uses the singular item operation and emits
+            // no db.operation.batch.size
+            BatchScenario.builder("getItemSingle")
+                .awsOperation("BatchGetItem")
+                .responseContent(getResponseContent("BatchGetItem"))
+                .execute(
+                    c ->
+                        c.batchGetItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        KeysAndAttributes.builder()
+                                            .keys(
+                                                singletonList(
+                                                    ImmutableMap.of(
+                                                        "key",
+                                                        AttributeValue.builder()
+                                                            .s("value")
+                                                            .build())))
+                                            .build()))))
+                .stableOperation("GetItem")
+                .hasCollection()
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .assertMetric()
+                .build(),
             BatchScenario.builder("getItemTwo")
                 .awsOperation("BatchGetItem")
                 .responseContent(getResponseContent("BatchGetItem"))
@@ -676,6 +627,42 @@ public abstract class AbstractAws2ClientCoreTest {
                 .hasCollection()
                 .batchSize(2)
                 .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .assertMetric()
+                .build(),
+            BatchScenario.builder("writeItemEmpty")
+                .awsOperation("BatchWriteItem")
+                .responseContent("{\"ConsumedCapacity\":[]}")
+                .execute(c -> c.batchWriteItem(b -> b.requestItems(ImmutableMap.of())))
+                .stableOperation("BatchWriteItem")
+                .build(),
+            // a single-item batch is not a batch, so it uses the singular item operation and emits
+            // no db.operation.batch.size
+            BatchScenario.builder("writeItemSingle")
+                .awsOperation("BatchWriteItem")
+                .responseContent(getResponseContent("BatchWriteItem"))
+                .execute(
+                    c ->
+                        c.batchWriteItem(
+                            b ->
+                                b.requestItems(
+                                    ImmutableMap.of(
+                                        "sometable",
+                                        singletonList(
+                                            WriteRequest.builder()
+                                                .putRequest(
+                                                    PutRequest.builder()
+                                                        .item(
+                                                            ImmutableMap.of(
+                                                                "key",
+                                                                AttributeValue.builder()
+                                                                    .s("value")
+                                                                    .build()))
+                                                        .build())
+                                                .build())))))
+                .stableOperation("WriteItem")
+                .hasCollection()
+                .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+                .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
                 .assertMetric()
                 .build(),
             BatchScenario.builder("writeItemTwo")
@@ -836,22 +823,6 @@ public abstract class AbstractAws2ClientCoreTest {
       BatchScenario build() {
         return new BatchScenario(this);
       }
-    }
-  }
-
-  private static String expectedDbOperationNameForSingleItemRequest(String operation) {
-    if (!emitStableDatabaseSemconv()) {
-      return operation;
-    }
-    // The parameterized Batch* requests contain one item. Stable DB semconv treats those as
-    // logical item operations; dedicated multi-item tests pass the BATCH operation name directly.
-    switch (operation) {
-      case "BatchGetItem":
-        return "GetItem";
-      case "BatchWriteItem":
-        return "WriteItem";
-      default:
-        return operation;
     }
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -708,6 +708,30 @@ public abstract class AbstractAws2ClientCoreTest {
         .map(Arguments::of);
   }
 
+  private static String getResponseContent(String operation) {
+    switch (operation) {
+      case "ListTables":
+        return "{\"TableNames\":[\"sometable\"]}";
+      case "BatchGetItem":
+        return "{\"ConsumedCapacity\":[{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}]}";
+      case "GetItem":
+      case "Query":
+      case "UpdateTable":
+        return "{\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}}";
+      case "BatchWriteItem":
+        return "{\"ConsumedCapacity\":[{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}],\"ItemCollectionMetrics\":{\"somekey1\":[{\"ItemCollectionKey\":{\"somekey2\":{}}}]}}";
+      case "CreateTable":
+      case "DeleteItem":
+      case "PutItem":
+      case "UpdateItem":
+        return "{\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0},\"ItemCollectionMetrics\":{\"ItemCollectionKey\":{\"somekey\":{}}}}";
+      case "Scan":
+        return "{\"Count\":1,\"ScannedCount\":1,\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}}";
+      default:
+        return "";
+    }
+  }
+
   private static final class BatchScenario {
     final String name;
     final String awsOperation;
@@ -823,30 +847,6 @@ public abstract class AbstractAws2ClientCoreTest {
       BatchScenario build() {
         return new BatchScenario(this);
       }
-    }
-  }
-
-  private static String getResponseContent(String operation) {
-    switch (operation) {
-      case "ListTables":
-        return "{\"TableNames\":[\"sometable\"]}";
-      case "BatchGetItem":
-        return "{\"ConsumedCapacity\":[{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}]}";
-      case "GetItem":
-      case "Query":
-      case "UpdateTable":
-        return "{\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}}";
-      case "BatchWriteItem":
-        return "{\"ConsumedCapacity\":[{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}],\"ItemCollectionMetrics\":{\"somekey1\":[{\"ItemCollectionKey\":{\"somekey2\":{}}}]}}";
-      case "CreateTable":
-      case "DeleteItem":
-      case "PutItem":
-      case "UpdateItem":
-        return "{\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0},\"ItemCollectionMetrics\":{\"ItemCollectionKey\":{\"somekey\":{}}}}";
-      case "Scan":
-        return "{\"Count\":1,\"ScannedCount\":1,\"ConsumedCapacity\":{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}}";
-      default:
-        return "";
     }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -492,10 +492,6 @@ public abstract class AbstractAws2ClientCoreTest {
                                         .doesNotContainKey(DB_COLLECTION_NAME))));
   }
 
-  // describes the batch cases for the two DynamoDB batch operations (BatchGetItem and
-  // BatchWriteItem): the request to send, the mocked response and the expected client span. batch
-  // attributes (db.operation.batch.size, BATCH operation name, db.collection.name) are only emitted
-  // under stable database semconv; the span and db.operation.name are emitted in both modes
   @ParameterizedTest
   @MethodSource("batchScenarios")
   @SuppressWarnings("deprecation") // uses deprecated semconv
@@ -566,17 +562,14 @@ public abstract class AbstractAws2ClientCoreTest {
   @SuppressWarnings("deprecation") // uses deprecated semconv
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch still produces a span with the raw batch operation name and
-        // db.operation.batch.size 0, but no db.collection.name or table-name attributes
+        // BatchGetItem entries are keys, not explicit operations, so the stable operation name
+        // remains the raw batch operation and db.operation.batch.size is not emitted.
         BatchScenario.builder("getItemEmpty")
             .awsOperation("BatchGetItem")
             .responseContent("{\"ConsumedCapacity\":[]}")
             .execute(c -> c.batchGetItem(b -> b.requestItems(ImmutableMap.of())))
             .stableOperation("BatchGetItem")
-            .batchSize(0)
             .build(),
-        // a single-item batch is not a batch, so it uses the singular item operation and emits
-        // no db.operation.batch.size
         BatchScenario.builder("getItemSingle")
             .awsOperation("BatchGetItem")
             .responseContent(getResponseContent("BatchGetItem"))
@@ -594,7 +587,7 @@ public abstract class AbstractAws2ClientCoreTest {
                                                     "key",
                                                     AttributeValue.builder().s("value").build())))
                                         .build()))))
-            .stableOperation("GetItem")
+            .stableOperation("BatchGetItem")
             .hasCollection()
             .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
             .assertMetric()
@@ -621,9 +614,8 @@ public abstract class AbstractAws2ClientCoreTest {
                                                         .s("anotherValue")
                                                         .build())))
                                         .build()))))
-            .stableOperation("BATCH GetItem")
+            .stableOperation("BatchGetItem")
             .hasCollection()
-            .batchSize(2)
             .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
             .assertMetric()
             .build(),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.java
@@ -636,7 +636,7 @@ public abstract class AbstractAws2ClientCoreTest {
             .build(),
         // a single-item batch is not a batch, so it uses the singular item operation and emits
         // no db.operation.batch.size
-        BatchScenario.builder("writeItemSingle")
+        BatchScenario.builder("writeItemSinglePut")
             .awsOperation("BatchWriteItem")
             .responseContent(getResponseContent("BatchWriteItem"))
             .execute(
@@ -658,13 +658,43 @@ public abstract class AbstractAws2ClientCoreTest {
                                                                 .build()))
                                                     .build())
                                             .build())))))
-            .stableOperation("WriteItem")
+            .stableOperation("PutItem")
             .hasCollection()
             .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
             .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
             .assertMetric()
             .build(),
-        BatchScenario.builder("writeItemTwo")
+        // a single delete request is reported as DeleteItem
+        BatchScenario.builder("writeItemSingleDelete")
+            .awsOperation("BatchWriteItem")
+            .responseContent(getResponseContent("BatchWriteItem"))
+            .execute(
+                c ->
+                    c.batchWriteItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    singletonList(
+                                        WriteRequest.builder()
+                                            .deleteRequest(
+                                                DeleteRequest.builder()
+                                                    .key(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("value")
+                                                                .build()))
+                                                    .build())
+                                            .build())))))
+            .stableOperation("DeleteItem")
+            .hasCollection()
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+            .assertMetric()
+            .build(),
+        // two put requests are reported as BATCH PutItem
+        BatchScenario.builder("writeItemTwoPuts")
             .awsOperation("BatchWriteItem")
             .responseContent(getResponseContent("BatchWriteItem"))
             .execute(
@@ -697,17 +727,56 @@ public abstract class AbstractAws2ClientCoreTest {
                                                                 .build()))
                                                     .build())
                                             .build())))))
-            .stableOperation("BATCH WriteItem")
+            .stableOperation("BATCH PutItem")
             .hasCollection()
             .batchSize(2)
             .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
             .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
             .assertMetric()
             .build(),
-        // a batch mixing a put and a delete in one table: unlike the SQL/Cassandra matrices where
-        // a batch with differing operations collapses to just "BATCH", DynamoDB derives the
-        // operation name from the item count alone, so a put+delete write batch still reports the
-        // shared "BATCH WriteItem" operation (and the single collection)
+        // two delete requests are reported as BATCH DeleteItem
+        BatchScenario.builder("writeItemTwoDeletes")
+            .awsOperation("BatchWriteItem")
+            .responseContent(getResponseContent("BatchWriteItem"))
+            .execute(
+                c ->
+                    c.batchWriteItem(
+                        b ->
+                            b.requestItems(
+                                ImmutableMap.of(
+                                    "sometable",
+                                    asList(
+                                        WriteRequest.builder()
+                                            .deleteRequest(
+                                                DeleteRequest.builder()
+                                                    .key(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("value")
+                                                                .build()))
+                                                    .build())
+                                            .build(),
+                                        WriteRequest.builder()
+                                            .deleteRequest(
+                                                DeleteRequest.builder()
+                                                    .key(
+                                                        ImmutableMap.of(
+                                                            "key",
+                                                            AttributeValue.builder()
+                                                                .s("anotherValue")
+                                                                .build()))
+                                                    .build())
+                                            .build())))))
+            .stableOperation("BATCH DeleteItem")
+            .hasCollection()
+            .batchSize(2)
+            .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")
+            .itemCollectionMetrics("[somekey1:[{\"ItemCollectionKey\":{\"somekey2\":{}}}]]")
+            .assertMetric()
+            .build(),
+        // a batch mixing a put and a delete in one table collapses to bare "BATCH"
+        // (consistent with SQL/Cassandra mixed-operation batches)
         BatchScenario.builder("writeItemMixed")
             .awsOperation("BatchWriteItem")
             .responseContent(getResponseContent("BatchWriteItem"))
@@ -741,7 +810,7 @@ public abstract class AbstractAws2ClientCoreTest {
                                                                 .build()))
                                                     .build())
                                             .build())))))
-            .stableOperation("BATCH WriteItem")
+            .stableOperation("BATCH")
             .hasCollection()
             .batchSize(2)
             .consumedCapacity("{\"TableName\":\"sometable\",\"CapacityUnits\":1.0}")

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -334,9 +334,6 @@ class CassandraClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                             equalTo(NETWORK_PEER_PORT, cassandraPort),
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
-                            // a single-statement batch is not a batch, so it carries the normal
-                            // statement's db.operation and db.cassandra.table; the real batch cases
-                            // do not
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 emitStableDatabaseSemconv()
@@ -348,8 +345,21 @@ class CassandraClientTest {
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? scenario.summary : null),
-                            equalTo(maybeStable(DB_OPERATION), scenario.operation),
-                            equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.table))));
+                            // under stable semconv a batch carries db.operation.name (BATCH, or
+                            // BATCH <operation> when all statements share one operation) and
+                            // db.collection.name (when all statements share one collection); a
+                            // single-statement batch is not a batch, so it carries the normal
+                            // statement's db.operation.name and db.cassandra.table
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.operation
+                                    : scenario.oldOperation),
+                            equalTo(
+                                maybeStable(DB_CASSANDRA_TABLE),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.collection
+                                    : scenario.oldCollection))));
   }
 
   private static Stream<Arguments> batchScenarios() {
@@ -380,7 +390,9 @@ class CassandraClientTest {
                 .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
                 .summary("INSERT batch_single_test.users")
                 .operation("INSERT")
-                .table("batch_single_test.users")
+                .oldOperation("INSERT")
+                .collection("batch_single_test.users")
+                .oldCollection("batch_single_test.users")
                 .build(),
             BatchScenario.builder("twoSameOperation")
                 .keyspace("batch_same_test")
@@ -397,6 +409,8 @@ class CassandraClientTest {
                 .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
+                .operation("BATCH INSERT batch_same_test.users")
+                .collection("batch_same_test.users")
                 .batchSize(2)
                 .build(),
             BatchScenario.builder("twoDifferentOperations")
@@ -417,6 +431,8 @@ class CassandraClientTest {
                 .statement(
                     "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
                 .summary("BATCH")
+                .operation("BATCH")
+                .collection("batch_mixed_test.users")
                 .batchSize(2)
                 .build())
         .map(Arguments::of);
@@ -433,7 +449,9 @@ class CassandraClientTest {
     final String summary;
     final Long batchSize;
     final String operation;
-    final String table;
+    final String oldOperation;
+    final String collection;
+    final String oldCollection;
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
@@ -446,7 +464,9 @@ class CassandraClientTest {
       this.summary = builder.summary;
       this.batchSize = builder.batchSize;
       this.operation = builder.operation;
-      this.table = builder.table;
+      this.oldOperation = builder.oldOperation;
+      this.collection = builder.collection;
+      this.oldCollection = builder.oldCollection;
     }
 
     @Override
@@ -470,7 +490,9 @@ class CassandraClientTest {
       private String summary;
       private Long batchSize;
       private String operation;
-      private String table;
+      private String oldOperation;
+      private String collection;
+      private String oldCollection;
 
       Builder(String name) {
         this.name = name;
@@ -521,8 +543,18 @@ class CassandraClientTest {
         return this;
       }
 
-      Builder table(String table) {
-        this.table = table;
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder collection(String collection) {
+        this.collection = collection;
+        return this;
+      }
+
+      Builder oldCollection(String oldCollection) {
+        this.oldCollection = oldCollection;
         return this;
       }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -438,132 +438,6 @@ class CassandraClientTest {
         .map(Arguments::of);
   }
 
-  private static final class BatchScenario {
-    final String name;
-    final String keyspace;
-    final Function<Session, BatchStatement> buildBatch;
-    final String spanName;
-    final String oldSpanName;
-    final String statement;
-    final String oldStatement;
-    final String summary;
-    final Long batchSize;
-    final String operation;
-    final String oldOperation;
-    final String collection;
-    final String oldCollection;
-
-    BatchScenario(Builder builder) {
-      this.name = builder.name;
-      this.keyspace = builder.keyspace;
-      this.buildBatch = builder.buildBatch;
-      this.spanName = builder.spanName;
-      this.oldSpanName = builder.oldSpanName;
-      this.statement = builder.statement;
-      this.oldStatement = builder.oldStatement;
-      this.summary = builder.summary;
-      this.batchSize = builder.batchSize;
-      this.operation = builder.operation;
-      this.oldOperation = builder.oldOperation;
-      this.collection = builder.collection;
-      this.oldCollection = builder.oldCollection;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
-
-    static Builder builder(String name) {
-      return new Builder(name);
-    }
-
-    static final class Builder {
-      private final String name;
-      private String keyspace;
-      private Function<Session, BatchStatement> buildBatch;
-      private String spanName;
-      private String oldSpanName;
-      private String statement;
-      private String oldStatement;
-      private String summary;
-      private Long batchSize;
-      private String operation;
-      private String oldOperation;
-      private String collection;
-      private String oldCollection;
-
-      Builder(String name) {
-        this.name = name;
-      }
-
-      Builder keyspace(String keyspace) {
-        this.keyspace = keyspace;
-        return this;
-      }
-
-      Builder buildBatch(Function<Session, BatchStatement> buildBatch) {
-        this.buildBatch = buildBatch;
-        return this;
-      }
-
-      Builder spanName(String spanName) {
-        this.spanName = spanName;
-        return this;
-      }
-
-      Builder oldSpanName(String oldSpanName) {
-        this.oldSpanName = oldSpanName;
-        return this;
-      }
-
-      Builder statement(String statement) {
-        this.statement = statement;
-        return this;
-      }
-
-      Builder oldStatement(String oldStatement) {
-        this.oldStatement = oldStatement;
-        return this;
-      }
-
-      Builder summary(String summary) {
-        this.summary = summary;
-        return this;
-      }
-
-      Builder batchSize(long batchSize) {
-        this.batchSize = batchSize;
-        return this;
-      }
-
-      Builder operation(String operation) {
-        this.operation = operation;
-        return this;
-      }
-
-      Builder oldOperation(String oldOperation) {
-        this.oldOperation = oldOperation;
-        return this;
-      }
-
-      Builder collection(String collection) {
-        this.collection = collection;
-        return this;
-      }
-
-      Builder oldCollection(String oldCollection) {
-        this.oldCollection = oldCollection;
-        return this;
-      }
-
-      BatchScenario build() {
-        return new BatchScenario(this);
-      }
-    }
-  }
-
   private static Stream<Arguments> provideSyncParameters() {
     return Stream.of(
         Arguments.of(
@@ -693,6 +567,132 @@ class CassandraClientTest {
       this.spanName = spanName;
       this.operation = operation;
       this.table = table;
+    }
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<Session, BatchStatement> buildBatch;
+    final String spanName;
+    final String oldSpanName;
+    final String statement;
+    final String oldStatement;
+    final String summary;
+    final Long batchSize;
+    final String operation;
+    final String oldOperation;
+    final String collection;
+    final String oldCollection;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
+      this.statement = builder.statement;
+      this.oldStatement = builder.oldStatement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+      this.operation = builder.operation;
+      this.oldOperation = builder.oldOperation;
+      this.collection = builder.collection;
+      this.oldCollection = builder.oldCollection;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<Session, BatchStatement> buildBatch;
+      private String spanName;
+      private String oldSpanName;
+      private String statement;
+      private String oldStatement;
+      private String summary;
+      private Long batchSize;
+      private String operation;
+      private String oldOperation;
+      private String collection;
+      private String oldCollection;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<Session, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder operation(String operation) {
+        this.operation = operation;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder collection(String collection) {
+        this.collection = collection;
+        return this;
+      }
+
+      Builder oldCollection(String oldCollection) {
+        this.oldCollection = oldCollection;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
     }
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -63,6 +63,10 @@ class CassandraClientTest {
 
   private static final ExecutorService executor = Executors.newCachedThreadPool();
 
+  // all batch scenarios share a single keyspace + table (recreated per scenario), so batch row ids
+  // can be reused without worrying about collisions from previous scenarios
+  private static final String BATCH_KEYSPACE = "batch_test";
+
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
@@ -307,12 +311,12 @@ class CassandraClientTest {
     Session session = cluster.connect();
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
+    session.execute("DROP KEYSPACE IF EXISTS " + BATCH_KEYSPACE);
     session.execute(
         "CREATE KEYSPACE "
-            + scenario.keyspace
+            + BATCH_KEYSPACE
             + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE " + scenario.keyspace + ".items ( id int PRIMARY KEY, num int )");
+    session.execute("CREATE TABLE " + BATCH_KEYSPACE + ".records ( id int PRIMARY KEY, num int )");
     testing.waitForTraces(3);
     testing.clearData();
 
@@ -366,7 +370,6 @@ class CassandraClientTest {
         // an empty batch still produces a client span, but with no query text, summary,
         // operation or batch size; the span name falls back to the database system name
         BatchScenario.builder("empty")
-            .keyspace("batch_empty_test")
             .buildBatch(session -> new BatchStatement())
             .spanName("cassandra")
             .oldSpanName("DB Query")
@@ -375,59 +378,55 @@ class CassandraClientTest {
         // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
         // db.operation.batch.size
         BatchScenario.builder("single")
-            .keyspace("batch_single_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_single_test.items (id, num) values (?, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (?, ?)");
                   return new BatchStatement().add(insert.bind(1, 1));
                 })
-            .spanName("INSERT batch_single_test.items")
-            .oldSpanName("INSERT batch_single_test.items")
-            .statement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
-            .oldStatement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
-            .summary("INSERT batch_single_test.items")
+            .spanName("INSERT batch_test.records")
+            .oldSpanName("INSERT batch_test.records")
+            .statement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .oldStatement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .summary("INSERT batch_test.records")
             .operation("INSERT")
             .oldOperation("INSERT")
-            .collection("batch_single_test.items")
-            .oldCollection("batch_single_test.items")
+            .collection("batch_test.records")
+            .oldCollection("batch_test.records")
             .build(),
         BatchScenario.builder("twoSameOperation")
-            .keyspace("batch_same_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare("INSERT INTO batch_same_test.items (id, num) values (?, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (?, ?)");
                   return new BatchStatement().add(insert.bind(1, 1)).add(insert.bind(2, 2));
                 })
-            .spanName("BATCH INSERT batch_same_test.items")
+            .spanName("BATCH INSERT batch_test.records")
             .oldSpanName("DB Query")
-            .statement("INSERT INTO batch_same_test.items (id, num) values (?, ?)")
-            .summary("BATCH INSERT batch_same_test.items")
+            .statement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .summary("BATCH INSERT batch_test.records")
             .operation("BATCH INSERT")
-            .collection("batch_same_test.items")
+            .collection("batch_test.records")
             .batchSize(2)
             .build(),
         BatchScenario.builder("twoDifferentOperations")
-            .keyspace("batch_mixed_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare("INSERT INTO batch_mixed_test.items (id, num) values (4, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (4, ?)");
                   return new BatchStatement()
                       .add(insert.bind(4))
                       .add(
                           new SimpleStatement(
-                              "UPDATE batch_mixed_test.items SET num = 5 WHERE id = 4"));
+                              "UPDATE batch_test.records SET num = 5 WHERE id = 4"));
                 })
             .spanName("BATCH")
             .oldSpanName("DB Query")
             .statement(
-                "INSERT INTO batch_mixed_test.items (id, num) values (4, ?); UPDATE batch_mixed_test.items SET num = ? WHERE id = ?")
+                "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
             .summary("BATCH")
             .operation("BATCH")
-            .collection("batch_mixed_test.items")
+            .collection("batch_test.records")
             .batchSize(2)
             .build());
   }
@@ -566,7 +565,6 @@ class CassandraClientTest {
 
   private static final class BatchScenario {
     final String name;
-    final String keyspace;
     final Function<Session, BatchStatement> buildBatch;
     final String spanName;
     final String oldSpanName;
@@ -581,7 +579,6 @@ class CassandraClientTest {
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
-      this.keyspace = builder.keyspace;
       this.buildBatch = builder.buildBatch;
       this.spanName = builder.spanName;
       this.oldSpanName = builder.oldSpanName;
@@ -607,7 +604,6 @@ class CassandraClientTest {
 
     static final class Builder {
       private final String name;
-      private String keyspace;
       private Function<Session, BatchStatement> buildBatch;
       private String spanName;
       private String oldSpanName;
@@ -622,11 +618,6 @@ class CassandraClientTest {
 
       Builder(String name) {
         this.name = name;
-      }
-
-      Builder keyspace(String keyspace) {
-        this.keyspace = keyspace;
-        return this;
       }
 
       Builder buildBatch(Function<Session, BatchStatement> buildBatch) {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -409,7 +409,7 @@ class CassandraClientTest {
                 .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
-                .operation("BATCH INSERT batch_same_test.users")
+                .operation("BATCH INSERT")
                 .collection("batch_same_test.users")
                 .batchSize(2)
                 .build(),

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -362,80 +362,79 @@ class CassandraClientTest {
                                     : scenario.oldCollection))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch still produces a client span, but with no query text, summary,
-            // operation or batch size; the span name falls back to the database system name
-            BatchScenario.builder("empty")
-                .keyspace("batch_empty_test")
-                .buildBatch(session -> new BatchStatement())
-                .spanName("cassandra")
-                .oldSpanName("DB Query")
-                .build(),
-            // a single-statement batch is executed as a normal statement (not a batch): it has the
-            // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
-            // db.operation.batch.size
-            BatchScenario.builder("single")
-                .keyspace("batch_single_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
-                      return new BatchStatement().add(insert.bind("alice", 1));
-                    })
-                .spanName("INSERT batch_single_test.users")
-                .oldSpanName("INSERT batch_single_test.users")
-                .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-                .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-                .summary("INSERT batch_single_test.users")
-                .operation("INSERT")
-                .oldOperation("INSERT")
-                .collection("batch_single_test.users")
-                .oldCollection("batch_single_test.users")
-                .build(),
-            BatchScenario.builder("twoSameOperation")
-                .keyspace("batch_same_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
-                      return new BatchStatement()
-                          .add(insert.bind("alice", 1))
-                          .add(insert.bind("bob", 2));
-                    })
-                .spanName("BATCH INSERT batch_same_test.users")
-                .oldSpanName("DB Query")
-                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
-                .summary("BATCH INSERT batch_same_test.users")
-                .operation("BATCH INSERT")
-                .collection("batch_same_test.users")
-                .batchSize(2)
-                .build(),
-            BatchScenario.builder("twoDifferentOperations")
-                .keyspace("batch_mixed_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-                      return new BatchStatement()
-                          .add(insert.bind(1))
-                          .add(
-                              new SimpleStatement(
-                                  "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-                    })
-                .spanName("BATCH")
-                .oldSpanName("DB Query")
-                .statement(
-                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
-                .summary("BATCH")
-                .operation("BATCH")
-                .collection("batch_mixed_test.users")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch still produces a client span, but with no query text, summary,
+        // operation or batch size; the span name falls back to the database system name
+        BatchScenario.builder("empty")
+            .keyspace("batch_empty_test")
+            .buildBatch(session -> new BatchStatement())
+            .spanName("cassandra")
+            .oldSpanName("DB Query")
+            .build(),
+        // a single-statement batch is executed as a normal statement (not a batch): it has the
+        // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
+        // db.operation.batch.size
+        BatchScenario.builder("single")
+            .keyspace("batch_single_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
+                  return new BatchStatement().add(insert.bind("alice", 1));
+                })
+            .spanName("INSERT batch_single_test.users")
+            .oldSpanName("INSERT batch_single_test.users")
+            .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+            .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+            .summary("INSERT batch_single_test.users")
+            .operation("INSERT")
+            .oldOperation("INSERT")
+            .collection("batch_single_test.users")
+            .oldCollection("batch_single_test.users")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .keyspace("batch_same_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                  return new BatchStatement()
+                      .add(insert.bind("alice", 1))
+                      .add(insert.bind("bob", 2));
+                })
+            .spanName("BATCH INSERT batch_same_test.users")
+            .oldSpanName("DB Query")
+            .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+            .summary("BATCH INSERT batch_same_test.users")
+            .operation("BATCH INSERT")
+            .collection("batch_same_test.users")
+            .batchSize(2)
+            .build(),
+        BatchScenario.builder("twoDifferentOperations")
+            .keyspace("batch_mixed_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                  return new BatchStatement()
+                      .add(insert.bind(1))
+                      .add(
+                          new SimpleStatement(
+                              "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                })
+            .spanName("BATCH")
+            .oldSpanName("DB Query")
+            .statement(
+                "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+            .summary("BATCH")
+            .operation("BATCH")
+            .collection("batch_mixed_test.users")
+            .batchSize(2)
+            .build());
   }
 
   private static Stream<Arguments> provideSyncParameters() {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -312,8 +312,7 @@ class CassandraClientTest {
         "CREATE KEYSPACE "
             + scenario.keyspace
             + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute(
-        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
+    session.execute("CREATE TABLE " + scenario.keyspace + ".items ( id int PRIMARY KEY, num int )");
     testing.waitForTraces(3);
     testing.clearData();
 
@@ -381,36 +380,33 @@ class CassandraClientTest {
                 session -> {
                   PreparedStatement insert =
                       session.prepare(
-                          "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
-                  return new BatchStatement().add(insert.bind("alice", 1));
+                          "INSERT INTO batch_single_test.items (id, num) values (?, ?)");
+                  return new BatchStatement().add(insert.bind(1, 1));
                 })
-            .spanName("INSERT batch_single_test.users")
-            .oldSpanName("INSERT batch_single_test.users")
-            .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-            .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-            .summary("INSERT batch_single_test.users")
+            .spanName("INSERT batch_single_test.items")
+            .oldSpanName("INSERT batch_single_test.items")
+            .statement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
+            .oldStatement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
+            .summary("INSERT batch_single_test.items")
             .operation("INSERT")
             .oldOperation("INSERT")
-            .collection("batch_single_test.users")
-            .oldCollection("batch_single_test.users")
+            .collection("batch_single_test.items")
+            .oldCollection("batch_single_test.items")
             .build(),
         BatchScenario.builder("twoSameOperation")
             .keyspace("batch_same_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
-                  return new BatchStatement()
-                      .add(insert.bind("alice", 1))
-                      .add(insert.bind("bob", 2));
+                      session.prepare("INSERT INTO batch_same_test.items (id, num) values (?, ?)");
+                  return new BatchStatement().add(insert.bind(1, 1)).add(insert.bind(2, 2));
                 })
-            .spanName("BATCH INSERT batch_same_test.users")
+            .spanName("BATCH INSERT batch_same_test.items")
             .oldSpanName("DB Query")
-            .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
-            .summary("BATCH INSERT batch_same_test.users")
+            .statement("INSERT INTO batch_same_test.items (id, num) values (?, ?)")
+            .summary("BATCH INSERT batch_same_test.items")
             .operation("BATCH INSERT")
-            .collection("batch_same_test.users")
+            .collection("batch_same_test.items")
             .batchSize(2)
             .build(),
         BatchScenario.builder("twoDifferentOperations")
@@ -418,21 +414,20 @@ class CassandraClientTest {
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      session.prepare("INSERT INTO batch_mixed_test.items (id, num) values (4, ?)");
                   return new BatchStatement()
-                      .add(insert.bind(1))
+                      .add(insert.bind(4))
                       .add(
                           new SimpleStatement(
-                              "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                              "UPDATE batch_mixed_test.items SET num = 5 WHERE id = 4"));
                 })
             .spanName("BATCH")
             .oldSpanName("DB Query")
             .statement(
-                "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                "INSERT INTO batch_mixed_test.items (id, num) values (4, ?); UPDATE batch_mixed_test.items SET num = ? WHERE id = ?")
             .summary("BATCH")
             .operation("BATCH")
-            .collection("batch_mixed_test.users")
+            .collection("batch_mixed_test.items")
             .batchSize(2)
             .build());
   }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -353,6 +353,14 @@ class CassandraClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch still produces a client span, but with no query text, summary,
+            // operation or batch size; the span name falls back to the database system name
+            BatchScenario.builder("empty")
+                .keyspace("batch_empty_test")
+                .buildBatch(session -> new BatchStatement())
+                .spanName("cassandra")
+                .oldSpanName("DB Query")
+                .build(),
             // a single-statement batch is executed as a normal statement (not a batch): it has the
             // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
             // db.operation.batch.size

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -296,10 +296,10 @@ class CassandraClientTest {
         SERVER_PORT);
   }
 
-  // describes the batch cases: two statements with the same query, and two statements with
-  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
-  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
-  // names and summaries) is only emitted under stable database semconv
+  // describes the batch cases: a single-statement batch (which is executed as a normal statement,
+  // not a batch), two statements with the same query, and two statements with different queries. (an
+  // empty batch is invalid CQL.) batch telemetry (db.operation.batch.size, BATCH span names and
+  // summaries) is only emitted under stable database semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchStatement(BatchScenario scenario) {
@@ -322,7 +322,8 @@ class CassandraClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
+                    span.hasName(
+                            emitStableDatabaseSemconv() ? scenario.spanName : scenario.oldSpanName)
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -332,19 +333,46 @@ class CassandraClientTest {
                             equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
                             equalTo(NETWORK_PEER_PORT, cassandraPort),
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            // a single-statement batch is not a batch, so it carries the normal
+                            // statement's db.operation and db.cassandra.table; the real batch cases
+                            // do not
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                emitStableDatabaseSemconv() ? scenario.statement : null),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.statement
+                                    : scenario.oldStatement),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv() ? scenario.summary : null))));
+                                emitStableDatabaseSemconv() ? scenario.summary : null),
+                            equalTo(maybeStable(DB_OPERATION), scenario.operation),
+                            equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.table))));
   }
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // a single-statement batch is executed as a normal statement (not a batch): it has the
+            // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
+            // db.operation.batch.size
+            BatchScenario.builder("single")
+                .keyspace("batch_single_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
+                      return new BatchStatement().add(insert.bind("alice", 1));
+                    })
+                .spanName("INSERT batch_single_test.users")
+                .oldSpanName("INSERT batch_single_test.users")
+                .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+                .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+                .summary("INSERT batch_single_test.users")
+                .operation("INSERT")
+                .table("batch_single_test.users")
+                .build(),
             BatchScenario.builder("twoSameOperation")
                 .keyspace("batch_same_test")
                 .buildBatch(
@@ -357,6 +385,7 @@ class CassandraClientTest {
                           .add(insert.bind("bob", 2));
                     })
                 .spanName("BATCH INSERT batch_same_test.users")
+                .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
                 .batchSize(2)
@@ -375,6 +404,7 @@ class CassandraClientTest {
                                   "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
                     })
                 .spanName("BATCH")
+                .oldSpanName("DB Query")
                 .statement(
                     "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
                 .summary("BATCH")
@@ -388,18 +418,26 @@ class CassandraClientTest {
     final String keyspace;
     final Function<Session, BatchStatement> buildBatch;
     final String spanName;
+    final String oldSpanName;
     final String statement;
+    final String oldStatement;
     final String summary;
     final Long batchSize;
+    final String operation;
+    final String table;
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
       this.keyspace = builder.keyspace;
       this.buildBatch = builder.buildBatch;
       this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
       this.statement = builder.statement;
+      this.oldStatement = builder.oldStatement;
       this.summary = builder.summary;
       this.batchSize = builder.batchSize;
+      this.operation = builder.operation;
+      this.table = builder.table;
     }
 
     @Override
@@ -417,9 +455,13 @@ class CassandraClientTest {
       private String keyspace;
       private Function<Session, BatchStatement> buildBatch;
       private String spanName;
+      private String oldSpanName;
       private String statement;
+      private String oldStatement;
       private String summary;
       private Long batchSize;
+      private String operation;
+      private String table;
 
       Builder(String name) {
         this.name = name;
@@ -440,8 +482,18 @@ class CassandraClientTest {
         return this;
       }
 
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
       Builder statement(String statement) {
         this.statement = statement;
+        return this;
+      }
+
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
         return this;
       }
 
@@ -452,6 +504,16 @@ class CassandraClientTest {
 
       Builder batchSize(long batchSize) {
         this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder operation(String operation) {
+        this.operation = operation;
+        return this;
+      }
+
+      Builder table(String table) {
+        this.table = table;
         return this;
       }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -297,7 +297,8 @@ class CassandraClientTest {
   }
 
   // describes the batch cases: a single-statement batch (which is executed as a normal statement,
-  // not a batch), two statements with the same query, and two statements with different queries. (an
+  // not a batch), two statements with the same query, and two statements with different queries.
+  // (an
   // empty batch is invalid CQL.) batch telemetry (db.operation.batch.size, BATCH span names and
   // summaries) is only emitted under stable database semconv
   @ParameterizedTest

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -368,10 +368,10 @@ class CassandraClientTest {
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch still produces a client span carrying db.operation.batch.size 0, but with
-        // no query text, summary or operation; the span name falls back to the database system name
+        // no query text, summary or operation; the stable span name is BATCH
         BatchScenario.builder("empty")
             .buildBatch(session -> new BatchStatement())
-            .spanName("cassandra")
+            .spanName("BATCH")
             .oldSpanName("DB Query")
             .batchSize(0)
             .build(),

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -367,12 +367,13 @@ class CassandraClientTest {
 
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch still produces a client span, but with no query text, summary,
-        // operation or batch size; the span name falls back to the database system name
+        // an empty batch still produces a client span carrying db.operation.batch.size 0, but with
+        // no query text, summary or operation; the span name falls back to the database system name
         BatchScenario.builder("empty")
             .buildBatch(session -> new BatchStatement())
             .spanName("cassandra")
             .oldSpanName("DB Query")
+            .batchSize(0)
             .build(),
         // a single-statement batch is executed as a normal statement (not a batch): it has the
         // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -43,6 +43,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -295,34 +296,33 @@ class CassandraClientTest {
         SERVER_PORT);
   }
 
-  @Test
-  void batchStatementWithSameQuery() {
+  // describes the batch cases: two statements with the same query, and two statements with
+  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
+  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
+  // names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchStatement(BatchScenario scenario) {
     Session session = cluster.connect();
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
     session.execute(
-        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement preparedStatement =
-        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+        "CREATE KEYSPACE "
+            + scenario.keyspace
+            + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute(
+        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
     testing.waitForTraces(3);
     testing.clearData();
 
-    BatchStatement batchStatement =
-        new BatchStatement()
-            .add(preparedStatement.bind("alice", 1))
-            .add(preparedStatement.bind("bob", 2));
-    session.execute(batchStatement);
+    session.execute(scenario.buildBatch.apply(session));
 
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "BATCH INSERT batch_same_test.users"
-                                : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -334,63 +334,131 @@ class CassandraClientTest {
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
-                                    : null),
+                                emitStableDatabaseSemconv() ? scenario.statement : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT batch_same_test.users"
-                                    : null))));
+                                emitStableDatabaseSemconv() ? scenario.summary : null))));
   }
 
-  @Test
-  void batchStatementWithDifferentQueries() {
-    Session session = cluster.connect();
-    cleanup.deferCleanup(session);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            BatchScenario.builder("twoSameOperation")
+                .keyspace("batch_same_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                      return new BatchStatement()
+                          .add(insert.bind("alice", 1))
+                          .add(insert.bind("bob", 2));
+                    })
+                .spanName("BATCH INSERT batch_same_test.users")
+                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+                .summary("BATCH INSERT batch_same_test.users")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder("twoDifferentOperations")
+                .keyspace("batch_mixed_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      return new BatchStatement()
+                          .add(insert.bind(1))
+                          .add(
+                              new SimpleStatement(
+                                  "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                    })
+                .spanName("BATCH")
+                .statement(
+                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
-    session.execute(
-        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing.waitForTraces(3);
-    testing.clearData();
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<Session, BatchStatement> buildBatch;
+    final String spanName;
+    final String statement;
+    final String summary;
+    final Long batchSize;
 
-    BatchStatement batchStatement =
-        new BatchStatement()
-            .add(insertStatement.bind(1))
-            .add(
-                new SimpleStatement(
-                    "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-    session.execute(batchStatement);
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.statement = builder.statement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
-                            equalTo(SERVER_ADDRESS, cassandraHost),
-                            equalTo(SERVER_PORT, cassandraPort),
-                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
-                            equalTo(NETWORK_PEER_PORT, cassandraPort),
-                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
-                            equalTo(
-                                maybeStable(DB_STATEMENT),
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
-                                    : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(
-                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null))));
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<Session, BatchStatement> buildBatch;
+      private String spanName;
+      private String statement;
+      private String summary;
+      private Long batchSize;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<Session, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   private static Stream<Arguments> provideSyncParameters() {

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -347,132 +347,6 @@ public abstract class AbstractCassandraTest {
         .map(Arguments::of);
   }
 
-  private static final class BatchScenario {
-    final String name;
-    final String keyspace;
-    final Function<CqlSession, BatchStatement> buildBatch;
-    final String spanName;
-    final String oldSpanName;
-    final String statement;
-    final String oldStatement;
-    final String summary;
-    final Long batchSize;
-    final String operation;
-    final String oldOperation;
-    final String collection;
-    final String oldCollection;
-
-    BatchScenario(Builder builder) {
-      this.name = builder.name;
-      this.keyspace = builder.keyspace;
-      this.buildBatch = builder.buildBatch;
-      this.spanName = builder.spanName;
-      this.oldSpanName = builder.oldSpanName;
-      this.statement = builder.statement;
-      this.oldStatement = builder.oldStatement;
-      this.summary = builder.summary;
-      this.batchSize = builder.batchSize;
-      this.operation = builder.operation;
-      this.oldOperation = builder.oldOperation;
-      this.collection = builder.collection;
-      this.oldCollection = builder.oldCollection;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
-
-    static Builder builder(String name) {
-      return new Builder(name);
-    }
-
-    static final class Builder {
-      private final String name;
-      private String keyspace;
-      private Function<CqlSession, BatchStatement> buildBatch;
-      private String spanName;
-      private String oldSpanName;
-      private String statement;
-      private String oldStatement;
-      private String summary;
-      private Long batchSize;
-      private String operation;
-      private String oldOperation;
-      private String collection;
-      private String oldCollection;
-
-      Builder(String name) {
-        this.name = name;
-      }
-
-      Builder keyspace(String keyspace) {
-        this.keyspace = keyspace;
-        return this;
-      }
-
-      Builder buildBatch(Function<CqlSession, BatchStatement> buildBatch) {
-        this.buildBatch = buildBatch;
-        return this;
-      }
-
-      Builder spanName(String spanName) {
-        this.spanName = spanName;
-        return this;
-      }
-
-      Builder oldSpanName(String oldSpanName) {
-        this.oldSpanName = oldSpanName;
-        return this;
-      }
-
-      Builder statement(String statement) {
-        this.statement = statement;
-        return this;
-      }
-
-      Builder oldStatement(String oldStatement) {
-        this.oldStatement = oldStatement;
-        return this;
-      }
-
-      Builder summary(String summary) {
-        this.summary = summary;
-        return this;
-      }
-
-      Builder batchSize(long batchSize) {
-        this.batchSize = batchSize;
-        return this;
-      }
-
-      Builder operation(String operation) {
-        this.operation = operation;
-        return this;
-      }
-
-      Builder oldOperation(String oldOperation) {
-        this.oldOperation = oldOperation;
-        return this;
-      }
-
-      Builder collection(String collection) {
-        this.collection = collection;
-        return this;
-      }
-
-      Builder oldCollection(String oldCollection) {
-        this.oldCollection = oldCollection;
-        return this;
-      }
-
-      BatchScenario build() {
-        return new BatchScenario(this);
-      }
-    }
-  }
-
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideSyncParameters")
   void syncTest(Parameter parameter) {
@@ -727,5 +601,131 @@ public abstract class AbstractCassandraTest {
   protected CqlSessionBuilder addContactPoint(CqlSessionBuilder sessionBuilder) {
     sessionBuilder.addContactPoint(new InetSocketAddress(cassandra.getHost(), cassandraPort));
     return sessionBuilder;
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<CqlSession, BatchStatement> buildBatch;
+    final String spanName;
+    final String oldSpanName;
+    final String statement;
+    final String oldStatement;
+    final String summary;
+    final Long batchSize;
+    final String operation;
+    final String oldOperation;
+    final String collection;
+    final String oldCollection;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
+      this.statement = builder.statement;
+      this.oldStatement = builder.oldStatement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+      this.operation = builder.operation;
+      this.oldOperation = builder.oldOperation;
+      this.collection = builder.collection;
+      this.oldCollection = builder.oldCollection;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<CqlSession, BatchStatement> buildBatch;
+      private String spanName;
+      private String oldSpanName;
+      private String statement;
+      private String oldStatement;
+      private String summary;
+      private Long batchSize;
+      private String operation;
+      private String oldOperation;
+      private String collection;
+      private String oldCollection;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<CqlSession, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder operation(String operation) {
+        this.operation = operation;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder collection(String collection) {
+        this.collection = collection;
+        return this;
+      }
+
+      Builder oldCollection(String oldCollection) {
+        this.oldCollection = oldCollection;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -203,8 +203,7 @@ public abstract class AbstractCassandraTest {
         "CREATE KEYSPACE "
             + scenario.keyspace
             + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute(
-        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
+    session.execute("CREATE TABLE " + scenario.keyspace + ".items ( id int PRIMARY KEY, num int )");
     testing().waitForTraces(3);
     testing().clearData();
 
@@ -290,36 +289,34 @@ public abstract class AbstractCassandraTest {
                 session -> {
                   PreparedStatement insert =
                       session.prepare(
-                          "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
-                  return BatchStatement.newInstance(
-                      DefaultBatchType.LOGGED, insert.bind("alice", 1));
+                          "INSERT INTO batch_single_test.items (id, num) values (?, ?)");
+                  return BatchStatement.newInstance(DefaultBatchType.LOGGED, insert.bind(1, 1));
                 })
-            .spanName("INSERT batch_single_test.users")
-            .oldSpanName("INSERT batch_single_test.users")
-            .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-            .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-            .summary("INSERT batch_single_test.users")
+            .spanName("INSERT batch_single_test.items")
+            .oldSpanName("INSERT batch_single_test.items")
+            .statement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
+            .oldStatement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
+            .summary("INSERT batch_single_test.items")
             .operation("INSERT")
             .oldOperation("INSERT")
-            .collection("batch_single_test.users")
-            .oldCollection("batch_single_test.users")
+            .collection("batch_single_test.items")
+            .oldCollection("batch_single_test.items")
             .build(),
         BatchScenario.builder("twoSameOperation")
             .keyspace("batch_same_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                      session.prepare("INSERT INTO batch_same_test.items (id, num) values (?, ?)");
                   return BatchStatement.newInstance(
-                      DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
+                      DefaultBatchType.LOGGED, insert.bind(1, 1), insert.bind(2, 2));
                 })
-            .spanName("BATCH INSERT batch_same_test.users")
+            .spanName("BATCH INSERT batch_same_test.items")
             .oldSpanName("DB Query")
-            .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
-            .summary("BATCH INSERT batch_same_test.users")
+            .statement("INSERT INTO batch_same_test.items (id, num) values (?, ?)")
+            .summary("BATCH INSERT batch_same_test.items")
             .operation("BATCH INSERT")
-            .collection("batch_same_test.users")
+            .collection("batch_same_test.items")
             .batchSize(2)
             .build(),
         BatchScenario.builder("twoDifferentOperations")
@@ -327,21 +324,20 @@ public abstract class AbstractCassandraTest {
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      session.prepare("INSERT INTO batch_mixed_test.items (id, num) values (4, ?)");
                   return BatchStatement.newInstance(
                       DefaultBatchType.LOGGED,
-                      insert.bind(1),
+                      insert.bind(4),
                       SimpleStatement.newInstance(
-                          "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                          "UPDATE batch_mixed_test.items SET num = 5 WHERE id = 4"));
                 })
             .spanName("BATCH")
             .oldSpanName("DB Query")
             .statement(
-                "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                "INSERT INTO batch_mixed_test.items (id, num) values (4, ?); UPDATE batch_mixed_test.items SET num = ? WHERE id = ?")
             .summary("BATCH")
             .operation("BATCH")
-            .collection("batch_mixed_test.users")
+            .collection("batch_mixed_test.items")
             .batchSize(2)
             .build());
   }

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -71,6 +71,10 @@ public abstract class AbstractCassandraTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractCassandraTest.class);
 
+  // all batch scenarios share a single keyspace + table (recreated per scenario), so batch row ids
+  // can be reused without worrying about collisions from previous scenarios
+  private static final String BATCH_KEYSPACE = "batch_test";
+
   @RegisterExtension protected final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   private GenericContainer<?> cassandra;
@@ -198,12 +202,12 @@ public abstract class AbstractCassandraTest {
     CqlSession session = getSession(null);
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
+    session.execute("DROP KEYSPACE IF EXISTS " + BATCH_KEYSPACE);
     session.execute(
         "CREATE KEYSPACE "
-            + scenario.keyspace
+            + BATCH_KEYSPACE
             + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE " + scenario.keyspace + ".items ( id int PRIMARY KEY, num int )");
+    session.execute("CREATE TABLE " + BATCH_KEYSPACE + ".records ( id int PRIMARY KEY, num int )");
     testing().waitForTraces(3);
     testing().clearData();
 
@@ -275,7 +279,6 @@ public abstract class AbstractCassandraTest {
         // an empty batch still produces a client span, but with no query text, summary,
         // operation or batch size; the span name falls back to the database system name
         BatchScenario.builder("empty")
-            .keyspace("batch_empty_test")
             .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
             .spanName("cassandra")
             .oldSpanName("DB Query")
@@ -284,60 +287,56 @@ public abstract class AbstractCassandraTest {
         // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
         // db.operation.batch.size
         BatchScenario.builder("single")
-            .keyspace("batch_single_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare(
-                          "INSERT INTO batch_single_test.items (id, num) values (?, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (?, ?)");
                   return BatchStatement.newInstance(DefaultBatchType.LOGGED, insert.bind(1, 1));
                 })
-            .spanName("INSERT batch_single_test.items")
-            .oldSpanName("INSERT batch_single_test.items")
-            .statement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
-            .oldStatement("INSERT INTO batch_single_test.items (id, num) values (?, ?)")
-            .summary("INSERT batch_single_test.items")
+            .spanName("INSERT batch_test.records")
+            .oldSpanName("INSERT batch_test.records")
+            .statement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .oldStatement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .summary("INSERT batch_test.records")
             .operation("INSERT")
             .oldOperation("INSERT")
-            .collection("batch_single_test.items")
-            .oldCollection("batch_single_test.items")
+            .collection("batch_test.records")
+            .oldCollection("batch_test.records")
             .build(),
         BatchScenario.builder("twoSameOperation")
-            .keyspace("batch_same_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare("INSERT INTO batch_same_test.items (id, num) values (?, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (?, ?)");
                   return BatchStatement.newInstance(
                       DefaultBatchType.LOGGED, insert.bind(1, 1), insert.bind(2, 2));
                 })
-            .spanName("BATCH INSERT batch_same_test.items")
+            .spanName("BATCH INSERT batch_test.records")
             .oldSpanName("DB Query")
-            .statement("INSERT INTO batch_same_test.items (id, num) values (?, ?)")
-            .summary("BATCH INSERT batch_same_test.items")
+            .statement("INSERT INTO batch_test.records (id, num) values (?, ?)")
+            .summary("BATCH INSERT batch_test.records")
             .operation("BATCH INSERT")
-            .collection("batch_same_test.items")
+            .collection("batch_test.records")
             .batchSize(2)
             .build(),
         BatchScenario.builder("twoDifferentOperations")
-            .keyspace("batch_mixed_test")
             .buildBatch(
                 session -> {
                   PreparedStatement insert =
-                      session.prepare("INSERT INTO batch_mixed_test.items (id, num) values (4, ?)");
+                      session.prepare("INSERT INTO batch_test.records (id, num) values (4, ?)");
                   return BatchStatement.newInstance(
                       DefaultBatchType.LOGGED,
                       insert.bind(4),
                       SimpleStatement.newInstance(
-                          "UPDATE batch_mixed_test.items SET num = 5 WHERE id = 4"));
+                          "UPDATE batch_test.records SET num = 5 WHERE id = 4"));
                 })
             .spanName("BATCH")
             .oldSpanName("DB Query")
             .statement(
-                "INSERT INTO batch_mixed_test.items (id, num) values (4, ?); UPDATE batch_mixed_test.items SET num = ? WHERE id = ?")
+                "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
             .summary("BATCH")
             .operation("BATCH")
-            .collection("batch_mixed_test.items")
+            .collection("batch_test.records")
             .batchSize(2)
             .build());
   }
@@ -600,7 +599,6 @@ public abstract class AbstractCassandraTest {
 
   private static final class BatchScenario {
     final String name;
-    final String keyspace;
     final Function<CqlSession, BatchStatement> buildBatch;
     final String spanName;
     final String oldSpanName;
@@ -615,7 +613,6 @@ public abstract class AbstractCassandraTest {
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
-      this.keyspace = builder.keyspace;
       this.buildBatch = builder.buildBatch;
       this.spanName = builder.spanName;
       this.oldSpanName = builder.oldSpanName;
@@ -641,7 +638,6 @@ public abstract class AbstractCassandraTest {
 
     static final class Builder {
       private final String name;
-      private String keyspace;
       private Function<CqlSession, BatchStatement> buildBatch;
       private String spanName;
       private String oldSpanName;
@@ -656,11 +652,6 @@ public abstract class AbstractCassandraTest {
 
       Builder(String name) {
         this.name = name;
-      }
-
-      Builder keyspace(String keyspace) {
-        this.keyspace = keyspace;
-        return this;
       }
 
       Builder buildBatch(Function<CqlSession, BatchStatement> buildBatch) {

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -276,12 +276,13 @@ public abstract class AbstractCassandraTest {
 
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-        // an empty batch still produces a client span, but with no query text, summary,
-        // operation or batch size; the span name falls back to the database system name
+        // an empty batch still produces a client span carrying db.operation.batch.size 0, but with
+        // no query text, summary or operation; the span name falls back to the database system name
         BatchScenario.builder("empty")
             .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
             .spanName("cassandra")
             .oldSpanName("DB Query")
+            .batchSize(0)
             .build(),
         // a single-statement batch is executed as a normal statement (not a batch): it has the
         // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -271,80 +271,79 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch still produces a client span, but with no query text, summary,
-            // operation or batch size; the span name falls back to the database system name
-            BatchScenario.builder("empty")
-                .keyspace("batch_empty_test")
-                .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
-                .spanName("cassandra")
-                .oldSpanName("DB Query")
-                .build(),
-            // a single-statement batch is executed as a normal statement (not a batch): it has the
-            // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
-            // db.operation.batch.size
-            BatchScenario.builder("single")
-                .keyspace("batch_single_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
-                      return BatchStatement.newInstance(
-                          DefaultBatchType.LOGGED, insert.bind("alice", 1));
-                    })
-                .spanName("INSERT batch_single_test.users")
-                .oldSpanName("INSERT batch_single_test.users")
-                .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-                .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
-                .summary("INSERT batch_single_test.users")
-                .operation("INSERT")
-                .oldOperation("INSERT")
-                .collection("batch_single_test.users")
-                .oldCollection("batch_single_test.users")
-                .build(),
-            BatchScenario.builder("twoSameOperation")
-                .keyspace("batch_same_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
-                      return BatchStatement.newInstance(
-                          DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
-                    })
-                .spanName("BATCH INSERT batch_same_test.users")
-                .oldSpanName("DB Query")
-                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
-                .summary("BATCH INSERT batch_same_test.users")
-                .operation("BATCH INSERT")
-                .collection("batch_same_test.users")
-                .batchSize(2)
-                .build(),
-            BatchScenario.builder("twoDifferentOperations")
-                .keyspace("batch_mixed_test")
-                .buildBatch(
-                    session -> {
-                      PreparedStatement insert =
-                          session.prepare(
-                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-                      return BatchStatement.newInstance(
-                          DefaultBatchType.LOGGED,
-                          insert.bind(1),
-                          SimpleStatement.newInstance(
-                              "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-                    })
-                .spanName("BATCH")
-                .oldSpanName("DB Query")
-                .statement(
-                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
-                .summary("BATCH")
-                .operation("BATCH")
-                .collection("batch_mixed_test.users")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch still produces a client span, but with no query text, summary,
+        // operation or batch size; the span name falls back to the database system name
+        BatchScenario.builder("empty")
+            .keyspace("batch_empty_test")
+            .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
+            .spanName("cassandra")
+            .oldSpanName("DB Query")
+            .build(),
+        // a single-statement batch is executed as a normal statement (not a batch): it has the
+        // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
+        // db.operation.batch.size
+        BatchScenario.builder("single")
+            .keyspace("batch_single_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
+                  return BatchStatement.newInstance(
+                      DefaultBatchType.LOGGED, insert.bind("alice", 1));
+                })
+            .spanName("INSERT batch_single_test.users")
+            .oldSpanName("INSERT batch_single_test.users")
+            .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+            .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+            .summary("INSERT batch_single_test.users")
+            .operation("INSERT")
+            .oldOperation("INSERT")
+            .collection("batch_single_test.users")
+            .oldCollection("batch_single_test.users")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .keyspace("batch_same_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                  return BatchStatement.newInstance(
+                      DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
+                })
+            .spanName("BATCH INSERT batch_same_test.users")
+            .oldSpanName("DB Query")
+            .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+            .summary("BATCH INSERT batch_same_test.users")
+            .operation("BATCH INSERT")
+            .collection("batch_same_test.users")
+            .batchSize(2)
+            .build(),
+        BatchScenario.builder("twoDifferentOperations")
+            .keyspace("batch_mixed_test")
+            .buildBatch(
+                session -> {
+                  PreparedStatement insert =
+                      session.prepare(
+                          "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                  return BatchStatement.newInstance(
+                      DefaultBatchType.LOGGED,
+                      insert.bind(1),
+                      SimpleStatement.newInstance(
+                          "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                })
+            .spanName("BATCH")
+            .oldSpanName("DB Query")
+            .statement(
+                "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+            .summary("BATCH")
+            .operation("BATCH")
+            .collection("batch_mixed_test.users")
+            .batchSize(2)
+            .build());
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -187,10 +187,10 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
   }
 
-  // describes the batch cases: two statements with the same query, and two statements with
-  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
-  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
-  // names and summaries) is only emitted under stable database semconv
+  // describes the batch cases: a single-statement batch (which is executed as a normal statement,
+  // not a batch), two statements with the same query, and two statements with different queries. (an
+  // empty batch is invalid CQL.) batch telemetry (db.operation.batch.size, BATCH span names and
+  // summaries) is only emitted under stable database semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchStatement(BatchScenario scenario) {
@@ -214,7 +214,10 @@ public abstract class AbstractCassandraTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? scenario.spanName
+                                    : scenario.oldSpanName)
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
@@ -230,13 +233,20 @@ public abstract class AbstractCassandraTest {
                                 equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                                 equalTo(
                                     maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv() ? scenario.statement : null),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.statement
+                                        : scenario.oldStatement),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
                                     emitStableDatabaseSemconv() ? scenario.batchSize : null),
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? scenario.summary : null),
+                                // a single-statement batch is not a batch, so it carries the normal
+                                // statement's db.operation and db.cassandra.table; the real batch
+                                // cases do not
+                                equalTo(maybeStable(DB_OPERATION), scenario.operation),
+                                equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.table),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -252,6 +262,27 @@ public abstract class AbstractCassandraTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // a single-statement batch is executed as a normal statement (not a batch): it has the
+            // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
+            // db.operation.batch.size
+            BatchScenario.builder("single")
+                .keyspace("batch_single_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_single_test.users (name, age) values (?, ?)");
+                      return BatchStatement.newInstance(
+                          DefaultBatchType.LOGGED, insert.bind("alice", 1));
+                    })
+                .spanName("INSERT batch_single_test.users")
+                .oldSpanName("INSERT batch_single_test.users")
+                .statement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+                .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
+                .summary("INSERT batch_single_test.users")
+                .operation("INSERT")
+                .table("batch_single_test.users")
+                .build(),
             BatchScenario.builder("twoSameOperation")
                 .keyspace("batch_same_test")
                 .buildBatch(
@@ -263,6 +294,7 @@ public abstract class AbstractCassandraTest {
                           DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
                     })
                 .spanName("BATCH INSERT batch_same_test.users")
+                .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
                 .batchSize(2)
@@ -281,6 +313,7 @@ public abstract class AbstractCassandraTest {
                               "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
                     })
                 .spanName("BATCH")
+                .oldSpanName("DB Query")
                 .statement(
                     "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
                 .summary("BATCH")
@@ -294,18 +327,26 @@ public abstract class AbstractCassandraTest {
     final String keyspace;
     final Function<CqlSession, BatchStatement> buildBatch;
     final String spanName;
+    final String oldSpanName;
     final String statement;
+    final String oldStatement;
     final String summary;
     final Long batchSize;
+    final String operation;
+    final String table;
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
       this.keyspace = builder.keyspace;
       this.buildBatch = builder.buildBatch;
       this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
       this.statement = builder.statement;
+      this.oldStatement = builder.oldStatement;
       this.summary = builder.summary;
       this.batchSize = builder.batchSize;
+      this.operation = builder.operation;
+      this.table = builder.table;
     }
 
     @Override
@@ -323,9 +364,13 @@ public abstract class AbstractCassandraTest {
       private String keyspace;
       private Function<CqlSession, BatchStatement> buildBatch;
       private String spanName;
+      private String oldSpanName;
       private String statement;
+      private String oldStatement;
       private String summary;
       private Long batchSize;
+      private String operation;
+      private String table;
 
       Builder(String name) {
         this.name = name;
@@ -346,8 +391,18 @@ public abstract class AbstractCassandraTest {
         return this;
       }
 
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
       Builder statement(String statement) {
         this.statement = statement;
+        return this;
+      }
+
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
         return this;
       }
 
@@ -358,6 +413,16 @@ public abstract class AbstractCassandraTest {
 
       Builder batchSize(long batchSize) {
         this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder operation(String operation) {
+        this.operation = operation;
+        return this;
+      }
+
+      Builder table(String table) {
+        this.table = table;
         return this;
       }
 

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -318,7 +318,7 @@ public abstract class AbstractCassandraTest {
                 .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
-                .operation("BATCH INSERT batch_same_test.users")
+                .operation("BATCH INSERT")
                 .collection("batch_same_test.users")
                 .batchSize(2)
                 .build(),

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -277,10 +277,10 @@ public abstract class AbstractCassandraTest {
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch still produces a client span carrying db.operation.batch.size 0, but with
-        // no query text, summary or operation; the span name falls back to the database system name
+        // no query text, summary or operation; the stable span name is BATCH
         BatchScenario.builder("empty")
             .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
-            .spanName("cassandra")
+            .spanName("BATCH")
             .oldSpanName("DB Query")
             .batchSize(0)
             .build(),

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -243,11 +243,21 @@ public abstract class AbstractCassandraTest {
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? scenario.summary : null),
-                                // a single-statement batch is not a batch, so it carries the normal
-                                // statement's db.operation and db.cassandra.table; the real batch
-                                // cases do not
-                                equalTo(maybeStable(DB_OPERATION), scenario.operation),
-                                equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.table),
+                                // under stable semconv a batch carries db.operation.name (BATCH,
+                                // or BATCH <operation> when all statements share one operation) and
+                                // db.collection.name (when all statements share one collection); a
+                                // single-statement batch is not a batch, so it carries the normal
+                                // statement's db.operation.name and db.cassandra.table
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.operation
+                                        : scenario.oldOperation),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_TABLE),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.collection
+                                        : scenario.oldCollection),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -290,7 +300,9 @@ public abstract class AbstractCassandraTest {
                 .oldStatement("INSERT INTO batch_single_test.users (name, age) values (?, ?)")
                 .summary("INSERT batch_single_test.users")
                 .operation("INSERT")
-                .table("batch_single_test.users")
+                .oldOperation("INSERT")
+                .collection("batch_single_test.users")
+                .oldCollection("batch_single_test.users")
                 .build(),
             BatchScenario.builder("twoSameOperation")
                 .keyspace("batch_same_test")
@@ -306,6 +318,8 @@ public abstract class AbstractCassandraTest {
                 .oldSpanName("DB Query")
                 .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
                 .summary("BATCH INSERT batch_same_test.users")
+                .operation("BATCH INSERT batch_same_test.users")
+                .collection("batch_same_test.users")
                 .batchSize(2)
                 .build(),
             BatchScenario.builder("twoDifferentOperations")
@@ -326,6 +340,8 @@ public abstract class AbstractCassandraTest {
                 .statement(
                     "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
                 .summary("BATCH")
+                .operation("BATCH")
+                .collection("batch_mixed_test.users")
                 .batchSize(2)
                 .build())
         .map(Arguments::of);
@@ -342,7 +358,9 @@ public abstract class AbstractCassandraTest {
     final String summary;
     final Long batchSize;
     final String operation;
-    final String table;
+    final String oldOperation;
+    final String collection;
+    final String oldCollection;
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
@@ -355,7 +373,9 @@ public abstract class AbstractCassandraTest {
       this.summary = builder.summary;
       this.batchSize = builder.batchSize;
       this.operation = builder.operation;
-      this.table = builder.table;
+      this.oldOperation = builder.oldOperation;
+      this.collection = builder.collection;
+      this.oldCollection = builder.oldCollection;
     }
 
     @Override
@@ -379,7 +399,9 @@ public abstract class AbstractCassandraTest {
       private String summary;
       private Long batchSize;
       private String operation;
-      private String table;
+      private String oldOperation;
+      private String collection;
+      private String oldCollection;
 
       Builder(String name) {
         this.name = name;
@@ -430,8 +452,18 @@ public abstract class AbstractCassandraTest {
         return this;
       }
 
-      Builder table(String table) {
-        this.table = table;
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder collection(String collection) {
+        this.collection = collection;
+        return this;
+      }
+
+      Builder oldCollection(String oldCollection) {
+        this.oldCollection = oldCollection;
         return this;
       }
 

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -262,6 +262,14 @@ public abstract class AbstractCassandraTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch still produces a client span, but with no query text, summary,
+            // operation or batch size; the span name falls back to the database system name
+            BatchScenario.builder("empty")
+                .keyspace("batch_empty_test")
+                .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
+                .spanName("cassandra")
+                .oldSpanName("DB Query")
+                .build(),
             // a single-statement batch is executed as a normal statement (not a batch): it has the
             // normal INSERT span name in both modes, db.operation and db.cassandra.table, and no
             // db.operation.batch.size

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -50,6 +50,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeAll;
@@ -186,36 +187,34 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
   }
 
-  @Test
-  void batchStatementWithSameQuery() {
+  // describes the batch cases: two statements with the same query, and two statements with
+  // different queries. (an empty batch is invalid CQL, and a single-statement batch is executed as
+  // a normal statement rather than a batch.) batch telemetry (db.operation.batch.size, BATCH span
+  // names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchStatement(BatchScenario scenario) {
     CqlSession session = getSession(null);
     cleanup.deferCleanup(session);
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_same_test");
+    session.execute("DROP KEYSPACE IF EXISTS " + scenario.keyspace);
     session.execute(
-        "CREATE KEYSPACE batch_same_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_same_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement preparedStatement =
-        session.prepare("INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+        "CREATE KEYSPACE "
+            + scenario.keyspace
+            + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute(
+        "CREATE TABLE " + scenario.keyspace + ".users ( name text PRIMARY KEY, age int )");
     testing().waitForTraces(3);
     testing().clearData();
 
-    BatchStatement batchStatement =
-        BatchStatement.newInstance(
-            DefaultBatchType.LOGGED,
-            preparedStatement.bind("alice", 1),
-            preparedStatement.bind("bob", 2));
-    session.execute(batchStatement);
+    session.execute(scenario.buildBatch.apply(session));
 
     testing()
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT batch_same_test.users"
-                                    : "DB Query")
+                        span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : "DB Query")
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
@@ -231,17 +230,13 @@ public abstract class AbstractCassandraTest {
                                 equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                                 equalTo(
                                     maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO batch_same_test.users (name, age) values (?, ?)"
-                                        : null),
+                                    emitStableDatabaseSemconv() ? scenario.statement : null),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null),
+                                    emitStableDatabaseSemconv() ? scenario.batchSize : null),
                                 equalTo(
                                     DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv()
-                                        ? "BATCH INSERT batch_same_test.users"
-                                        : null),
+                                    emitStableDatabaseSemconv() ? scenario.summary : null),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -255,68 +250,121 @@ public abstract class AbstractCassandraTest {
                                     maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
   }
 
-  @Test
-  void batchStatementWithDifferentQueries() {
-    CqlSession session = getSession(null);
-    cleanup.deferCleanup(session);
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            BatchScenario.builder("twoSameOperation")
+                .keyspace("batch_same_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_same_test.users (name, age) values (?, ?)");
+                      return BatchStatement.newInstance(
+                          DefaultBatchType.LOGGED, insert.bind("alice", 1), insert.bind("bob", 2));
+                    })
+                .spanName("BATCH INSERT batch_same_test.users")
+                .statement("INSERT INTO batch_same_test.users (name, age) values (?, ?)")
+                .summary("BATCH INSERT batch_same_test.users")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder("twoDifferentOperations")
+                .keyspace("batch_mixed_test")
+                .buildBatch(
+                    session -> {
+                      PreparedStatement insert =
+                          session.prepare(
+                              "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
+                      return BatchStatement.newInstance(
+                          DefaultBatchType.LOGGED,
+                          insert.bind(1),
+                          SimpleStatement.newInstance(
+                              "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
+                    })
+                .spanName("BATCH")
+                .statement(
+                    "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
 
-    session.execute("DROP KEYSPACE IF EXISTS batch_mixed_test");
-    session.execute(
-        "CREATE KEYSPACE batch_mixed_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
-    session.execute("CREATE TABLE batch_mixed_test.users ( name text PRIMARY KEY, age int )");
-    PreparedStatement insertStatement =
-        session.prepare("INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?)");
-    testing().waitForTraces(3);
-    testing().clearData();
+  private static final class BatchScenario {
+    final String name;
+    final String keyspace;
+    final Function<CqlSession, BatchStatement> buildBatch;
+    final String spanName;
+    final String statement;
+    final String summary;
+    final Long batchSize;
 
-    BatchStatement batchStatement =
-        BatchStatement.newInstance(
-            DefaultBatchType.LOGGED,
-            insertStatement.bind(1),
-            SimpleStatement.newInstance(
-                "UPDATE batch_mixed_test.users SET age = 2 WHERE name = 'alice'"));
-    session.execute(batchStatement);
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.keyspace = builder.keyspace;
+      this.buildBatch = builder.buildBatch;
+      this.spanName = builder.spanName;
+      this.statement = builder.statement;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
 
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "DB Query")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasNoParent()
-                            .hasAttributesSatisfyingExactly(
-                                satisfies(
-                                    NETWORK_TYPE,
-                                    emitStableDatabaseSemconv()
-                                        ? val -> val.isNull()
-                                        : val -> val.isIn("ipv4", "ipv6")),
-                                equalTo(SERVER_ADDRESS, cassandraHost),
-                                equalTo(SERVER_PORT, cassandraPort),
-                                equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
-                                equalTo(NETWORK_PEER_PORT, cassandraPort),
-                                equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO batch_mixed_test.users (name, age) values ('alice', ?); UPDATE batch_mixed_test.users SET age = ? WHERE name = ?"
-                                        : null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
-                                equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
-                                equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
-                                satisfies(
-                                    maybeStable(DB_CASSANDRA_COORDINATOR_ID),
-                                    val -> val.isInstanceOf(String.class)),
-                                satisfies(
-                                    maybeStable(DB_CASSANDRA_IDEMPOTENCE),
-                                    val -> val.isInstanceOf(Boolean.class)),
-                                equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
-                                equalTo(
-                                    maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT), 0))));
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    static final class Builder {
+      private final String name;
+      private String keyspace;
+      private Function<CqlSession, BatchStatement> buildBatch;
+      private String spanName;
+      private String statement;
+      private String summary;
+      private Long batchSize;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder keyspace(String keyspace) {
+        this.keyspace = keyspace;
+        return this;
+      }
+
+      Builder buildBatch(Function<CqlSession, BatchStatement> buildBatch) {
+        this.buildBatch = buildBatch;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -188,7 +188,8 @@ public abstract class AbstractCassandraTest {
   }
 
   // describes the batch cases: a single-statement batch (which is executed as a normal statement,
-  // not a batch), two statements with the same query, and two statements with different queries. (an
+  // not a batch), two statements with the same query, and two statements with different queries.
+  // (an
   // empty batch is invalid CQL.) batch telemetry (db.operation.batch.size, BATCH span names and
   // summaries) is only emitted under stable database semconv
   @ParameterizedTest

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/AbstractRpcClientInstrumentation.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/AbstractRpcClientInstrumentation.java
@@ -24,6 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
 import org.apache.hbase.thirdparty.com.google.protobuf.Descriptors;
 
 class AbstractRpcClientInstrumentation implements TypeInstrumentation {
@@ -51,6 +52,7 @@ class AbstractRpcClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static RequestAndContext onEnter(
         @Advice.Argument(0) Descriptors.MethodDescriptor md,
+        @Advice.Argument(2) Object param,
         @Advice.Argument(4) User ticket,
         @Advice.Argument(5) Object addr) {
       String hostname = null;
@@ -65,7 +67,8 @@ class AbstractRpcClientInstrumentation implements TypeInstrumentation {
         hostname = address.getHostString();
       }
       HbaseRequest request =
-          HbaseRequest.create(md.getName(), getTableName(), ticket.getName(), hostname, port);
+          HbaseRequest.create(
+              md.getName(), getTableName(), ticket.getName(), hostname, port, getBatchSize(param));
       Context parentContext = Java8BytecodeBridge.currentContext();
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
@@ -75,6 +78,19 @@ class AbstractRpcClientInstrumentation implements TypeInstrumentation {
       RequestAndContext requestAndContext = RequestAndContext.create(request, scope, context);
       setRequestAndContext(requestAndContext);
       return requestAndContext;
+    }
+
+    @Nullable
+    public static Long getBatchSize(Object param) {
+      if (!(param instanceof ClientProtos.MultiRequest)) {
+        return null;
+      }
+      long batchSize = 0;
+      for (ClientProtos.RegionAction regionAction :
+          ((ClientProtos.MultiRequest) param).getRegionActionList()) {
+        batchSize += regionAction.getActionCount();
+      }
+      return batchSize > 1 ? batchSize : null;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseAttributesGetter.java
@@ -64,6 +64,12 @@ final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseReque
 
   @Nullable
   @Override
+  public Long getDbOperationBatchSize(HbaseRequest hbaseRequest) {
+    return hbaseRequest.getBatchSize();
+  }
+
+  @Nullable
+  @Override
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       HbaseRequest request, @Nullable Void unused) {
     if (request.getHost() == null || request.getPort() == null) {

--- a/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseRequest.java
+++ b/instrumentation/hbase-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/v2_0/HbaseRequest.java
@@ -17,8 +17,9 @@ public abstract class HbaseRequest {
       @Nullable TableName tableName,
       @Nullable String user,
       @Nullable String host,
-      @Nullable Integer port) {
-    return new AutoValue_HbaseRequest(operation, tableName, user, host, port);
+      @Nullable Integer port,
+      @Nullable Long batchSize) {
+    return new AutoValue_HbaseRequest(operation, tableName, user, host, port, batchSize);
   }
 
   @Nullable
@@ -35,4 +36,7 @@ public abstract class HbaseRequest {
 
   @Nullable
   public abstract Integer getPort();
+
+  @Nullable
+  public abstract Long getBatchSize();
 }

--- a/instrumentation/hbase-client-2.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
+++ b/instrumentation/hbase-client-2.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
@@ -23,6 +24,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -41,6 +43,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -59,6 +62,7 @@ import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
@@ -71,6 +75,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
@@ -98,7 +104,6 @@ public abstract class AbstractHbaseTest {
   private static final int GET_TIMEOUT_OPERATION_TIMEOUT_MILLIS = 1000;
   private static final int GET_TIMEOUT_RPC_TIMEOUT_MILLIS = 200;
   private static final String ROW_1 = "row1";
-  private static final String ROW_2 = "row2";
   private static final String ROW_3 = "row3";
   private static final String ROW_4 = "row4";
   private static final String ROW_5 = "row5";
@@ -354,47 +359,100 @@ public abstract class AbstractHbaseTest {
     testing().waitAndAssertTraces(traceAssertConsumer(TABLE_NAME, SCAN, REGION_SERVER_PORT, true));
   }
 
-  @Test
-  void testBatchGet() throws IOException {
-    Result[] results;
+  // describes the batch cases: empty, single action, two actions with the same type, and two
+  // actions with different types. HBase reports all non-empty Table.batch(...) calls as Multi;
+  // db.operation.batch.size is emitted only when there are multiple actions under stable database
+  // semconv.
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void testBatch(BatchScenario scenario) throws IOException, InterruptedException {
+    Object[] results = new Object[scenario.actions.size()];
     try (Table table = connection.getTable(TABLE_NAME)) {
-      List<Get> getList = new ArrayList<>();
-      getList.add(new Get(Bytes.toBytes(ROW_1)));
-      getList.add(new Get(Bytes.toBytes(ROW_2)));
-      getList.add(new Get(Bytes.toBytes(ROW_5)));
-      results = table.get(getList);
+      table.batch(scenario.actions, results);
     }
-    assertThat(results).hasSize(3);
-    {
-      assertThat(Bytes.toString(results[0].getRow())).isEqualTo(ROW_1);
-      assertThat(value(results[0], "col1")).isEqualTo("col1_val_1");
-      assertThat(value(results[0], "col2")).isEqualTo("col2_val_1");
+    scenario.resultAssertions.accept(results);
+
+    if (scenario.empty) {
+      assertThat(testing().spans()).isEmpty();
+      return;
     }
-    {
-      assertThat(Bytes.toString(results[1].getRow())).isNull();
-      assertThat(value(results[1], "col1")).isNull();
-      assertThat(value(results[1], "col2")).isNull();
-    }
-    {
-      assertThat(Bytes.toString(results[2].getRow())).isNull();
-      assertThat(value(results[2], "col1")).isNull();
-      assertThat(value(results[2], "col2")).isNull();
-    }
-    testing().waitAndAssertTraces(traceAssertConsumer(TABLE_NAME, MULTI, REGION_SERVER_PORT, true));
+
+    testing()
+        .waitAndAssertTraces(
+            scenario.batchSize != null
+                ? traceAssertConsumer(
+                    TABLE_NAME,
+                    scenario.operation,
+                    REGION_SERVER_PORT,
+                    true,
+                    scenario.batchSize.intValue())
+                : traceAssertConsumer(TABLE_NAME, scenario.operation, REGION_SERVER_PORT, true));
   }
 
-  @Test
-  void testBatchPut() throws IOException {
-    try (Table table = connection.getTable(TABLE_NAME)) {
-      List<Put> putList = new ArrayList<>();
-      for (int i = 2; i < 5; i++) {
-        Put put = new Put(Bytes.toBytes("batch-put-row" + i));
-        put.addColumn(COLUMN_FAMILY, Bytes.toBytes("col1"), Bytes.toBytes("col1_val_" + i));
-        putList.add(put);
-      }
-      table.put(putList);
-    }
-    testing().waitAndAssertTraces(traceAssertConsumer(TABLE_NAME, MULTI, REGION_SERVER_PORT, true));
+  private static Stream<BatchScenario> batchScenarios() {
+    return Stream.of(
+        // an empty batch produces no span
+        BatchScenario.builder("empty").empty().build(),
+        // a single-action batch is sent as Multi but is not a batch for db.operation.batch.size
+        BatchScenario.builder("single")
+            .actions(get(ROW_1))
+            .results(
+                results -> {
+                  assertThat(results).hasSize(1);
+                  assertExistingRow(result(results[0]), ROW_1, "col1_val_1", "col2_val_1");
+                })
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .actions(get(ROW_1), get(ROW_5))
+            .batchSize(2)
+            .results(
+                results -> {
+                  assertThat(results).hasSize(2);
+                  assertExistingRow(result(results[0]), ROW_1, "col1_val_1", "col2_val_1");
+                  assertMissingRow(result(results[1]));
+                })
+            .build(),
+        BatchScenario.builder("twoDifferentOperations")
+            .actions(put("batch-matrix-put-row"), get(ROW_1))
+            .batchSize(2)
+            .results(
+                results -> {
+                  assertThat(results).hasSize(2);
+                  assertExistingRow(result(results[1]), ROW_1, "col1_val_1", "col2_val_1");
+                })
+            .build());
+  }
+
+  private static List<Row> batchActions(Row... rows) {
+    return asList(rows);
+  }
+
+  private static Get get(String rowKey) {
+    return new Get(Bytes.toBytes(rowKey));
+  }
+
+  private static Put put(String rowKey) {
+    Put put = new Put(Bytes.toBytes(rowKey));
+    put.addColumn(COLUMN_FAMILY, Bytes.toBytes("col1"), Bytes.toBytes("col1_val"));
+    return put;
+  }
+
+  private static Result result(Object result) {
+    assertThat(result).isInstanceOf(Result.class);
+    return (Result) result;
+  }
+
+  private static void assertExistingRow(
+      Result result, String rowKey, String col1Value, String col2Value) {
+    assertThat(Bytes.toString(result.getRow())).isEqualTo(rowKey);
+    assertThat(value(result, "col1")).isEqualTo(col1Value);
+    assertThat(value(result, "col2")).isEqualTo(col2Value);
+  }
+
+  private static void assertMissingRow(Result result) {
+    assertThat(Bytes.toString(result.getRow())).isNull();
+    assertThat(value(result, "col1")).isNull();
+    assertThat(value(result, "col2")).isNull();
   }
 
   @Test
@@ -487,7 +545,7 @@ public abstract class AbstractHbaseTest {
     }
     testing()
         .waitAndAssertTraces(
-            traceAssertConsumer(TABLE_NAME, MULTI, REGION_SERVER_PORT, true),
+            traceAssertConsumer(TABLE_NAME, MULTI, REGION_SERVER_PORT, true, 2),
             traceAssertConsumer(TABLE_NAME, GET, REGION_SERVER_PORT, true));
   }
 
@@ -526,6 +584,21 @@ public abstract class AbstractHbaseTest {
 
   protected Consumer<TraceAssert> traceAssertConsumer(
       TableName table, String operation, int port, boolean hasTable) {
+    return traceAssertConsumer(table, operation, port, hasTable, false, 0);
+  }
+
+  protected Consumer<TraceAssert> traceAssertConsumer(
+      TableName table, String operation, int port, boolean hasTable, int batchSize) {
+    return traceAssertConsumer(table, operation, port, hasTable, true, batchSize);
+  }
+
+  private Consumer<TraceAssert> traceAssertConsumer(
+      TableName table,
+      String operation,
+      int port,
+      boolean hasTable,
+      boolean hasBatchSize,
+      int batchSize) {
     String spanName;
     if (hasTable) {
       spanName = operation + " " + table.getNameAsString();
@@ -544,6 +617,11 @@ public abstract class AbstractHbaseTest {
                         equalTo(maybeStable(DB_OPERATION), operation),
                         equalTo(maybeStable(DB_NAME), dbNamespace(table, hasTable)),
                         equalTo(DB_COLLECTION_NAME, dbCollectionName(table, hasTable)),
+                        equalTo(
+                            DB_OPERATION_BATCH_SIZE,
+                            emitStableDatabaseSemconv() && hasBatchSize
+                                ? Long.valueOf(batchSize)
+                                : null),
                         equalTo(SERVER_ADDRESS, hostname),
                         equalTo(SERVER_PORT, port),
                         satisfies(
@@ -568,5 +646,69 @@ public abstract class AbstractHbaseTest {
       return table.getNameAsString();
     }
     return null;
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Row> actions;
+    final String operation;
+    final Long batchSize;
+    final boolean empty;
+    final Consumer<Object[]> resultAssertions;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.actions = builder.actions;
+      this.operation = MULTI;
+      this.batchSize = builder.batchSize;
+      this.empty = builder.empty;
+      this.resultAssertions = builder.resultAssertions;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static final class Builder {
+      private final String name;
+      private List<Row> actions = batchActions();
+      private Long batchSize;
+      private boolean empty;
+      private Consumer<Object[]> resultAssertions = results -> assertThat(results).isEmpty();
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder actions(Row... actions) {
+        this.actions = batchActions(actions);
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder empty() {
+        this.empty = true;
+        return this;
+      }
+
+      Builder results(Consumer<Object[]> resultAssertions) {
+        this.resultAssertions = resultAssertions;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
@@ -77,6 +77,8 @@ public class JdbcAdviceScope {
 
   @Nullable
   private static DbRequest createBatchRequest(Statement statement) {
+    // reaching here means executeBatch()/executeLargeBatch() was called, so this is always a batch
+    // execution; an empty batch (no addBatch() calls) reports db.operation.batch.size 0
     if (statement instanceof PreparedStatement) {
       String sql = JdbcData.PREPARED_STATEMENT.get((PreparedStatement) statement);
       if (sql == null) {
@@ -84,11 +86,11 @@ public class JdbcAdviceScope {
       }
       Long batchSize = JdbcData.getPreparedStatementBatchSize((PreparedStatement) statement);
       Map<String, String> parameters = JdbcData.getParameters((PreparedStatement) statement);
-      return DbRequest.create(statement, sql, batchSize, parameters, true);
+      return DbRequest.create(statement, sql, batchSize != null ? batchSize : 0L, parameters, true);
     } else {
       JdbcData.StatementBatchInfo batchInfo = JdbcData.getStatementBatchInfo(statement);
       if (batchInfo == null) {
-        return DbRequest.create(statement, emptyList(), null, false);
+        return DbRequest.create(statement, emptyList(), 0L, false);
       } else {
         return DbRequest.create(
             statement, batchInfo.getQueryTexts(), batchInfo.getBatchSize(), false);

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAdviceScope.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.jdbc;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.jdbc.JdbcSingletons.statementInstrumenter;
+import static java.util.Collections.emptyList;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -87,7 +88,7 @@ public class JdbcAdviceScope {
     } else {
       JdbcData.StatementBatchInfo batchInfo = JdbcData.getStatementBatchInfo(statement);
       if (batchInfo == null) {
-        return DbRequest.create(statement, null);
+        return DbRequest.create(statement, emptyList(), null, false);
       } else {
         return DbRequest.create(
             statement, batchInfo.getQueryTexts(), batchInfo.getBatchSize(), false);

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1879,10 +1879,11 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasParent(trace.getSpan(0))));
   }
 
-  // describes the four batch cases: the tables to create, the statements added to the batch, the
-  // expected executeBatch() result, and the expected client span. batch telemetry comes from the
-  // shared SQL extractors and is database-agnostic, so a single (in-memory) database is enough to
-  // lock down its shape
+  // describes the four batch cases: the statements added to the batch, the expected
+  // executeBatch() result, and the expected client span. each scenario runs against a freshly
+  // recreated items table, so batch row ids can be reused across scenarios. batch telemetry comes
+  // from the shared SQL extractors and is database-agnostic, so a single (in-memory) database is
+  // enough to lock down its shape
   static Stream<BatchScenario> batchCasesStream() {
     return Stream.of(
         // an empty batch still produces a client span, but with no query text or batch size;
@@ -1896,7 +1897,6 @@ public abstract class AbstractJdbcInstrumentationTest {
         // statement and carries db.statement/db.operation/db.sql.table under old semconv
         BatchScenario.builder()
             .name("single")
-            .createTable("items")
             .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
             .expectedResult(1)
             .spanName("INSERT items")
@@ -1912,9 +1912,8 @@ public abstract class AbstractJdbcInstrumentationTest {
         // name falls back to the namespace
         BatchScenario.builder()
             .name("twoSameOperation")
-            .createTable("items")
+            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
             .addQuery("INSERT INTO items (id, num) VALUES (2, 2)")
-            .addQuery("INSERT INTO items (id, num) VALUES (3, 3)")
             .expectedResult(1, 1)
             .spanName("BATCH INSERT items")
             .oldSpanName(DATABASE_NAME_LOWER)
@@ -1927,9 +1926,8 @@ public abstract class AbstractJdbcInstrumentationTest {
         // statement-level attributes and the span name falls back to the namespace
         BatchScenario.builder()
             .name("twoDifferentOperations")
-            .createTable("items")
-            .addQuery("INSERT INTO items (id, num) VALUES (4, 4)")
-            .addQuery("UPDATE items SET num = 5 WHERE id = 4")
+            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
+            .addQuery("UPDATE items SET num = 5 WHERE id = 1")
             .expectedResult(1, 1)
             .spanName("BATCH")
             .oldSpanName(DATABASE_NAME_LOWER)
@@ -1946,18 +1944,17 @@ public abstract class AbstractJdbcInstrumentationTest {
     Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
     cleanup.deferCleanup(connection);
 
-    for (String table : scenario.tablesToCreate) {
-      Statement createTable = connection.createStatement();
-      createTable.execute(
-          "CREATE TABLE IF NOT EXISTS "
-              + table
-              + " (id INTEGER not NULL, num INTEGER, PRIMARY KEY ( id ))");
-      cleanup.deferCleanup(createTable);
-    }
-    if (!scenario.tablesToCreate.isEmpty()) {
-      testing().waitForTraces(scenario.tablesToCreate.size());
-      testing().clearData();
-    }
+    // recreate a fresh items table for each scenario so that batch row ids can be reused without
+    // worrying about collisions from previous scenarios
+    Statement dropTable = connection.createStatement();
+    dropTable.execute("DROP TABLE IF EXISTS items");
+    cleanup.deferCleanup(dropTable);
+    Statement createTable = connection.createStatement();
+    createTable.execute(
+        "CREATE TABLE items (id INTEGER not NULL, num INTEGER, PRIMARY KEY ( id ))");
+    cleanup.deferCleanup(createTable);
+    testing().waitForTraces(2);
+    testing().clearData();
 
     Statement statement = connection.createStatement();
     cleanup.deferCleanup(statement);
@@ -2406,7 +2403,6 @@ public abstract class AbstractJdbcInstrumentationTest {
 
   private static final class BatchScenario {
     final String name;
-    final List<String> tablesToCreate;
     final List<String> statementsToAdd;
     final int[] expectedResult;
     final String spanName;
@@ -2420,7 +2416,6 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     BatchScenario(Builder builder) {
       this.name = builder.name;
-      this.tablesToCreate = builder.tablesToCreate;
       this.statementsToAdd = builder.statementsToAdd;
       this.expectedResult = builder.expectedResult;
       this.spanName = builder.spanName;
@@ -2445,7 +2440,6 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     static final class Builder {
       private String name;
-      private final List<String> tablesToCreate = new ArrayList<>();
       private final List<String> statementsToAdd = new ArrayList<>();
       private int[] expectedResult = new int[] {};
       private String spanName;
@@ -2459,11 +2453,6 @@ public abstract class AbstractJdbcInstrumentationTest {
 
       Builder name(String name) {
         this.name = name;
-        return this;
-      }
-
-      Builder createTable(String table) {
-        this.tablesToCreate.add(table);
         return this;
       }
 

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
-import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -1887,18 +1886,30 @@ public abstract class AbstractJdbcInstrumentationTest {
   static Stream<Arguments> batchCasesStream() {
     return Stream.of(
             // an empty batch still produces a client span, but with no query text or batch size;
-            // the span name falls back to the database namespace
-            BatchScenario.builder().name("empty").spanName(DATABASE_NAME_LOWER).build(),
-            // a single-statement batch is not a batch (size 1), so it looks like a normal statement
+            // the span name falls back to the database namespace in both modes
+            BatchScenario.builder()
+                .name("empty")
+                .spanName(DATABASE_NAME_LOWER)
+                .oldSpanName(DATABASE_NAME_LOWER)
+                .build(),
+            // a single-statement batch is not a batch (size 1), so it looks like a normal
+            // statement and carries db.statement/db.operation/db.sql.table under old semconv
             BatchScenario.builder()
                 .name("single")
                 .createTable("stmt_batch_single")
                 .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
                 .expectedResult(1)
                 .spanName("INSERT stmt_batch_single")
+                .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".stmt_batch_single")
                 .queryText("INSERT INTO stmt_batch_single VALUES(?)")
+                .oldStatement("INSERT INTO stmt_batch_single VALUES(?)")
                 .summary("INSERT stmt_batch_single")
+                .oldOperation("INSERT")
+                .oldTable("stmt_batch_single")
                 .build(),
+            // a multi-statement batch only emits db.query.text/summary and BATCH span name under
+            // stable semconv; under old semconv it has no statement-level attributes and the span
+            // name falls back to the namespace
             BatchScenario.builder()
                 .name("twoSameOperation")
                 .createTable("stmt_batch_same")
@@ -1906,6 +1917,7 @@ public abstract class AbstractJdbcInstrumentationTest {
                 .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
                 .expectedResult(1, 1)
                 .spanName("BATCH INSERT stmt_batch_same")
+                .oldSpanName(DATABASE_NAME_LOWER)
                 .queryText("INSERT INTO stmt_batch_same VALUES(?)")
                 .summary("BATCH INSERT stmt_batch_same")
                 .batchSize(2)
@@ -1918,6 +1930,7 @@ public abstract class AbstractJdbcInstrumentationTest {
                 .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
                 .expectedResult(1, 1)
                 .spanName("BATCH")
+                .oldSpanName(DATABASE_NAME_LOWER)
                 .queryText(
                     "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
                         + " VALUES(?)")
@@ -1930,10 +1943,6 @@ public abstract class AbstractJdbcInstrumentationTest {
   @ParameterizedTest
   @MethodSource("batchCasesStream")
   void testStatementBatch(BatchScenario scenario) throws SQLException {
-    // batch telemetry (db.operation.batch.size, BATCH span names and summaries) is only emitted
-    // under stable database semconv
-    Assumptions.assumeTrue(emitStableDatabaseSemconv());
-
     Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
     cleanup.deferCleanup(connection);
 
@@ -1964,15 +1973,41 @@ public abstract class AbstractJdbcInstrumentationTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                     span ->
-                        span.hasName(scenario.spanName)
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? scenario.spanName
+                                    : scenario.oldSpanName)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(DB_SYSTEM_NAME, maybeStableDbSystemName("h2")),
-                                equalTo(DB_NAMESPACE, DATABASE_NAME_LOWER),
-                                equalTo(DB_QUERY_TEXT, scenario.queryText),
-                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
-                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize))));
+                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName("h2")),
+                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
+                                equalTo(
+                                    DB_CONNECTION_STRING,
+                                    emitStableDatabaseSemconv() ? null : "h2:mem:"),
+                                // batch telemetry (db.query.summary, BATCH span names and
+                                // db.operation.batch.size) is only emitted under stable semconv;
+                                // under old semconv the statement-level attributes (db.statement,
+                                // db.operation, db.sql.table) are only set for a single-statement
+                                // batch and multi-statement batches fall back to the namespace span
+                                // name
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.queryText
+                                        : scenario.oldStatement),
+                                equalTo(
+                                    DB_QUERY_SUMMARY,
+                                    emitStableDatabaseSemconv() ? scenario.summary : null),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv() ? null : scenario.oldOperation),
+                                equalTo(
+                                    maybeStable(DB_SQL_TABLE),
+                                    emitStableDatabaseSemconv() ? null : scenario.oldTable),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? scenario.batchSize : null))));
   }
 
   static Stream<Arguments> batchStream() throws SQLException {
@@ -2372,8 +2407,12 @@ public abstract class AbstractJdbcInstrumentationTest {
     final List<String> statementsToAdd;
     final int[] expectedResult;
     final String spanName;
+    final String oldSpanName;
     final String queryText;
+    final String oldStatement;
     final String summary;
+    final String oldOperation;
+    final String oldTable;
     final Long batchSize;
 
     BatchScenario(Builder builder) {
@@ -2382,8 +2421,12 @@ public abstract class AbstractJdbcInstrumentationTest {
       this.statementsToAdd = builder.statementsToAdd;
       this.expectedResult = builder.expectedResult;
       this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
       this.queryText = builder.queryText;
+      this.oldStatement = builder.oldStatement;
       this.summary = builder.summary;
+      this.oldOperation = builder.oldOperation;
+      this.oldTable = builder.oldTable;
       this.batchSize = builder.batchSize;
     }
 
@@ -2403,8 +2446,12 @@ public abstract class AbstractJdbcInstrumentationTest {
       private final List<String> statementsToAdd = new ArrayList<>();
       private int[] expectedResult = new int[] {};
       private String spanName;
+      private String oldSpanName;
       private String queryText;
+      private String oldStatement;
       private String summary;
+      private String oldOperation;
+      private String oldTable;
       private Long batchSize;
 
       Builder name(String name) {
@@ -2432,13 +2479,33 @@ public abstract class AbstractJdbcInstrumentationTest {
         return this;
       }
 
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
       Builder queryText(String queryText) {
         this.queryText = queryText;
         return this;
       }
 
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
+        return this;
+      }
+
       Builder summary(String summary) {
         this.summary = summary;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder oldTable(String oldTable) {
+        this.oldTable = oldTable;
         return this;
       }
 

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1896,44 +1896,45 @@ public abstract class AbstractJdbcInstrumentationTest {
         // statement and carries db.statement/db.operation/db.sql.table under old semconv
         BatchScenario.builder()
             .name("single")
-            .createTable("stmt_batch_single")
-            .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
+            .createTable("items")
+            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
             .expectedResult(1)
-            .spanName("INSERT stmt_batch_single")
-            .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".stmt_batch_single")
-            .queryText("INSERT INTO stmt_batch_single VALUES(?)")
-            .oldStatement("INSERT INTO stmt_batch_single VALUES(?)")
-            .summary("INSERT stmt_batch_single")
+            .spanName("INSERT items")
+            .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".items")
+            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
+            .oldStatement("INSERT INTO items (id, num) VALUES (?, ?)")
+            .summary("INSERT items")
             .oldOperation("INSERT")
-            .oldTable("stmt_batch_single")
+            .oldTable("items")
             .build(),
         // a multi-statement batch only emits db.query.text/summary and BATCH span name under
         // stable semconv; under old semconv it has no statement-level attributes and the span
         // name falls back to the namespace
         BatchScenario.builder()
             .name("twoSameOperation")
-            .createTable("stmt_batch_same")
-            .addQuery("INSERT INTO stmt_batch_same VALUES(1)")
-            .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
+            .createTable("items")
+            .addQuery("INSERT INTO items (id, num) VALUES (2, 2)")
+            .addQuery("INSERT INTO items (id, num) VALUES (3, 3)")
             .expectedResult(1, 1)
-            .spanName("BATCH INSERT stmt_batch_same")
+            .spanName("BATCH INSERT items")
             .oldSpanName(DATABASE_NAME_LOWER)
-            .queryText("INSERT INTO stmt_batch_same VALUES(?)")
-            .summary("BATCH INSERT stmt_batch_same")
+            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
+            .summary("BATCH INSERT items")
             .batchSize(2)
             .build(),
+        // a multi-statement batch with different operations has no shared operation or summary,
+        // so db.query.summary (and the span name) is just BATCH; under old semconv it has no
+        // statement-level attributes and the span name falls back to the namespace
         BatchScenario.builder()
             .name("twoDifferentOperations")
-            .createTable("stmt_batch_diff_1")
-            .createTable("stmt_batch_diff_2")
-            .addQuery("INSERT INTO stmt_batch_diff_1 VALUES(1)")
-            .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
+            .createTable("items")
+            .addQuery("INSERT INTO items (id, num) VALUES (4, 4)")
+            .addQuery("UPDATE items SET num = 5 WHERE id = 4")
             .expectedResult(1, 1)
             .spanName("BATCH")
             .oldSpanName(DATABASE_NAME_LOWER)
             .queryText(
-                "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
-                    + " VALUES(?)")
+                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
             .summary("BATCH")
             .batchSize(2)
             .build());
@@ -1947,7 +1948,10 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     for (String table : scenario.tablesToCreate) {
       Statement createTable = connection.createStatement();
-      createTable.execute("CREATE TABLE " + table + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+      createTable.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + table
+              + " (id INTEGER not NULL, num INTEGER, PRIMARY KEY ( id ))");
       cleanup.deferCleanup(createTable);
     }
     if (!scenario.tablesToCreate.isEmpty()) {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1886,11 +1886,11 @@ public abstract class AbstractJdbcInstrumentationTest {
   // is enough to lock down its shape
   static Stream<BatchScenario> batchCasesStream() {
     return Stream.of(
-        // an empty batch still produces a client span carrying db.operation.batch.size 0, but no
-        // query text; the span name falls back to the database namespace in both modes
+        // an empty batch still produces a client span carrying db.operation.batch.size 0 and the
+        // BATCH span name under stable semconv, but no query text
         BatchScenario.builder()
             .name("empty")
-            .spanName(DATABASE_NAME_LOWER)
+            .spanName("BATCH")
             .oldSpanName(DATABASE_NAME_LOWER)
             .batchSize(0)
             .build(),

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1881,9 +1881,9 @@ public abstract class AbstractJdbcInstrumentationTest {
 
   // describes the four batch cases: the statements added to the batch, the expected
   // executeBatch() result, and the expected client span. each scenario runs against a freshly
-  // recreated items table, so batch row ids can be reused across scenarios. batch telemetry comes
-  // from the shared SQL extractors and is database-agnostic, so a single (in-memory) database is
-  // enough to lock down its shape
+  // recreated batch_test table, so batch row ids can be reused across scenarios. batch telemetry
+  // comes from the shared SQL extractors and is database-agnostic, so a single (in-memory) database
+  // is enough to lock down its shape
   static Stream<BatchScenario> batchCasesStream() {
     return Stream.of(
         // an empty batch still produces a client span, but with no query text or batch size;
@@ -1897,28 +1897,28 @@ public abstract class AbstractJdbcInstrumentationTest {
         // statement and carries db.statement/db.operation/db.sql.table under old semconv
         BatchScenario.builder()
             .name("single")
-            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
+            .addQuery("INSERT INTO batch_test (id, num) VALUES (1, 1)")
             .expectedResult(1)
-            .spanName("INSERT items")
-            .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".items")
-            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
-            .oldStatement("INSERT INTO items (id, num) VALUES (?, ?)")
-            .summary("INSERT items")
+            .spanName("INSERT batch_test")
+            .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".batch_test")
+            .queryText("INSERT INTO batch_test (id, num) VALUES (?, ?)")
+            .oldStatement("INSERT INTO batch_test (id, num) VALUES (?, ?)")
+            .summary("INSERT batch_test")
             .oldOperation("INSERT")
-            .oldTable("items")
+            .oldTable("batch_test")
             .build(),
         // a multi-statement batch only emits db.query.text/summary and BATCH span name under
         // stable semconv; under old semconv it has no statement-level attributes and the span
         // name falls back to the namespace
         BatchScenario.builder()
             .name("twoSameOperation")
-            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
-            .addQuery("INSERT INTO items (id, num) VALUES (2, 2)")
+            .addQuery("INSERT INTO batch_test (id, num) VALUES (1, 1)")
+            .addQuery("INSERT INTO batch_test (id, num) VALUES (2, 2)")
             .expectedResult(1, 1)
-            .spanName("BATCH INSERT items")
+            .spanName("BATCH INSERT batch_test")
             .oldSpanName(DATABASE_NAME_LOWER)
-            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
-            .summary("BATCH INSERT items")
+            .queryText("INSERT INTO batch_test (id, num) VALUES (?, ?)")
+            .summary("BATCH INSERT batch_test")
             .batchSize(2)
             .build(),
         // a multi-statement batch with different operations has no shared operation or summary,
@@ -1926,13 +1926,13 @@ public abstract class AbstractJdbcInstrumentationTest {
         // statement-level attributes and the span name falls back to the namespace
         BatchScenario.builder()
             .name("twoDifferentOperations")
-            .addQuery("INSERT INTO items (id, num) VALUES (1, 1)")
-            .addQuery("UPDATE items SET num = 5 WHERE id = 1")
+            .addQuery("INSERT INTO batch_test (id, num) VALUES (1, 1)")
+            .addQuery("UPDATE batch_test SET num = 5 WHERE id = 1")
             .expectedResult(1, 1)
             .spanName("BATCH")
             .oldSpanName(DATABASE_NAME_LOWER)
             .queryText(
-                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
+                "INSERT INTO batch_test (id, num) VALUES (?, ?); UPDATE batch_test SET num = ? WHERE id = ?")
             .summary("BATCH")
             .batchSize(2)
             .build());
@@ -1944,14 +1944,14 @@ public abstract class AbstractJdbcInstrumentationTest {
     Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
     cleanup.deferCleanup(connection);
 
-    // recreate a fresh items table for each scenario so that batch row ids can be reused without
-    // worrying about collisions from previous scenarios
+    // recreate a fresh batch_test table for each scenario so that batch row ids can be reused
+    // without worrying about collisions from previous scenarios
     Statement dropTable = connection.createStatement();
-    dropTable.execute("DROP TABLE IF EXISTS items");
+    dropTable.execute("DROP TABLE IF EXISTS batch_test");
     cleanup.deferCleanup(dropTable);
     Statement createTable = connection.createStatement();
     createTable.execute(
-        "CREATE TABLE items (id INTEGER not NULL, num INTEGER, PRIMARY KEY ( id ))");
+        "CREATE TABLE batch_test (id INTEGER not NULL, num INTEGER, PRIMARY KEY ( id ))");
     cleanup.deferCleanup(createTable);
     testing().waitForTraces(2);
     testing().clearData();

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1883,61 +1883,60 @@ public abstract class AbstractJdbcInstrumentationTest {
   // expected executeBatch() result, and the expected client span. batch telemetry comes from the
   // shared SQL extractors and is database-agnostic, so a single (in-memory) database is enough to
   // lock down its shape
-  static Stream<Arguments> batchCasesStream() {
+  static Stream<BatchScenario> batchCasesStream() {
     return Stream.of(
-            // an empty batch still produces a client span, but with no query text or batch size;
-            // the span name falls back to the database namespace in both modes
-            BatchScenario.builder()
-                .name("empty")
-                .spanName(DATABASE_NAME_LOWER)
-                .oldSpanName(DATABASE_NAME_LOWER)
-                .build(),
-            // a single-statement batch is not a batch (size 1), so it looks like a normal
-            // statement and carries db.statement/db.operation/db.sql.table under old semconv
-            BatchScenario.builder()
-                .name("single")
-                .createTable("stmt_batch_single")
-                .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
-                .expectedResult(1)
-                .spanName("INSERT stmt_batch_single")
-                .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".stmt_batch_single")
-                .queryText("INSERT INTO stmt_batch_single VALUES(?)")
-                .oldStatement("INSERT INTO stmt_batch_single VALUES(?)")
-                .summary("INSERT stmt_batch_single")
-                .oldOperation("INSERT")
-                .oldTable("stmt_batch_single")
-                .build(),
-            // a multi-statement batch only emits db.query.text/summary and BATCH span name under
-            // stable semconv; under old semconv it has no statement-level attributes and the span
-            // name falls back to the namespace
-            BatchScenario.builder()
-                .name("twoSameOperation")
-                .createTable("stmt_batch_same")
-                .addQuery("INSERT INTO stmt_batch_same VALUES(1)")
-                .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
-                .expectedResult(1, 1)
-                .spanName("BATCH INSERT stmt_batch_same")
-                .oldSpanName(DATABASE_NAME_LOWER)
-                .queryText("INSERT INTO stmt_batch_same VALUES(?)")
-                .summary("BATCH INSERT stmt_batch_same")
-                .batchSize(2)
-                .build(),
-            BatchScenario.builder()
-                .name("twoDifferentOperations")
-                .createTable("stmt_batch_diff_1")
-                .createTable("stmt_batch_diff_2")
-                .addQuery("INSERT INTO stmt_batch_diff_1 VALUES(1)")
-                .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
-                .expectedResult(1, 1)
-                .spanName("BATCH")
-                .oldSpanName(DATABASE_NAME_LOWER)
-                .queryText(
-                    "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
-                        + " VALUES(?)")
-                .summary("BATCH")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch still produces a client span, but with no query text or batch size;
+        // the span name falls back to the database namespace in both modes
+        BatchScenario.builder()
+            .name("empty")
+            .spanName(DATABASE_NAME_LOWER)
+            .oldSpanName(DATABASE_NAME_LOWER)
+            .build(),
+        // a single-statement batch is not a batch (size 1), so it looks like a normal
+        // statement and carries db.statement/db.operation/db.sql.table under old semconv
+        BatchScenario.builder()
+            .name("single")
+            .createTable("stmt_batch_single")
+            .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
+            .expectedResult(1)
+            .spanName("INSERT stmt_batch_single")
+            .oldSpanName("INSERT " + DATABASE_NAME_LOWER + ".stmt_batch_single")
+            .queryText("INSERT INTO stmt_batch_single VALUES(?)")
+            .oldStatement("INSERT INTO stmt_batch_single VALUES(?)")
+            .summary("INSERT stmt_batch_single")
+            .oldOperation("INSERT")
+            .oldTable("stmt_batch_single")
+            .build(),
+        // a multi-statement batch only emits db.query.text/summary and BATCH span name under
+        // stable semconv; under old semconv it has no statement-level attributes and the span
+        // name falls back to the namespace
+        BatchScenario.builder()
+            .name("twoSameOperation")
+            .createTable("stmt_batch_same")
+            .addQuery("INSERT INTO stmt_batch_same VALUES(1)")
+            .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
+            .expectedResult(1, 1)
+            .spanName("BATCH INSERT stmt_batch_same")
+            .oldSpanName(DATABASE_NAME_LOWER)
+            .queryText("INSERT INTO stmt_batch_same VALUES(?)")
+            .summary("BATCH INSERT stmt_batch_same")
+            .batchSize(2)
+            .build(),
+        BatchScenario.builder()
+            .name("twoDifferentOperations")
+            .createTable("stmt_batch_diff_1")
+            .createTable("stmt_batch_diff_2")
+            .addQuery("INSERT INTO stmt_batch_diff_1 VALUES(1)")
+            .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
+            .expectedResult(1, 1)
+            .spanName("BATCH")
+            .oldSpanName(DATABASE_NAME_LOWER)
+            .queryText(
+                "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
+                    + " VALUES(?)")
+            .summary("BATCH")
+            .batchSize(2)
+            .build());
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1886,12 +1886,13 @@ public abstract class AbstractJdbcInstrumentationTest {
   // is enough to lock down its shape
   static Stream<BatchScenario> batchCasesStream() {
     return Stream.of(
-        // an empty batch still produces a client span, but with no query text or batch size;
-        // the span name falls back to the database namespace in both modes
+        // an empty batch still produces a client span carrying db.operation.batch.size 0, but no
+        // query text; the span name falls back to the database namespace in both modes
         BatchScenario.builder()
             .name("empty")
             .spanName(DATABASE_NAME_LOWER)
             .oldSpanName(DATABASE_NAME_LOWER)
+            .batchSize(0)
             .build(),
         // a single-statement batch is not a batch (size 1), so it looks like a normal
         // statement and carries db.statement/db.operation/db.sql.table under old semconv

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -18,6 +18,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -1879,6 +1880,101 @@ public abstract class AbstractJdbcInstrumentationTest {
                             .hasParent(trace.getSpan(0))));
   }
 
+  // describes the four batch cases: the tables to create, the statements added to the batch, the
+  // expected executeBatch() result, and the expected client span. batch telemetry comes from the
+  // shared SQL extractors and is database-agnostic, so a single (in-memory) database is enough to
+  // lock down its shape
+  static Stream<Arguments> batchCasesStream() {
+    return Stream.of(
+            // an empty batch still produces a client span, but with no query text or batch size;
+            // the span name falls back to the database namespace
+            BatchScenario.builder().name("empty").spanName(DATABASE_NAME_LOWER).build(),
+            // a single-statement batch is not a batch (size 1), so it looks like a normal statement
+            BatchScenario.builder()
+                .name("single")
+                .createTable("stmt_batch_single")
+                .addQuery("INSERT INTO stmt_batch_single VALUES(1)")
+                .expectedResult(1)
+                .spanName("INSERT stmt_batch_single")
+                .queryText("INSERT INTO stmt_batch_single VALUES(?)")
+                .summary("INSERT stmt_batch_single")
+                .build(),
+            BatchScenario.builder()
+                .name("twoSameOperation")
+                .createTable("stmt_batch_same")
+                .addQuery("INSERT INTO stmt_batch_same VALUES(1)")
+                .addQuery("INSERT INTO stmt_batch_same VALUES(2)")
+                .expectedResult(1, 1)
+                .spanName("BATCH INSERT stmt_batch_same")
+                .queryText("INSERT INTO stmt_batch_same VALUES(?)")
+                .summary("BATCH INSERT stmt_batch_same")
+                .batchSize(2)
+                .build(),
+            BatchScenario.builder()
+                .name("twoDifferentOperations")
+                .createTable("stmt_batch_diff_1")
+                .createTable("stmt_batch_diff_2")
+                .addQuery("INSERT INTO stmt_batch_diff_1 VALUES(1)")
+                .addQuery("INSERT INTO stmt_batch_diff_2 VALUES(2)")
+                .expectedResult(1, 1)
+                .spanName("BATCH")
+                .queryText(
+                    "INSERT INTO stmt_batch_diff_1 VALUES(?); INSERT INTO stmt_batch_diff_2"
+                        + " VALUES(?)")
+                .summary("BATCH")
+                .batchSize(2)
+                .build())
+        .map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("batchCasesStream")
+  void testStatementBatch(BatchScenario scenario) throws SQLException {
+    // batch telemetry (db.operation.batch.size, BATCH span names and summaries) is only emitted
+    // under stable database semconv
+    Assumptions.assumeTrue(emitStableDatabaseSemconv());
+
+    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+    cleanup.deferCleanup(connection);
+
+    for (String table : scenario.tablesToCreate) {
+      Statement createTable = connection.createStatement();
+      createTable.execute("CREATE TABLE " + table + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+      cleanup.deferCleanup(createTable);
+    }
+    if (!scenario.tablesToCreate.isEmpty()) {
+      testing().waitForTraces(scenario.tablesToCreate.size());
+      testing().clearData();
+    }
+
+    Statement statement = connection.createStatement();
+    cleanup.deferCleanup(statement);
+    for (String sql : scenario.statementsToAdd) {
+      statement.addBatch(sql);
+    }
+
+    testing()
+        .runWithSpan(
+            "parent",
+            () -> assertThat(statement.executeBatch()).isEqualTo(scenario.expectedResult));
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasName(scenario.spanName)
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(DB_SYSTEM_NAME, maybeStableDbSystemName("h2")),
+                                equalTo(DB_NAMESPACE, DATABASE_NAME_LOWER),
+                                equalTo(DB_QUERY_TEXT, scenario.queryText),
+                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
+                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize))));
+  }
+
   static Stream<Arguments> batchStream() throws SQLException {
     return Stream.of(
         Arguments.of("h2", new org.h2.Driver().connect(JDBC_URLS.get("h2"), null), null, "h2:mem:"),
@@ -1894,19 +1990,6 @@ public abstract class AbstractJdbcInstrumentationTest {
             new JDBC().connect(JDBC_URLS.get("sqlite"), new Properties()),
             null,
             "sqlite:memory:"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testBatch(String system, Connection connection, String username, String url)
-      throws SQLException {
-    testBatchImpl(
-        system,
-        wrap(connection),
-        username,
-        url,
-        "simple_batch_test",
-        statement -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1, 1}));
   }
 
   @ParameterizedTest
@@ -1931,170 +2014,6 @@ public abstract class AbstractJdbcInstrumentationTest {
       assertThatThrownBy(statement::executeLargeBatch)
           .isInstanceOf(UnsupportedOperationException.class);
     }
-  }
-
-  private void testBatchImpl(
-      String system,
-      Connection connection,
-      String username,
-      String url,
-      String tableName,
-      ThrowingConsumer<Statement> action)
-      throws SQLException {
-    Statement createTable = connection.createStatement();
-    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable);
-
-    testing().waitForTraces(1);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO non_existent_table VALUES(1)");
-    statement.clearBatch();
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(1)");
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(2)");
-    testing().runWithSpan("parent", () -> action.accept(statement));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "BATCH INSERT " + tableName
-                                    : "jdbcunittest")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO " + tableName + " VALUES(?)"
-                                        : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv()
-                                        ? "BATCH INSERT " + tableName
-                                        : null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null))));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testMultiBatch(String system, Connection conn, String username, String url)
-      throws SQLException {
-    Connection connection = wrap(conn);
-    String tableName1 = "multi_batch_test_1";
-    String tableName2 = "multi_batch_test_2";
-    Statement createTable1 = connection.createStatement();
-    createTable1.execute(
-        "CREATE TABLE " + tableName1 + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable1);
-    Statement createTable2 = connection.createStatement();
-    createTable2.execute(
-        "CREATE TABLE " + tableName2 + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable2);
-
-    testing().waitForTraces(2);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO " + tableName1 + " VALUES(1)");
-    statement.addBatch("INSERT INTO " + tableName2 + " VALUES(2)");
-    testing()
-        .runWithSpan(
-            "parent", () -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1, 1}));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(emitStableDatabaseSemconv() ? "BATCH" : "jdbcunittest")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    emitStableDatabaseSemconv()
-                                        ? "INSERT INTO "
-                                            + tableName1
-                                            + " VALUES(?); INSERT INTO multi_batch_test_2 VALUES(?)"
-                                        : null),
-                                equalTo(
-                                    DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
-                                equalTo(maybeStable(DB_OPERATION), null),
-                                equalTo(
-                                    DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? 2L : null))));
-  }
-
-  @ParameterizedTest
-  @MethodSource("batchStream")
-  void testSingleItemBatch(String system, Connection conn, String username, String url)
-      throws SQLException {
-    Connection connection = wrap(conn);
-    String tableName = "single_item_batch_test";
-    Statement createTable = connection.createStatement();
-    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    cleanup.deferCleanup(createTable);
-
-    testing().waitForTraces(1);
-    testing().clearData();
-
-    Statement statement = connection.createStatement();
-    cleanup.deferCleanup(statement);
-    statement.addBatch("INSERT INTO " + tableName + " VALUES(1)");
-    testing()
-        .runWithSpan("parent", () -> assertThat(statement.executeBatch()).isEqualTo(new int[] {1}));
-
-    testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasName(
-                                emitStableDatabaseSemconv()
-                                    ? "INSERT " + tableName
-                                    : "INSERT jdbcunittest." + tableName)
-                            .hasKind(SpanKind.CLIENT)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
-                                equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
-                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
-                                equalTo(
-                                    DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "INSERT INTO " + tableName + " VALUES(?)"),
-                                equalTo(
-                                    DB_QUERY_SUMMARY,
-                                    emitStableDatabaseSemconv() ? "INSERT " + tableName : null),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv() ? null : "INSERT"),
-                                equalTo(
-                                    maybeStable(DB_SQL_TABLE),
-                                    emitStableDatabaseSemconv() ? null : tableName))));
   }
 
   @ParameterizedTest
@@ -2445,5 +2364,92 @@ public abstract class AbstractJdbcInstrumentationTest {
                                     : "SELECT " + DATABASE_NAME_LOWER)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(1))));
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<String> tablesToCreate;
+    final List<String> statementsToAdd;
+    final int[] expectedResult;
+    final String spanName;
+    final String queryText;
+    final String summary;
+    final Long batchSize;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.tablesToCreate = builder.tablesToCreate;
+      this.statementsToAdd = builder.statementsToAdd;
+      this.expectedResult = builder.expectedResult;
+      this.spanName = builder.spanName;
+      this.queryText = builder.queryText;
+      this.summary = builder.summary;
+      this.batchSize = builder.batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+      private String name;
+      private final List<String> tablesToCreate = new ArrayList<>();
+      private final List<String> statementsToAdd = new ArrayList<>();
+      private int[] expectedResult = new int[] {};
+      private String spanName;
+      private String queryText;
+      private String summary;
+      private Long batchSize;
+
+      Builder name(String name) {
+        this.name = name;
+        return this;
+      }
+
+      Builder createTable(String table) {
+        this.tablesToCreate.add(table);
+        return this;
+      }
+
+      Builder addQuery(String query) {
+        this.statementsToAdd.add(query);
+        return this;
+      }
+
+      Builder expectedResult(int... result) {
+        this.expectedResult = result;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisConnectionInstrumentation.java
@@ -18,7 +18,10 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
 import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisRequestContext;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -56,6 +59,8 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
                         "redis.clients.jedis.ProtocolCommand")))
             .and(takesArgument(1, is(byte[][].class))),
         getClass().getName() + "$SendCommandWithArgsAdvice");
+    transformer.applyAdviceToMethod(
+        named("getAll").and(takesArguments(0)), getClass().getName() + "$GetAllAdvice");
   }
 
   public static class AdviceScope {
@@ -72,6 +77,9 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     @Nullable
     public static AdviceScope start(JedisRequest request) {
       Context parentContext = currentContext();
+      if (JedisPipelineContext.capture(request)) {
+        return null;
+      }
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
       }
@@ -82,6 +90,65 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     public void end(@Nullable Throwable throwable) {
       scope.close();
       JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class GetAllAdvice {
+
+    public static class PipelineAdviceScope {
+      private final Context context;
+      private final Scope scope;
+      private final JedisRequest request;
+
+      private PipelineAdviceScope(Context context, Scope scope, JedisRequest request) {
+        this.context = context;
+        this.scope = scope;
+        this.request = request;
+      }
+
+      @Nullable
+      public static PipelineAdviceScope start() {
+        Object pipeline = JedisPipelineContext.currentPipeline();
+        if (pipeline == null) {
+          return null;
+        }
+        List<Object> capturedRequests = JedisPipelineContext.drain(pipeline);
+        if (capturedRequests.isEmpty()) {
+          return null;
+        }
+        List<JedisRequest> requests = new ArrayList<>(capturedRequests.size());
+        for (Object capturedRequest : capturedRequests) {
+          requests.add((JedisRequest) capturedRequest);
+        }
+        JedisRequest request = JedisRequest.createPipeline(requests);
+        Context parentContext = currentContext();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+        Context context = instrumenter().start(parentContext, request);
+        return new PipelineAdviceScope(context, context.makeCurrent(), request);
+      }
+
+      public void end(@Nullable Throwable throwable) {
+        scope.close();
+        instrumenter().end(context, request, null, throwable);
+      }
+    }
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static PipelineAdviceScope onEnter() {
+      return PipelineAdviceScope.start();
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void stopSpan(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Enter @Nullable PipelineAdviceScope adviceScope) {
+      if (adviceScope != null) {
+        adviceScope.end(throwable);
+      }
     }
   }
 

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
@@ -5,18 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
-import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import javax.annotation.Nullable;
 
 final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, Void> {
-
-  private static final RedisCommandSanitizer sanitizer =
-      RedisCommandSanitizer.create(
-          DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "jedis"));
 
   @Override
   public String getDbSystemName(JedisRequest request) {
@@ -31,12 +24,18 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
 
   @Override
   public String getDbQueryText(JedisRequest request) {
-    return sanitizer.sanitize(request.getCommand().name(), request.getArgs());
+    return request.getQueryText();
   }
 
   @Override
   public String getDbOperationName(JedisRequest request) {
-    return request.getCommand().name();
+    return request.getOperationName();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(JedisRequest request) {
+    return request.getBatchSize();
   }
 
   @Override

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
@@ -30,6 +30,9 @@ public class JedisInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
+    return asList(
+        new JedisConnectionInstrumentation(),
+        new JedisInstrumentation(),
+        new JedisPipelineInstrumentation());
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisPipelineInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisPipelineInstrumentation.java
@@ -5,12 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.instrumentation.jedis.v1_4.JedisSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -18,7 +29,11 @@ import net.bytebuddy.matcher.ElementMatcher;
 class JedisPipelineInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("redis.clients.jedis.Jedis");
+    return namedOneOf(
+        "redis.clients.jedis.Jedis",
+        "redis.clients.jedis.Pipeline",
+        "redis.clients.jedis.PipelineBase",
+        "redis.clients.jedis.MultiKeyPipelineBase");
   }
 
   @Override
@@ -26,6 +41,11 @@ class JedisPipelineInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         named("pipelined").and(takesArgument(0, named("redis.clients.jedis.JedisPipeline"))),
         getClass().getName() + "$PipelinedAdvice");
+    transformer.applyAdviceToMethod(
+        isPublic().and(isMethod()).and(returns(named("redis.clients.jedis.Response"))),
+        getClass().getName() + "$QueueCommandAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("sync", "syncAndReturnAll"), getClass().getName() + "$SyncAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -39,6 +59,75 @@ class JedisPipelineInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit() {
       JedisPipelineContext.exit();
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class QueueCommandAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.This Object pipeline) {
+      JedisPipelineContext.enter(pipeline);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void stopCollecting() {
+      JedisPipelineContext.exit();
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SyncAdvice {
+
+    public static class AdviceScope {
+      private final Context context;
+      private final Scope scope;
+      private final JedisRequest request;
+
+      private AdviceScope(Context context, Scope scope, JedisRequest request) {
+        this.context = context;
+        this.scope = scope;
+        this.request = request;
+      }
+
+      @Nullable
+      public static AdviceScope start(Object pipeline) {
+        List<Object> capturedRequests = JedisPipelineContext.drain(pipeline);
+        if (capturedRequests.isEmpty()) {
+          return null;
+        }
+        List<JedisRequest> requests = new ArrayList<>(capturedRequests.size());
+        for (Object capturedRequest : capturedRequests) {
+          requests.add((JedisRequest) capturedRequest);
+        }
+        JedisRequest request = JedisRequest.createPipeline(requests);
+        Context parentContext = currentContext();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(context, context.makeCurrent(), request);
+      }
+
+      public void end(@Nullable Throwable throwable) {
+        scope.close();
+        instrumenter().end(context, request, null, throwable);
+      }
+    }
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static AdviceScope onEnter(@Advice.This Object pipeline) {
+      return AdviceScope.start(pipeline);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void stopSpan(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Enter @Nullable AdviceScope adviceScope) {
+      if (adviceScope != null) {
+        adviceScope.end(throwable);
+      }
     }
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisPipelineInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisPipelineInstrumentation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class JedisPipelineInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("redis.clients.jedis.Jedis");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("pipelined").and(takesArgument(0, named("redis.clients.jedis.JedisPipeline"))),
+        getClass().getName() + "$PipelinedAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class PipelinedAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.Argument(0) Object pipeline) {
+      JedisPipelineContext.enter(pipeline);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit() {
+      JedisPipelineContext.exit();
+    }
+  }
+}

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisRequest.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisRequest.java
@@ -8,25 +8,85 @@ package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 import static java.util.Collections.emptyList;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import java.util.List;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
 
 @AutoValue
 public abstract class JedisRequest {
+  private static final RedisCommandSanitizer sanitizer =
+      RedisCommandSanitizer.create(
+          DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "jedis"));
 
   public static JedisRequest create(Connection connection, Protocol.Command command) {
-    return new AutoValue_JedisRequest(connection, command, emptyList());
+    return new AutoValue_JedisRequest(connection, command, emptyList(), null, null, null);
   }
 
   public static JedisRequest create(
       Connection connection, Protocol.Command command, List<byte[]> args) {
-    return new AutoValue_JedisRequest(connection, command, args);
+    return new AutoValue_JedisRequest(connection, command, args, null, null, null);
+  }
+
+  public static JedisRequest createPipeline(List<JedisRequest> requests) {
+    JedisRequest first = requests.get(0);
+    return new AutoValue_JedisRequest(
+        first.getConnection(),
+        null,
+        emptyList(),
+        pipelineOperationName(requests),
+        pipelineQueryText(requests),
+        requests.size() > 1 ? (long) requests.size() : null);
   }
 
   public abstract Connection getConnection();
 
+  @Nullable
   public abstract Protocol.Command getCommand();
 
   public abstract List<byte[]> getArgs();
+
+  @Nullable
+  abstract String getOperationNameOverride();
+
+  @Nullable
+  abstract String getQueryTextOverride();
+
+  @Nullable
+  public abstract Long getBatchSize();
+
+  public String getOperationName() {
+    String operationName = getOperationNameOverride();
+    return operationName != null ? operationName : getCommand().name();
+  }
+
+  public String getQueryText() {
+    String queryText = getQueryTextOverride();
+    return queryText != null ? queryText : sanitizer.sanitize(getOperationName(), getArgs());
+  }
+
+  private static String pipelineOperationName(List<JedisRequest> requests) {
+    if (requests.size() == 1) {
+      return requests.get(0).getOperationName();
+    }
+    String commonOperationName = requests.get(0).getOperationName();
+    for (int i = 1; i < requests.size(); i++) {
+      if (!commonOperationName.equals(requests.get(i).getOperationName())) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + commonOperationName;
+  }
+
+  private static String pipelineQueryText(List<JedisRequest> requests) {
+    StringJoiner joiner = new StringJoiner(";");
+    for (JedisRequest request : requests) {
+      joiner.add(request.getQueryText());
+    }
+    return joiner.toString();
+  }
 }

--- a/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
+++ b/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
@@ -37,9 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
-import redis.clients.jedis.Client;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPipeline;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractJedisTest {
@@ -177,14 +175,9 @@ public abstract class AbstractJedisTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("pipelineScenarios")
   void pipelineCommand(
-      String name, PipelineScenario scenario, List<ExpectedCommand> expectedCommands) {
-    jedis.pipelined(
-        new JedisPipeline() {
-          @Override
-          public void execute() {
-            scenario.run(client);
-          }
-        });
+      String name, PipelineScenario scenario, List<ExpectedCommand> expectedCommands)
+      throws ReflectiveOperationException {
+    runPipeline(scenario);
 
     if (expectedCommands.isEmpty()) {
       assertThat(testing.spans()).isEmpty();
@@ -274,8 +267,62 @@ public abstract class AbstractJedisTest {
     return new ExpectedCommand(operation, statement);
   }
 
-  private interface PipelineScenario {
-    void run(Client client);
+  private static void runPipeline(PipelineScenario scenario) throws ReflectiveOperationException {
+    if (hasJedisPipelineCallback()) {
+      Jedis14PipelineRunner.run(jedis, scenario);
+      return;
+    }
+    Object pipeline = Jedis.class.getMethod("pipelined").invoke(jedis);
+    scenario.run(new ReflectivePipelineOperations(pipeline));
+    pipeline.getClass().getMethod("sync").invoke(pipeline);
+  }
+
+  private static boolean hasJedisPipelineCallback() {
+    try {
+      Class.forName("redis.clients.jedis.JedisPipeline");
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  interface PipelineScenario {
+    void run(PipelineOperations pipeline);
+  }
+
+  interface PipelineOperations {
+    void set(String key, String value);
+
+    void get(String key);
+  }
+
+  private static class ReflectivePipelineOperations implements PipelineOperations {
+    private final Object pipeline;
+
+    private ReflectivePipelineOperations(Object pipeline) {
+      this.pipeline = pipeline;
+    }
+
+    @Override
+    public void set(String key, String value) {
+      try {
+        pipeline
+            .getClass()
+            .getMethod("set", String.class, String.class)
+            .invoke(pipeline, key, value);
+      } catch (ReflectiveOperationException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    @Override
+    public void get(String key) {
+      try {
+        pipeline.getClass().getMethod("get", String.class).invoke(pipeline, key);
+      } catch (ReflectiveOperationException e) {
+        throw new IllegalStateException(e);
+      }
+    }
   }
 
   private static class ExpectedCommand {

--- a/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
+++ b/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/AbstractJedisTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -18,18 +19,27 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Client;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPipeline;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractJedisTest {
@@ -161,5 +171,120 @@ public abstract class AbstractJedisTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
+  }
+
+  // Jedis pipelines are traced as one aggregate span from queueing through completion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("pipelineScenarios")
+  void pipelineCommand(
+      String name, PipelineScenario scenario, List<ExpectedCommand> expectedCommands) {
+    jedis.pipelined(
+        new JedisPipeline() {
+          @Override
+          public void execute() {
+            scenario.run(client);
+          }
+        });
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
+    String operation = pipelineOperation(expectedCommands);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? operation + " " + host + ":" + port
+                                : operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), pipelineStatement(expectedCommands)),
+                            equalTo(maybeStable(DB_OPERATION), operation),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                    ? (long) expectedCommands.size()
+                                    : null),
+                            equalTo(maybeStablePeerService(), "test-peer-service"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))));
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static String pipelineStatement(List<ExpectedCommand> commands) {
+    StringBuilder statement = new StringBuilder();
+    for (ExpectedCommand command : commands) {
+      if (statement.length() > 0) {
+        statement.append(';');
+      }
+      statement.append(command.statement);
+    }
+    return statement.toString();
+  }
+
+  private static Stream<Arguments> pipelineScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (PipelineScenario) pipeline -> {}, emptyList()),
+        Arguments.of(
+            "single",
+            (PipelineScenario) pipeline -> pipeline.set("batch1", "v1"),
+            expectedCommands(expectedCommand("SET", "SET batch1 ?"))),
+        Arguments.of(
+            "twoSameOperation",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.set("batch2", "v2");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("SET", "SET batch2 ?"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.get("batch1");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("GET", "GET batch1"))));
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation, String statement) {
+    return new ExpectedCommand(operation, statement);
+  }
+
+  private interface PipelineScenario {
+    void run(Client client);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+    private final String statement;
+
+    private ExpectedCommand(String operation, String statement) {
+      this.operation = operation;
+      this.statement = statement;
+    }
   }
 }

--- a/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/Jedis14PipelineRunner.java
+++ b/instrumentation/jedis/jedis-1.4/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/Jedis14PipelineRunner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis;
+
+import redis.clients.jedis.Client;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPipeline;
+
+class Jedis14PipelineRunner {
+
+  static void run(Jedis jedis, AbstractJedisTest.PipelineScenario scenario) {
+    jedis.pipelined(
+        new JedisPipeline() {
+          @Override
+          public void execute() {
+            scenario.run(new ClientPipelineOperations(client));
+          }
+        });
+  }
+
+  private static class ClientPipelineOperations implements AbstractJedisTest.PipelineOperations {
+    private final Client client;
+
+    private ClientPipelineOperations(Client client) {
+      this.client = client;
+    }
+
+    @Override
+    public void set(String key, String value) {
+      client.set(key, value);
+    }
+
+    @Override
+    public void get(String key) {
+      client.get(key);
+    }
+  }
+
+  private Jedis14PipelineRunner() {}
+}

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
@@ -35,6 +35,12 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
   }
 
   @Override
+  @Nullable
+  public Long getDbOperationBatchSize(JedisRequest request) {
+    return request.getBatchSize();
+  }
+
+  @Override
   public String getServerAddress(JedisRequest request) {
     return request.getConnection().getHost();
   }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
@@ -32,6 +32,9 @@ public class JedisInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
+    return asList(
+        new JedisConnectionInstrumentation(),
+        new JedisInstrumentation(),
+        new JedisPipelineInstrumentation());
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisPipelineInstrumentation.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisPipelineInstrumentation.java
@@ -7,43 +7,58 @@ package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.jedis.v3_0.JedisSingletons.instrumenter;
-import static java.util.Arrays.asList;
-import static net.bytebuddy.matcher.ElementMatchers.is;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
-import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisRequestContext;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import redis.clients.jedis.Connection;
-import redis.clients.jedis.commands.ProtocolCommand;
 
-class JedisConnectionInstrumentation implements TypeInstrumentation {
+class JedisPipelineInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("redis.clients.jedis.Connection");
+    return namedOneOf(
+        "redis.clients.jedis.Pipeline",
+        "redis.clients.jedis.PipelineBase",
+        "redis.clients.jedis.MultiKeyPipelineBase");
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("sendCommand")
-            .and(takesArguments(2))
-            .and(takesArgument(0, named("redis.clients.jedis.commands.ProtocolCommand")))
-            .and(takesArgument(1, is(byte[][].class))),
-        getClass().getName() + "$SendCommandAdvice");
+        isPublic().and(isMethod()).and(returns(named("redis.clients.jedis.Response"))),
+        getClass().getName() + "$QueueCommandAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("sync", "syncAndReturnAll"), getClass().getName() + "$SyncAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class SendCommandAdvice {
+  public static class QueueCommandAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.This Object pipeline) {
+      JedisPipelineContext.enter(pipeline);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void stopCollecting() {
+      JedisPipelineContext.exit();
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SyncAdvice {
 
     public static class AdviceScope {
       private final Context context;
@@ -57,13 +72,17 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
       }
 
       @Nullable
-      public static AdviceScope start(
-          Connection connection, ProtocolCommand command, byte[][] args) {
-        Context parentContext = currentContext();
-        JedisRequest request = JedisRequest.create(connection, command, asList(args));
-        if (JedisPipelineContext.capture(request)) {
+      public static AdviceScope start(Object pipeline) {
+        List<Object> capturedRequests = JedisPipelineContext.drain(pipeline);
+        if (capturedRequests.isEmpty()) {
           return null;
         }
+        List<JedisRequest> requests = new ArrayList<>(capturedRequests.size());
+        for (Object capturedRequest : capturedRequests) {
+          requests.add((JedisRequest) capturedRequest);
+        }
+        JedisRequest request = JedisRequest.createPipeline(requests);
+        Context parentContext = currentContext();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
         }
@@ -73,17 +92,14 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
 
       public void end(@Nullable Throwable throwable) {
         scope.close();
-        JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
+        instrumenter().end(context, request, null, throwable);
       }
     }
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static AdviceScope onEnter(
-        @Advice.This Connection connection,
-        @Advice.Argument(0) ProtocolCommand command,
-        @Advice.Argument(1) byte[][] args) {
-      return AdviceScope.start(connection, command, args);
+    public static AdviceScope onEnter(@Advice.This Object pipeline) {
+      return AdviceScope.start(pipeline);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisRequest.java
@@ -6,12 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.ProtocolCommand;
@@ -25,27 +29,80 @@ public abstract class JedisRequest {
 
   public static JedisRequest create(
       Connection connection, ProtocolCommand command, List<byte[]> args) {
-    return new AutoValue_JedisRequest(connection, command, args);
+    return new AutoValue_JedisRequest(connection, command, args, null, null, null);
+  }
+
+  public static JedisRequest createPipeline(List<JedisRequest> requests) {
+    JedisRequest first = requests.get(0);
+    return new AutoValue_JedisRequest(
+        first.getConnection(),
+        null,
+        emptyList(),
+        pipelineOperationName(requests),
+        pipelineQueryText(requests),
+        requests.size() > 1 ? (long) requests.size() : null);
   }
 
   public abstract Connection getConnection();
 
+  @Nullable
   public abstract ProtocolCommand getCommand();
 
   public abstract List<byte[]> getArgs();
 
+  @Nullable
+  abstract String getOperationNameOverride();
+
+  @Nullable
+  abstract String getQueryTextOverride();
+
+  @Nullable
+  public abstract Long getBatchSize();
+
   public String getOperationName() {
+    String operationName = getOperationNameOverride();
+    if (operationName != null) {
+      return operationName;
+    }
     ProtocolCommand command = getCommand();
     if (command instanceof Protocol.Command) {
       return ((Protocol.Command) command).name();
-    } else {
-      // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
-      // us if that changes
-      return new String(command.getRaw(), UTF_8);
     }
+    // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
+    // us if that changes
+    return new String(command.getRaw(), UTF_8);
   }
 
   public String getQueryText() {
+    String queryText = getQueryTextOverride();
+    if (queryText != null) {
+      return queryText;
+    }
     return sanitizer.sanitize(getOperationName(), getArgs());
+  }
+
+  private static String pipelineOperationName(List<JedisRequest> requests) {
+    if (requests.size() == 1) {
+      return requests.get(0).getOperationName();
+    }
+    String commonOperationName = requests.get(0).getOperationName();
+    for (int i = 1; i < requests.size(); i++) {
+      if (!commonOperationName.equals(requests.get(i).getOperationName())) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + commonOperationName;
+  }
+
+  private static String pipelineQueryText(List<JedisRequest> requests) {
+    StringJoiner joiner = new StringJoiner(";");
+    List<String> queryTexts = new ArrayList<>(requests.size());
+    for (JedisRequest request : requests) {
+      queryTexts.add(request.getQueryText());
+    }
+    for (String queryText : queryTexts) {
+      joiner.add(queryText);
+    }
+    return joiner.toString();
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/Jedis30ClientTest.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/Jedis30ClientTest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -24,6 +25,8 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -32,13 +35,19 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
+import java.util.stream.Stream;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class Jedis30ClientTest {
@@ -190,5 +199,119 @@ class Jedis30ClientTest {
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))));
+  }
+
+  // Jedis pipelines are traced as one aggregate span from queueing through sync completion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("pipelineScenarios")
+  void pipelineCommand(
+      String name, PipelineScenario scenario, List<ExpectedCommand> expectedCommands) {
+    Pipeline pipeline = jedis.pipelined();
+    scenario.run(pipeline);
+    pipeline.sync();
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
+    String operation = pipelineOperation(expectedCommands);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? operation + " " + host + ":" + port
+                                : operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), pipelineStatement(expectedCommands)),
+                            equalTo(maybeStable(DB_OPERATION), operation),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                    ? (long) expectedCommands.size()
+                                    : null),
+                            equalTo(maybeStablePeerService(), "test-peer-service"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative))));
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static String pipelineStatement(List<ExpectedCommand> commands) {
+    StringBuilder statement = new StringBuilder();
+    for (ExpectedCommand command : commands) {
+      if (statement.length() > 0) {
+        statement.append(';');
+      }
+      statement.append(command.statement);
+    }
+    return statement.toString();
+  }
+
+  private static Stream<Arguments> pipelineScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (PipelineScenario) pipeline -> {}, emptyList()),
+        Arguments.of(
+            "single",
+            (PipelineScenario) pipeline -> pipeline.set("batch1", "v1"),
+            expectedCommands(expectedCommand("SET", "SET batch1 ?"))),
+        Arguments.of(
+            "twoSameOperation",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.set("batch2", "v2");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("SET", "SET batch2 ?"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.get("batch1");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("GET", "GET batch1"))));
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation, String statement) {
+    return new ExpectedCommand(operation, statement);
+  }
+
+  private interface PipelineScenario {
+    void run(Pipeline pipeline);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+    private final String statement;
+
+    private ExpectedCommand(String operation, String statement) {
+      this.operation = operation;
+      this.statement = statement;
+    }
   }
 }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisConnectionInstrumentation.java
@@ -19,6 +19,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
 import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisRequestContext;
 import java.net.Socket;
 import javax.annotation.Nullable;
@@ -66,8 +67,12 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     }
 
     @Nullable
-    public static AdviceScope start(JedisRequest request) {
+    public static AdviceScope start(JedisRequest request, @Nullable Socket socket) {
       Context parentContext = currentContext();
+      request.setSocket(socket);
+      if (JedisPipelineContext.capture(request)) {
+        return null;
+      }
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
       }
@@ -101,8 +106,9 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     public static AdviceScope onEnter(
         @Advice.This Connection connection,
         @Advice.Argument(0) ProtocolCommand command,
-        @Advice.Argument(1) byte[][] args) {
-      return AdviceScope.start(JedisRequest.create(connection, command, asList(args)));
+        @Advice.Argument(1) byte[][] args,
+        @Advice.FieldValue("socket") Socket socket) {
+      return AdviceScope.start(JedisRequest.create(connection, command, asList(args)), socket);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -122,8 +128,10 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static AdviceScope onEnter(
-        @Advice.This Connection connection, @Advice.Argument(0) CommandArguments command) {
-      return AdviceScope.start(JedisRequest.create(connection, command));
+        @Advice.This Connection connection,
+        @Advice.Argument(0) CommandArguments command,
+        @Advice.FieldValue("socket") Socket socket) {
+      return AdviceScope.start(JedisRequest.create(connection, command), socket);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
@@ -43,6 +43,12 @@ class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, 
 
   @Override
   @Nullable
+  public Long getDbOperationBatchSize(JedisRequest request) {
+    return request.getBatchSize();
+  }
+
+  @Override
+  @Nullable
   public String getServerAddress(JedisRequest request) {
     return request.getServerAddress();
   }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
@@ -32,7 +32,10 @@ public class JedisInstrumentationModule extends InstrumentationModule
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
+    return asList(
+        new JedisConnectionInstrumentation(),
+        new JedisInstrumentation(),
+        new JedisPipelineInstrumentation());
   }
 
   @Override

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisPipelineInstrumentation.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisPipelineInstrumentation.java
@@ -3,47 +3,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
+package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
-import static io.opentelemetry.javaagent.instrumentation.jedis.v3_0.JedisSingletons.instrumenter;
-import static java.util.Arrays.asList;
-import static net.bytebuddy.matcher.ElementMatchers.is;
+import static io.opentelemetry.javaagent.instrumentation.jedis.v4_0.JedisSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisPipelineContext;
-import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisRequestContext;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import redis.clients.jedis.Connection;
-import redis.clients.jedis.commands.ProtocolCommand;
 
-class JedisConnectionInstrumentation implements TypeInstrumentation {
+class JedisPipelineInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("redis.clients.jedis.Connection");
+    return namedOneOf("redis.clients.jedis.Pipeline", "redis.clients.jedis.PipelineBase");
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("sendCommand")
-            .and(takesArguments(2))
-            .and(takesArgument(0, named("redis.clients.jedis.commands.ProtocolCommand")))
-            .and(takesArgument(1, is(byte[][].class))),
-        getClass().getName() + "$SendCommandAdvice");
+        named("appendCommand"), getClass().getName() + "$QueueCommandAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("sync", "syncAndReturnAll"), getClass().getName() + "$SyncAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class SendCommandAdvice {
+  public static class QueueCommandAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.This Object pipeline) {
+      JedisPipelineContext.enter(pipeline);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void stopCollecting() {
+      JedisPipelineContext.exit();
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SyncAdvice {
 
     public static class AdviceScope {
       private final Context context;
@@ -57,13 +65,17 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
       }
 
       @Nullable
-      public static AdviceScope start(
-          Connection connection, ProtocolCommand command, byte[][] args) {
-        Context parentContext = currentContext();
-        JedisRequest request = JedisRequest.create(connection, command, asList(args));
-        if (JedisPipelineContext.capture(request)) {
+      public static AdviceScope start(Object pipeline) {
+        List<Object> capturedRequests = JedisPipelineContext.drain(pipeline);
+        if (capturedRequests.isEmpty()) {
           return null;
         }
+        List<JedisRequest> requests = new ArrayList<>(capturedRequests.size());
+        for (Object capturedRequest : capturedRequests) {
+          requests.add((JedisRequest) capturedRequest);
+        }
+        JedisRequest request = JedisRequest.createPipeline(requests);
+        Context parentContext = currentContext();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
         }
@@ -73,17 +85,15 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
 
       public void end(@Nullable Throwable throwable) {
         scope.close();
-        JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
+        request.setSocket(null);
+        instrumenter().end(context, request, null, throwable);
       }
     }
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static AdviceScope onEnter(
-        @Advice.This Connection connection,
-        @Advice.Argument(0) ProtocolCommand command,
-        @Advice.Argument(1) byte[][] args) {
-      return AdviceScope.start(connection, command, args);
+    public static AdviceScope onEnter(@Advice.This Object pipeline) {
+      return AdviceScope.start(pipeline);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisRequest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -15,6 +16,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 import javax.annotation.Nullable;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Connection;
@@ -43,7 +45,10 @@ public abstract class JedisRequest {
         args,
         connectionInfo != null ? connectionInfo.getServerAddress() : null,
         connectionInfo != null ? connectionInfo.getServerPort() : null,
-        connectionInfo != null ? connectionInfo.getDatabaseIndex() : null);
+        connectionInfo != null ? connectionInfo.getDatabaseIndex() : null,
+        null,
+        null,
+        null);
   }
 
   public static JedisRequest create(CommandArguments commandArguments) {
@@ -65,6 +70,22 @@ public abstract class JedisRequest {
     return create(connection, command, arguments);
   }
 
+  public static JedisRequest createPipeline(List<JedisRequest> requests) {
+    JedisRequest first = requests.get(0);
+    JedisRequest request =
+        new AutoValue_JedisRequest(
+            null,
+            emptyList(),
+            first.getServerAddress(),
+            first.getServerPort(),
+            first.getDatabaseIndex(),
+            pipelineOperationName(requests),
+            pipelineQueryText(requests),
+            requests.size() > 1 ? (long) requests.size() : null);
+    request.remoteSocketAddress = first.getRemoteSocketAddress();
+    return request;
+  }
+
   @Nullable
   private static JedisConnectionInfo getConnectionInfo(@Nullable Object connection) {
     return connection instanceof Connection
@@ -72,6 +93,7 @@ public abstract class JedisRequest {
         : null;
   }
 
+  @Nullable
   public abstract ProtocolCommand getCommand();
 
   public abstract List<byte[]> getArgs();
@@ -85,19 +107,56 @@ public abstract class JedisRequest {
   @Nullable
   public abstract Long getDatabaseIndex();
 
+  @Nullable
+  abstract String getOperationNameOverride();
+
+  @Nullable
+  abstract String getQueryTextOverride();
+
+  @Nullable
+  public abstract Long getBatchSize();
+
   public String getOperationName() {
+    String operationName = getOperationNameOverride();
+    if (operationName != null) {
+      return operationName;
+    }
     ProtocolCommand command = getCommand();
     if (command instanceof Protocol.Command) {
       return ((Protocol.Command) command).name();
-    } else {
-      // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
-      // us if that changes
-      return new String(command.getRaw(), UTF_8);
     }
+    // Protocol.Command is the only implementation in the Jedis lib as of 3.1 but this will save
+    // us if that changes
+    return new String(command.getRaw(), UTF_8);
   }
 
   public String getQueryText() {
+    String queryText = getQueryTextOverride();
+    if (queryText != null) {
+      return queryText;
+    }
     return sanitizer.sanitize(getOperationName(), getArgs());
+  }
+
+  private static String pipelineOperationName(List<JedisRequest> requests) {
+    if (requests.size() == 1) {
+      return requests.get(0).getOperationName();
+    }
+    String commonOperationName = requests.get(0).getOperationName();
+    for (int i = 1; i < requests.size(); i++) {
+      if (!commonOperationName.equals(requests.get(i).getOperationName())) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + commonOperationName;
+  }
+
+  private static String pipelineQueryText(List<JedisRequest> requests) {
+    StringJoiner joiner = new StringJoiner(";");
+    for (JedisRequest request : requests) {
+      joiner.add(request.getQueryText());
+    }
+    return joiner.toString();
   }
 
   public void setSocket(@Nullable Socket socket) {

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/Jedis40ClientTest.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/Jedis40ClientTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -23,6 +24,8 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -31,14 +34,20 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class Jedis40ClientTest {
@@ -257,5 +266,119 @@ class Jedis40ClientTest {
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(NETWORK_PEER_ADDRESS, ip))));
+  }
+
+  // Jedis pipelines are traced as one aggregate span from queueing through sync completion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("pipelineScenarios")
+  void pipelineCommand(
+      String name, PipelineScenario scenario, List<ExpectedCommand> expectedCommands) {
+    Pipeline pipeline = jedis.pipelined();
+    scenario.run(pipeline);
+    pipeline.sync();
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
+    String operation = pipelineOperation(expectedCommands);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? operation + " " + host + ":" + port
+                                : operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), pipelineStatement(expectedCommands)),
+                            equalTo(maybeStable(DB_OPERATION), operation),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                    ? (long) expectedCommands.size()
+                                    : null),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))));
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static String pipelineStatement(List<ExpectedCommand> commands) {
+    StringBuilder statement = new StringBuilder();
+    for (ExpectedCommand command : commands) {
+      if (statement.length() > 0) {
+        statement.append(';');
+      }
+      statement.append(command.statement);
+    }
+    return statement.toString();
+  }
+
+  private static Stream<Arguments> pipelineScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (PipelineScenario) pipeline -> {}, emptyList()),
+        Arguments.of(
+            "single",
+            (PipelineScenario) pipeline -> pipeline.set("batch1", "v1"),
+            expectedCommands(expectedCommand("SET", "SET batch1 ?"))),
+        Arguments.of(
+            "twoSameOperation",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.set("batch2", "v2");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("SET", "SET batch2 ?"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (PipelineScenario)
+                pipeline -> {
+                  pipeline.set("batch1", "v1");
+                  pipeline.get("batch1");
+                },
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("GET", "GET batch1"))));
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation, String statement) {
+    return new ExpectedCommand(operation, statement);
+  }
+
+  private interface PipelineScenario {
+    void run(Pipeline pipeline);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+    private final String statement;
+
+    private ExpectedCommand(String operation, String statement) {
+      this.operation = operation;
+      this.statement = statement;
+    }
   }
 }

--- a/instrumentation/jedis/jedis-common-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/common/v1_4/JedisPipelineContext.java
+++ b/instrumentation/jedis/jedis-common-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/common/v1_4/JedisPipelineContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.annotation.Nullable;
+
+public final class JedisPipelineContext {
+  private static final ThreadLocal<Object> currentPipeline = new ThreadLocal<>();
+  private static final Map<Object, List<Object>> requestsByPipeline =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  public static void enter(Object pipeline) {
+    currentPipeline.set(pipeline);
+  }
+
+  public static void exit() {
+    currentPipeline.remove();
+  }
+
+  public static boolean capture(Object request) {
+    Object pipeline = currentPipeline.get();
+    if (pipeline == null) {
+      return false;
+    }
+    requestsByPipeline.computeIfAbsent(pipeline, unused -> new ArrayList<>()).add(request);
+    return true;
+  }
+
+  public static List<Object> drain(Object pipeline) {
+    List<Object> requests = requestsByPipeline.remove(pipeline);
+    return requests != null ? requests : emptyList();
+  }
+
+  @Nullable
+  public static Object currentPipeline() {
+    return currentPipeline.get();
+  }
+
+  private JedisPipelineContext() {}
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSin
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.lambdaworks.redis.protocol.AsyncCommand;
 import com.lambdaworks.redis.protocol.RedisCommand;
@@ -35,24 +36,53 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
         named("dispatch")
             .and(takesArgument(0, named("com.lambdaworks.redis.protocol.RedisCommand"))),
         getClass().getName() + "$DispatchAdvice");
+    transformer.applyAdviceToMethod(
+        named("setAutoFlushCommands").and(takesArguments(1)),
+        getClass().getName() + "$SetAutoFlushAdvice");
+    transformer.applyAdviceToMethod(
+        named("flushCommands").and(takesArguments(0)), getClass().getName() + "$FlushAdvice");
   }
 
   @SuppressWarnings("unused")
   public static class DispatchAdvice {
 
     public static class AdviceScope {
-      private final Context context;
-      private final Scope scope;
+      private final Object commands;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean captured;
 
-      public AdviceScope(Context context, Scope scope) {
+      public AdviceScope(
+          Object commands, @Nullable Context context, @Nullable Scope scope, boolean captured) {
+        this.commands = commands;
         this.context = context;
         this.scope = scope;
+        this.captured = captured;
+      }
+
+      public static AdviceScope captured(Object commands) {
+        Context parentContext = currentContext();
+        Context context = parentContext.with(COMMAND_CONTEXT_KEY, parentContext);
+        return new AdviceScope(commands, null, context.makeCurrent(), true);
       }
 
       public void end(
           @Nullable Throwable throwable,
           RedisCommand<?, ?, ?> command,
           @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+        if (captured) {
+          try {
+            LettuceBatchContext.capture(commands, command, asyncCommand);
+          } finally {
+            if (scope != null) {
+              scope.close();
+            }
+          }
+          return;
+        }
+        if (scope == null || context == null) {
+          return;
+        }
         scope.close();
         InstrumentationPoints.afterCommand(command, context, throwable, asyncCommand);
       }
@@ -60,7 +90,11 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     @Nullable
-    public static AdviceScope onEnter(@Advice.Argument(0) RedisCommand<?, ?, ?> command) {
+    public static AdviceScope onEnter(
+        @Advice.This Object commands, @Advice.Argument(0) RedisCommand<?, ?, ?> command) {
+      if (LettuceBatchContext.isCollecting(commands)) {
+        return AdviceScope.captured(commands);
+      }
 
       Context parentContext = currentContext();
       if (!instrumenter().shouldStart(parentContext, command)) {
@@ -70,7 +104,7 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
       Context context = instrumenter().start(parentContext, command);
       // remember the context that called dispatch, it is used in LettuceAsyncCommandInstrumentation
       context = context.with(COMMAND_CONTEXT_KEY, parentContext);
-      return new AdviceScope(context, context.makeCurrent());
+      return new AdviceScope(commands, context, context.makeCurrent(), false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -81,6 +115,51 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
         @Advice.Enter @Nullable AdviceScope adviceScope) {
       if (adviceScope != null) {
         adviceScope.end(throwable, command, asyncCommand);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SetAutoFlushAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This Object commands, @Advice.Argument(0) boolean autoFlush) {
+      LettuceBatchContext.setCollecting(commands, !autoFlush);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class FlushAdvice {
+
+    public static class FlushAdviceScope {
+      @Nullable private final LettuceBatchContext.BatchScope batchScope;
+
+      private FlushAdviceScope(@Nullable LettuceBatchContext.BatchScope batchScope) {
+        this.batchScope = batchScope;
+      }
+
+      public static FlushAdviceScope start(Object commands) {
+        return new FlushAdviceScope(LettuceBatchContext.start(commands));
+      }
+
+      public void end(@Nullable Throwable throwable) {
+        if (throwable != null && batchScope != null) {
+          batchScope.endOne(throwable);
+        }
+      }
+    }
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static FlushAdviceScope onEnter(@Advice.This Object commands) {
+      return FlushAdviceScope.start(commands);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Enter @Nullable FlushAdviceScope adviceScope) {
+      if (adviceScope != null) {
+        adviceScope.end(throwable);
       }
     }
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchAttributesGetter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import javax.annotation.Nullable;
+
+final class LettuceBatchAttributesGetter
+    implements DbClientAttributesGetter<LettuceBatchRequest, Void> {
+
+  @Override
+  public String getDbSystemName(LettuceBatchRequest request) {
+    return DbSystemNameIncubatingValues.REDIS;
+  }
+
+  @Override
+  @Nullable
+  public String getDbNamespace(LettuceBatchRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public String getDbQueryText(LettuceBatchRequest request) {
+    return null;
+  }
+
+  @Override
+  public String getDbOperationName(LettuceBatchRequest request) {
+    return request.getOperationName();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(LettuceBatchRequest request) {
+    return request.getBatchSize();
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchContext.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchContext.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.CONTEXT;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.batchInstrumenter;
+
+import com.lambdaworks.redis.protocol.AsyncCommand;
+import com.lambdaworks.redis.protocol.RedisCommand;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+public final class LettuceBatchContext {
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "lettuce")
+          .getBoolean("experimental_span_attributes/development", false);
+
+  private static final Map<Object, BatchState> states =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  public static void setCollecting(Object commands, boolean collecting) {
+    if (collecting) {
+      states.put(commands, new BatchState());
+    } else {
+      states.remove(commands);
+    }
+  }
+
+  public static boolean isCollecting(Object commands) {
+    return states.containsKey(commands);
+  }
+
+  public static boolean capture(
+      Object commands,
+      RedisCommand<?, ?, ?> command,
+      @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+    BatchState state = states.get(commands);
+    if (state == null) {
+      return false;
+    }
+    state.add(command, asyncCommand);
+    return true;
+  }
+
+  @Nullable
+  public static BatchScope start(Object commands) {
+    BatchState state = states.get(commands);
+    if (state == null || state.commands.isEmpty()) {
+      return null;
+    }
+    return BatchScope.start(state.drainCommands(), state.drainAsyncCommands(), state.parentContext);
+  }
+
+  private LettuceBatchContext() {}
+
+  public static final class BatchScope {
+    private final Context context;
+    private final LettuceBatchRequest request;
+    private final AtomicInteger remaining;
+
+    private BatchScope(Context context, LettuceBatchRequest request, int remaining) {
+      this.context = context;
+      this.request = request;
+      this.remaining = new AtomicInteger(remaining);
+    }
+
+    @Nullable
+    private static BatchScope start(
+        List<RedisCommand<?, ?, ?>> commands,
+        List<AsyncCommand<?, ?, ?>> asyncCommands,
+        @Nullable Context capturedParentContext) {
+      LettuceBatchRequest request = LettuceBatchRequest.create(commands);
+      Context parentContext =
+          capturedParentContext == null ? currentContext() : capturedParentContext;
+      if (!batchInstrumenter().shouldStart(parentContext, request)) {
+        return null;
+      }
+      Context context = batchInstrumenter().start(parentContext, request);
+      if (asyncCommands.isEmpty()) {
+        batchInstrumenter().end(context, request, null, null);
+        return null;
+      }
+      BatchScope scope = new BatchScope(context, request, asyncCommands.size());
+      for (AsyncCommand<?, ?, ?> asyncCommand : asyncCommands) {
+        asyncCommand.handleAsync(
+            (value, throwable) -> {
+              scope.endOne(throwable);
+              return null;
+            });
+      }
+      return scope;
+    }
+
+    public void endOne(@Nullable Throwable throwable) {
+      if (throwable instanceof CancellationException) {
+        if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+          Span.fromContext(context).setAttribute("lettuce.command.cancelled", true);
+        }
+        throwable = null;
+      }
+      if (remaining.getAndDecrement() == 1) {
+        batchInstrumenter().end(context, request, null, throwable);
+      }
+    }
+  }
+
+  private static final class BatchState {
+    private final List<RedisCommand<?, ?, ?>> commands = new ArrayList<>();
+    private final List<AsyncCommand<?, ?, ?>> asyncCommands = new ArrayList<>();
+    @Nullable private Context parentContext;
+
+    private void add(RedisCommand<?, ?, ?> command, @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+      commands.add(command);
+      if (parentContext == null && asyncCommand != null) {
+        parentContext = CONTEXT.get(asyncCommand);
+      }
+      if (asyncCommand != null && InstrumentationPoints.expectsResponse(command)) {
+        asyncCommands.add(asyncCommand);
+      }
+    }
+
+    private List<RedisCommand<?, ?, ?>> drainCommands() {
+      List<RedisCommand<?, ?, ?>> drainedCommands = new ArrayList<>(commands);
+      commands.clear();
+      return drainedCommands;
+    }
+
+    private List<AsyncCommand<?, ?, ?>> drainAsyncCommands() {
+      List<AsyncCommand<?, ?, ?>> drainedAsyncCommands = new ArrayList<>(asyncCommands);
+      asyncCommands.clear();
+      return drainedAsyncCommands;
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchRequest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import com.lambdaworks.redis.protocol.RedisCommand;
+import java.util.List;
+import javax.annotation.Nullable;
+
+final class LettuceBatchRequest {
+  private final String operationName;
+  @Nullable private final Long batchSize;
+
+  private LettuceBatchRequest(String operationName, @Nullable Long batchSize) {
+    this.operationName = operationName;
+    this.batchSize = batchSize;
+  }
+
+  static LettuceBatchRequest create(List<RedisCommand<?, ?, ?>> commands) {
+    return new LettuceBatchRequest(
+        operationName(commands), commands.size() > 1 ? (long) commands.size() : null);
+  }
+
+  String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
+  }
+
+  private static String operationName(List<RedisCommand<?, ?, ?>> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).getType().name();
+    }
+    String operationName = commands.get(0).getType().name();
+    for (int i = 1; i < commands.size(); i++) {
+      if (!operationName.equals(commands.get(i).getType().name())) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operationName;
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -28,6 +28,7 @@ public class LettuceSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.lettuce-4.0";
 
   private static final Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter;
+  private static final Instrumenter<LettuceBatchRequest, Void> batchInstrumenter;
   private static final Instrumenter<RedisURI, Void> connectInstrumenter;
 
   public static final ContextKey<Context> COMMAND_CONTEXT_KEY =
@@ -50,6 +51,17 @@ public class LettuceSingletons {
 
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
+    LettuceBatchAttributesGetter batchAttributesGetter = new LettuceBatchAttributesGetter();
+    InstrumenterBuilder<LettuceBatchRequest, Void> batchBuilder =
+        Instrumenter.<LettuceBatchRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(batchAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(batchAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(batchBuilder);
+    batchInstrumenter = batchBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
+
     LettuceConnectNetworkAttributesGetter netAttributesGetter =
         new LettuceConnectNetworkAttributesGetter();
 
@@ -70,6 +82,10 @@ public class LettuceSingletons {
 
   public static Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter() {
     return instrumenter;
+  }
+
+  public static Instrumenter<LettuceBatchRequest, Void> batchInstrumenter() {
+    return batchInstrumenter;
   }
 
   public static Instrumenter<RedisURI, Void> connectInstrumenter() {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -462,7 +462,7 @@ class LettuceAsyncClientTest {
     await().untilAsserted(() -> assertThat(cancelSuccess).isTrue());
     testing.waitAndAssertTraces(
         trace ->
-            trace.hasSpansSatisfyingExactly(
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
                 span ->
                     span.hasName("parent")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.ExperimentalHelper.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
@@ -18,6 +19,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
@@ -52,9 +54,13 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -474,6 +480,99 @@ class LettuceAsyncClientTest {
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+  }
+
+  // Lettuce auto-flush batching is traced as one aggregate span from flush through completion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("deferredFlushScenarios")
+  void deferredFlushCommand(
+      String name, AsyncCommandsScenario scenario, List<ExpectedCommand> expectedCommands)
+      throws Exception {
+    asyncCommands.setAutoFlushCommands(false);
+    cleanup.deferCleanup(() -> asyncCommands.setAutoFlushCommands(true));
+
+    List<RedisFuture<?>> futures = scenario.run(asyncCommands);
+    asyncCommands.flushCommands();
+    for (RedisFuture<?> future : futures) {
+      future.get(10, SECONDS);
+    }
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
+    String operation = pipelineOperation(expectedCommands);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_OPERATION), operation),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                    ? (long) expectedCommands.size()
+                                    : null))));
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static Stream<Arguments> deferredFlushScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (AsyncCommandsScenario) commands -> emptyList(), emptyList()),
+        Arguments.of(
+            "single",
+            (AsyncCommandsScenario) commands -> futures(commands.set("batch1", "v1")),
+            expectedCommands(expectedCommand("SET"))),
+        Arguments.of(
+            "twoSameOperation",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.set("batch2", "v2")),
+            expectedCommands(expectedCommand("SET"), expectedCommand("SET"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.get("batch1")),
+            expectedCommands(expectedCommand("SET"), expectedCommand("GET"))));
+  }
+
+  private static List<RedisFuture<?>> futures(RedisFuture<?>... futures) {
+    return asList(futures);
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation) {
+    return new ExpectedCommand(operation);
+  }
+
+  private interface AsyncCommandsScenario {
+    List<RedisFuture<?>> run(RedisAsyncCommands<String, String> commands);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+
+    private ExpectedCommand(String operation) {
+      this.operation = operation;
+    }
   }
 
   @Test

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncCommandsInstrumentation.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSin
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.lettuce.core.protocol.AsyncCommand;
 import io.lettuce.core.protocol.RedisCommand;
@@ -35,24 +36,53 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         named("dispatch").and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand"))),
         getClass().getName() + "$DispatchAdvice");
+    transformer.applyAdviceToMethod(
+        named("setAutoFlushCommands").and(takesArguments(1)),
+        getClass().getName() + "$SetAutoFlushAdvice");
+    transformer.applyAdviceToMethod(
+        named("flushCommands").and(takesArguments(0)), getClass().getName() + "$FlushAdvice");
   }
 
   @SuppressWarnings("unused")
   public static class DispatchAdvice {
 
     public static class AdviceScope {
-      private final Context context;
-      private final Scope scope;
+      private final Object commands;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean captured;
 
-      public AdviceScope(Context context, Scope scope) {
+      public AdviceScope(
+          Object commands, @Nullable Context context, @Nullable Scope scope, boolean captured) {
+        this.commands = commands;
         this.context = context;
         this.scope = scope;
+        this.captured = captured;
+      }
+
+      public static AdviceScope captured(Object commands) {
+        Context parentContext = currentContext();
+        Context context = parentContext.with(COMMAND_CONTEXT_KEY, parentContext);
+        return new AdviceScope(commands, null, context.makeCurrent(), true);
       }
 
       public void end(
           @Nullable Throwable throwable,
           RedisCommand<?, ?, ?> command,
           @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+        if (captured) {
+          try {
+            LettuceBatchContext.capture(commands, command, asyncCommand);
+          } finally {
+            if (scope != null) {
+              scope.close();
+            }
+          }
+          return;
+        }
+        if (scope == null || context == null) {
+          return;
+        }
         scope.close();
 
         if (throwable != null || asyncCommand == null) {
@@ -71,7 +101,11 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     @Nullable
-    public static AdviceScope onEnter(@Advice.Argument(0) RedisCommand<?, ?, ?> command) {
+    public static AdviceScope onEnter(
+        @Advice.This Object commands, @Advice.Argument(0) RedisCommand<?, ?, ?> command) {
+      if (LettuceBatchContext.isCollecting(commands)) {
+        return AdviceScope.captured(commands);
+      }
 
       Context parentContext = currentContext();
       if (!instrumenter().shouldStart(parentContext, command)) {
@@ -81,7 +115,7 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
       Context context = instrumenter().start(parentContext, command);
       // remember the context that called dispatch, it is used in LettuceAsyncCommandInstrumentation
       context = context.with(COMMAND_CONTEXT_KEY, parentContext);
-      return new AdviceScope(context, context.makeCurrent());
+      return new AdviceScope(commands, context, context.makeCurrent(), false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -93,6 +127,51 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
       if (adviceScope != null) {
         adviceScope.end(throwable, command, asyncCommand);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SetAutoFlushAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This Object commands, @Advice.Argument(0) boolean autoFlush) {
+      LettuceBatchContext.setCollecting(commands, !autoFlush);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class FlushAdvice {
+
+    public static class FlushAdviceScope {
+      @Nullable private final LettuceBatchContext.BatchScope batchScope;
+
+      private FlushAdviceScope(@Nullable LettuceBatchContext.BatchScope batchScope) {
+        this.batchScope = batchScope;
+      }
+
+      public static FlushAdviceScope start(Object commands) {
+        return new FlushAdviceScope(LettuceBatchContext.start(commands));
+      }
+
+      public void end(@Nullable Throwable throwable) {
+        if (throwable != null && batchScope != null) {
+          batchScope.endOne(throwable);
+        }
+      }
+    }
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static FlushAdviceScope onEnter(@Advice.This Object commands) {
+      return FlushAdviceScope.start(commands);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Enter @Nullable FlushAdviceScope adviceScope) {
+      if (adviceScope != null) {
+        adviceScope.end(throwable);
       }
     }
   }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchAttributesGetter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import javax.annotation.Nullable;
+
+final class LettuceBatchAttributesGetter
+    implements DbClientAttributesGetter<LettuceBatchRequest, Void> {
+
+  @Override
+  public String getDbSystemName(LettuceBatchRequest request) {
+    return DbSystemNameIncubatingValues.REDIS;
+  }
+
+  @Override
+  @Nullable
+  public String getDbNamespace(LettuceBatchRequest request) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public String getDbQueryText(LettuceBatchRequest request) {
+    return request.getQueryText();
+  }
+
+  @Override
+  public String getDbOperationName(LettuceBatchRequest request) {
+    return request.getOperationName();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(LettuceBatchRequest request) {
+    return request.getBatchSize();
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchContext.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchContext.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
+
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.CONTEXT;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceSingletons.batchInstrumenter;
+
+import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.protocol.RedisCommand;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+public final class LettuceBatchContext {
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "lettuce")
+          .getBoolean("experimental_span_attributes/development", false);
+
+  private static final Map<Object, BatchState> states =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  public static void setCollecting(Object commands, boolean collecting) {
+    if (collecting) {
+      states.put(commands, new BatchState());
+    } else {
+      states.remove(commands);
+    }
+  }
+
+  public static boolean isCollecting(Object commands) {
+    return states.containsKey(commands);
+  }
+
+  public static boolean capture(
+      Object commands,
+      RedisCommand<?, ?, ?> command,
+      @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+    BatchState state = states.get(commands);
+    if (state == null) {
+      return false;
+    }
+    state.add(command, asyncCommand);
+    return true;
+  }
+
+  @Nullable
+  public static BatchScope start(Object commands) {
+    BatchState state = states.get(commands);
+    if (state == null || state.commands.isEmpty()) {
+      return null;
+    }
+    return BatchScope.start(state.drainCommands(), state.drainAsyncCommands(), state.parentContext);
+  }
+
+  private LettuceBatchContext() {}
+
+  public static final class BatchScope {
+    private final Context context;
+    private final LettuceBatchRequest request;
+    private final AtomicInteger remaining;
+
+    private BatchScope(Context context, LettuceBatchRequest request, int remaining) {
+      this.context = context;
+      this.request = request;
+      this.remaining = new AtomicInteger(remaining);
+    }
+
+    @Nullable
+    private static BatchScope start(
+        List<RedisCommand<?, ?, ?>> commands,
+        List<AsyncCommand<?, ?, ?>> asyncCommands,
+        @Nullable Context capturedParentContext) {
+      LettuceBatchRequest request = LettuceBatchRequest.create(commands);
+      Context parentContext =
+          capturedParentContext == null ? currentContext() : capturedParentContext;
+      if (!batchInstrumenter().shouldStart(parentContext, request)) {
+        return null;
+      }
+      Context context = batchInstrumenter().start(parentContext, request);
+      if (asyncCommands.isEmpty()) {
+        batchInstrumenter().end(context, request, null, null);
+        return null;
+      }
+      BatchScope scope = new BatchScope(context, request, asyncCommands.size());
+      for (AsyncCommand<?, ?, ?> asyncCommand : asyncCommands) {
+        asyncCommand.handleAsync(
+            (value, throwable) -> {
+              scope.endOne(throwable);
+              return null;
+            });
+      }
+      return scope;
+    }
+
+    public void endOne(@Nullable Throwable throwable) {
+      if (throwable instanceof CancellationException) {
+        if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+          Span.fromContext(context).setAttribute("lettuce.command.cancelled", true);
+        }
+        throwable = null;
+      }
+      if (remaining.getAndDecrement() == 1) {
+        batchInstrumenter().end(context, request, null, throwable);
+      }
+    }
+  }
+
+  private static final class BatchState {
+    private final List<RedisCommand<?, ?, ?>> commands = new ArrayList<>();
+    private final List<AsyncCommand<?, ?, ?>> asyncCommands = new ArrayList<>();
+    @Nullable private Context parentContext;
+
+    private void add(RedisCommand<?, ?, ?> command, @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+      commands.add(command);
+      if (parentContext == null && asyncCommand != null) {
+        parentContext = CONTEXT.get(asyncCommand);
+      }
+      if (asyncCommand != null && LettuceInstrumentationUtil.expectsResponse(command)) {
+        asyncCommands.add(asyncCommand);
+      }
+    }
+
+    private List<RedisCommand<?, ?, ?>> drainCommands() {
+      List<RedisCommand<?, ?, ?>> drainedCommands = new ArrayList<>(commands);
+      commands.clear();
+      return drainedCommands;
+    }
+
+    private List<AsyncCommand<?, ?, ?>> drainAsyncCommands() {
+      List<AsyncCommand<?, ?, ?>> drainedAsyncCommands = new ArrayList<>(asyncCommands);
+      asyncCommands.clear();
+      return drainedAsyncCommands;
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchRequest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceBatchRequest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
+
+import static java.util.Collections.emptyList;
+
+import io.lettuce.core.protocol.RedisCommand;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
+import io.opentelemetry.instrumentation.lettuce.common.LettuceArgSplitter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+
+final class LettuceBatchRequest {
+  private static final RedisCommandSanitizer sanitizer =
+      RedisCommandSanitizer.create(
+          DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "lettuce"));
+
+  private final String operationName;
+  @Nullable private final String queryText;
+  @Nullable private final Long batchSize;
+
+  private LettuceBatchRequest(
+      String operationName, @Nullable String queryText, @Nullable Long batchSize) {
+    this.operationName = operationName;
+    this.queryText = queryText;
+    this.batchSize = batchSize;
+  }
+
+  static LettuceBatchRequest create(List<RedisCommand<?, ?, ?>> commands) {
+    return new LettuceBatchRequest(
+        operationName(commands),
+        queryText(commands),
+        commands.size() > 1 ? (long) commands.size() : null);
+  }
+
+  String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  String getQueryText() {
+    return queryText;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
+  }
+
+  private static String operationName(List<RedisCommand<?, ?, ?>> commands) {
+    if (commands.size() == 1) {
+      return LettuceInstrumentationUtil.getCommandName(commands.get(0));
+    }
+    String operationName = LettuceInstrumentationUtil.getCommandName(commands.get(0));
+    for (int i = 1; i < commands.size(); i++) {
+      if (!operationName.equals(LettuceInstrumentationUtil.getCommandName(commands.get(i)))) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operationName;
+  }
+
+  @Nullable
+  private static String queryText(List<RedisCommand<?, ?, ?>> commands) {
+    StringJoiner joiner = new StringJoiner(";");
+    List<String> queryTexts = new ArrayList<>(commands.size());
+    for (RedisCommand<?, ?, ?> command : commands) {
+      queryTexts.add(queryText(command));
+    }
+    if (queryTexts.isEmpty()) {
+      return null;
+    }
+    for (String queryText : queryTexts) {
+      joiner.add(queryText);
+    }
+    return joiner.toString();
+  }
+
+  private static String queryText(RedisCommand<?, ?, ?> command) {
+    String commandName = LettuceInstrumentationUtil.getCommandName(command);
+    List<String> args =
+        command.getArgs() == null
+            ? emptyList()
+            : LettuceArgSplitter.splitArgs(command.getArgs().toCommandString());
+    return sanitizer.sanitize(commandName, args);
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -28,6 +28,7 @@ public class LettuceSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.lettuce-5.0";
 
   private static final Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter;
+  private static final Instrumenter<LettuceBatchRequest, Void> batchInstrumenter;
   private static final Instrumenter<RedisURI, Void> connectInstrumenter;
 
   public static final ContextKey<Context> COMMAND_CONTEXT_KEY =
@@ -50,6 +51,17 @@ public class LettuceSingletons {
 
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
+    LettuceBatchAttributesGetter batchAttributesGetter = new LettuceBatchAttributesGetter();
+    InstrumenterBuilder<LettuceBatchRequest, Void> batchBuilder =
+        Instrumenter.<LettuceBatchRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                INSTRUMENTATION_NAME,
+                DbClientSpanNameExtractor.create(batchAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(batchAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(batchBuilder);
+    batchInstrumenter = batchBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
+
     LettuceConnectNetworkAttributesGetter connectNetworkAttributesGetter =
         new LettuceConnectNetworkAttributesGetter();
 
@@ -71,6 +83,10 @@ public class LettuceSingletons {
 
   public static Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter() {
     return instrumenter;
+  }
+
+  public static Instrumenter<LettuceBatchRequest, Void> batchInstrumenter() {
+    return batchInstrumenter;
   }
 
   public static Instrumenter<RedisURI, Void> connectInstrumenter() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServ
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.ExperimentalHelper.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
@@ -21,6 +22,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
@@ -54,10 +56,14 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class LettuceAsyncClientTest extends AbstractLettuceClientTest {
@@ -482,6 +488,115 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+  }
+
+  // Lettuce auto-flush batching is traced as one aggregate span from flush through completion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("deferredFlushScenarios")
+  void deferredFlushCommand(
+      String name, AsyncCommandsScenario scenario, List<ExpectedCommand> expectedCommands)
+      throws Exception {
+    asyncCommands.setAutoFlushCommands(false);
+    cleanup.deferCleanup(() -> asyncCommands.setAutoFlushCommands(true));
+
+    List<RedisFuture<?>> futures = scenario.run(asyncCommands);
+    asyncCommands.flushCommands();
+    for (RedisFuture<?> future : futures) {
+      future.get(10, SECONDS);
+    }
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
+    String operation = pipelineOperation(expectedCommands);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), pipelineStatement(expectedCommands)),
+                            equalTo(maybeStable(DB_OPERATION), operation),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                    ? (long) expectedCommands.size()
+                                    : null))));
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static String pipelineStatement(List<ExpectedCommand> commands) {
+    StringBuilder statement = new StringBuilder();
+    for (ExpectedCommand command : commands) {
+      if (statement.length() > 0) {
+        statement.append(';');
+      }
+      statement.append(command.statement);
+    }
+    return statement.toString();
+  }
+
+  private static Stream<Arguments> deferredFlushScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (AsyncCommandsScenario) commands -> emptyList(), emptyList()),
+        Arguments.of(
+            "single",
+            (AsyncCommandsScenario) commands -> futures(commands.set("batch1", "v1")),
+            expectedCommands(expectedCommand("SET", "SET batch1 ?"))),
+        Arguments.of(
+            "twoSameOperation",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.set("batch2", "v2")),
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("SET", "SET batch2 ?"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.get("batch1")),
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("GET", "GET batch1"))));
+  }
+
+  private static List<RedisFuture<?>> futures(RedisFuture<?>... futures) {
+    return asList(futures);
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation, String statement) {
+    return new ExpectedCommand(operation, statement);
+  }
+
+  private interface AsyncCommandsScenario {
+    List<RedisFuture<?>> run(RedisAsyncCommands<String, String> commands);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+    private final String statement;
+
+    private ExpectedCommand(String operation, String statement) {
+      this.operation = operation;
+      this.statement = statement;
+    }
   }
 
   @Test

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -469,7 +469,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
     await().untilAsserted(() -> assertThat(cancelSuccess).isTrue());
     testing.waitAndAssertTraces(
         trace ->
-            trace.hasSpansSatisfyingExactly(
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
                 span ->
                     span.hasName("parent")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncCommandsInstrumentation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_1;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.lettuce.core.protocol.RedisCommand;
+import io.opentelemetry.instrumentation.lettuce.v5_1.LettuceTelemetry;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("io.lettuce.core.AbstractRedisAsyncCommands");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("dispatch").and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand"))),
+        getClass().getName() + "$DispatchAdvice");
+    transformer.applyAdviceToMethod(
+        named("setAutoFlushCommands").and(takesArguments(1)),
+        getClass().getName() + "$SetAutoFlushAdvice");
+    transformer.applyAdviceToMethod(
+        named("flushCommands").and(takesArguments(0)), getClass().getName() + "$FlushAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class DispatchAdvice {
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This Object commands,
+        @Advice.Argument(0) RedisCommand<?, ?, ?> command,
+        @Advice.Thrown @Nullable Throwable throwable) {
+      if (throwable == null) {
+        LettuceTelemetry.capture(commands, command);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class SetAutoFlushAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This Object commands, @Advice.Argument(0) boolean autoFlush) {
+      LettuceTelemetry.setAutoFlushCommands(commands, autoFlush);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class FlushAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Nullable
+    public static Object onEnter(@Advice.This Object commands) {
+      return LettuceTelemetry.startBatch(commands);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Thrown @Nullable Throwable throwable, @Advice.Enter @Nullable Object batch) {
+      if (batch != null) {
+        LettuceTelemetry.finishBatch(batch, throwable);
+      }
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncCommandsInstrumentation.java
@@ -22,13 +22,16 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("io.lettuce.core.AbstractRedisAsyncCommands");
+    return named("io.lettuce.core.AbstractRedisAsyncCommands")
+        .or(named("io.lettuce.core.protocol.DefaultEndpoint"));
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("dispatch").and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand"))),
+        named("dispatch")
+            .or(named("write"))
+            .and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand"))),
         getClass().getName() + "$DispatchAdvice");
     transformer.applyAdviceToMethod(
         named("setAutoFlushCommands").and(takesArguments(1)),

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceCommandHandlerInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceCommandHandlerInstrumentation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_1;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.lettuce.core.protocol.RedisCommand;
+import io.opentelemetry.instrumentation.lettuce.v5_1.LettuceTelemetry;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class LettuceCommandHandlerInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("io.lettuce.core.protocol.CommandHandler");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("writeSingleCommand")
+            .and(takesArgument(1, named("io.lettuce.core.protocol.RedisCommand"))),
+        getClass().getName() + "$WriteSingleCommandAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class WriteSingleCommandAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.Argument(1) RedisCommand<?, ?, ?> command) {
+      LettuceTelemetry.startCommand(command);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit() {
+      LettuceTelemetry.endCommand();
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
@@ -34,6 +34,10 @@ public class LettuceInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new ClientResourcesInstrumentation(), new LettuceAsyncCommandInstrumentation());
+    return asList(
+        new ClientResourcesInstrumentation(),
+        new LettuceAsyncCommandsInstrumentation(),
+        new LettuceCommandHandlerInstrumentation(),
+        new LettuceAsyncCommandInstrumentation());
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.java
@@ -31,4 +31,9 @@ class LettuceAsyncClientTest extends AbstractLettuceAsyncClientTest {
   protected boolean connectHasSpans() {
     return testLatestDeps();
   }
+
+  @Override
+  protected boolean aggregateDeferredFlush() {
+    return true;
+  }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/lettuce/core/protocol/OtelCommandArgsUtil.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/lettuce/core/protocol/OtelCommandArgsUtil.java
@@ -5,43 +5,18 @@
 
 package io.lettuce.core.protocol;
 
-import io.lettuce.core.codec.StringCodec;
-import io.lettuce.core.protocol.CommandArgs.KeyArgument;
-import io.lettuce.core.protocol.CommandArgs.SingularArgument;
-import io.lettuce.core.protocol.CommandArgs.ValueArgument;
 import io.opentelemetry.instrumentation.lettuce.common.LettuceArgSplitter;
-import java.util.ArrayList;
 import java.util.List;
 
-// Helper class for accessing package private fields in CommandArgs and its inner classes.
-// https://github.com/lettuce-io/lettuce-core/blob/main/src/main/java/io/lettuce/core/protocol/CommandArgs.java
 public final class OtelCommandArgsUtil {
 
   /**
-   * Extract argument {@link List} from {@link CommandArgs} so that we wouldn't need to parse them
-   * from command {@link String} with {@link LettuceArgSplitter#splitArgs}.
+   * Extract argument {@link List} from {@link CommandArgs} using public API only. Helper classes
+   * can be loaded by a different class loader than Lettuce, so package-private field access is not
+   * safe even from the same package name.
    */
   public static List<String> getCommandArgs(CommandArgs<?, ?> commandArgs) {
-    List<String> result = new ArrayList<>();
-
-    for (SingularArgument argument : commandArgs.singularArguments) {
-      String value = getArgValue(StringCodec.UTF8, argument);
-      result.add(value);
-    }
-    return result;
-  }
-
-  @SuppressWarnings("unchecked") // type is checked before casting
-  private static String getArgValue(StringCodec stringCodec, SingularArgument argument) {
-    if (argument instanceof KeyArgument) {
-      KeyArgument<Object, ?> keyArg = (KeyArgument<Object, ?>) argument;
-      return stringCodec.decodeKey(keyArg.codec.encodeKey(keyArg.key));
-    }
-    if (argument instanceof ValueArgument) {
-      ValueArgument<?, Object> valueArg = (ValueArgument<?, Object>) argument;
-      return stringCodec.decodeValue(valueArg.codec.encodeValue(valueArg.val));
-    }
-    return argument.toString();
+    return LettuceArgSplitter.splitArgs(commandArgs.toCommandString());
   }
 
   private OtelCommandArgsUtil() {}

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesGetter.java
@@ -41,6 +41,12 @@ class LettuceDbAttributesGetter
 
   @Nullable
   @Override
+  public Long getDbOperationBatchSize(LettuceRequest request) {
+    return request.getBatchSize();
+  }
+
+  @Nullable
+  @Override
   public String getServerAddress(LettuceRequest request) {
     InetSocketAddress address = request.getAddress();
     return address != null ? address.getHostString() : null;

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceRequest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceRequest.java
@@ -6,10 +6,14 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.lettuce.common.LettuceArgSplitter.splitArgs;
+import static java.util.Collections.emptyList;
 
+import io.lettuce.core.protocol.OtelCommandArgsUtil;
+import io.lettuce.core.protocol.RedisCommand;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 final class LettuceRequest {
@@ -20,6 +24,8 @@ final class LettuceRequest {
   @Nullable private String argsString;
   @Nullable private InetSocketAddress address;
   @Nullable private Long databaseIndex;
+  @Nullable private Long batchSize;
+  private boolean pipeline;
 
   LettuceRequest(RedisCommandSanitizer sanitizer) {
     this.sanitizer = sanitizer;
@@ -55,9 +61,22 @@ final class LettuceRequest {
     this.databaseIndex = databaseIndex;
   }
 
+  void setPipeline(List<RedisCommand<?, ?, ?>> commands) {
+    command = pipelineOperationName(commands);
+    argsList = null;
+    argsString = pipelineStatement(commands);
+    batchSize = commands.size() > 1 ? (long) commands.size() : null;
+    pipeline = true;
+  }
+
   @Nullable
   Long getDatabaseIndex() {
     return databaseIndex;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
   }
 
   @Nullable
@@ -66,10 +85,39 @@ final class LettuceRequest {
     if (cmd == null) {
       return null;
     }
+    if (pipeline) {
+      return argsString;
+    }
     List<String> args = argsList;
     if (args == null) {
       args = splitArgs(argsString);
     }
     return sanitizer.sanitize(cmd, args);
+  }
+
+  private static String pipelineOperationName(List<RedisCommand<?, ?, ?>> commands) {
+    String operationName = commands.get(0).getType().name();
+    if (commands.size() == 1) {
+      return operationName;
+    }
+    for (int i = 1; i < commands.size(); i++) {
+      if (!operationName.equals(commands.get(i).getType().name())) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operationName;
+  }
+
+  private String pipelineStatement(List<RedisCommand<?, ?, ?>> commands) {
+    StringJoiner joiner = new StringJoiner(";");
+    for (RedisCommand<?, ?, ?> command : commands) {
+      String commandName = command.getType().name();
+      List<String> args =
+          command.getArgs() == null
+              ? emptyList()
+              : OtelCommandArgsUtil.getCommandArgs(command.getArgs());
+      joiner.add(sanitizer.sanitize(commandName, args));
+    }
+    return joiner.toString();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceRequest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceRequest.java
@@ -96,12 +96,12 @@ final class LettuceRequest {
   }
 
   private static String pipelineOperationName(List<RedisCommand<?, ?, ?>> commands) {
-    String operationName = commands.get(0).getType().name();
+    String operationName = commands.get(0).getType().toString();
     if (commands.size() == 1) {
       return operationName;
     }
     for (int i = 1; i < commands.size(); i++) {
-      if (!operationName.equals(commands.get(i).getType().name())) {
+      if (!operationName.equals(commands.get(i).getType().toString())) {
         return "PIPELINE";
       }
     }
@@ -111,7 +111,7 @@ final class LettuceRequest {
   private String pipelineStatement(List<RedisCommand<?, ?, ?>> commands) {
     StringJoiner joiner = new StringJoiner(";");
     for (RedisCommand<?, ?, ?> command : commands) {
-      String commandName = command.getType().name();
+      String commandName = command.getType().toString();
       List<String> args =
           command.getArgs() == null
               ? emptyList()

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetry.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetry.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
+import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.tracing.Tracing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import javax.annotation.Nullable;
 
 /** Entrypoint for instrumenting Lettuce or clients. */
 public final class LettuceTelemetry {
@@ -28,6 +30,37 @@ public final class LettuceTelemetry {
    */
   public static LettuceTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new LettuceTelemetryBuilder(openTelemetry);
+  }
+
+  /** Used by the javaagent to track Lettuce auto-flush batches. */
+  public static void setAutoFlushCommands(Object commands, boolean autoFlush) {
+    OpenTelemetryTracing.setAutoFlushCommands(commands, autoFlush);
+  }
+
+  /** Used by the javaagent to capture commands while Lettuce auto-flush is disabled. */
+  public static void capture(Object commands, RedisCommand<?, ?, ?> command) {
+    OpenTelemetryTracing.capture(commands, command);
+  }
+
+  /** Used by the javaagent to start an aggregate span for a flushed Lettuce batch. */
+  @Nullable
+  public static Object startBatch(Object commands) {
+    return OpenTelemetryTracing.startBatch(commands);
+  }
+
+  /** Used by the javaagent to clear the active flushed batch and end it on synchronous failure. */
+  public static void finishBatch(Object batch, @Nullable Throwable throwable) {
+    OpenTelemetryTracing.finishBatch(batch, throwable);
+  }
+
+  /** Used by the javaagent to activate batch suppression while Lettuce writes a command. */
+  public static void startCommand(RedisCommand<?, ?, ?> command) {
+    OpenTelemetryTracing.startCommand(command);
+  }
+
+  /** Used by the javaagent to clear the active command write batch suppression. */
+  public static void endCommand() {
+    OpenTelemetryTracing.endCommand();
   }
 
   LettuceTelemetry(

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.lettuce.core.output.CommandOutput;
+import io.lettuce.core.protocol.CommandWrapper;
 import io.lettuce.core.protocol.CompleteableCommand;
 import io.lettuce.core.protocol.OtelCommandArgsUtil;
 import io.lettuce.core.protocol.RedisCommand;
@@ -25,12 +26,67 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
 final class OpenTelemetryTracing implements Tracing {
+  private static final Map<Object, BatchState> batchStates =
+      Collections.synchronizedMap(new WeakHashMap<>());
+  private static final Map<RedisCommand<?, ?, ?>, BatchScope> activeBatchCommands =
+      Collections.synchronizedMap(new WeakHashMap<>());
+  private static final ThreadLocal<BatchScope> currentBatchScope = new ThreadLocal<>();
 
   private final TracerProvider tracerProvider;
+
+  static void setAutoFlushCommands(Object commands, boolean autoFlush) {
+    if (autoFlush) {
+      batchStates.remove(commands);
+    } else {
+      batchStates.put(commands, new BatchState());
+    }
+  }
+
+  static void capture(Object commands, RedisCommand<?, ?, ?> command) {
+    BatchState batchState = batchStates.get(commands);
+    if (batchState != null) {
+      batchState.capture(command);
+    }
+  }
+
+  @Nullable
+  static Object startBatch(Object commands) {
+    BatchState batchState = batchStates.get(commands);
+    if (batchState == null) {
+      return null;
+    }
+    BatchScope batchScope = batchState.start();
+    return batchScope;
+  }
+
+  static void finishBatch(Object batch, @Nullable Throwable throwable) {
+    currentBatchScope.remove();
+    if (throwable != null && batch instanceof BatchScope) {
+      ((BatchScope) batch).finish(throwable);
+    }
+  }
+
+  static void startCommand(RedisCommand<?, ?, ?> command) {
+    BatchScope batchScope = activeBatchCommands.get(command);
+    if (batchScope == null) {
+      batchScope = activeBatchCommands.get(CommandWrapper.unwrap(command));
+    }
+    if (batchScope != null) {
+      currentBatchScope.set(batchScope);
+    }
+  }
+
+  static void endCommand() {
+    currentBatchScope.remove();
+  }
 
   OpenTelemetryTracing(
       Instrumenter<LettuceRequest, LettuceResponse> instrumenter,
@@ -150,6 +206,81 @@ final class OpenTelemetryTracing implements Tracing {
     }
   }
 
+  private static final class BatchState {
+    private final List<RedisCommand<?, ?, ?>> commands = new ArrayList<>();
+
+    private synchronized void capture(RedisCommand<?, ?, ?> command) {
+      commands.add(command);
+    }
+
+    @Nullable
+    private synchronized BatchScope start() {
+      if (commands.isEmpty()) {
+        return null;
+      }
+
+      List<RedisCommand<?, ?, ?>> batchCommands = new ArrayList<>(commands);
+      commands.clear();
+      return new BatchScope(batchCommands);
+    }
+  }
+
+  private static final class BatchScope {
+    private final List<RedisCommand<?, ?, ?>> commands;
+    private final AtomicInteger remaining;
+    @Nullable private OpenTelemetrySpan aggregateSpan;
+    @Nullable private Throwable error;
+    @Nullable private String errorMessage;
+
+    private BatchScope(List<RedisCommand<?, ?, ?>> commands) {
+      this.commands = commands;
+      this.remaining = new AtomicInteger(commands.size());
+      for (RedisCommand<?, ?, ?> command : commands) {
+        activeBatchCommands.put(command, this);
+      }
+    }
+
+    private synchronized boolean capture(OpenTelemetrySpan span) {
+      if (aggregateSpan == null) {
+        aggregateSpan = span.createAggregateSpan(commands);
+      }
+      span.batchScope = this;
+      return true;
+    }
+
+    private synchronized void finishOne(OpenTelemetrySpan span) {
+      LettuceResponse response = span.response;
+      if (response != null && response.getErrorMessage() != null && errorMessage == null) {
+        errorMessage = response.getErrorMessage();
+      }
+      if (span.errorMessage != null && errorMessage == null) {
+        errorMessage = span.errorMessage;
+      }
+      if (span.error != null && error == null) {
+        error = span.error;
+      }
+
+      if (remaining.getAndDecrement() == 1) {
+        finish(null);
+      }
+    }
+
+    private synchronized void finish(@Nullable Throwable throwable) {
+      OpenTelemetrySpan span = aggregateSpan;
+      if (span == null) {
+        return;
+      }
+      aggregateSpan = null;
+      for (RedisCommand<?, ?, ?> command : commands) {
+        activeBatchCommands.remove(command);
+      }
+      if (throwable != null) {
+        error = throwable;
+      }
+      span.finishWithResponse(new LettuceResponse(errorMessage, error));
+    }
+  }
+
   // The order that callbacks will be called in or which thread they are called from is not well
   // defined. We go ahead and buffer all data until we know we have a span. This implementation is
   // particularly safe, synchronizing all accesses. Relying on implementation details would allow
@@ -158,13 +289,17 @@ final class OpenTelemetryTracing implements Tracing {
 
     private final Context parentContext;
     private final Instrumenter<LettuceRequest, LettuceResponse> instrumenter;
+    private final RedisCommandSanitizer sanitizer;
     private final boolean encodingEventsEnabled;
     private final LettuceRequest request;
 
     @Nullable private List<Object> events;
     @Nullable private Throwable error;
+    @Nullable private String errorMessage;
     @Nullable private LettuceResponse response;
     @Nullable private Context context;
+    @Nullable private BatchScope batchScope;
+    private boolean aggregate;
 
     OpenTelemetrySpan(
         Context parentContext,
@@ -173,6 +308,7 @@ final class OpenTelemetryTracing implements Tracing {
         boolean encodingEventsEnabled) {
       this.parentContext = parentContext;
       this.instrumenter = instrumenter;
+      this.sanitizer = sanitizer;
       this.encodingEventsEnabled = encodingEventsEnabled;
       this.request = new LettuceRequest(sanitizer);
     }
@@ -204,6 +340,20 @@ final class OpenTelemetryTracing implements Tracing {
         request.setArgsList(OtelCommandArgsUtil.getCommandArgs(command.getArgs()));
       }
 
+      BatchScope batchScope = aggregate ? null : currentBatchScope.get();
+      if (batchScope != null && batchScope.capture(this)) {
+        if (command instanceof CompleteableCommand) {
+          CompleteableCommand<?> completeableCommand = (CompleteableCommand<?>) command;
+          completeableCommand.onComplete(
+              (o, throwable) -> {
+                CommandOutput<?, ?, ?> output = command.getOutput();
+                String errorMsg = output != null ? output.getError() : null;
+                finishWithResponse(new LettuceResponse(errorMsg, throwable));
+              });
+        }
+        return this;
+      }
+
       start();
 
       if (context == null) {
@@ -227,6 +377,11 @@ final class OpenTelemetryTracing implements Tracing {
     @Override
     @CanIgnoreReturnValue
     public synchronized Tracer.Span start() {
+      BatchScope batchScope = aggregate ? null : currentBatchScope.get();
+      if (batchScope != null && batchScope.capture(this)) {
+        return this;
+      }
+
       if (instrumenter.shouldStart(parentContext, request)) {
         context = instrumenter.start(parentContext, request);
 
@@ -241,6 +396,23 @@ final class OpenTelemetryTracing implements Tracing {
       }
 
       return this;
+    }
+
+    private OpenTelemetrySpan createAggregateSpan(List<RedisCommand<?, ?, ?>> commands) {
+      OpenTelemetrySpan span =
+          new OpenTelemetrySpan(parentContext, instrumenter, sanitizer, encodingEventsEnabled);
+      span.aggregate = true;
+      span.request.setPipeline(commands);
+      InetSocketAddress address = request.getAddress();
+      if (address != null) {
+        span.request.setAddress(address);
+      }
+      Long databaseIndex = request.getDatabaseIndex();
+      if (databaseIndex != null) {
+        span.request.setDatabaseIndex(databaseIndex);
+      }
+      span.start();
+      return span;
     }
 
     @Override
@@ -281,6 +453,10 @@ final class OpenTelemetryTracing implements Tracing {
         }
         return this;
       }
+      if (key.equals("error")) {
+        errorMessage = value;
+        return this;
+      }
       // Under old semconv forward unknown tags as raw span attributes for backward compatibility;
       // under stable semconv these are either captured structurally (e.g. error.type) or not needed
       if (emitOldDatabaseSemconv() && context != null) {
@@ -306,6 +482,12 @@ final class OpenTelemetryTracing implements Tracing {
 
     @Override
     public synchronized void finish() {
+      BatchScope batchScope = this.batchScope;
+      if (batchScope != null) {
+        this.batchScope = null;
+        batchScope.finishOne(this);
+        return;
+      }
       if (context != null) {
         instrumenter.end(context, request, response, error);
         // Null out context to prevent double-ending if both the onComplete callback and Lettuce's

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -396,11 +396,13 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
   void deferredFlushCommand(
       String name, AsyncCommandsScenario scenario, List<ExpectedCommand> expectedCommands)
       throws Exception {
-    asyncCommands.setAutoFlushCommands(false);
-    cleanup.deferCleanup(() -> asyncCommands.setAutoFlushCommands(true));
+    StatefulRedisConnection<String, String> statefulConnection =
+        asyncCommands.getStatefulConnection();
+    statefulConnection.setAutoFlushCommands(false);
+    cleanup.deferCleanup(() -> statefulConnection.setAutoFlushCommands(true));
 
     List<RedisFuture<?>> futures = scenario.run(asyncCommands);
-    asyncCommands.flushCommands();
+    statefulConnection.flushCommands();
     for (RedisFuture<?> future : futures) {
       future.get(10, SECONDS);
     }

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -6,8 +6,10 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -19,6 +21,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -35,6 +38,7 @@ import io.lettuce.core.codec.StringCodec;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -46,8 +50,12 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings({"InterruptedExceptionSwallowed", "deprecation"}) // using deprecated semconv
 public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClientTest {
@@ -95,6 +103,10 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
   }
 
   protected boolean connectHasSpans() {
+    return false;
+  }
+
+  protected boolean aggregateDeferredFlush() {
     return false;
   }
 
@@ -377,6 +389,150 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
               }
               trace.hasSpansSatisfyingExactly(spanAsserts);
             });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("deferredFlushScenarios")
+  void deferredFlushCommand(
+      String name, AsyncCommandsScenario scenario, List<ExpectedCommand> expectedCommands)
+      throws Exception {
+    asyncCommands.setAutoFlushCommands(false);
+    cleanup.deferCleanup(() -> asyncCommands.setAutoFlushCommands(true));
+
+    List<RedisFuture<?>> futures = scenario.run(asyncCommands);
+    asyncCommands.flushCommands();
+    for (RedisFuture<?> future : futures) {
+      future.get(10, SECONDS);
+    }
+
+    if (expectedCommands.isEmpty()) {
+      assertThat(testing().spans()).isEmpty();
+      return;
+    }
+
+    if (aggregateDeferredFlush()) {
+      String operation = pipelineOperation(expectedCommands);
+      testing()
+          .waitAndAssertTraces(
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          span.hasName(spanName(operation))
+                              .hasKind(SpanKind.CLIENT)
+                              .hasAttributesSatisfyingExactly(
+                                  addExtraAttributes(
+                                      equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                                      equalTo(NETWORK_PEER_ADDRESS, ip),
+                                      equalTo(NETWORK_PEER_PORT, port),
+                                      equalTo(SERVER_ADDRESS, host),
+                                      equalTo(SERVER_PORT, port),
+                                      equalTo(maybeStable(DB_SYSTEM), REDIS),
+                                      equalTo(
+                                          maybeStable(DB_STATEMENT),
+                                          pipelineStatement(expectedCommands)),
+                                      equalTo(maybeStable(DB_OPERATION), operation),
+                                      equalTo(
+                                          DB_OPERATION_BATCH_SIZE,
+                                          emitStableDatabaseSemconv() && expectedCommands.size() > 1
+                                              ? (long) expectedCommands.size()
+                                              : null)))));
+      return;
+    }
+
+    List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+    for (ExpectedCommand command : expectedCommands) {
+      ExpectedCommand expected = command;
+      assertions.add(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName(expected.operation))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasAttributesSatisfyingExactly(
+                              addExtraAttributes(
+                                  equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                                  equalTo(NETWORK_PEER_ADDRESS, ip),
+                                  equalTo(NETWORK_PEER_PORT, port),
+                                  equalTo(SERVER_ADDRESS, host),
+                                  equalTo(SERVER_PORT, port),
+                                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                                  equalTo(maybeStable(DB_STATEMENT), expected.statement),
+                                  equalTo(maybeStable(DB_OPERATION), expected.operation),
+                                  equalTo(DB_OPERATION_BATCH_SIZE, null)))
+                          .satisfies(AbstractLettuceClientTest::assertCommandEncodeEvents)));
+    }
+    testing().waitAndAssertTraces(assertions);
+  }
+
+  private static String pipelineOperation(List<ExpectedCommand> commands) {
+    if (commands.size() == 1) {
+      return commands.get(0).operation;
+    }
+    String operation = commands.get(0).operation;
+    for (ExpectedCommand command : commands) {
+      if (!operation.equals(command.operation)) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operation;
+  }
+
+  private static String pipelineStatement(List<ExpectedCommand> commands) {
+    StringBuilder statement = new StringBuilder();
+    for (ExpectedCommand command : commands) {
+      if (statement.length() > 0) {
+        statement.append(';');
+      }
+      statement.append(command.statement);
+    }
+    return statement.toString();
+  }
+
+  private static Stream<Arguments> deferredFlushScenarios() {
+    return Stream.of(
+        Arguments.of("empty", (AsyncCommandsScenario) commands -> emptyList(), emptyList()),
+        Arguments.of(
+            "single",
+            (AsyncCommandsScenario) commands -> futures(commands.set("batch1", "v1")),
+            expectedCommands(expectedCommand("SET", "SET batch1 ?"))),
+        Arguments.of(
+            "twoSameOperation",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.set("batch2", "v2")),
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("SET", "SET batch2 ?"))),
+        Arguments.of(
+            "twoDifferentOperations",
+            (AsyncCommandsScenario)
+                commands -> futures(commands.set("batch1", "v1"), commands.get("batch1")),
+            expectedCommands(
+                expectedCommand("SET", "SET batch1 ?"), expectedCommand("GET", "GET batch1"))));
+  }
+
+  private static List<RedisFuture<?>> futures(RedisFuture<?>... futures) {
+    return asList(futures);
+  }
+
+  private static List<ExpectedCommand> expectedCommands(ExpectedCommand... commands) {
+    return asList(commands);
+  }
+
+  private static ExpectedCommand expectedCommand(String operation, String statement) {
+    return new ExpectedCommand(operation, statement);
+  }
+
+  private interface AsyncCommandsScenario {
+    List<RedisFuture<?>> run(RedisAsyncCommands<String, String> commands);
+  }
+
+  private static class ExpectedCommand {
+    private final String operation;
+    private final String statement;
+
+    private ExpectedCommand(String operation, String statement) {
+      this.operation = operation;
+      this.statement = statement;
+    }
   }
 
   @Test

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -542,11 +542,7 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
                           .hasKind(SpanKind.CLIENT)
                           .hasAttributesSatisfyingExactly(
                               addExtraAttributes(
-                                  equalTo(
-                                      stringKey("error"),
-                                      testLatestDeps() || emitStableDatabaseSemconv()
-                                          ? null
-                                          : "Connection disconnected"),
+                                  equalTo(stringKey("error"), null),
                                   equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                                   equalTo(NETWORK_PEER_ADDRESS, ip),
                                   equalTo(NETWORK_PEER_PORT, containerConnection.port),

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -14,6 +14,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
@@ -109,8 +110,13 @@ public final class DbExecution {
                 query ->
                     R2dbcSqlCommenterUtil.getOriginalQuery(queryInfo.getConnectionInfo(), query))
             .collect(toList());
+    // db.operation.batch.size applies only to Batch executions (Connection#createBatch); a plain
+    // Statement always reports getBatchSize() == 0 and must not be treated as a batch. For a Batch
+    // the size is captured for every execution (including an empty batch with size 0) and only
+    // omitted for a single-statement batch (size 1)
     int queryInfoBatchSize = queryInfo.getBatchSize();
-    this.batchSize = queryInfoBatchSize > 1 ? (long) queryInfoBatchSize : null;
+    boolean isBatch = queryInfo.getType() == ExecutionType.BATCH;
+    this.batchSize = isBatch && queryInfoBatchSize != 1 ? (long) queryInfoBatchSize : null;
     this.parameterizedQuery =
         queryInfo.getQueries().stream()
             .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.proxy.test.MockConnectionInfo;
@@ -58,6 +59,7 @@ class DbExecutionTest {
   void dbExecutionWithBatch() {
     QueryExecutionInfo queryExecutionInfo =
         MockQueryExecutionInfo.builder()
+            .type(ExecutionType.BATCH)
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
             .batchSize(2)
@@ -74,9 +76,27 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionWithEmptyBatch() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .type(ExecutionType.BATCH)
+            .batchSize(0)
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    // an empty batch still reports db.operation.batch.size 0
+    assertThat(dbExecution.getBatchSize()).isEqualTo(0);
+  }
+
+  @Test
   void dbExecutionWithBatchSizeOne() {
     QueryExecutionInfo queryExecutionInfo =
         MockQueryExecutionInfo.builder()
+            .type(ExecutionType.BATCH)
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
             .batchSize(1)
             .connectionInfo(MockConnectionInfo.builder().build())
@@ -87,6 +107,7 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
 
     assertThat(dbExecution.getRawQueryTexts()).containsExactly("INSERT INTO person VALUES(1)");
+    // a single-statement batch is reported as a non-batch, so it has no db.operation.batch.size
     assertThat(dbExecution.getBatchSize()).isNull();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.R2dbcSqlAttributesGetter;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.proxy.test.MockConnectionInfo;
@@ -43,6 +44,7 @@ class R2dbcSqlAttributesGetterTest {
   void rawQueryTextsForBatch() {
     QueryExecutionInfo queryExecutionInfo =
         MockQueryExecutionInfo.builder()
+            .type(ExecutionType.BATCH)
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
             .batchSize(2)

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -328,6 +328,15 @@ public abstract class AbstractR2dbcStatementTest {
                 .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
                 .build());
 
+    // the batch statements target a real table so that the collection name is captured (in
+    // db.query.summary and, under old semconv for a single-statement batch, db.sql.table); the
+    // table must exist for the non-empty batches to execute successfully
+    if (!scenario.queries.isEmpty()) {
+      createPlayersTable(connectionFactory);
+      getTesting().waitForTraces(1);
+      getTesting().clearData();
+    }
+
     Throwable thrown =
         catchThrowable(
             () ->
@@ -422,6 +431,12 @@ public abstract class AbstractR2dbcStatementTest {
                                 equalTo(
                                     maybeStable(DB_OPERATION),
                                     emitStableDatabaseSemconv() ? null : scenario.oldOperation),
+                                // db.sql.table is only set under old semconv and only for a
+                                // single-statement batch (multi-statement batches do not capture a
+                                // collection name)
+                                equalTo(
+                                    maybeStable(DB_SQL_TABLE),
+                                    emitStableDatabaseSemconv() ? null : scenario.oldCollection),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
                                     emitStableDatabaseSemconv() ? scenario.batchSize : null),
@@ -435,31 +450,48 @@ public abstract class AbstractR2dbcStatementTest {
             // an empty batch produces an error client span
             BatchScenario.builder("empty").queries(emptyList()).build(),
             // a single-statement batch is not a batch (size 1), so it emits no
-            // db.operation.batch.size and no BATCH prefix; under old semconv it carries
-            // db.statement/db.operation and the operation+namespace span name
+            // db.operation.batch.size and no BATCH prefix; under old semconv it carries the
+            // statement, operation, collection and the operation+namespace+table span name
             BatchScenario.builder("single")
-                .queries(singletonList("SELECT 1"))
-                .spanName("SELECT")
-                .oldSpanName("SELECT " + DB)
-                .summary("SELECT")
-                .queryText("SELECT ?")
-                .oldStatement("SELECT ?")
-                .oldOperation("SELECT")
+                .queries(singletonList("INSERT INTO players VALUES (1)"))
+                .spanName("INSERT players")
+                .oldSpanName("INSERT " + DB + ".players")
+                .summary("INSERT players")
+                .queryText("INSERT INTO players VALUES (?)")
+                .oldStatement("INSERT INTO players VALUES (?)")
+                .oldOperation("INSERT")
+                .oldCollection("players")
                 .build(),
             // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
-            // db.operation.batch.size under stable semconv; under old semconv the individual
-            // statements are concatenated and the span name is operation+namespace
+            // db.operation.batch.size under stable semconv; the collection name is captured in the
+            // summary (BATCH INSERT players). under old semconv the individual statements are
+            // concatenated but the shared operation and collection are still captured
             BatchScenario.builder("twoSameOperation")
-                .queries(asList("SELECT 1", "SELECT 2"))
-                .spanName("BATCH SELECT")
-                .oldSpanName("SELECT " + DB)
-                .summary("BATCH SELECT")
-                .queryText("SELECT ?")
-                .oldStatement("SELECT ?; SELECT ?")
-                .oldOperation("SELECT")
+                .queries(asList("INSERT INTO players VALUES (2)", "INSERT INTO players VALUES (3)"))
+                .spanName("BATCH INSERT players")
+                .oldSpanName("INSERT " + DB + ".players")
+                .summary("BATCH INSERT players")
+                .queryText("INSERT INTO players VALUES (?)")
+                .oldStatement("INSERT INTO players VALUES (?); INSERT INTO players VALUES (?)")
+                .oldOperation("INSERT")
+                .oldCollection("players")
                 .batchSize(2)
                 .build())
         .map(Arguments::of);
+  }
+
+  private void createPlayersTable(ConnectionFactory connectionFactory) {
+    Mono.from(connectionFactory.create())
+        .flatMapMany(
+            connection ->
+                Mono.from(
+                        connection
+                            .createStatement(
+                                "CREATE TABLE IF NOT EXISTS players (id INTEGER PRIMARY KEY)")
+                            .execute())
+                    .flatMapMany(result -> result.map((row, metadata) -> ""))
+                    .concatWith(Mono.from(connection.close()).cast(String.class)))
+        .blockLast(Duration.ofMinutes(1));
   }
 
   private static class Parameter {
@@ -527,6 +559,8 @@ public abstract class AbstractR2dbcStatementTest {
     // the old-semconv db.statement (individual query texts concatenated with "; ")
     final String oldStatement;
     final String oldOperation;
+    // the old-semconv db.sql.table (only captured for a single-statement batch)
+    final String oldCollection;
     final Long batchSize;
 
     BatchScenario(Builder builder) {
@@ -538,6 +572,7 @@ public abstract class AbstractR2dbcStatementTest {
       this.queryText = builder.queryText;
       this.oldStatement = builder.oldStatement;
       this.oldOperation = builder.oldOperation;
+      this.oldCollection = builder.oldCollection;
       this.batchSize = builder.batchSize;
     }
 
@@ -560,6 +595,7 @@ public abstract class AbstractR2dbcStatementTest {
       private String queryText;
       private String oldStatement;
       private String oldOperation;
+      private String oldCollection;
       private Long batchSize;
 
       Builder(String name) {
@@ -598,6 +634,11 @@ public abstract class AbstractR2dbcStatementTest {
 
       Builder oldOperation(String oldOperation) {
         this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder oldCollection(String oldCollection) {
+        this.oldCollection = oldCollection;
         return this;
       }
 

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -433,88 +433,33 @@ public abstract class AbstractR2dbcStatementTest {
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
             // an empty batch produces an error client span
-            new BatchScenario("empty", emptyList(), null, null, null, null, null, null),
+            BatchScenario.builder("empty").queries(emptyList()).build(),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix; under old semconv it carries
             // db.statement/db.operation and the operation+namespace span name
-            new BatchScenario(
-                "single",
-                singletonList("SELECT 1"),
-                "SELECT",
-                "SELECT " + DB,
-                "SELECT",
-                "SELECT ?",
-                "SELECT ?",
-                "SELECT"),
+            BatchScenario.builder("single")
+                .queries(singletonList("SELECT 1"))
+                .spanName("SELECT")
+                .oldSpanName("SELECT " + DB)
+                .summary("SELECT")
+                .queryText("SELECT ?")
+                .oldStatement("SELECT ?")
+                .oldOperation("SELECT")
+                .build(),
             // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
             // db.operation.batch.size under stable semconv; under old semconv the individual
             // statements are concatenated and the span name is operation+namespace
-            new BatchScenario(
-                "twoSameOperation",
-                asList("SELECT 1", "SELECT 2"),
-                "BATCH SELECT",
-                "SELECT " + DB,
-                "BATCH SELECT",
-                "SELECT ?",
-                "SELECT ?; SELECT ?",
-                "SELECT",
-                2L))
+            BatchScenario.builder("twoSameOperation")
+                .queries(asList("SELECT 1", "SELECT 2"))
+                .spanName("BATCH SELECT")
+                .oldSpanName("SELECT " + DB)
+                .summary("BATCH SELECT")
+                .queryText("SELECT ?")
+                .oldStatement("SELECT ?; SELECT ?")
+                .oldOperation("SELECT")
+                .batchSize(2)
+                .build())
         .map(Arguments::of);
-  }
-
-  private static final class BatchScenario {
-    final String name;
-    final List<String> queries;
-    final String spanName;
-    final String oldSpanName;
-    final String summary;
-    // the stable-semconv db.query.text (identical query texts are deduplicated)
-    final String queryText;
-    // the old-semconv db.statement (individual query texts concatenated with "; ")
-    final String oldStatement;
-    final String oldOperation;
-    final Long batchSize;
-
-    // empty-batch scenario (no stable batch attributes, handled separately in the test)
-    BatchScenario(
-        String name,
-        List<String> queries,
-        String spanName,
-        String oldSpanName,
-        String summary,
-        String queryText,
-        String oldStatement,
-        String oldOperation) {
-      this(name, queries, spanName, oldSpanName, summary, queryText, oldStatement, oldOperation,
-          null);
-    }
-
-    BatchScenario(
-        String name,
-        List<String> queries,
-        String spanName,
-        String oldSpanName,
-        String summary,
-        String queryText,
-        String oldStatement,
-        String oldOperation,
-        Long batchSize) {
-      this.name = name;
-      this.queries = queries;
-      this.spanName = spanName;
-      this.oldSpanName = oldSpanName;
-      this.summary = summary;
-      this.queryText = queryText;
-      this.oldStatement = oldStatement;
-      this.oldOperation = oldOperation;
-      this.batchSize = batchSize;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
   }
 
   private static class Parameter {
@@ -568,6 +513,102 @@ public abstract class AbstractR2dbcStatementTest {
         envVariables.put(keyValues[2 * i], keyValues[2 * i + 1]);
       }
       return this;
+    }
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<String> queries;
+    final String spanName;
+    final String oldSpanName;
+    final String summary;
+    // the stable-semconv db.query.text (identical query texts are deduplicated)
+    final String queryText;
+    // the old-semconv db.statement (individual query texts concatenated with "; ")
+    final String oldStatement;
+    final String oldOperation;
+    final Long batchSize;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.queries = builder.queries;
+      this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
+      this.summary = builder.summary;
+      this.queryText = builder.queryText;
+      this.oldStatement = builder.oldStatement;
+      this.oldOperation = builder.oldOperation;
+      this.batchSize = builder.batchSize;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static final class Builder {
+      private final String name;
+      private List<String> queries;
+      private String spanName;
+      private String oldSpanName;
+      private String summary;
+      private String queryText;
+      private String oldStatement;
+      private String oldOperation;
+      private Long batchSize;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder queries(List<String> queries) {
+        this.queries = queries;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder summary(String summary) {
+        this.summary = summary;
+        return this;
+      }
+
+      Builder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+      }
+
+      Builder oldStatement(String oldStatement) {
+        this.oldStatement = oldStatement;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
     }
   }
 }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -332,7 +332,7 @@ public abstract class AbstractR2dbcStatementTest {
     // db.query.summary and, under old semconv for a single-statement batch, db.sql.table); the
     // table must exist for the non-empty batches to execute successfully
     if (!scenario.queries.isEmpty()) {
-      createPlayersTable(connectionFactory);
+      createItemsTable(connectionFactory);
       getTesting().waitForTraces(1);
       getTesting().clearData();
     }
@@ -453,28 +453,32 @@ public abstract class AbstractR2dbcStatementTest {
         // db.operation.batch.size and no BATCH prefix; under old semconv it carries the
         // statement, operation, collection and the operation+namespace+table span name
         BatchScenario.builder("single")
-            .queries(singletonList("INSERT INTO players VALUES (1)"))
-            .spanName("INSERT players")
-            .oldSpanName("INSERT " + DB + ".players")
-            .summary("INSERT players")
-            .queryText("INSERT INTO players VALUES (?)")
-            .oldStatement("INSERT INTO players VALUES (?)")
+            .queries(singletonList("INSERT INTO items (id, num) VALUES (1, 1)"))
+            .spanName("INSERT items")
+            .oldSpanName("INSERT " + DB + ".items")
+            .summary("INSERT items")
+            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
+            .oldStatement("INSERT INTO items (id, num) VALUES (?, ?)")
             .oldOperation("INSERT")
-            .oldCollection("players")
+            .oldCollection("items")
             .build(),
         // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
         // db.operation.batch.size under stable semconv; the collection name is captured in the
-        // summary (BATCH INSERT players). under old semconv the individual statements are
+        // summary (BATCH INSERT items). under old semconv the individual statements are
         // concatenated but the shared operation and collection are still captured
         BatchScenario.builder("twoSameOperation")
-            .queries(asList("INSERT INTO players VALUES (2)", "INSERT INTO players VALUES (3)"))
-            .spanName("BATCH INSERT players")
-            .oldSpanName("INSERT " + DB + ".players")
-            .summary("BATCH INSERT players")
-            .queryText("INSERT INTO players VALUES (?)")
-            .oldStatement("INSERT INTO players VALUES (?); INSERT INTO players VALUES (?)")
+            .queries(
+                asList(
+                    "INSERT INTO items (id, num) VALUES (2, 2)",
+                    "INSERT INTO items (id, num) VALUES (3, 3)"))
+            .spanName("BATCH INSERT items")
+            .oldSpanName("INSERT " + DB + ".items")
+            .summary("BATCH INSERT items")
+            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
+            .oldStatement(
+                "INSERT INTO items (id, num) VALUES (?, ?); INSERT INTO items (id, num) VALUES (?, ?)")
             .oldOperation("INSERT")
-            .oldCollection("players")
+            .oldCollection("items")
             .batchSize(2)
             .build(),
         // a multi-statement batch with different operations has no shared operation or summary,
@@ -482,26 +486,30 @@ public abstract class AbstractR2dbcStatementTest {
         // still concatenated into db.query.text / db.statement
         BatchScenario.builder("twoDifferentOperations")
             .queries(
-                asList("INSERT INTO players VALUES (4)", "UPDATE players SET id = 5 WHERE id = 4"))
+                asList(
+                    "INSERT INTO items (id, num) VALUES (4, 4)",
+                    "UPDATE items SET num = 5 WHERE id = 4"))
             .spanName("BATCH")
-            .oldSpanName("INSERT " + DB + ".players")
+            .oldSpanName("INSERT " + DB + ".items")
             .summary("BATCH")
-            .queryText("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
-            .oldStatement("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
+            .queryText(
+                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
+            .oldStatement(
+                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
             .oldOperation("INSERT")
-            .oldCollection("players")
+            .oldCollection("items")
             .batchSize(2)
             .build());
   }
 
-  private void createPlayersTable(ConnectionFactory connectionFactory) {
+  private void createItemsTable(ConnectionFactory connectionFactory) {
     Mono.from(connectionFactory.create())
         .flatMapMany(
             connection ->
                 Mono.from(
                         connection
                             .createStatement(
-                                "CREATE TABLE IF NOT EXISTS players (id INTEGER PRIMARY KEY)")
+                                "CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, num INTEGER)")
                             .execute())
                     .flatMapMany(result -> result.map((row, metadata) -> ""))
                     .concatWith(Mono.from(connection.close()).cast(String.class)))

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -360,10 +360,10 @@ public abstract class AbstractR2dbcStatementTest {
     String connectionString = MARIADB.system + "://localhost:" + port;
 
     if (scenario.queries.isEmpty()) {
-      // an empty batch fails to execute and produces a client span with no operation, summary or
-      // batch size; the span name falls back to the database namespace. under old semconv it still
-      // carries db.user/db.connection_string and an empty db.statement; under stable semconv it
-      // records the error instead (error.type is stable-only)
+      // an empty batch fails to execute and produces a client span with no operation or summary,
+      // but carries db.operation.batch.size 0; the span name falls back to the database namespace.
+      // under old semconv it still carries db.user/db.connection_string and an empty db.statement;
+      // under stable semconv it records the error instead (error.type is stable-only)
       assertThat(thrown).isInstanceOf(NoSuchElementException.class);
       getTesting()
           .waitAndAssertTraces(
@@ -384,6 +384,9 @@ public abstract class AbstractR2dbcStatementTest {
                                   equalTo(
                                       maybeStable(DB_STATEMENT),
                                       emitStableDatabaseSemconv() ? null : ""),
+                                  equalTo(
+                                      DB_OPERATION_BATCH_SIZE,
+                                      emitStableDatabaseSemconv() ? 0L : null),
                                   equalTo(maybeStablePeerService(), "test-peer-service"),
                                   equalTo(SERVER_ADDRESS, container.getHost()),
                                   equalTo(SERVER_PORT, port),

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -328,14 +328,12 @@ public abstract class AbstractR2dbcStatementTest {
                 .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
                 .build());
 
-    // the batch statements target a real table so that the collection name is captured (in
-    // db.query.summary and, under old semconv for a single-statement batch, db.sql.table); the
-    // table must exist for the non-empty batches to execute successfully
-    if (!scenario.queries.isEmpty()) {
-      createItemsTable(connectionFactory);
-      getTesting().waitForTraces(1);
-      getTesting().clearData();
-    }
+    // recreate a fresh items table for each scenario so that batch row ids can be reused without
+    // worrying about collisions from previous scenarios; the table also lets the collection name
+    // be captured (in db.query.summary and, under old semconv, db.sql.table)
+    recreateItemsTable(connectionFactory);
+    getTesting().waitForTraces(2);
+    getTesting().clearData();
 
     Throwable thrown =
         catchThrowable(
@@ -469,8 +467,8 @@ public abstract class AbstractR2dbcStatementTest {
         BatchScenario.builder("twoSameOperation")
             .queries(
                 asList(
-                    "INSERT INTO items (id, num) VALUES (2, 2)",
-                    "INSERT INTO items (id, num) VALUES (3, 3)"))
+                    "INSERT INTO items (id, num) VALUES (1, 1)",
+                    "INSERT INTO items (id, num) VALUES (2, 2)"))
             .spanName("BATCH INSERT items")
             .oldSpanName("INSERT " + DB + ".items")
             .summary("BATCH INSERT items")
@@ -487,8 +485,8 @@ public abstract class AbstractR2dbcStatementTest {
         BatchScenario.builder("twoDifferentOperations")
             .queries(
                 asList(
-                    "INSERT INTO items (id, num) VALUES (4, 4)",
-                    "UPDATE items SET num = 5 WHERE id = 4"))
+                    "INSERT INTO items (id, num) VALUES (1, 1)",
+                    "UPDATE items SET num = 5 WHERE id = 1"))
             .spanName("BATCH")
             .oldSpanName("INSERT " + DB + ".items")
             .summary("BATCH")
@@ -502,16 +500,19 @@ public abstract class AbstractR2dbcStatementTest {
             .build());
   }
 
-  private void createItemsTable(ConnectionFactory connectionFactory) {
+  private void recreateItemsTable(ConnectionFactory connectionFactory) {
     Mono.from(connectionFactory.create())
         .flatMapMany(
             connection ->
-                Mono.from(
-                        connection
-                            .createStatement(
-                                "CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, num INTEGER)")
-                            .execute())
+                Mono.from(connection.createStatement("DROP TABLE IF EXISTS items").execute())
                     .flatMapMany(result -> result.map((row, metadata) -> ""))
+                    .concatWith(
+                        Mono.from(
+                                connection
+                                    .createStatement(
+                                        "CREATE TABLE items (id INTEGER PRIMARY KEY, num INTEGER)")
+                                    .execute())
+                            .flatMapMany(result -> result.map((row, metadata) -> "")))
                     .concatWith(Mono.from(connection.close()).cast(String.class)))
         .blockLast(Duration.ofMinutes(1));
   }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
@@ -33,7 +34,10 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 
@@ -49,6 +53,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -302,9 +307,10 @@ public abstract class AbstractR2dbcStatementTest {
         SERVER_PORT);
   }
 
-  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
-  // and two statements with the same operation. batch telemetry (db.operation.batch.size, BATCH
-  // span names and summaries) is only emitted under stable database semconv
+  // describes the batch cases: an empty batch (no statements -> no client span), a single-statement
+  // batch (not a batch -> no db.operation.batch.size) and two statements with the same operation.
+  // batch telemetry (db.operation.batch.size, BATCH span names and summaries) is only emitted under
+  // stable database semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchQueries(BatchScenario scenario) {
@@ -324,24 +330,52 @@ public abstract class AbstractR2dbcStatementTest {
                 .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
                 .build());
 
-    getTesting()
-        .runWithSpan(
-            "parent",
-            () -> {
-              Mono.from(connectionFactory.create())
-                  .flatMapMany(
-                      connection -> {
-                        Batch batch = connection.createBatch();
-                        for (String query : scenario.queries) {
-                          batch.add(query);
-                        }
-                        return Flux.from(batch.execute())
-                            .flatMap(result -> result.map((row, metadata) -> ""))
-                            .concatWith(Mono.from(connection.close()).cast(String.class));
-                      })
-                  .blockLast(Duration.ofMinutes(1));
-            });
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                getTesting()
+                    .runWithSpan(
+                        "parent",
+                        () -> {
+                          Mono.from(connectionFactory.create())
+                              .flatMapMany(
+                                  connection -> {
+                                    Batch batch = connection.createBatch();
+                                    for (String query : scenario.queries) {
+                                      batch.add(query);
+                                    }
+                                    return Flux.from(batch.execute())
+                                        .flatMap(result -> result.map((row, metadata) -> ""))
+                                        .concatWith(
+                                            Mono.from(connection.close()).cast(String.class));
+                                  })
+                              .blockLast(Duration.ofMinutes(1));
+                        }));
 
+    if (scenario.queries.isEmpty()) {
+      // an empty batch fails to execute and produces a client span with no query text, summary or
+      // batch size; the span name falls back to the database namespace and records the error
+      assertThat(thrown).isInstanceOf(NoSuchElementException.class);
+      getTesting()
+          .waitAndAssertTraces(
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
+                      span ->
+                          span.hasName(DB)
+                              .hasKind(SpanKind.CLIENT)
+                              .hasParent(trace.getSpan(0))
+                              .hasAttributesSatisfyingExactly(
+                                  equalTo(DB_SYSTEM_NAME, MARIADB.system),
+                                  equalTo(DB_NAMESPACE, DB),
+                                  equalTo(maybeStablePeerService(), "test-peer-service"),
+                                  equalTo(SERVER_ADDRESS, container.getHost()),
+                                  equalTo(SERVER_PORT, port),
+                                  equalTo(ERROR_TYPE, "java.util.NoSuchElementException"))));
+      return;
+    }
+
+    assertThat(thrown).isNull();
     getTesting()
         .waitAndAssertTraces(
             trace ->
@@ -364,6 +398,8 @@ public abstract class AbstractR2dbcStatementTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch produces no client span
+            new BatchScenario("empty", emptyList(), null, null, null),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix
             new BatchScenario("single", singletonList("SELECT 1"), "SELECT", "SELECT", null),

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -32,18 +32,22 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -298,8 +302,12 @@ public abstract class AbstractR2dbcStatementTest {
         SERVER_PORT);
   }
 
-  @Test
-  void testBatchQueries() {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements with the same operation. batch telemetry (db.operation.batch.size, BATCH
+  // span names and summaries) is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchQueries(BatchScenario scenario) {
     assumeTrue(emitStableDatabaseSemconv());
 
     DbSystemProps props = systems.get(MARIADB.system);
@@ -322,15 +330,15 @@ public abstract class AbstractR2dbcStatementTest {
             () -> {
               Mono.from(connectionFactory.create())
                   .flatMapMany(
-                      connection ->
-                          Flux.from(
-                                  connection
-                                      .createBatch()
-                                      .add("SELECT 1")
-                                      .add("SELECT 2")
-                                      .execute())
-                              .flatMap(result -> result.map((row, metadata) -> ""))
-                              .concatWith(Mono.from(connection.close()).cast(String.class)))
+                      connection -> {
+                        Batch batch = connection.createBatch();
+                        for (String query : scenario.queries) {
+                          batch.add(query);
+                        }
+                        return Flux.from(batch.execute())
+                            .flatMap(result -> result.map((row, metadata) -> ""))
+                            .concatWith(Mono.from(connection.close()).cast(String.class));
+                      })
                   .blockLast(Duration.ofMinutes(1));
             });
 
@@ -340,18 +348,55 @@ public abstract class AbstractR2dbcStatementTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("BATCH SELECT")
+                        span.hasName(scenario.spanName)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(DB_SYSTEM_NAME, MARIADB.system),
                                 equalTo(DB_NAMESPACE, DB),
                                 equalTo(DB_QUERY_TEXT, "SELECT ?"),
-                                equalTo(DB_QUERY_SUMMARY, "BATCH SELECT"),
-                                equalTo(DB_OPERATION_BATCH_SIZE, 2),
+                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
+                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize),
                                 equalTo(maybeStablePeerService(), "test-peer-service"),
                                 equalTo(SERVER_ADDRESS, container.getHost()),
                                 equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario("single", singletonList("SELECT 1"), "SELECT", "SELECT", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList("SELECT 1", "SELECT 2"),
+                "BATCH SELECT",
+                "BATCH SELECT",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<String> queries;
+    final String spanName;
+    final String summary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name, List<String> queries, String spanName, String summary, Long batchSize) {
+      this.name = name;
+      this.queries = queries;
+      this.spanName = spanName;
+      this.summary = summary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   private static class Parameter {

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -476,6 +476,23 @@ public abstract class AbstractR2dbcStatementTest {
                 .oldOperation("INSERT")
                 .oldCollection("players")
                 .batchSize(2)
+                .build(),
+            // a multi-statement batch with different operations has no shared operation or summary,
+            // so db.query.summary (and the span name) is just BATCH; the individual statements are
+            // still concatenated into db.query.text / db.statement
+            BatchScenario.builder("twoDifferentOperations")
+                .queries(
+                    asList(
+                        "INSERT INTO players VALUES (4)", "UPDATE players SET id = 5 WHERE id = 4"))
+                .spanName("BATCH")
+                .oldSpanName("INSERT " + DB + ".players")
+                .summary("BATCH")
+                .queryText("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
+                .oldStatement(
+                    "INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
+                .oldOperation("INSERT")
+                .oldCollection("players")
+                .batchSize(2)
                 .build())
         .map(Arguments::of);
   }

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -328,10 +328,10 @@ public abstract class AbstractR2dbcStatementTest {
                 .option(CONNECT_TIMEOUT, Duration.ofSeconds(30))
                 .build());
 
-    // recreate a fresh items table for each scenario so that batch row ids can be reused without
-    // worrying about collisions from previous scenarios; the table also lets the collection name
-    // be captured (in db.query.summary and, under old semconv, db.sql.table)
-    recreateItemsTable(connectionFactory);
+    // recreate a fresh batch_test table for each scenario so that batch row ids can be reused
+    // without worrying about collisions from previous scenarios; the table also lets the collection
+    // name be captured (in db.query.summary and, under old semconv, db.sql.table)
+    recreateBatchTestTable(connectionFactory);
     getTesting().waitForTraces(2);
     getTesting().clearData();
 
@@ -451,32 +451,32 @@ public abstract class AbstractR2dbcStatementTest {
         // db.operation.batch.size and no BATCH prefix; under old semconv it carries the
         // statement, operation, collection and the operation+namespace+table span name
         BatchScenario.builder("single")
-            .queries(singletonList("INSERT INTO items (id, num) VALUES (1, 1)"))
-            .spanName("INSERT items")
-            .oldSpanName("INSERT " + DB + ".items")
-            .summary("INSERT items")
-            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
-            .oldStatement("INSERT INTO items (id, num) VALUES (?, ?)")
+            .queries(singletonList("INSERT INTO batch_test (id, num) VALUES (1, 1)"))
+            .spanName("INSERT batch_test")
+            .oldSpanName("INSERT " + DB + ".batch_test")
+            .summary("INSERT batch_test")
+            .queryText("INSERT INTO batch_test (id, num) VALUES (?, ?)")
+            .oldStatement("INSERT INTO batch_test (id, num) VALUES (?, ?)")
             .oldOperation("INSERT")
-            .oldCollection("items")
+            .oldCollection("batch_test")
             .build(),
         // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
         // db.operation.batch.size under stable semconv; the collection name is captured in the
-        // summary (BATCH INSERT items). under old semconv the individual statements are
+        // summary (BATCH INSERT batch_test). under old semconv the individual statements are
         // concatenated but the shared operation and collection are still captured
         BatchScenario.builder("twoSameOperation")
             .queries(
                 asList(
-                    "INSERT INTO items (id, num) VALUES (1, 1)",
-                    "INSERT INTO items (id, num) VALUES (2, 2)"))
-            .spanName("BATCH INSERT items")
-            .oldSpanName("INSERT " + DB + ".items")
-            .summary("BATCH INSERT items")
-            .queryText("INSERT INTO items (id, num) VALUES (?, ?)")
+                    "INSERT INTO batch_test (id, num) VALUES (1, 1)",
+                    "INSERT INTO batch_test (id, num) VALUES (2, 2)"))
+            .spanName("BATCH INSERT batch_test")
+            .oldSpanName("INSERT " + DB + ".batch_test")
+            .summary("BATCH INSERT batch_test")
+            .queryText("INSERT INTO batch_test (id, num) VALUES (?, ?)")
             .oldStatement(
-                "INSERT INTO items (id, num) VALUES (?, ?); INSERT INTO items (id, num) VALUES (?, ?)")
+                "INSERT INTO batch_test (id, num) VALUES (?, ?); INSERT INTO batch_test (id, num) VALUES (?, ?)")
             .oldOperation("INSERT")
-            .oldCollection("items")
+            .oldCollection("batch_test")
             .batchSize(2)
             .build(),
         // a multi-statement batch with different operations has no shared operation or summary,
@@ -485,32 +485,32 @@ public abstract class AbstractR2dbcStatementTest {
         BatchScenario.builder("twoDifferentOperations")
             .queries(
                 asList(
-                    "INSERT INTO items (id, num) VALUES (1, 1)",
-                    "UPDATE items SET num = 5 WHERE id = 1"))
+                    "INSERT INTO batch_test (id, num) VALUES (1, 1)",
+                    "UPDATE batch_test SET num = 5 WHERE id = 1"))
             .spanName("BATCH")
-            .oldSpanName("INSERT " + DB + ".items")
+            .oldSpanName("INSERT " + DB + ".batch_test")
             .summary("BATCH")
             .queryText(
-                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
+                "INSERT INTO batch_test (id, num) VALUES (?, ?); UPDATE batch_test SET num = ? WHERE id = ?")
             .oldStatement(
-                "INSERT INTO items (id, num) VALUES (?, ?); UPDATE items SET num = ? WHERE id = ?")
+                "INSERT INTO batch_test (id, num) VALUES (?, ?); UPDATE batch_test SET num = ? WHERE id = ?")
             .oldOperation("INSERT")
-            .oldCollection("items")
+            .oldCollection("batch_test")
             .batchSize(2)
             .build());
   }
 
-  private void recreateItemsTable(ConnectionFactory connectionFactory) {
+  private void recreateBatchTestTable(ConnectionFactory connectionFactory) {
     Mono.from(connectionFactory.create())
         .flatMapMany(
             connection ->
-                Mono.from(connection.createStatement("DROP TABLE IF EXISTS items").execute())
+                Mono.from(connection.createStatement("DROP TABLE IF EXISTS batch_test").execute())
                     .flatMapMany(result -> result.map((row, metadata) -> ""))
                     .concatWith(
                         Mono.from(
                                 connection
                                     .createStatement(
-                                        "CREATE TABLE items (id INTEGER PRIMARY KEY, num INTEGER)")
+                                        "CREATE TABLE batch_test (id INTEGER PRIMARY KEY, num INTEGER)")
                                     .execute())
                             .flatMapMany(result -> result.map((row, metadata) -> "")))
                     .concatWith(Mono.from(connection.close()).cast(String.class)))

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -361,7 +361,7 @@ public abstract class AbstractR2dbcStatementTest {
 
     if (scenario.queries.isEmpty()) {
       // an empty batch fails to execute and produces a client span with no operation or summary,
-      // but carries db.operation.batch.size 0; the span name falls back to the database namespace.
+      // but carries db.operation.batch.size 0 and the BATCH span name under stable semconv.
       // under old semconv it still carries db.user/db.connection_string and an empty db.statement;
       // under stable semconv it records the error instead (error.type is stable-only)
       assertThat(thrown).isInstanceOf(NoSuchElementException.class);
@@ -371,7 +371,7 @@ public abstract class AbstractR2dbcStatementTest {
                   trace.hasSpansSatisfyingExactly(
                       span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                       span ->
-                          span.hasName(DB)
+                          span.hasName(emitStableDatabaseSemconv() ? "BATCH" : DB)
                               .hasKind(SpanKind.CLIENT)
                               .hasParent(trace.getSpan(0))
                               .hasAttributesSatisfyingExactly(

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -14,7 +14,6 @@ import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
-import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -38,7 +37,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -307,15 +305,15 @@ public abstract class AbstractR2dbcStatementTest {
         SERVER_PORT);
   }
 
-  // describes the batch cases: an empty batch (no statements -> no client span), a single-statement
-  // batch (not a batch -> no db.operation.batch.size) and two statements with the same operation.
-  // batch telemetry (db.operation.batch.size, BATCH span names and summaries) is only emitted under
-  // stable database semconv
+  // describes the batch cases: an empty batch (no statements -> error client span), a
+  // single-statement batch (not a batch -> no db.operation.batch.size) and two statements with the
+  // same operation. batch telemetry (db.operation.batch.size, BATCH span names and summaries) is
+  // only emitted under stable database semconv; old semconv only sets statement-level attributes
+  // (db.statement, db.operation, db.sql.table) for a single-statement batch
+  @SuppressWarnings("deprecation") // using deprecated semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchQueries(BatchScenario scenario) {
-    assumeTrue(emitStableDatabaseSemconv());
-
     DbSystemProps props = systems.get(MARIADB.system);
     startContainer(props);
     ConnectionFactory connectionFactory =
@@ -352,9 +350,13 @@ public abstract class AbstractR2dbcStatementTest {
                               .blockLast(Duration.ofMinutes(1));
                         }));
 
+    String connectionString = MARIADB.system + "://localhost:" + port;
+
     if (scenario.queries.isEmpty()) {
-      // an empty batch fails to execute and produces a client span with no query text, summary or
-      // batch size; the span name falls back to the database namespace and records the error
+      // an empty batch fails to execute and produces a client span with no operation, summary or
+      // batch size; the span name falls back to the database namespace. under old semconv it still
+      // carries db.user/db.connection_string and an empty db.statement; under stable semconv it
+      // records the error instead (error.type is stable-only)
       assertThat(thrown).isInstanceOf(NoSuchElementException.class);
       getTesting()
           .waitAndAssertTraces(
@@ -366,12 +368,23 @@ public abstract class AbstractR2dbcStatementTest {
                               .hasKind(SpanKind.CLIENT)
                               .hasParent(trace.getSpan(0))
                               .hasAttributesSatisfyingExactly(
-                                  equalTo(DB_SYSTEM_NAME, MARIADB.system),
-                                  equalTo(DB_NAMESPACE, DB),
+                                  equalTo(
+                                      DB_CONNECTION_STRING,
+                                      emitStableDatabaseSemconv() ? null : connectionString),
+                                  equalTo(maybeStable(DB_SYSTEM), MARIADB.system),
+                                  equalTo(maybeStable(DB_NAME), DB),
+                                  equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                                  equalTo(
+                                      maybeStable(DB_STATEMENT),
+                                      emitStableDatabaseSemconv() ? null : ""),
                                   equalTo(maybeStablePeerService(), "test-peer-service"),
                                   equalTo(SERVER_ADDRESS, container.getHost()),
                                   equalTo(SERVER_PORT, port),
-                                  equalTo(ERROR_TYPE, "java.util.NoSuchElementException"))));
+                                  equalTo(
+                                      ERROR_TYPE,
+                                      emitStableDatabaseSemconv()
+                                          ? "java.util.NoSuchElementException"
+                                          : null))));
       return;
     }
 
@@ -382,15 +395,36 @@ public abstract class AbstractR2dbcStatementTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(scenario.spanName)
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? scenario.spanName
+                                    : scenario.oldSpanName)
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(DB_SYSTEM_NAME, MARIADB.system),
-                                equalTo(DB_NAMESPACE, DB),
-                                equalTo(DB_QUERY_TEXT, "SELECT ?"),
-                                equalTo(DB_QUERY_SUMMARY, scenario.summary),
-                                equalTo(DB_OPERATION_BATCH_SIZE, scenario.batchSize),
+                                equalTo(
+                                    DB_CONNECTION_STRING,
+                                    emitStableDatabaseSemconv() ? null : connectionString),
+                                equalTo(maybeStable(DB_SYSTEM), MARIADB.system),
+                                equalTo(maybeStable(DB_NAME), DB),
+                                equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                                // maybeStable(DB_STATEMENT) is db.query.text under stable semconv
+                                // (identical query texts are deduplicated) and db.statement under
+                                // old semconv (individual texts are concatenated with "; ")
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.queryText
+                                        : scenario.oldStatement),
+                                equalTo(
+                                    DB_QUERY_SUMMARY,
+                                    emitStableDatabaseSemconv() ? scenario.summary : null),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv() ? null : scenario.oldOperation),
+                                equalTo(
+                                    DB_OPERATION_BATCH_SIZE,
+                                    emitStableDatabaseSemconv() ? scenario.batchSize : null),
                                 equalTo(maybeStablePeerService(), "test-peer-service"),
                                 equalTo(SERVER_ADDRESS, container.getHost()),
                                 equalTo(SERVER_PORT, port))));
@@ -398,16 +432,32 @@ public abstract class AbstractR2dbcStatementTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
-            // an empty batch produces no client span
-            new BatchScenario("empty", emptyList(), null, null, null),
+            // an empty batch produces an error client span
+            new BatchScenario("empty", emptyList(), null, null, null, null, null, null),
             // a single-statement batch is not a batch (size 1), so it emits no
-            // db.operation.batch.size and no BATCH prefix
-            new BatchScenario("single", singletonList("SELECT 1"), "SELECT", "SELECT", null),
+            // db.operation.batch.size and no BATCH prefix; under old semconv it carries
+            // db.statement/db.operation and the operation+namespace span name
+            new BatchScenario(
+                "single",
+                singletonList("SELECT 1"),
+                "SELECT",
+                "SELECT " + DB,
+                "SELECT",
+                "SELECT ?",
+                "SELECT ?",
+                "SELECT"),
+            // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
+            // db.operation.batch.size under stable semconv; under old semconv the individual
+            // statements are concatenated and the span name is operation+namespace
             new BatchScenario(
                 "twoSameOperation",
                 asList("SELECT 1", "SELECT 2"),
                 "BATCH SELECT",
+                "SELECT " + DB,
                 "BATCH SELECT",
+                "SELECT ?",
+                "SELECT ?; SELECT ?",
+                "SELECT",
                 2L))
         .map(Arguments::of);
   }
@@ -416,15 +466,47 @@ public abstract class AbstractR2dbcStatementTest {
     final String name;
     final List<String> queries;
     final String spanName;
+    final String oldSpanName;
     final String summary;
+    // the stable-semconv db.query.text (identical query texts are deduplicated)
+    final String queryText;
+    // the old-semconv db.statement (individual query texts concatenated with "; ")
+    final String oldStatement;
+    final String oldOperation;
     final Long batchSize;
 
+    // empty-batch scenario (no stable batch attributes, handled separately in the test)
     BatchScenario(
-        String name, List<String> queries, String spanName, String summary, Long batchSize) {
+        String name,
+        List<String> queries,
+        String spanName,
+        String oldSpanName,
+        String summary,
+        String queryText,
+        String oldStatement,
+        String oldOperation) {
+      this(name, queries, spanName, oldSpanName, summary, queryText, oldStatement, oldOperation,
+          null);
+    }
+
+    BatchScenario(
+        String name,
+        List<String> queries,
+        String spanName,
+        String oldSpanName,
+        String summary,
+        String queryText,
+        String oldStatement,
+        String oldOperation,
+        Long batchSize) {
       this.name = name;
       this.queries = queries;
       this.spanName = spanName;
+      this.oldSpanName = oldSpanName;
       this.summary = summary;
+      this.queryText = queryText;
+      this.oldStatement = oldStatement;
+      this.oldOperation = oldOperation;
       this.batchSize = batchSize;
     }
 

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -445,56 +445,53 @@ public abstract class AbstractR2dbcStatementTest {
                                 equalTo(SERVER_PORT, port))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch produces an error client span
-            BatchScenario.builder("empty").queries(emptyList()).build(),
-            // a single-statement batch is not a batch (size 1), so it emits no
-            // db.operation.batch.size and no BATCH prefix; under old semconv it carries the
-            // statement, operation, collection and the operation+namespace+table span name
-            BatchScenario.builder("single")
-                .queries(singletonList("INSERT INTO players VALUES (1)"))
-                .spanName("INSERT players")
-                .oldSpanName("INSERT " + DB + ".players")
-                .summary("INSERT players")
-                .queryText("INSERT INTO players VALUES (?)")
-                .oldStatement("INSERT INTO players VALUES (?)")
-                .oldOperation("INSERT")
-                .oldCollection("players")
-                .build(),
-            // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
-            // db.operation.batch.size under stable semconv; the collection name is captured in the
-            // summary (BATCH INSERT players). under old semconv the individual statements are
-            // concatenated but the shared operation and collection are still captured
-            BatchScenario.builder("twoSameOperation")
-                .queries(asList("INSERT INTO players VALUES (2)", "INSERT INTO players VALUES (3)"))
-                .spanName("BATCH INSERT players")
-                .oldSpanName("INSERT " + DB + ".players")
-                .summary("BATCH INSERT players")
-                .queryText("INSERT INTO players VALUES (?)")
-                .oldStatement("INSERT INTO players VALUES (?); INSERT INTO players VALUES (?)")
-                .oldOperation("INSERT")
-                .oldCollection("players")
-                .batchSize(2)
-                .build(),
-            // a multi-statement batch with different operations has no shared operation or summary,
-            // so db.query.summary (and the span name) is just BATCH; the individual statements are
-            // still concatenated into db.query.text / db.statement
-            BatchScenario.builder("twoDifferentOperations")
-                .queries(
-                    asList(
-                        "INSERT INTO players VALUES (4)", "UPDATE players SET id = 5 WHERE id = 4"))
-                .spanName("BATCH")
-                .oldSpanName("INSERT " + DB + ".players")
-                .summary("BATCH")
-                .queryText("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
-                .oldStatement(
-                    "INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
-                .oldOperation("INSERT")
-                .oldCollection("players")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch produces an error client span
+        BatchScenario.builder("empty").queries(emptyList()).build(),
+        // a single-statement batch is not a batch (size 1), so it emits no
+        // db.operation.batch.size and no BATCH prefix; under old semconv it carries the
+        // statement, operation, collection and the operation+namespace+table span name
+        BatchScenario.builder("single")
+            .queries(singletonList("INSERT INTO players VALUES (1)"))
+            .spanName("INSERT players")
+            .oldSpanName("INSERT " + DB + ".players")
+            .summary("INSERT players")
+            .queryText("INSERT INTO players VALUES (?)")
+            .oldStatement("INSERT INTO players VALUES (?)")
+            .oldOperation("INSERT")
+            .oldCollection("players")
+            .build(),
+        // a multi-statement batch emits the BATCH span name, deduplicated db.query.text and
+        // db.operation.batch.size under stable semconv; the collection name is captured in the
+        // summary (BATCH INSERT players). under old semconv the individual statements are
+        // concatenated but the shared operation and collection are still captured
+        BatchScenario.builder("twoSameOperation")
+            .queries(asList("INSERT INTO players VALUES (2)", "INSERT INTO players VALUES (3)"))
+            .spanName("BATCH INSERT players")
+            .oldSpanName("INSERT " + DB + ".players")
+            .summary("BATCH INSERT players")
+            .queryText("INSERT INTO players VALUES (?)")
+            .oldStatement("INSERT INTO players VALUES (?); INSERT INTO players VALUES (?)")
+            .oldOperation("INSERT")
+            .oldCollection("players")
+            .batchSize(2)
+            .build(),
+        // a multi-statement batch with different operations has no shared operation or summary,
+        // so db.query.summary (and the span name) is just BATCH; the individual statements are
+        // still concatenated into db.query.text / db.statement
+        BatchScenario.builder("twoDifferentOperations")
+            .queries(
+                asList("INSERT INTO players VALUES (4)", "UPDATE players SET id = 5 WHERE id = 4"))
+            .spanName("BATCH")
+            .oldSpanName("INSERT " + DB + ".players")
+            .summary("BATCH")
+            .queryText("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
+            .oldStatement("INSERT INTO players VALUES (?); UPDATE players SET id = ? WHERE id = ?")
+            .oldOperation("INSERT")
+            .oldCollection("players")
+            .batchSize(2)
+            .build());
   }
 
   private void createPlayersTable(ConnectionFactory connectionFactory) {

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/OnCompleteHandler.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/OnCompleteHandler.java
@@ -9,15 +9,14 @@ import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.Rediscal
 
 import io.opentelemetry.context.Context;
 import javax.annotation.Nullable;
-import redis.RedisCommand;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
 class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void> {
   private final Context context;
-  private final RedisCommand<?, ?> request;
+  private final RediscalaRequest request;
 
-  OnCompleteHandler(Context context, RedisCommand<?, ?> request) {
+  OnCompleteHandler(Context context, RediscalaRequest request) {
     this.context = context;
     this.request = request;
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -7,32 +7,35 @@ package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
-import java.util.Locale;
 import javax.annotation.Nullable;
-import redis.RedisCommand;
 
-final class RediscalaAttributesGetter
-    implements DbClientAttributesGetter<RedisCommand<?, ?>, Void> {
+final class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
 
   @Override
-  public String getDbSystemName(RedisCommand<?, ?> redisCommand) {
+  public String getDbSystemName(RediscalaRequest request) {
     return DbSystemNameIncubatingValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String getDbNamespace(RedisCommand<?, ?> redisCommand) {
+  public String getDbNamespace(RediscalaRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String getDbQueryText(RedisCommand<?, ?> redisCommand) {
+  public String getDbQueryText(RediscalaRequest request) {
     return null;
   }
 
   @Override
-  public String getDbOperationName(RedisCommand<?, ?> redisCommand) {
-    return redisCommand.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+  public String getDbOperationName(RediscalaRequest request) {
+    return request.getOperationName();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(RediscalaRequest request) {
+    return request.getBatchSize();
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -21,6 +21,6 @@ public class RediscalaInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new RequestInstrumentation());
+    return asList(new RequestInstrumentation(), new TransactionInstrumentation());
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+import java.util.Locale;
+import javax.annotation.Nullable;
+import redis.Operation;
+import redis.RedisCommand;
+import scala.collection.Iterator;
+import scala.collection.immutable.Queue;
+
+class RediscalaRequest {
+  private final String operationName;
+  @Nullable private final Long batchSize;
+
+  static RediscalaRequest create(RedisCommand<?, ?> command) {
+    return new RediscalaRequest(operationName(command), null);
+  }
+
+  static RediscalaRequest createTransaction(Queue<Operation<?, ?>> operations) {
+    return new RediscalaRequest(transactionOperationName(operations), batchSize(operations));
+  }
+
+  private RediscalaRequest(String operationName, @Nullable Long batchSize) {
+    this.operationName = operationName;
+    this.batchSize = batchSize;
+  }
+
+  String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
+  }
+
+  private static String transactionOperationName(Queue<Operation<?, ?>> operations) {
+    if (operations.isEmpty()) {
+      return "MULTI";
+    }
+
+    Iterator<Operation<?, ?>> iterator = operations.iterator();
+    String operationName = operationName(iterator.next().redisCommand());
+    while (iterator.hasNext()) {
+      if (!operationName.equals(operationName(iterator.next().redisCommand()))) {
+        return "MULTI";
+      }
+    }
+    return "MULTI " + operationName;
+  }
+
+  @Nullable
+  private static Long batchSize(Queue<Operation<?, ?>> operations) {
+    int size = operations.size();
+    return size > 1 ? (long) size : null;
+  }
+
+  private static String operationName(RedisCommand<?, ?> command) {
+    return command.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -14,19 +14,18 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import redis.RedisCommand;
 
 public class RediscalaSingletons {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rediscala-1.8";
 
-  private static final Instrumenter<RedisCommand<?, ?>, Void> instrumenter;
+  private static final Instrumenter<RediscalaRequest, Void> instrumenter;
 
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();
 
-    InstrumenterBuilder<RedisCommand<?, ?>, Void> builder =
-        Instrumenter.<RedisCommand<?, ?>, Void>builder(
+    InstrumenterBuilder<RediscalaRequest, Void> builder =
+        Instrumenter.<RediscalaRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
@@ -37,7 +36,7 @@ public class RediscalaSingletons {
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
-  public static Instrumenter<RedisCommand<?, ?>, Void> instrumenter() {
+  public static Instrumenter<RediscalaRequest, Void> instrumenter() {
     return instrumenter;
   }
 

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
@@ -62,28 +62,32 @@ class RequestInstrumentation implements TypeInstrumentation {
     public static class AdviceScope {
       private final Context context;
       private final Scope scope;
+      private final RediscalaRequest request;
 
-      private AdviceScope(Context context, Scope scope) {
+      private AdviceScope(Context context, Scope scope, RediscalaRequest request) {
         this.context = context;
         this.scope = scope;
+        this.request = request;
       }
 
       @Nullable
-      public static AdviceScope start(RedisCommand<?, ?> cmd) {
-        Context parentContext = Context.current();
-        if (!instrumenter().shouldStart(parentContext, cmd)) {
+      public static AdviceScope start(Object action, RedisCommand<?, ?> cmd) {
+        if (action instanceof BufferedRequest) {
           return null;
         }
 
-        Context context = instrumenter().start(parentContext, cmd);
-        return new AdviceScope(context, context.makeCurrent());
+        RediscalaRequest request = RediscalaRequest.create(cmd);
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(context, context.makeCurrent(), request);
       }
 
       public void end(
-          Object action,
-          RedisCommand<?, ?> cmd,
-          @Nullable Future<Object> responseFuture,
-          @Nullable Throwable throwable) {
+          Object action, @Nullable Future<Object> responseFuture, @Nullable Throwable throwable) {
         scope.close();
 
         ExecutionContext ctx = null;
@@ -98,17 +102,18 @@ class RequestInstrumentation implements TypeInstrumentation {
         }
 
         if (throwable != null || responseFuture == null) {
-          instrumenter().end(context, cmd, null, throwable);
+          instrumenter().end(context, request, null, throwable);
         } else {
-          responseFuture.onComplete(new OnCompleteHandler(context, cmd), ctx);
+          responseFuture.onComplete(new OnCompleteHandler(context, request), ctx);
         }
       }
     }
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static AdviceScope onEnter(@Advice.Argument(0) RedisCommand<?, ?> cmd) {
-      return AdviceScope.start(cmd);
+    public static AdviceScope onEnter(
+        @Advice.This Object action, @Advice.Argument(0) RedisCommand<?, ?> cmd) {
+      return AdviceScope.start(action, cmd);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -119,7 +124,7 @@ class RequestInstrumentation implements TypeInstrumentation {
         @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Return @Nullable Future<Object> responseFuture) {
       if (adviceScope != null) {
-        adviceScope.end(action, cmd, responseFuture, throwable);
+        adviceScope.end(action, responseFuture, throwable);
       }
     }
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import redis.Operation;
+import redis.commands.TransactionBuilder;
+import scala.collection.immutable.Queue;
+import scala.concurrent.Future;
+
+class TransactionInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("redis.commands.TransactionBuilder");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("exec").and(returns(named("scala.concurrent.Future"))),
+        getClass().getName() + "$ExecAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ExecAdvice {
+    public static class AdviceScope {
+      private final Context context;
+      private final Scope scope;
+      private final RediscalaRequest request;
+
+      private AdviceScope(Context context, Scope scope, RediscalaRequest request) {
+        this.context = context;
+        this.scope = scope;
+        this.request = request;
+      }
+
+      @Nullable
+      public static AdviceScope start(TransactionBuilder transactionBuilder) {
+        Queue<Operation<?, ?>> operations = transactionBuilder.operations().result();
+        RediscalaRequest request = RediscalaRequest.createTransaction(operations);
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(context, context.makeCurrent(), request);
+      }
+
+      public void end(
+          TransactionBuilder transactionBuilder,
+          @Nullable Future<Object> responseFuture,
+          @Nullable Throwable throwable) {
+        scope.close();
+        if (throwable != null || responseFuture == null) {
+          instrumenter().end(context, request, null, throwable);
+        } else {
+          responseFuture.onComplete(
+              new OnCompleteHandler(context, request), transactionBuilder.executionContext());
+        }
+      }
+    }
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static AdviceScope onEnter(@Advice.This TransactionBuilder transactionBuilder) {
+      return AdviceScope.start(transactionBuilder);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This TransactionBuilder transactionBuilder,
+        @Advice.Enter @Nullable AdviceScope adviceScope,
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Return @Nullable Future<Object> responseFuture) {
+      if (adviceScope != null) {
+        adviceScope.end(transactionBuilder, responseFuture, throwable);
+      }
+    }
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -6,12 +6,14 @@
 package rediscala
 
 import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.assertj.{SpanDataAssert, TraceAssert}
+import io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS
@@ -19,10 +21,14 @@ import io.opentelemetry.semconv.DbAttributes.{DB_OPERATION_NAME, DB_SYSTEM_NAME}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterAll, BeforeAll, Test, TestInstance}
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.testcontainers.containers.GenericContainer
+import redis.commands.TransactionBuilder
 import redis.{RedisClient, RedisDispatcher}
 
 import java.util.function.Consumer
+import java.util.stream.Stream
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
@@ -194,5 +200,121 @@ class RediscalaClientTest {
           }
         )
     })
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource(Array("transactionScenarios"))
+  def testTransaction(scenario: BatchScenario): Unit = {
+    val result = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] = {
+          val transaction = redisClient.multi()
+          scenario.commands(transaction)
+          transaction.exec()
+        }
+      }
+    )
+
+    Await.result(result, Duration.apply("3 second"))
+
+    assertTransactionSpan(scenario.operation, scenario.batchSize)
+  }
+
+  private def transactionScenarios(): Stream[BatchScenario] = {
+    Stream.of(
+      BatchScenario
+        .builder("single")
+        .commands(transaction => transaction.set("transaction-single", "value"))
+        .operation("MULTI SET")
+        .build(),
+      BatchScenario
+        .builder("twoSameOperation")
+        .commands((transaction: TransactionBuilder) => {
+          transaction.set("transaction-same-1", "value")
+          transaction.set("transaction-same-2", "value")
+        })
+        .operation("MULTI SET")
+        .batchSize(2)
+        .build(),
+      BatchScenario
+        .builder("twoDifferentOperations")
+        .commands((transaction: TransactionBuilder) => {
+          transaction.set("transaction-different", "value")
+          transaction.get[String]("transaction-different")
+        })
+        .operation("MULTI")
+        .batchSize(2)
+        .build()
+    )
+  }
+
+  private def assertTransactionSpan(
+      operation: String,
+      batchSize: java.lang.Long
+  ): Unit = {
+    testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+      override def accept(trace: TraceAssert): Unit =
+        trace.hasSpansSatisfyingExactly(
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span.hasName("parent").hasNoParent
+            }
+          },
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span
+                .hasName(operation)
+                .hasKind(CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                  equalTo(maybeStable(DB_OPERATION), operation),
+                  equalTo(
+                    DB_OPERATION_BATCH_SIZE,
+                    if (emitStableDatabaseSemconv()) batchSize else null
+                  )
+                )
+            }
+          }
+        )
+    })
+  }
+
+  private class BatchScenario private (
+      val name: String,
+      val commands: TransactionBuilder => Unit,
+      val operation: String,
+      val batchSize: java.lang.Long
+  ) {
+    override def toString: String = name
+  }
+
+  private object BatchScenario {
+    def builder(name: String): Builder = new Builder(name)
+
+    class Builder private[BatchScenario] (name: String) {
+      private var commands: TransactionBuilder => Unit = _
+      private var operation: String = _
+      private var batchSize: java.lang.Long = _
+
+      def commands(commands: TransactionBuilder => Unit): Builder = {
+        this.commands = commands
+        this
+      }
+
+      def operation(operation: String): Builder = {
+        this.operation = operation
+        this
+      }
+
+      def batchSize(batchSize: Long): Builder = {
+        this.batchSize = batchSize
+        this
+      }
+
+      def build(): BatchScenario =
+        new BatchScenario(name, commands, operation, batchSize)
+    }
   }
 }

--- a/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.EndOperationListener;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.PromiseWrapper;
+import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonBatchSpanManager;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonRequest;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
@@ -38,14 +39,30 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
   public static class SendAdvice {
 
     public static class AdviceScope {
-      private final RedissonRequest request;
-      private final Context context;
-      private final Scope scope;
+      private final RedisConnection connection;
+      @Nullable private final RedissonRequest request;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean multiSpan;
+      private final boolean suppressedSpan;
 
-      private AdviceScope(RedissonRequest request, Context context, Scope scope) {
+      private AdviceScope(
+          RedisConnection connection,
+          @Nullable RedissonRequest request,
+          @Nullable Context context,
+          @Nullable Scope scope,
+          boolean multiSpan,
+          boolean suppressedSpan) {
+        this.connection = connection;
         this.request = request;
         this.context = context;
         this.scope = scope;
+        this.multiSpan = multiSpan;
+        this.suppressedSpan = suppressedSpan;
+      }
+
+      private static AdviceScope suppressed(RedisConnection connection) {
+        return new AdviceScope(connection, null, null, null, false, true);
       }
 
       @Nullable
@@ -57,6 +74,9 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         if (promise == null) {
           return null;
         }
+        if (RedissonBatchSpanManager.suppressSpanOrEndMultiSpan(connection, request, promise)) {
+          return suppressed(connection);
+        }
         Context parentContext = currentContext();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
@@ -65,16 +85,26 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         Context context = instrumenter().start(parentContext, request);
         Scope scope = context.makeCurrent();
 
+        if (request.isMultiBatch()) {
+          RedissonBatchSpanManager.startMultiSpan(connection, instrumenter(), context, request);
+          return new AdviceScope(connection, request, context, scope, true, false);
+        }
         promise.setEndOperationListener(
             new EndOperationListener<>(instrumenter(), context, request));
-        return new AdviceScope(request, context, scope);
+        return new AdviceScope(connection, request, context, scope, false, false);
       }
 
       public void end(@Nullable Throwable throwable) {
-        scope.close();
+        if (scope != null) {
+          scope.close();
+        }
 
         if (throwable != null) {
-          instrumenter().end(context, request, null, throwable);
+          if (multiSpan || suppressedSpan) {
+            RedissonBatchSpanManager.endMultiSpan(connection, throwable);
+          } else if (context != null && request != null) {
+            instrumenter().end(context, request, null, throwable);
+          }
         }
         // span ended in EndOperationListener
       }

--- a/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.EndOperationListener;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.PromiseWrapper;
+import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonBatchSpanManager;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonRequest;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
@@ -38,14 +39,30 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
   public static class SendAdvice {
 
     public static class AdviceScope {
-      private final RedissonRequest request;
-      private final Context context;
-      private final Scope scope;
+      private final RedisConnection connection;
+      @Nullable private final RedissonRequest request;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean multiSpan;
+      private final boolean suppressedSpan;
 
-      private AdviceScope(RedissonRequest request, Context context, Scope scope) {
+      private AdviceScope(
+          RedisConnection connection,
+          @Nullable RedissonRequest request,
+          @Nullable Context context,
+          @Nullable Scope scope,
+          boolean multiSpan,
+          boolean suppressedSpan) {
+        this.connection = connection;
         this.request = request;
         this.context = context;
         this.scope = scope;
+        this.multiSpan = multiSpan;
+        this.suppressedSpan = suppressedSpan;
+      }
+
+      private static AdviceScope suppressed(RedisConnection connection) {
+        return new AdviceScope(connection, null, null, null, false, true);
       }
 
       @Nullable
@@ -58,6 +75,9 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         if (promise == null) {
           return null;
         }
+        if (RedissonBatchSpanManager.suppressSpanOrEndMultiSpan(connection, request, promise)) {
+          return suppressed(connection);
+        }
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
         }
@@ -65,15 +85,25 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         Context context = instrumenter().start(parentContext, request);
         Scope scope = context.makeCurrent();
 
+        if (request.isMultiBatch()) {
+          RedissonBatchSpanManager.startMultiSpan(connection, instrumenter(), context, request);
+          return new AdviceScope(connection, request, context, scope, true, false);
+        }
         promise.setEndOperationListener(
             new EndOperationListener<>(instrumenter(), context, request));
-        return new AdviceScope(request, context, scope);
+        return new AdviceScope(connection, request, context, scope, false, false);
       }
 
       public void end(@Nullable Throwable throwable) {
-        scope.close();
+        if (scope != null) {
+          scope.close();
+        }
         if (throwable != null) {
-          instrumenter().end(context, request, null, throwable);
+          if (multiSpan || suppressedSpan) {
+            RedissonBatchSpanManager.endMultiSpan(connection, throwable);
+          } else if (context != null && request != null) {
+            instrumenter().end(context, request, null, throwable);
+          }
         }
         // span ended in EndOperationListener
       }

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
@@ -5,6 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.Collections;
@@ -13,6 +21,9 @@ import java.util.WeakHashMap;
 import javax.annotation.Nullable;
 
 public final class RedissonBatchSpanManager {
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_STATEMENT = AttributeKey.stringKey("db.statement");
+
   private static final Map<Object, ActiveSpan> activeMultiSpans =
       Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -31,6 +42,10 @@ public final class RedissonBatchSpanManager {
       return false;
     }
 
+    if (!request.isExecCommand()) {
+      activeSpan.request.addCommandsFrom(request);
+      activeSpan.updateAttributes();
+    }
     setEndOperationListener(connection, promise, activeSpan, request.isExecCommand());
     return true;
   }
@@ -76,6 +91,21 @@ public final class RedissonBatchSpanManager {
 
     private void end(@Nullable Throwable error) {
       instrumenter.end(context, request, null, error);
+    }
+
+    private void updateAttributes() {
+      Span span = Span.fromContext(context);
+      if (emitStableDatabaseSemconv()) {
+        span.setAttribute(DB_OPERATION_NAME, request.getOperationName());
+        span.setAttribute(DB_QUERY_TEXT, request.getQueryText());
+        Long batchSize = request.getOperationBatchSize();
+        if (batchSize != null) {
+          span.setAttribute(DB_OPERATION_BATCH_SIZE, batchSize);
+        }
+      }
+      if (emitOldDatabaseSemconv()) {
+        span.setAttribute(DB_STATEMENT, request.getQueryText());
+      }
     }
   }
 }

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.annotation.Nullable;
+
+public final class RedissonBatchSpanManager {
+  private static final Map<Object, ActiveSpan> activeMultiSpans =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  public static void startMultiSpan(
+      Object connection,
+      Instrumenter<RedissonRequest, Void> instrumenter,
+      Context context,
+      RedissonRequest request) {
+    activeMultiSpans.put(connection, new ActiveSpan(instrumenter, context, request));
+  }
+
+  public static boolean suppressSpanOrEndMultiSpan(
+      Object connection, RedissonRequest request, PromiseWrapper<?> promise) {
+    ActiveSpan activeSpan = activeMultiSpans.get(connection);
+    if (activeSpan == null) {
+      return false;
+    }
+
+    setEndOperationListener(connection, promise, activeSpan, request.isExecCommand());
+    return true;
+  }
+
+  public static void endMultiSpan(Object connection, @Nullable Throwable error) {
+    ActiveSpan activeSpan = activeMultiSpans.remove(connection);
+    if (activeSpan != null) {
+      activeSpan.end(error);
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"}) // promise value type is irrelevant to span ending
+  private static void setEndOperationListener(
+      Object connection, PromiseWrapper<?> promise, ActiveSpan activeSpan, boolean endOnSuccess) {
+    ((PromiseWrapper) promise)
+        .setEndOperationListener(
+            new EndOperationListener(
+                activeSpan.instrumenter, activeSpan.context, activeSpan.request) {
+              @Override
+              public void accept(@Nullable Object unused, @Nullable Throwable error) {
+                if (endOnSuccess || error != null) {
+                  endMultiSpan(connection, error);
+                }
+              }
+            });
+  }
+
+  private RedissonBatchSpanManager() {}
+
+  private static final class ActiveSpan {
+    private final Instrumenter<RedissonRequest, Void> instrumenter;
+    private final Context context;
+    private final RedissonRequest request;
+
+    private ActiveSpan(
+        Instrumenter<RedissonRequest, Void> instrumenter,
+        Context context,
+        RedissonRequest request) {
+      this.instrumenter = instrumenter;
+      this.context = context;
+      this.request = request;
+    }
+
+    private void end(@Nullable Throwable error) {
+      instrumenter.end(context, request, null, error);
+    }
+  }
+}

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -99,6 +99,30 @@ public abstract class RedissonRequest {
     return null;
   }
 
+  public boolean isMultiBatch() {
+    Object command = getCommand();
+    if (!(command instanceof CommandsData)) {
+      return false;
+    }
+    List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+    return !commands.isEmpty() && commands.get(0).getCommand().getName().equals(MULTI);
+  }
+
+  public boolean isExecCommand() {
+    Object command = getCommand();
+    if (command instanceof CommandData) {
+      return ((CommandData<?, ?>) command).getCommand().getName().equals("EXEC");
+    }
+    if (command instanceof CommandsData) {
+      for (CommandData<?, ?> singleCommand : ((CommandsData) command).getCommands()) {
+        if (singleCommand.getCommand().getName().equals("EXEC")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   @Nullable
   public Long getOperationBatchSize() {
     Object command = getCommand();

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -43,6 +43,8 @@ public abstract class RedissonRequest {
   // note that RedisCommandSanitizer already limits the size of sanitized commands
   private static final int LIMIT = 32 * 1024;
 
+  private final List<CommandData<?, ?>> additionalCommands = new ArrayList<>();
+
   @Nullable
   private static final MethodHandle COMMAND_DATA_GET_PROMISE =
       findGetPromiseMethod(CommandData.class);
@@ -83,14 +85,37 @@ public abstract class RedissonRequest {
 
   public abstract Object getCommand();
 
+  void addCommandsFrom(RedissonRequest request) {
+    if (!isMultiBatch()) {
+      return;
+    }
+    Object command = request.getCommand();
+    if (command == getCommand()) {
+      return;
+    }
+    if (command instanceof CommandData) {
+      addCommand((CommandData<?, ?>) command);
+    } else if (command instanceof CommandsData) {
+      for (CommandData<?, ?> singleCommand : ((CommandsData) command).getCommands()) {
+        addCommand(singleCommand);
+      }
+    }
+  }
+
+  private void addCommand(CommandData<?, ?> command) {
+    String commandName = command.getCommand().getName();
+    if (!commandName.equals(MULTI) && !commandName.equals("EXEC")) {
+      additionalCommands.add(command);
+    }
+  }
+
   @Nullable
   public String getOperationName() {
     Object command = getCommand();
     if (command instanceof CommandData) {
       return ((CommandData<?, ?>) command).getCommand().getName();
     } else if (command instanceof CommandsData) {
-      CommandsData commandsData = (CommandsData) command;
-      List<CommandData<?, ?>> commands = commandsData.getCommands();
+      List<CommandData<?, ?>> commands = getCommands();
       if (commands.size() == 1) {
         return commands.get(0).getCommand().getName();
       }
@@ -104,7 +129,7 @@ public abstract class RedissonRequest {
     if (!(command instanceof CommandsData)) {
       return false;
     }
-    List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+    List<CommandData<?, ?>> commands = getCommands();
     return !commands.isEmpty() && commands.get(0).getCommand().getName().equals(MULTI);
   }
 
@@ -114,7 +139,7 @@ public abstract class RedissonRequest {
       return ((CommandData<?, ?>) command).getCommand().getName().equals("EXEC");
     }
     if (command instanceof CommandsData) {
-      for (CommandData<?, ?> singleCommand : ((CommandsData) command).getCommands()) {
+      for (CommandData<?, ?> singleCommand : getCommands()) {
         if (singleCommand.getCommand().getName().equals("EXEC")) {
           return true;
         }
@@ -129,7 +154,7 @@ public abstract class RedissonRequest {
     if (!(command instanceof CommandsData)) {
       return null;
     }
-    List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+    List<CommandData<?, ?>> commands = getCommands();
     if (commands.isEmpty()) {
       return null;
     }
@@ -175,7 +200,7 @@ public abstract class RedissonRequest {
     // get command
     if (command instanceof CommandsData) {
       int length = 0;
-      List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+      List<CommandData<?, ?>> commands = getCommands();
       List<String> normalizedCommands = new ArrayList<>(commands.size());
       for (CommandData<?, ?> singleCommand : commands) {
         String s = normalizeSingleCommand(singleCommand);
@@ -231,6 +256,18 @@ public abstract class RedissonRequest {
       }
     }
     return sanitizer.sanitize(command.getCommand().getName(), args);
+  }
+
+  private List<CommandData<?, ?>> getCommands() {
+    List<CommandData<?, ?>> commands = ((CommandsData) getCommand()).getCommands();
+    if (additionalCommands.isEmpty()) {
+      return commands;
+    }
+    List<CommandData<?, ?>> combinedCommands =
+        new ArrayList<>(commands.size() + additionalCommands.size());
+    combinedCommands.addAll(commands);
+    combinedCommands.addAll(additionalCommands);
+    return combinedCommands;
   }
 
   @Nullable

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -257,10 +258,9 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
-                            // db.operation.batch.size is not emitted because MULTI transaction
-                            // telemetry is split across wrapper and command spans, so this span
-                            // does not represent the full logical batch.
-                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?;SET batch2 ?"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -125,6 +125,7 @@ public abstract class AbstractRedissonAsyncClientTest {
   void cleanup() {
     if (redisson != null) {
       redisson.shutdown();
+      testing.clearData();
     }
   }
 
@@ -241,7 +242,7 @@ public abstract class AbstractRedissonAsyncClientTest {
     assertThat(result.toCompletableFuture()).succeedsWithin(TIMEOUT);
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("parent", "SADD", "callback"),
+        orderByRootSpanName("parent", "DB Query", "callback"),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
@@ -260,28 +261,6 @@ public abstract class AbstractRedissonAsyncClientTest {
                             // telemetry is split across wrapper and command spans, so this span
                             // does not represent the full logical batch.
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("SET")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(maybeStable(DB_OPERATION), "SET"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("EXEC")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
-                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.BatchOptions;
@@ -302,43 +301,42 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_STATEMENT), scenario.statement))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch fails to execute and produces no span
-            BatchScenario.builder("empty").commands(batch -> {}).empty().build(),
-            // a single-command batch is executed as a normal command (not a pipeline): the span is
-            // named after the command, it carries db.operation (old) / db.operation.name (stable),
-            // and emits no db.operation.batch.size
-            BatchScenario.builder("single")
-                .commands(batch -> batch.getBucket("batch1").setAsync("v1"))
-                .spanName("SET")
-                .oldSpanName("SET")
-                .oldOperation("SET")
-                .statement("SET batch1 ?")
-                .build(),
-            BatchScenario.builder("twoSameOperation")
-                .commands(
-                    batch -> {
-                      batch.getBucket("batch1").setAsync("v1");
-                      batch.getBucket("batch2").setAsync("v2");
-                    })
-                .spanName("PIPELINE SET")
-                .oldSpanName("DB Query")
-                .batchSize(2)
-                .statement("SET batch1 ?;SET batch2 ?")
-                .build(),
-            BatchScenario.builder("twoDifferentOperations")
-                .commands(
-                    batch -> {
-                      batch.getBucket("batch1").setAsync("v1");
-                      batch.getBucket("batch1").getAsync();
-                    })
-                .spanName("PIPELINE")
-                .oldSpanName("DB Query")
-                .batchSize(2)
-                .statement("SET batch1 ?;GET batch1")
-                .build())
-        .map(Arguments::of);
+        // an empty batch fails to execute and produces no span
+        BatchScenario.builder("empty").commands(batch -> {}).empty().build(),
+        // a single-command batch is executed as a normal command (not a pipeline): the span is
+        // named after the command, it carries db.operation (old) / db.operation.name (stable),
+        // and emits no db.operation.batch.size
+        BatchScenario.builder("single")
+            .commands(batch -> batch.getBucket("batch1").setAsync("v1"))
+            .spanName("SET")
+            .oldSpanName("SET")
+            .oldOperation("SET")
+            .statement("SET batch1 ?")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .commands(
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch2").setAsync("v2");
+                })
+            .spanName("PIPELINE SET")
+            .oldSpanName("DB Query")
+            .batchSize(2)
+            .statement("SET batch1 ?;SET batch2 ?")
+            .build(),
+        BatchScenario.builder("twoDifferentOperations")
+            .commands(
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch1").getAsync();
+                })
+            .spanName("PIPELINE")
+            .oldSpanName("DB Query")
+            .batchSize(2)
+            .statement("SET batch1 ?;GET batch1")
+            .build());
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -145,6 +145,7 @@ public abstract class AbstractRedissonClientTest {
   void cleanup() {
     if (redisson != null) {
       redisson.shutdown();
+      testing.clearData();
     }
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -250,10 +250,10 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
-  // describes the batch cases: two commands with the same operation, and two commands with
-  // different operations. (a single-command batch is executed as a normal command rather than a
-  // pipeline.) batch telemetry (db.operation.batch.size, PIPELINE operation name) is only emitted
-  // under stable database semconv
+  // describes the batch cases: a single-command batch (which is executed as a normal command, not a
+  // pipeline), two commands with the same operation, and two commands with different operations.
+  // batch telemetry (db.operation.batch.size, PIPELINE operation name) is only emitted under stable
+  // database semconv
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchCommand(BatchScenario scenario) throws ReflectiveOperationException {
@@ -267,24 +267,42 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? scenario.operationName : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : scenario.oldSpanName)
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            // a single-command batch is not a batch, so in stable mode it is named
+                            // after the command (db.operation.name = SET) and in old mode carries
+                            // db.operation = SET; the real pipeline cases carry db.operation.name =
+                            // PIPELINE* (stable only) and db.operation.batch.size
                             equalTo(
                                 DB_OPERATION_NAME,
-                                emitStableDatabaseSemconv() ? scenario.operationName : null),
+                                emitStableDatabaseSemconv() ? scenario.operationName() : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                            equalTo(
+                                DB_OPERATION,
+                                emitStableDatabaseSemconv() ? null : scenario.oldOperation),
                             equalTo(maybeStable(DB_STATEMENT), scenario.statement))));
   }
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // a single-command batch is executed as a normal command (not a pipeline): the span is
+            // named after the command, it carries db.operation (old) / db.operation.name (stable),
+            // and emits no db.operation.batch.size
+            new BatchScenario(
+                "single",
+                batch -> batch.getBucket("batch1").setAsync("v1"),
+                "SET",
+                "SET",
+                null,
+                "SET",
+                "SET batch1 ?"),
             new BatchScenario(
                 "twoSameOperation",
                 batch -> {
@@ -292,7 +310,9 @@ public abstract class AbstractRedissonClientTest {
                   batch.getBucket("batch2").setAsync("v2");
                 },
                 "PIPELINE SET",
+                "DB Query",
                 2L,
+                null,
                 "SET batch1 ?;SET batch2 ?"),
             new BatchScenario(
                 "twoDifferentOperations",
@@ -301,7 +321,9 @@ public abstract class AbstractRedissonClientTest {
                   batch.getBucket("batch1").getAsync();
                 },
                 "PIPELINE",
+                "DB Query",
                 2L,
+                null,
                 "SET batch1 ?;GET batch1"))
         .map(Arguments::of);
   }
@@ -309,21 +331,32 @@ public abstract class AbstractRedissonClientTest {
   private static final class BatchScenario {
     final String name;
     final Consumer<RBatch> commands;
-    final String operationName;
+    final String spanName;
+    final String oldSpanName;
     final Long batchSize;
+    final String oldOperation;
     final String statement;
 
     BatchScenario(
         String name,
         Consumer<RBatch> commands,
-        String operationName,
+        String spanName,
+        String oldSpanName,
         Long batchSize,
+        String oldOperation,
         String statement) {
       this.name = name;
       this.commands = commands;
-      this.operationName = operationName;
+      this.spanName = spanName;
+      this.oldSpanName = oldSpanName;
       this.batchSize = batchSize;
+      this.oldOperation = oldOperation;
       this.statement = statement;
+    }
+
+    // the stable-mode db.operation.name (= the span name in stable mode)
+    String operationName() {
+      return spanName;
     }
 
     @Override

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -52,6 +53,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.RAtomicLong;
@@ -246,12 +250,16 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
-  @Test
-  void batchCommand() throws ReflectiveOperationException {
+  // describes the batch cases: two commands with the same operation, and two commands with
+  // different operations. (a single-command batch is executed as a normal command rather than a
+  // pipeline.) batch telemetry (db.operation.batch.size, PIPELINE operation name) is only emitted
+  // under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchCommand(BatchScenario scenario) throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch2").setAsync("v2");
+    scenario.commands.accept(batch);
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
     invokeExecute(batch);
@@ -259,7 +267,7 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
+                    span.hasName(emitStableDatabaseSemconv() ? scenario.operationName : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
@@ -268,41 +276,65 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(
                                 DB_OPERATION_NAME,
-                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                                emitStableDatabaseSemconv() ? scenario.operationName : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                            equalTo(maybeStable(DB_STATEMENT), scenario.statement))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            new BatchScenario(
+                "twoSameOperation",
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch2").setAsync("v2");
+                },
+                "PIPELINE SET",
+                2L,
+                "SET batch1 ?;SET batch2 ?"),
+            new BatchScenario(
+                "twoDifferentOperations",
+                batch -> {
+                  batch.getBucket("batch1").setAsync("v1");
+                  batch.getBucket("batch1").getAsync();
+                },
+                "PIPELINE",
+                2L,
+                "SET batch1 ?;GET batch1"))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final Consumer<RBatch> commands;
+    final String operationName;
+    final Long batchSize;
+    final String statement;
+
+    BatchScenario(
+        String name,
+        Consumer<RBatch> commands,
+        String operationName,
+        Long batchSize,
+        String statement) {
+      this.name = name;
+      this.commands = commands;
+      this.operationName = operationName;
+      this.batchSize = batchSize;
+      this.statement = statement;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {
     batch.getClass().getMethod("execute").invoke(batch);
-  }
-
-  @Test
-  void mixedBatchCommand() throws ReflectiveOperationException {
-    RBatch batch = createBatch(redisson);
-    assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch1").getAsync();
-    // Adapt different method signature:
-    // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE" : "DB Query")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(
-                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
   }
 
   @Test

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -278,7 +278,8 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? scenario.spanName : scenario.oldSpanName)
+                    span.hasName(
+                            emitStableDatabaseSemconv() ? scenario.spanName : scenario.oldSpanName)
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -415,9 +415,9 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
-                            // db.operation.batch.size is not emitted because MULTI transaction
-                            // wrapper only sees MULTI plus the first queued command.
-                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?;SET batch2 ?"))
                         .hasParent(trace.getSpan(0))));
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -305,96 +305,40 @@ public abstract class AbstractRedissonClientTest {
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
             // an empty batch fails to execute and produces no span
-            BatchScenario.empty(),
+            BatchScenario.builder("empty").commands(batch -> {}).empty().build(),
             // a single-command batch is executed as a normal command (not a pipeline): the span is
             // named after the command, it carries db.operation (old) / db.operation.name (stable),
             // and emits no db.operation.batch.size
-            new BatchScenario(
-                "single",
-                batch -> batch.getBucket("batch1").setAsync("v1"),
-                "SET",
-                "SET",
-                null,
-                "SET",
-                "SET batch1 ?"),
-            new BatchScenario(
-                "twoSameOperation",
-                batch -> {
-                  batch.getBucket("batch1").setAsync("v1");
-                  batch.getBucket("batch2").setAsync("v2");
-                },
-                "PIPELINE SET",
-                "DB Query",
-                2L,
-                null,
-                "SET batch1 ?;SET batch2 ?"),
-            new BatchScenario(
-                "twoDifferentOperations",
-                batch -> {
-                  batch.getBucket("batch1").setAsync("v1");
-                  batch.getBucket("batch1").getAsync();
-                },
-                "PIPELINE",
-                "DB Query",
-                2L,
-                null,
-                "SET batch1 ?;GET batch1"))
+            BatchScenario.builder("single")
+                .commands(batch -> batch.getBucket("batch1").setAsync("v1"))
+                .spanName("SET")
+                .oldSpanName("SET")
+                .oldOperation("SET")
+                .statement("SET batch1 ?")
+                .build(),
+            BatchScenario.builder("twoSameOperation")
+                .commands(
+                    batch -> {
+                      batch.getBucket("batch1").setAsync("v1");
+                      batch.getBucket("batch2").setAsync("v2");
+                    })
+                .spanName("PIPELINE SET")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .statement("SET batch1 ?;SET batch2 ?")
+                .build(),
+            BatchScenario.builder("twoDifferentOperations")
+                .commands(
+                    batch -> {
+                      batch.getBucket("batch1").setAsync("v1");
+                      batch.getBucket("batch1").getAsync();
+                    })
+                .spanName("PIPELINE")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .statement("SET batch1 ?;GET batch1")
+                .build())
         .map(Arguments::of);
-  }
-
-  private static final class BatchScenario {
-    final String name;
-    final Consumer<RBatch> commands;
-    final String spanName;
-    final String oldSpanName;
-    final Long batchSize;
-    final String oldOperation;
-    final String statement;
-    final boolean empty;
-
-    BatchScenario(
-        String name,
-        Consumer<RBatch> commands,
-        String spanName,
-        String oldSpanName,
-        Long batchSize,
-        String oldOperation,
-        String statement) {
-      this.name = name;
-      this.commands = commands;
-      this.spanName = spanName;
-      this.oldSpanName = oldSpanName;
-      this.batchSize = batchSize;
-      this.oldOperation = oldOperation;
-      this.statement = statement;
-      this.empty = false;
-    }
-
-    private BatchScenario() {
-      this.name = "empty";
-      this.commands = batch -> {};
-      this.spanName = null;
-      this.oldSpanName = null;
-      this.batchSize = null;
-      this.oldOperation = null;
-      this.statement = null;
-      this.empty = true;
-    }
-
-    static BatchScenario empty() {
-      return new BatchScenario();
-    }
-
-    // the stable-mode db.operation.name (= the span name in stable mode)
-    String operationName() {
-      return spanName;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {
@@ -702,5 +646,96 @@ public abstract class AbstractRedissonClientTest {
 
   protected RBatch createBatch(RedissonClient redisson) {
     return redisson.createBatch(BatchOptions.defaults());
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final Consumer<RBatch> commands;
+    final String spanName;
+    final String oldSpanName;
+    final Long batchSize;
+    final String oldOperation;
+    final String statement;
+    final boolean empty;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.commands = builder.commands;
+      this.spanName = builder.spanName;
+      this.oldSpanName = builder.oldSpanName;
+      this.batchSize = builder.batchSize;
+      this.oldOperation = builder.oldOperation;
+      this.statement = builder.statement;
+      this.empty = builder.empty;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    // the stable-mode db.operation.name (= the span name in stable mode)
+    String operationName() {
+      return spanName;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static final class Builder {
+      private final String name;
+      private Consumer<RBatch> commands;
+      private String spanName;
+      private String oldSpanName;
+      private Long batchSize;
+      private String oldOperation;
+      private String statement;
+      private boolean empty;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder commands(Consumer<RBatch> commands) {
+        this.commands = commands;
+        return this;
+      }
+
+      Builder spanName(String spanName) {
+        this.spanName = spanName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      Builder empty() {
+        this.empty = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -399,8 +399,7 @@ public abstract class AbstractRedissonClientTest {
           batch.getBucket("batch2").setAsync("v2");
           batch.execute();
         });
-    testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("MULTI SET", "DB Query", "SET", "EXEC"),
+    testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasKind(INTERNAL),
@@ -416,31 +415,8 @@ public abstract class AbstractRedissonClientTest {
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
                             // db.operation.batch.size is not emitted because MULTI transaction
-                            // telemetry is split across wrapper and command spans, so this span
-                            // does not represent the full logical batch.
+                            // wrapper only sees MULTI plus the first queued command.
                             equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("SET")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(maybeStable(DB_OPERATION), "SET"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("EXEC")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
-                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0))));
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -262,7 +262,18 @@ public abstract class AbstractRedissonClientTest {
     scenario.commands.accept(batch);
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
+    try {
+      invokeExecute(batch);
+    } catch (ReflectiveOperationException e) {
+      // an empty batch fails to execute
+    }
+
+    if (scenario.empty) {
+      // an empty batch produces no span
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -292,6 +303,8 @@ public abstract class AbstractRedissonClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch fails to execute and produces no span
+            BatchScenario.empty(),
             // a single-command batch is executed as a normal command (not a pipeline): the span is
             // named after the command, it carries db.operation (old) / db.operation.name (stable),
             // and emits no db.operation.batch.size
@@ -336,6 +349,7 @@ public abstract class AbstractRedissonClientTest {
     final Long batchSize;
     final String oldOperation;
     final String statement;
+    final boolean empty;
 
     BatchScenario(
         String name,
@@ -352,6 +366,22 @@ public abstract class AbstractRedissonClientTest {
       this.batchSize = batchSize;
       this.oldOperation = oldOperation;
       this.statement = statement;
+      this.empty = false;
+    }
+
+    private BatchScenario() {
+      this.name = "empty";
+      this.commands = batch -> {};
+      this.spanName = null;
+      this.oldSpanName = null;
+      this.batchSize = null;
+      this.oldOperation = null;
+      this.statement = null;
+      this.empty = true;
+    }
+
+    static BatchScenario empty() {
+      return new BatchScenario();
     }
 
     // the stable-mode db.operation.name (= the span name in stable mode)

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
@@ -20,6 +20,7 @@ import io.vertx.redis.client.Response;
 import io.vertx.redis.client.impl.RedisStandaloneConnection;
 import io.vertx.redis.client.impl.RedisURI;
 import io.vertx.redis.client.impl.RequestUtil;
+import java.util.List;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
@@ -35,6 +36,7 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(named("send"), getClass().getName() + "$SendAdvice");
+    transformer.applyAdviceToMethod(named("batch"), getClass().getName() + "$BatchAdvice");
     transformer.applyAdviceToMethod(isConstructor(), getClass().getName() + "$ConstructorAdvice");
   }
 
@@ -107,6 +109,90 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Return @Nullable Future<Response> responseFuture,
         @Advice.Enter @Nullable AdviceScope adviceScope) {
+
+      if (adviceScope != null) {
+        return adviceScope.end(responseFuture, throwable);
+      }
+
+      return responseFuture;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class BatchAdvice {
+    public static class BatchAdviceScope {
+      private final VertxRedisClientRequest otelRequest;
+      private final Context context;
+      private final Scope scope;
+
+      private BatchAdviceScope(VertxRedisClientRequest otelRequest, Context context, Scope scope) {
+        this.otelRequest = otelRequest;
+        this.context = context;
+        this.scope = scope;
+      }
+
+      @Nullable
+      public static BatchAdviceScope start(
+          RedisStandaloneConnection connection,
+          @Nullable List<Request> requests,
+          NetSocket netSocket) {
+
+        if (requests == null || requests.isEmpty()) {
+          return null;
+        }
+        for (Request request : requests) {
+          if (request == null
+              || VertxRedisClientSingletons.getCommandName(request.command()) == null) {
+            return null;
+          }
+        }
+
+        RedisURI redisUri = VertxRedisClientSingletons.getRedisUri(connection);
+        if (redisUri == null) {
+          return null;
+        }
+
+        VertxRedisClientRequest otelRequest =
+            VertxRedisClientRequest.createBatch(requests, redisUri, netSocket);
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, otelRequest)) {
+          return null;
+        }
+        Context context = instrumenter().start(parentContext, otelRequest);
+        return new BatchAdviceScope(otelRequest, context, context.makeCurrent());
+      }
+
+      @Nullable
+      public Future<List<Response>> end(
+          @Nullable Future<List<Response>> responseFuture, @Nullable Throwable throwable) {
+        scope.close();
+        if (throwable != null) {
+          instrumenter().end(context, otelRequest, null, throwable);
+        } else {
+          responseFuture =
+              VertxRedisClientSingletons.wrapEndSpan(responseFuture, context, otelRequest);
+        }
+        return responseFuture;
+      }
+    }
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static BatchAdviceScope onEnter(
+        @Advice.This RedisStandaloneConnection connection,
+        @Advice.Argument(0) @Nullable List<Request> requests,
+        @Advice.FieldValue("netSocket") NetSocket netSocket) {
+
+      return BatchAdviceScope.start(connection, requests, netSocket);
+    }
+
+    @Nullable
+    @AssignReturned.ToReturned
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static Future<List<Response>> onExit(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Return @Nullable Future<List<Response>> responseFuture,
+        @Advice.Enter @Nullable BatchAdviceScope adviceScope) {
 
       if (adviceScope != null) {
         return adviceScope.end(responseFuture, throwable);

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientAttributesGetter.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import java.util.List;
 import javax.annotation.Nullable;
 
 class VertxRedisClientAttributesGetter
@@ -20,6 +21,10 @@ class VertxRedisClientAttributesGetter
   private static final RedisCommandSanitizer sanitizer =
       RedisCommandSanitizer.create(
           DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "vertx_redis_client"));
+
+  static String sanitize(String command, List<byte[]> args) {
+    return sanitizer.sanitize(command, args);
+  }
 
   @Override
   public String getDbSystemName(VertxRedisClientRequest request) {
@@ -52,13 +57,23 @@ class VertxRedisClientAttributesGetter
 
   @Override
   public String getDbQueryText(VertxRedisClientRequest request) {
-    return sanitizer.sanitize(request.getCommand(), request.getArgs());
+    String queryText = request.getQueryTextOverride();
+    if (queryText != null) {
+      return queryText;
+    }
+    return sanitize(request.getCommand(), request.getArgs());
   }
 
   @Nullable
   @Override
   public String getDbOperationName(VertxRedisClientRequest request) {
     return request.getCommand();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(VertxRedisClientRequest request) {
+    return request.getBatchSize();
   }
 
   @Nullable

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientRequest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientRequest.java
@@ -6,9 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.redisclient.v4_0;
 
 import io.vertx.core.net.NetSocket;
+import io.vertx.redis.client.Request;
 import io.vertx.redis.client.impl.RedisURI;
+import io.vertx.redis.client.impl.RequestUtil;
 import java.util.List;
 import java.util.Locale;
+import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 class VertxRedisClientRequest {
@@ -16,13 +19,38 @@ class VertxRedisClientRequest {
   private final List<byte[]> args;
   private final RedisURI redisUri;
   private final NetSocket netSocket;
+  @Nullable private final String queryTextOverride;
+  @Nullable private final Long batchSize;
 
   VertxRedisClientRequest(
       String command, List<byte[]> args, RedisURI redisUri, NetSocket netSocket) {
+    this(command, args, redisUri, netSocket, null, null);
+  }
+
+  private VertxRedisClientRequest(
+      String command,
+      List<byte[]> args,
+      RedisURI redisUri,
+      NetSocket netSocket,
+      @Nullable String queryTextOverride,
+      @Nullable Long batchSize) {
     this.command = command.toUpperCase(Locale.ROOT);
     this.args = args;
     this.redisUri = redisUri;
     this.netSocket = netSocket;
+    this.queryTextOverride = queryTextOverride;
+    this.batchSize = batchSize;
+  }
+
+  static VertxRedisClientRequest createBatch(
+      List<Request> requests, RedisURI redisUri, NetSocket netSocket) {
+    return new VertxRedisClientRequest(
+        batchOperationName(requests),
+        RequestUtil.getArgs(requests.get(0)),
+        redisUri,
+        netSocket,
+        batchQueryText(requests),
+        requests.size() > 1 ? (long) requests.size() : null);
   }
 
   String getCommand() {
@@ -31,6 +59,16 @@ class VertxRedisClientRequest {
 
   List<byte[]> getArgs() {
     return args;
+  }
+
+  @Nullable
+  String getQueryTextOverride() {
+    return queryTextOverride;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
   }
 
   @Nullable
@@ -67,5 +105,30 @@ class VertxRedisClientRequest {
   Integer getPeerPort() {
     int port = netSocket.remoteAddress().port();
     return port != -1 ? port : null;
+  }
+
+  private static String batchOperationName(List<Request> requests) {
+    String operationName = VertxRedisClientSingletons.getCommandName(requests.get(0).command());
+    if (requests.size() == 1) {
+      return operationName;
+    }
+    for (int i = 1; i < requests.size(); i++) {
+      if (!operationName.equals(
+          VertxRedisClientSingletons.getCommandName(requests.get(i).command()))) {
+        return "PIPELINE";
+      }
+    }
+    return "PIPELINE " + operationName;
+  }
+
+  private static String batchQueryText(List<Request> requests) {
+    StringJoiner joiner = new StringJoiner(";");
+    for (Request request : requests) {
+      String commandName =
+          VertxRedisClientSingletons.getCommandName(request.command()).toUpperCase(Locale.ROOT);
+      joiner.add(
+          VertxRedisClientAttributesGetter.sanitize(commandName, RequestUtil.getArgs(request)));
+    }
+    return joiner.toString();
   }
 }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -32,14 +33,20 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.vertx.core.Vertx;
+import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.Request;
 import java.net.InetAddress;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -201,7 +208,58 @@ class VertxRedisClientTest {
                             redisSpanAttributes("RANDOMKEY", "RANDOMKEY"))));
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("batchScenarios")
+  void batchCommand(BatchScenario scenario) throws Exception {
+    testing.clearData();
+
+    client.batch(scenario.requests).toCompletionStage().toCompletableFuture().get(30, SECONDS);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? scenario.operation + " " + host + ":" + port
+                                : scenario.operation)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            redisSpanAttributes(
+                                scenario.operation, scenario.statement, scenario.batchSize))));
+  }
+
+  private static Stream<BatchScenario> batchScenarios() {
+    return Stream.of(
+        BatchScenario.builder("single")
+            .requests(Request.cmd(Command.SET).arg("batch1").arg("v1"))
+            .operation("SET")
+            .statement("SET batch1 ?")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .requests(
+                Request.cmd(Command.SET).arg("batch1").arg("v1"),
+                Request.cmd(Command.SET).arg("batch2").arg("v2"))
+            .operation("PIPELINE SET")
+            .statement("SET batch1 ?;SET batch2 ?")
+            .batchSize(2)
+            .build(),
+        BatchScenario.builder("twoDifferentOperations")
+            .requests(
+                Request.cmd(Command.SET).arg("batch1").arg("v1"),
+                Request.cmd(Command.GET).arg("batch1"))
+            .operation("PIPELINE")
+            .statement("SET batch1 ?;GET batch1")
+            .batchSize(2)
+            .build());
+  }
+
   private static AttributeAssertion[] redisSpanAttributes(String operation, String queryText) {
+    return redisSpanAttributes(operation, queryText, null);
+  }
+
+  private static AttributeAssertion[] redisSpanAttributes(
+      String operation, String queryText, Long batchSize) {
     // not testing database/dup
     if (emitStableDatabaseSemconv()) {
       return new AttributeAssertion[] {
@@ -209,6 +267,7 @@ class VertxRedisClientTest {
         equalTo(DB_QUERY_TEXT, queryText),
         equalTo(DB_OPERATION_NAME, operation),
         equalTo(DB_NAMESPACE, "1"),
+        equalTo(DB_OPERATION_BATCH_SIZE, batchSize),
         equalTo(SERVER_ADDRESS, host),
         equalTo(SERVER_PORT, port),
         equalTo(maybeStablePeerService(), "test-peer-service"),
@@ -227,6 +286,68 @@ class VertxRedisClientTest {
         equalTo(NETWORK_PEER_PORT, port),
         equalTo(NETWORK_PEER_ADDRESS, ip)
       };
+    }
+  }
+
+  private static class BatchScenario {
+    private final String name;
+    private final List<Request> requests;
+    private final String operation;
+    private final String statement;
+    private final Long batchSize;
+
+    private BatchScenario(
+        String name, List<Request> requests, String operation, String statement, Long batchSize) {
+      this.name = name;
+      this.requests = requests;
+      this.operation = operation;
+      this.statement = statement;
+      this.batchSize = batchSize;
+    }
+
+    private static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+
+    private static class Builder {
+      private final String name;
+      private List<Request> requests;
+      private String operation;
+      private String statement;
+      private Long batchSize;
+
+      private Builder(String name) {
+        this.name = name;
+      }
+
+      private Builder requests(Request... requests) {
+        this.requests = asList(requests);
+        return this;
+      }
+
+      private Builder operation(String operation) {
+        this.operation = operation;
+        return this;
+      }
+
+      private Builder statement(String statement) {
+        this.statement = statement;
+        return this;
+      }
+
+      private Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      private BatchScenario build() {
+        return new BatchScenario(name, requests, operation, statement, batchSize);
+      }
     }
   }
 }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -24,6 +24,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,6 +84,14 @@ class VertxRedisClientTest {
         client.connect().toCompletionStage().toCompletableFuture().get(30, SECONDS);
     redis = RedisAPI.api(connection);
     cleanup.deferAfterAll(redis::close);
+
+    client
+        .batch(singletonList(Request.cmd(Command.PING)))
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+    testing.waitForTraces(1);
+    testing.clearData();
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
@@ -101,7 +101,9 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            // capture the batch size for every batch execution (including an empty batch with size
+            // 0); it is only omitted for a single-statement batch (size 1)
+            batchSize = size != 1 ? (long) size : null;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -348,30 +347,29 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch is rejected before sending, so it looks like a single statement but
-            // records the error and emits no db.operation.batch.size
-            BatchScenario.builder("empty")
-                .tuples(emptyList())
-                .stableSpanName("insert test")
-                .stableSummary("insert test")
-                .errorType("io.vertx.core.impl.NoStackTraceThrowable")
-                .build(),
-            // a single-statement batch is not a batch (size 1), so it emits no
-            // db.operation.batch.size and no BATCH prefix
-            BatchScenario.builder("single")
-                .tuples(singletonList(Tuple.of(3, "Three")))
-                .stableSpanName("insert test")
-                .stableSummary("insert test")
-                .build(),
-            BatchScenario.builder("twoSameOperation")
-                .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
-                .stableSpanName("BATCH insert test")
-                .stableSummary("BATCH insert test")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch is rejected before sending, so it looks like a single statement but
+        // records the error and emits no db.operation.batch.size
+        BatchScenario.builder("empty")
+            .tuples(emptyList())
+            .stableSpanName("insert test")
+            .stableSummary("insert test")
+            .errorType("io.vertx.core.impl.NoStackTraceThrowable")
+            .build(),
+        // a single-statement batch is not a batch (size 1), so it emits no
+        // db.operation.batch.size and no BATCH prefix
+        BatchScenario.builder("single")
+            .tuples(singletonList(Tuple.of(3, "Three")))
+            .stableSpanName("insert test")
+            .stableSummary("insert test")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
+            .stableSpanName("BATCH insert test")
+            .stableSummary("BATCH insert test")
+            .batchSize(2)
+            .build());
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,9 +54,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -280,14 +285,18 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  @Test
-  void testBatch() throws Exception {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements. batch telemetry (db.operation.batch.size, BATCH span names and summaries)
+  // is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void testBatch(BatchScenario scenario) throws Exception {
     testing
         .runWithSpan(
             "parent",
             () ->
                 pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(asList(Tuple.of(3, "Three"), Tuple.of(4, "Four"))))
+                    .executeBatch(scenario.tuples))
         .toCompletionStage()
         .toCompletableFuture()
         .get(30, SECONDS);
@@ -299,7 +308,7 @@ class VertxSqlClientTest {
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
-                                ? "BATCH insert test"
+                                ? scenario.stableSpanName
                                 : "INSERT tempdb.test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
@@ -314,9 +323,10 @@ class VertxSqlClientTest {
                                 "insert into test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv() ? "BATCH insert test" : null),
+                                emitStableDatabaseSemconv() ? scenario.stableSummary : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
@@ -326,6 +336,48 @@ class VertxSqlClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario(
+                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
+                "BATCH insert test",
+                "BATCH insert test",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name,
+        List<Tuple> tuples,
+        String stableSpanName,
+        String stableSummary,
+        Long batchSize) {
+      this.name = name;
+      this.tuples = tuples;
+      this.stableSpanName = stableSpanName;
+      this.stableSummary = stableSummary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -365,12 +365,13 @@ class VertxSqlClientTest {
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch is rejected before sending, so it looks like a single statement but
-        // records the error and emits no db.operation.batch.size
+        // records the error and carries db.operation.batch.size 0
         BatchScenario.builder("empty")
             .tuples(emptyList())
             .stableSpanName("insert batch_test")
             .stableSummary("insert batch_test")
             .errorType("io.vertx.core.impl.NoStackTraceThrowable")
+            .batchSize(0)
             .build(),
         // a single-statement batch is not a batch (size 1), so it emits no
         // db.operation.batch.size and no BATCH prefix

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -292,13 +292,19 @@ class VertxSqlClientTest {
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void testBatch(BatchScenario scenario) throws Exception {
+    // recreate a fresh batch_test table for each scenario so that batch row ids can be reused
+    // without worrying about collisions from previous scenarios
+    recreateBatchTestTable();
+    testing.waitForTraces(2);
+    testing.clearData();
+
     // an empty batch is rejected before sending, so its execution fails; non-empty batches succeed
     try {
       testing
           .runWithSpan(
               "parent",
               () ->
-                  pool.preparedQuery("insert into test values ($1, $2) returning *")
+                  pool.preparedQuery("insert into batch_test values ($1, $2) returning *")
                       .executeBatch(scenario.tuples))
           .toCompletionStage()
           .toCompletableFuture()
@@ -315,7 +321,7 @@ class VertxSqlClientTest {
                     span.hasName(
                             emitStableDatabaseSemconv()
                                 ? scenario.stableSpanName
-                                : "INSERT tempdb.test")
+                                : "INSERT tempdb.batch_test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -326,7 +332,7 @@ class VertxSqlClientTest {
                             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                "insert into test values ($1, $2) returning *"),
+                                "insert into batch_test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? scenario.stableSummary : null),
@@ -338,7 +344,7 @@ class VertxSqlClientTest {
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
                             equalTo(
                                 maybeStable(DB_SQL_TABLE),
-                                emitStableDatabaseSemconv() ? null : "test"),
+                                emitStableDatabaseSemconv() ? null : "batch_test"),
                             equalTo(
                                 ERROR_TYPE,
                                 emitStableDatabaseSemconv() ? scenario.errorType : null),
@@ -347,27 +353,36 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
+  private static void recreateBatchTestTable() throws Exception {
+    pool.query("drop table if exists batch_test")
+        .execute()
+        .compose(r -> pool.query("create table batch_test(id int primary key, num int)").execute())
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+  }
+
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch is rejected before sending, so it looks like a single statement but
         // records the error and emits no db.operation.batch.size
         BatchScenario.builder("empty")
             .tuples(emptyList())
-            .stableSpanName("insert test")
-            .stableSummary("insert test")
+            .stableSpanName("insert batch_test")
+            .stableSummary("insert batch_test")
             .errorType("io.vertx.core.impl.NoStackTraceThrowable")
             .build(),
         // a single-statement batch is not a batch (size 1), so it emits no
         // db.operation.batch.size and no BATCH prefix
         BatchScenario.builder("single")
-            .tuples(singletonList(Tuple.of(3, "Three")))
-            .stableSpanName("insert test")
-            .stableSummary("insert test")
+            .tuples(singletonList(Tuple.of(1, 1)))
+            .stableSpanName("insert batch_test")
+            .stableSummary("insert batch_test")
             .build(),
         BatchScenario.builder("twoSameOperation")
-            .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
-            .stableSpanName("BATCH insert test")
-            .stableSummary("BATCH insert test")
+            .tuples(asList(Tuple.of(1, 1), Tuple.of(2, 2)))
+            .stableSpanName("BATCH insert batch_test")
+            .stableSummary("BATCH insert batch_test")
             .batchSize(2)
             .build());
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -352,60 +352,26 @@ class VertxSqlClientTest {
     return Stream.of(
             // an empty batch is rejected before sending, so it looks like a single statement but
             // records the error and emits no db.operation.batch.size
-            new BatchScenario(
-                "empty",
-                emptyList(),
-                "insert test",
-                "insert test",
-                null,
-                "io.vertx.core.impl.NoStackTraceThrowable"),
+            BatchScenario.builder("empty")
+                .tuples(emptyList())
+                .stableSpanName("insert test")
+                .stableSummary("insert test")
+                .errorType("io.vertx.core.impl.NoStackTraceThrowable")
+                .build(),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix
-            new BatchScenario(
-                "single",
-                singletonList(Tuple.of(3, "Three")),
-                "insert test",
-                "insert test",
-                null,
-                null),
-            new BatchScenario(
-                "twoSameOperation",
-                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
-                "BATCH insert test",
-                "BATCH insert test",
-                2L,
-                null))
+            BatchScenario.builder("single")
+                .tuples(singletonList(Tuple.of(3, "Three")))
+                .stableSpanName("insert test")
+                .stableSummary("insert test")
+                .build(),
+            BatchScenario.builder("twoSameOperation")
+                .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
+                .stableSpanName("BATCH insert test")
+                .stableSummary("BATCH insert test")
+                .batchSize(2)
+                .build())
         .map(Arguments::of);
-  }
-
-  private static final class BatchScenario {
-    final String name;
-    final List<Tuple> tuples;
-    final String stableSpanName;
-    final String stableSummary;
-    final Long batchSize;
-    final String errorType;
-
-    BatchScenario(
-        String name,
-        List<Tuple> tuples,
-        String stableSpanName,
-        String stableSummary,
-        Long batchSize,
-        String errorType) {
-      this.name = name;
-      this.tuples = tuples;
-      this.stableSpanName = stableSpanName;
-      this.stableSummary = stableSummary;
-      this.batchSize = batchSize;
-      this.errorType = errorType;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
   }
 
   @Test
@@ -587,5 +553,75 @@ class VertxSqlClientTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasParent(trace.getSpan(0))));
     testing.waitAndAssertTraces(assertions);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+    final String errorType;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.tuples = builder.tuples;
+      this.stableSpanName = builder.stableSpanName;
+      this.stableSummary = builder.stableSummary;
+      this.batchSize = builder.batchSize;
+      this.errorType = builder.errorType;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static final class Builder {
+      private final String name;
+      private List<Tuple> tuples;
+      private String stableSpanName;
+      private String stableSummary;
+      private Long batchSize;
+      private String errorType;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder tuples(List<Tuple> tuples) {
+        this.tuples = tuples;
+        return this;
+      }
+
+      Builder stableSpanName(String stableSpanName) {
+        this.stableSpanName = stableSpanName;
+        return this;
+      }
+
+      Builder stableSummary(String stableSummary) {
+        this.stableSummary = stableSummary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder errorType(String errorType) {
+        this.errorType = errorType;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -291,15 +292,20 @@ class VertxSqlClientTest {
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void testBatch(BatchScenario scenario) throws Exception {
-    testing
-        .runWithSpan(
-            "parent",
-            () ->
-                pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(scenario.tuples))
-        .toCompletionStage()
-        .toCompletableFuture()
-        .get(30, SECONDS);
+    // an empty batch is rejected before sending, so its execution fails; non-empty batches succeed
+    try {
+      testing
+          .runWithSpan(
+              "parent",
+              () ->
+                  pool.preparedQuery("insert into test values ($1, $2) returning *")
+                      .executeBatch(scenario.tuples))
+          .toCompletionStage()
+          .toCompletableFuture()
+          .get(30, SECONDS);
+    } catch (ExecutionException e) {
+      // an empty batch fails to execute; the failure is recorded on the client span
+    }
 
     testing.waitAndAssertTraces(
         trace ->
@@ -333,6 +339,9 @@ class VertxSqlClientTest {
                             equalTo(
                                 maybeStable(DB_SQL_TABLE),
                                 emitStableDatabaseSemconv() ? null : "test"),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv() ? scenario.errorType : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
@@ -340,16 +349,31 @@ class VertxSqlClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch is rejected before sending, so it looks like a single statement but
+            // records the error and emits no db.operation.batch.size
+            new BatchScenario(
+                "empty",
+                Collections.emptyList(),
+                "insert test",
+                "insert test",
+                null,
+                "io.vertx.core.impl.NoStackTraceThrowable"),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix
             new BatchScenario(
-                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+                "single",
+                singletonList(Tuple.of(3, "Three")),
+                "insert test",
+                "insert test",
+                null,
+                null),
             new BatchScenario(
                 "twoSameOperation",
                 asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
                 "BATCH insert test",
                 "BATCH insert test",
-                2L))
+                2L,
+                null))
         .map(Arguments::of);
   }
 
@@ -359,18 +383,21 @@ class VertxSqlClientTest {
     final String stableSpanName;
     final String stableSummary;
     final Long batchSize;
+    final String errorType;
 
     BatchScenario(
         String name,
         List<Tuple> tuples,
         String stableSpanName,
         String stableSummary,
-        Long batchSize) {
+        Long batchSize,
+        String errorType) {
       this.name = name;
       this.tuples = tuples;
       this.stableSpanName = stableSpanName;
       this.stableSummary = stableSummary;
       this.batchSize = batchSize;
+      this.errorType = errorType;
     }
 
     @Override

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -353,7 +354,7 @@ class VertxSqlClientTest {
             // records the error and emits no db.operation.batch.size
             new BatchScenario(
                 "empty",
-                Collections.emptyList(),
+                emptyList(),
                 "insert test",
                 "insert test",
                 null,

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -368,8 +368,8 @@ class VertxSqlClientTest {
         // records the error and carries db.operation.batch.size 0
         BatchScenario.builder("empty")
             .tuples(emptyList())
-            .stableSpanName("insert batch_test")
-            .stableSummary("insert batch_test")
+            .stableSpanName("BATCH insert batch_test")
+            .stableSummary("BATCH insert batch_test")
             .errorType("io.vertx.core.impl.NoStackTraceThrowable")
             .batchSize(0)
             .build(),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
@@ -100,7 +100,9 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            // capture the batch size for every batch execution (including an empty batch with size
+            // 0); it is only omitted for a single-statement batch (size 1)
+            batchSize = size != 1 ? (long) size : null;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -349,30 +348,29 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  private static Stream<Arguments> batchScenarios() {
+  private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
-            // an empty batch is rejected before sending, so it looks like a single statement but
-            // records the error and emits no db.operation.batch.size
-            BatchScenario.builder("empty")
-                .tuples(emptyList())
-                .stableSpanName("insert test")
-                .stableSummary("insert test")
-                .errorType("io.vertx.core.VertxException")
-                .build(),
-            // a single-statement batch is not a batch (size 1), so it emits no
-            // db.operation.batch.size and no BATCH prefix
-            BatchScenario.builder("single")
-                .tuples(singletonList(Tuple.of(3, "Three")))
-                .stableSpanName("insert test")
-                .stableSummary("insert test")
-                .build(),
-            BatchScenario.builder("twoSameOperation")
-                .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
-                .stableSpanName("BATCH insert test")
-                .stableSummary("BATCH insert test")
-                .batchSize(2)
-                .build())
-        .map(Arguments::of);
+        // an empty batch is rejected before sending, so it looks like a single statement but
+        // records the error and emits no db.operation.batch.size
+        BatchScenario.builder("empty")
+            .tuples(emptyList())
+            .stableSpanName("insert test")
+            .stableSummary("insert test")
+            .errorType("io.vertx.core.VertxException")
+            .build(),
+        // a single-statement batch is not a batch (size 1), so it emits no
+        // db.operation.batch.size and no BATCH prefix
+        BatchScenario.builder("single")
+            .tuples(singletonList(Tuple.of(3, "Three")))
+            .stableSpanName("insert test")
+            .stableSummary("insert test")
+            .build(),
+        BatchScenario.builder("twoSameOperation")
+            .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
+            .stableSpanName("BATCH insert test")
+            .stableSummary("BATCH insert test")
+            .batchSize(2)
+            .build());
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -353,60 +353,26 @@ class VertxSqlClientTest {
     return Stream.of(
             // an empty batch is rejected before sending, so it looks like a single statement but
             // records the error and emits no db.operation.batch.size
-            new BatchScenario(
-                "empty",
-                emptyList(),
-                "insert test",
-                "insert test",
-                null,
-                "io.vertx.core.VertxException"),
+            BatchScenario.builder("empty")
+                .tuples(emptyList())
+                .stableSpanName("insert test")
+                .stableSummary("insert test")
+                .errorType("io.vertx.core.VertxException")
+                .build(),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix
-            new BatchScenario(
-                "single",
-                singletonList(Tuple.of(3, "Three")),
-                "insert test",
-                "insert test",
-                null,
-                null),
-            new BatchScenario(
-                "twoSameOperation",
-                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
-                "BATCH insert test",
-                "BATCH insert test",
-                2L,
-                null))
+            BatchScenario.builder("single")
+                .tuples(singletonList(Tuple.of(3, "Three")))
+                .stableSpanName("insert test")
+                .stableSummary("insert test")
+                .build(),
+            BatchScenario.builder("twoSameOperation")
+                .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
+                .stableSpanName("BATCH insert test")
+                .stableSummary("BATCH insert test")
+                .batchSize(2)
+                .build())
         .map(Arguments::of);
-  }
-
-  private static final class BatchScenario {
-    final String name;
-    final List<Tuple> tuples;
-    final String stableSpanName;
-    final String stableSummary;
-    final Long batchSize;
-    final String errorType;
-
-    BatchScenario(
-        String name,
-        List<Tuple> tuples,
-        String stableSpanName,
-        String stableSummary,
-        Long batchSize,
-        String errorType) {
-      this.name = name;
-      this.tuples = tuples;
-      this.stableSpanName = stableSpanName;
-      this.stableSummary = stableSummary;
-      this.batchSize = batchSize;
-      this.errorType = errorType;
-    }
-
-    @Override
-    public String toString() {
-      // used as the parameterized test display name
-      return name;
-    }
   }
 
   @Test
@@ -589,5 +555,75 @@ class VertxSqlClientTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasParent(trace.getSpan(0))));
     testing.waitAndAssertTraces(assertions);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+    final String errorType;
+
+    BatchScenario(Builder builder) {
+      this.name = builder.name;
+      this.tuples = builder.tuples;
+      this.stableSpanName = builder.stableSpanName;
+      this.stableSummary = builder.stableSummary;
+      this.batchSize = builder.batchSize;
+      this.errorType = builder.errorType;
+    }
+
+    static Builder builder(String name) {
+      return new Builder(name);
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
+
+    static final class Builder {
+      private final String name;
+      private List<Tuple> tuples;
+      private String stableSpanName;
+      private String stableSummary;
+      private Long batchSize;
+      private String errorType;
+
+      Builder(String name) {
+        this.name = name;
+      }
+
+      Builder tuples(List<Tuple> tuples) {
+        this.tuples = tuples;
+        return this;
+      }
+
+      Builder stableSpanName(String stableSpanName) {
+        this.stableSpanName = stableSpanName;
+        return this;
+      }
+
+      Builder stableSummary(String stableSummary) {
+        this.stableSummary = stableSummary;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder errorType(String errorType) {
+        this.errorType = errorType;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -293,13 +293,19 @@ class VertxSqlClientTest {
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void testBatch(BatchScenario scenario) throws Exception {
+    // recreate a fresh batch_test table for each scenario so that batch row ids can be reused
+    // without worrying about collisions from previous scenarios
+    recreateBatchTestTable();
+    testing.waitForTraces(2);
+    testing.clearData();
+
     // an empty batch is rejected before sending, so its execution fails; non-empty batches succeed
     try {
       testing
           .runWithSpan(
               "parent",
               () ->
-                  pool.preparedQuery("insert into test values ($1, $2) returning *")
+                  pool.preparedQuery("insert into batch_test values ($1, $2) returning *")
                       .executeBatch(scenario.tuples))
           .toCompletionStage()
           .toCompletableFuture()
@@ -316,7 +322,7 @@ class VertxSqlClientTest {
                     span.hasName(
                             emitStableDatabaseSemconv()
                                 ? scenario.stableSpanName
-                                : "INSERT tempdb.test")
+                                : "INSERT tempdb.batch_test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -327,7 +333,7 @@ class VertxSqlClientTest {
                             equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                "insert into test values ($1, $2) returning *"),
+                                "insert into batch_test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? scenario.stableSummary : null),
@@ -339,7 +345,7 @@ class VertxSqlClientTest {
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
                             equalTo(
                                 maybeStable(DB_SQL_TABLE),
-                                emitStableDatabaseSemconv() ? null : "test"),
+                                emitStableDatabaseSemconv() ? null : "batch_test"),
                             equalTo(
                                 ERROR_TYPE,
                                 emitStableDatabaseSemconv() ? scenario.errorType : null),
@@ -348,27 +354,36 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
+  private static void recreateBatchTestTable() throws Exception {
+    pool.query("drop table if exists batch_test")
+        .execute()
+        .compose(r -> pool.query("create table batch_test(id int primary key, num int)").execute())
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+  }
+
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch is rejected before sending, so it looks like a single statement but
         // records the error and emits no db.operation.batch.size
         BatchScenario.builder("empty")
             .tuples(emptyList())
-            .stableSpanName("insert test")
-            .stableSummary("insert test")
+            .stableSpanName("insert batch_test")
+            .stableSummary("insert batch_test")
             .errorType("io.vertx.core.VertxException")
             .build(),
         // a single-statement batch is not a batch (size 1), so it emits no
         // db.operation.batch.size and no BATCH prefix
         BatchScenario.builder("single")
-            .tuples(singletonList(Tuple.of(3, "Three")))
-            .stableSpanName("insert test")
-            .stableSummary("insert test")
+            .tuples(singletonList(Tuple.of(1, 1)))
+            .stableSpanName("insert batch_test")
+            .stableSummary("insert batch_test")
             .build(),
         BatchScenario.builder("twoSameOperation")
-            .tuples(asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")))
-            .stableSpanName("BATCH insert test")
-            .stableSummary("BATCH insert test")
+            .tuples(asList(Tuple.of(1, 1), Tuple.of(2, 2)))
+            .stableSpanName("BATCH insert batch_test")
+            .stableSummary("BATCH insert batch_test")
             .batchSize(2)
             .build());
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,9 +54,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -281,14 +286,18 @@ class VertxSqlClientTest {
                             equalTo(SERVER_PORT, port))));
   }
 
-  @Test
-  void testBatch() throws Exception {
+  // describes the batch cases: a single-statement batch (not a batch -> no db.operation.batch.size)
+  // and two statements. batch telemetry (db.operation.batch.size, BATCH span names and summaries)
+  // is only emitted under stable database semconv
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void testBatch(BatchScenario scenario) throws Exception {
     testing
         .runWithSpan(
             "parent",
             () ->
                 pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(asList(Tuple.of(3, "Three"), Tuple.of(4, "Four"))))
+                    .executeBatch(scenario.tuples))
         .toCompletionStage()
         .toCompletableFuture()
         .get(30, SECONDS);
@@ -300,7 +309,7 @@ class VertxSqlClientTest {
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
-                                ? "BATCH insert test"
+                                ? scenario.stableSpanName
                                 : "INSERT tempdb.test")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
@@ -315,9 +324,10 @@ class VertxSqlClientTest {
                                 "insert into test values ($1, $2) returning *"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
-                                emitStableDatabaseSemconv() ? "BATCH insert test" : null),
+                                emitStableDatabaseSemconv() ? scenario.stableSummary : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "INSERT"),
@@ -327,6 +337,48 @@ class VertxSqlClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+            // a single-statement batch is not a batch (size 1), so it emits no
+            // db.operation.batch.size and no BATCH prefix
+            new BatchScenario(
+                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+            new BatchScenario(
+                "twoSameOperation",
+                asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
+                "BATCH insert test",
+                "BATCH insert test",
+                2L))
+        .map(Arguments::of);
+  }
+
+  private static final class BatchScenario {
+    final String name;
+    final List<Tuple> tuples;
+    final String stableSpanName;
+    final String stableSummary;
+    final Long batchSize;
+
+    BatchScenario(
+        String name,
+        List<Tuple> tuples,
+        String stableSpanName,
+        String stableSummary,
+        Long batchSize) {
+      this.name = name;
+      this.tuples = tuples;
+      this.stableSpanName = stableSpanName;
+      this.stableSummary = stableSummary;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public String toString() {
+      // used as the parameterized test display name
+      return name;
+    }
   }
 
   @Test

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -369,8 +369,8 @@ class VertxSqlClientTest {
         // records the error and carries db.operation.batch.size 0
         BatchScenario.builder("empty")
             .tuples(emptyList())
-            .stableSpanName("insert batch_test")
-            .stableSummary("insert batch_test")
+            .stableSpanName("BATCH insert batch_test")
+            .stableSummary("BATCH insert batch_test")
             .errorType("io.vertx.core.VertxException")
             .batchSize(0)
             .build(),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -366,12 +366,13 @@ class VertxSqlClientTest {
   private static Stream<BatchScenario> batchScenarios() {
     return Stream.of(
         // an empty batch is rejected before sending, so it looks like a single statement but
-        // records the error and emits no db.operation.batch.size
+        // records the error and carries db.operation.batch.size 0
         BatchScenario.builder("empty")
             .tuples(emptyList())
             .stableSpanName("insert batch_test")
             .stableSummary("insert batch_test")
             .errorType("io.vertx.core.VertxException")
+            .batchSize(0)
             .build(),
         // a single-statement batch is not a batch (size 1), so it emits no
         // db.operation.batch.size and no BATCH prefix

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -29,6 +29,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.POSTGRESQL;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -354,7 +355,7 @@ class VertxSqlClientTest {
             // records the error and emits no db.operation.batch.size
             new BatchScenario(
                 "empty",
-                Collections.emptyList(),
+                emptyList(),
                 "insert test",
                 "insert test",
                 null,

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -292,15 +293,20 @@ class VertxSqlClientTest {
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void testBatch(BatchScenario scenario) throws Exception {
-    testing
-        .runWithSpan(
-            "parent",
-            () ->
-                pool.preparedQuery("insert into test values ($1, $2) returning *")
-                    .executeBatch(scenario.tuples))
-        .toCompletionStage()
-        .toCompletableFuture()
-        .get(30, SECONDS);
+    // an empty batch is rejected before sending, so its execution fails; non-empty batches succeed
+    try {
+      testing
+          .runWithSpan(
+              "parent",
+              () ->
+                  pool.preparedQuery("insert into test values ($1, $2) returning *")
+                      .executeBatch(scenario.tuples))
+          .toCompletionStage()
+          .toCompletableFuture()
+          .get(30, SECONDS);
+    } catch (ExecutionException e) {
+      // an empty batch fails to execute; the failure is recorded on the client span
+    }
 
     testing.waitAndAssertTraces(
         trace ->
@@ -334,6 +340,9 @@ class VertxSqlClientTest {
                             equalTo(
                                 maybeStable(DB_SQL_TABLE),
                                 emitStableDatabaseSemconv() ? null : "test"),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv() ? scenario.errorType : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port))));
@@ -341,16 +350,31 @@ class VertxSqlClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
+            // an empty batch is rejected before sending, so it looks like a single statement but
+            // records the error and emits no db.operation.batch.size
+            new BatchScenario(
+                "empty",
+                Collections.emptyList(),
+                "insert test",
+                "insert test",
+                null,
+                "io.vertx.core.VertxException"),
             // a single-statement batch is not a batch (size 1), so it emits no
             // db.operation.batch.size and no BATCH prefix
             new BatchScenario(
-                "single", singletonList(Tuple.of(3, "Three")), "insert test", "insert test", null),
+                "single",
+                singletonList(Tuple.of(3, "Three")),
+                "insert test",
+                "insert test",
+                null,
+                null),
             new BatchScenario(
                 "twoSameOperation",
                 asList(Tuple.of(4, "Four"), Tuple.of(5, "Five")),
                 "BATCH insert test",
                 "BATCH insert test",
-                2L))
+                2L,
+                null))
         .map(Arguments::of);
   }
 
@@ -360,18 +384,21 @@ class VertxSqlClientTest {
     final String stableSpanName;
     final String stableSummary;
     final Long batchSize;
+    final String errorType;
 
     BatchScenario(
         String name,
         List<Tuple> tuples,
         String stableSpanName,
         String stableSummary,
-        Long batchSize) {
+        Long batchSize,
+        String errorType) {
       this.name = name;
       this.tuples = tuples;
       this.stableSpanName = stableSpanName;
       this.stableSummary = stableSummary;
       this.batchSize = batchSize;
+      this.errorType = errorType;
     }
 
     @Override


### PR DESCRIPTION
## Description

Consolidates the per-case batch tests across the database instrumentations that emit `db.operation.batch.size` into a single `@ParameterizedTest` driven by a small `BatchScenario` holder, locking down the shape of batch telemetry (BATCH-prefixed span names/summaries, `db.operation.batch.size`, joined `db.query.text`).

Each unified test covers the relevant cases:

- **empty** — only where the driver allows it and it produces telemetry
- **single** — a size-1 batch (verifies it is *not* treated as a batch: no `db.operation.batch.size`)
- **two, same operation** — `BATCH <op>` span/summary, `db.operation.batch.size = 2`
- **two, different operations** — `BATCH` span/summary, joined query text

Modules updated:

| Module | Cases | Notes |
|---|---|---|
| JDBC (`Statement`) | empty / single / two-same / two-different | stable-only, h2 |
| DynamoDB aws-sdk 1.11 | GetItem & WriteItem × empty / single / two | dual-mode |
| DynamoDB aws-sdk 2.2 | empty / two-get / two-write | dual-mode |
| Cassandra 3.0 / 4.0 / 4.4 | two-same / two-different | dual-mode |
| R2DBC 1.0 | single / two-same | stable-only |
| Vert.x SQL client 4.0 / 5.0 | single / two-same | dual-mode |
| Redisson | two-same / two-different | dual-mode |

### Notes

- Batch telemetry is database-agnostic (it comes from the shared SQL extractors), so JDBC locks the shape against a single in-memory database rather than the full driver cross-product.
- A size-1 batch is executed as a normal single statement/command (e.g. Cassandra `INSERT ks.users`, Redisson `SET`), not a batch — so the `single` case is dropped where that path diverges and kept where the size-1 span still looks batch-shaped.
- Alternate-API batch tests that exercise genuinely different behavior (JDBC `executeLargeBatch`/prepared batch, Redisson large/atomic batch) are left as separate tests.

Opening as a draft to run CI across the Docker-based integration suites.
