### PR TITLE
Add another port wait for hadoop test

### DIFF
--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/HadoopTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/HadoopTest.java
@@ -42,8 +42,8 @@ class HadoopTest extends TargetSystemTest {
                 "/hadoop/etc/hadoop/hadoop-env.sh")
             .withCreateContainerCmdModifier(cmd -> cmd.withHostName("test-host"))
             .withStartupTimeout(Duration.ofMinutes(3))
-            .withExposedPorts(50070)
-            .waitingFor(Wait.forListeningPorts(50070));
+            .withExposedPorts(50070, 50090)
+            .waitingFor(Wait.forListeningPorts(50070, 50090));
 
     copyAgentToTarget(target);
     copyYamlFilesToTarget(target, yamlFiles);


### PR DESCRIPTION
https://develocity.opentelemetry.io/s/jamqbjy7ytdw6/tests/task/:instrumentation:jmx-metrics:library:test/details/io.opentelemetry.instrumentation.jmx.rules.HadoopTest/testMetrics_Hadoop2x()?expanded-stacktrace=WyIwIl0&page=eyIwIjoxLCJvdXRwdXQiOnsiMCI6M319&top-execution=1
I think the metrics are missing because it didn't completely start yet. Hopefully waiting for another port will help.