### PR TITLE
Fix MSSQL JDBC "database=" parameter not extracting db.name, issue 19024

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -68,7 +68,7 @@ public final class JtdsUrlParser implements JdbcUrlParser {
 
       // If no path, use databasename or database param as fallback for database
       if (ctx.databaseName() == null) {
-        String databaseName = UrlParsingUtils.getDatabaseNameParam(urlParams);
+        String databaseName = MssqlUrlParser.getDatabaseNameParam(urlParams);
         if (databaseName != null) {
           ctx.databaseName(databaseName);
         }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.splitQuery;
 
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Parser for jTDS SQL Server JDBC URLs.
@@ -91,4 +90,3 @@ public final class JtdsUrlParser implements JdbcUrlParser {
     }
   }
 
-}

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -68,13 +68,7 @@ public final class JtdsUrlParser implements JdbcUrlParser {
 
       // If no path, use databasename or database param as fallback for database
       if (ctx.databaseName() == null) {
-        String databaseName = urlParams.get("databasename");
-        if (databaseName == null || databaseName.isEmpty()) {
-          databaseName = urlParams.get("database");
-        }
-        if (databaseName != null && !databaseName.isEmpty()) {
-          ctx.databaseName(databaseName);
-        }
+        ctx.applyDatabaseNameParam(urlParams);
       }
     }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.splitQuery;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Parser for jTDS SQL Server JDBC URLs.
@@ -68,7 +69,7 @@ public final class JtdsUrlParser implements JdbcUrlParser {
 
       // If no path, use databasename or database param as fallback for database
       if (ctx.databaseName() == null) {
-        ctx.applyDatabaseNameParam(urlParams);
+        ctx.databaseName(getDatabaseNameParam(urlParams));
       }
     }
 
@@ -85,5 +86,14 @@ public final class JtdsUrlParser implements JdbcUrlParser {
         ctx.namespace(instanceName);
       }
     }
+  }
+
+  @Nullable
+  private static String getDatabaseNameParam(Map<String, String> params) {
+    String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
+    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -66,9 +66,13 @@ public final class JtdsUrlParser implements JdbcUrlParser {
         instanceName = urlParams.get("instance");
       }
 
-      // If no path, use databasename param as fallback for database
-      if (ctx.databaseName() == null && urlParams.containsKey("databasename")) {
-        ctx.databaseName(urlParams.get("databasename"));
+      // If no path, use databasename or database param as fallback for database
+      if (ctx.databaseName() == null) {
+        if (urlParams.containsKey("databasename")) {
+          ctx.databaseName(urlParams.get("databasename"));
+        } else if (urlParams.containsKey("database")) {
+          ctx.databaseName(urlParams.get("database"));
+        }
       }
     }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -89,4 +89,4 @@ public final class JtdsUrlParser implements JdbcUrlParser {
       }
     }
   }
-
+}

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -68,10 +68,12 @@ public final class JtdsUrlParser implements JdbcUrlParser {
 
       // If no path, use databasename or database param as fallback for database
       if (ctx.databaseName() == null) {
-        if (urlParams.containsKey("databasename")) {
-          ctx.databaseName(urlParams.get("databasename"));
-        } else if (urlParams.containsKey("database")) {
-          ctx.databaseName(urlParams.get("database"));
+        String databaseName = urlParams.get("databasename");
+        if (databaseName == null || databaseName.isEmpty()) {
+          databaseName = urlParams.get("database");
+        }
+        if (databaseName != null && !databaseName.isEmpty()) {
+          ctx.databaseName(databaseName);
         }
       }
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -69,7 +69,10 @@ public final class JtdsUrlParser implements JdbcUrlParser {
 
       // If no path, use databasename or database param as fallback for database
       if (ctx.databaseName() == null) {
-        ctx.databaseName(getDatabaseNameParam(urlParams));
+        String databaseName = UrlParsingUtils.getDatabaseNameParam(urlParams);
+        if (databaseName != null) {
+          ctx.databaseName(databaseName);
+        }
       }
     }
 
@@ -88,12 +91,4 @@ public final class JtdsUrlParser implements JdbcUrlParser {
     }
   }
 
-  @Nullable
-  private static String getDatabaseNameParam(Map<String, String> params) {
-    String databaseName = params.get("databasename");
-    if (databaseName == null || databaseName.isEmpty()) {
-      databaseName = params.get("database");
-    }
-    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
-  }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -57,7 +57,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     // Parse semicolon-delimited parameters once and apply both standard and
     // MSSQL-specific properties from the same map to avoid re-parsing the URL.
     Map<String, String> urlParams = UrlParsingUtils.extractSemicolonParams(jdbcUrl);
-    applyCommonParams(ctx, urlParams);
+    ctx.applyCommonParams(urlParams);
     applyDatabaseAliasParam(ctx, urlParams);
 
     // Layer 4: Parse URL structure (host:port/path)
@@ -149,33 +149,8 @@ public final class MssqlUrlParser implements JdbcUrlParser {
   }
 
   /**
-   * Apply standard URL parameters from a pre-parsed map. Equivalent to {@link
-   * ParseContext#applyCommonParams} but operates on an already-extracted parameter map to avoid
-   * re-parsing the URL string.
-   */
-  private static void applyCommonParams(ParseContext ctx, Map<String, String> params) {
-    if (params.isEmpty()) {
-      return;
-    }
-    if (params.containsKey("servername")) {
-      ctx.host(params.get("servername"));
-    }
-    Integer port = UrlParsingUtils.parsePort(params.get("portnumber"));
-    if (port != null) {
-      ctx.port(port);
-    }
-    String databaseName = params.get("databasename");
-    if (databaseName != null && !databaseName.isEmpty()) {
-      ctx.databaseName(databaseName);
-    }
-    if (params.containsKey("user")) {
-      ctx.user(params.get("user"));
-    }
-  }
-
-  /**
    * Apply the {@code database} URL parameter alias when {@code databasename} has not already been
-   * set by {@link #applyCommonParams(ParseContext, Map)}.
+   * set by {@link ParseContext#applyCommonParams(Map)}.
    */
   private static void applyDatabaseAliasParam(ParseContext ctx, Map<String, String> params) {
     if (ctx.databaseName() != null) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -55,8 +55,11 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     }
 
     // Layer 3: URL params (SQL Server-specific: servername)
-    ctx.applyCommonParams(jdbcUrl, ";", ";");
-    applyDatabaseAliasParam(jdbcUrl, ctx);
+    // Parse semicolon-delimited parameters once and apply both standard and
+    // MSSQL-specific properties from the same map to avoid re-parsing the URL.
+    Map<String, String> urlParams = UrlParsingUtils.extractSemicolonParams(jdbcUrl);
+    applyCommonParams(ctx, urlParams);
+    applyDatabaseAliasParam(ctx, urlParams);
 
     // Layer 4: Parse URL structure (host:port/path)
     String instanceName = parseUrlWithInstance(jdbcUrl, ctx);
@@ -146,24 +149,43 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return instanceName;
   }
 
-  private static void applyDatabaseAliasParam(String jdbcUrl, ParseContext ctx) {
-    if (ctx.databaseName() != null) {
+  /**
+   * Apply standard URL parameters from a pre-parsed map. Equivalent to {@link
+   * ParseContext#applyCommonParams} but operates on an already-extracted parameter map to avoid
+   * re-parsing the URL string.
+   */
+  private static void applyCommonParams(ParseContext ctx, Map<String, String> params) {
+    if (params.isEmpty()) {
       return;
     }
-    Map<String, String> params = UrlParsingUtils.extractSemicolonParams(jdbcUrl);
-    String databaseName = getDatabaseNameParam(params);
-    if (databaseName != null) {
+    if (params.containsKey("servername")) {
+      ctx.host(params.get("servername"));
+    }
+    Integer port = UrlParsingUtils.parsePort(params.get("portnumber"));
+    if (port != null) {
+      ctx.port(port);
+    }
+    String databaseName = params.get("databasename");
+    if (databaseName != null && !databaseName.isEmpty()) {
       ctx.databaseName(databaseName);
+    }
+    if (params.containsKey("user")) {
+      ctx.user(params.get("user"));
     }
   }
 
-  @Nullable
-  private static String getDatabaseNameParam(Map<String, String> params) {
-    String databaseName = params.get("databasename");
-    if (databaseName == null || databaseName.isEmpty()) {
-      databaseName = params.get("database");
+  /**
+   * Apply the {@code database} URL parameter alias when {@code databasename} has not already been
+   * set by {@link #applyCommonParams(ParseContext, Map)}.
+   */
+  private static void applyDatabaseAliasParam(ParseContext ctx, Map<String, String> params) {
+    if (ctx.databaseName() != null) {
+      return;
     }
-    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
+    String databaseName = UrlParsingUtils.getDatabaseNameParam(params);
+    if (databaseName != null) {
+      ctx.databaseName(databaseName);
+    }
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Parser for Microsoft SQL Server JDBC URLs.

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Parser for Microsoft SQL Server JDBC URLs.
@@ -156,10 +157,23 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     if (ctx.databaseName() != null) {
       return;
     }
-    String databaseName = UrlParsingUtils.getDatabaseNameParam(params);
+    String databaseName = getDatabaseNameParam(params);
     if (databaseName != null) {
       ctx.databaseName(databaseName);
     }
+  }
+
+  /**
+   * Resolve the SQL Server database name from URL parameters, trying {@code databasename} first and
+   * falling back to {@code database}. Returns {@code null} if neither key has a non-empty value.
+   */
+  @Nullable
+  static String getDatabaseNameParam(Map<String, String> params) {
+    String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
+    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Parser for Microsoft SQL Server JDBC URLs.
@@ -54,6 +56,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
 
     // Layer 3: URL params (SQL Server-specific: servername)
     ctx.applyCommonParams(jdbcUrl, ";", ";");
+    applyDatabaseAliasParam(jdbcUrl, ctx);
 
     // Layer 4: Parse URL structure (host:port/path)
     String instanceName = parseUrlWithInstance(jdbcUrl, ctx);
@@ -141,6 +144,26 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     }
 
     return instanceName;
+  }
+
+  private static void applyDatabaseAliasParam(String jdbcUrl, ParseContext ctx) {
+    if (ctx.databaseName() != null) {
+      return;
+    }
+    Map<String, String> params = UrlParsingUtils.extractSemicolonParams(jdbcUrl);
+    String databaseName = getDatabaseNameParam(params);
+    if (databaseName != null) {
+      ctx.databaseName(databaseName);
+    }
+  }
+
+  @Nullable
+  private static String getDatabaseNameParam(Map<String, String> params) {
+    String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
+    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -167,23 +167,6 @@ public final class ParseContext {
   }
 
   /**
-   * Resolve the database name from URL parameters, trying {@code databasename} first and falling
-   * back to {@code database}. Used by URL-based parsers ({@link #applyCommonParams}) and by parsers
-   * that handle params separately (e.g., {@code JtdsUrlParser}).
-   *
-   * @param params the URL parameter map
-   */
-  public void applyDatabaseNameParam(Map<String, String> params) {
-    String databaseName = params.get("databasename");
-    if (databaseName == null || databaseName.isEmpty()) {
-      databaseName = params.get("database");
-    }
-    if (databaseName != null && !databaseName.isEmpty()) {
-      this.databaseName = databaseName;
-    }
-  }
-
-  /**
    * Apply common parameters from URL parameters to the context.
    *
    * <p>Extracts the same properties as {@link #applyDataSourceProperties()} but using lowercase
@@ -207,7 +190,10 @@ public final class ParseContext {
     if (port != null) {
       this.port = port;
     }
-    applyDatabaseNameParam(params);
+    String databaseName = params.get("databasename");
+    if (databaseName != null && !databaseName.isEmpty()) {
+      this.databaseName = databaseName;
+    }
     if (params.containsKey("user")) {
       this.user = params.get("user");
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -177,9 +177,17 @@ public final class ParseContext {
    * @param splitSeparator the separator between individual parameters (";" or "&amp;")
    */
   public void applyCommonParams(String jdbcUrl, String startDelimiter, String splitSeparator) {
-    Map<String, String> params =
-        UrlParsingUtils.extractParams(jdbcUrl, startDelimiter, splitSeparator);
+    applyCommonParams(UrlParsingUtils.extractParams(jdbcUrl, startDelimiter, splitSeparator));
+  }
 
+  /**
+   * Apply common parameters from a pre-parsed parameter map. Equivalent to {@link
+   * #applyCommonParams(String, String, String)} but avoids re-parsing the URL when the caller has
+   * already extracted the parameters.
+   *
+   * @param params the parameter map (keys must be lowercase)
+   */
+  public void applyCommonParams(Map<String, String> params) {
     if (params.isEmpty()) {
       return;
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -168,8 +168,8 @@ public final class ParseContext {
 
   /**
    * Resolve the database name from URL parameters, trying {@code databasename} first and falling
-   * back to {@code database}. This is used by URL-based parsers ({@link #applyCommonParams}) and
-   * by parsers that handle params separately (e.g., {@code JtdsUrlParser}).
+   * back to {@code database}. Used by URL-based parsers ({@link #applyCommonParams}) and by
+   * parsers that handle params separately (e.g., {@code JtdsUrlParser}).
    *
    * @param params the URL parameter map
    */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -167,6 +167,23 @@ public final class ParseContext {
   }
 
   /**
+   * Resolve the database name from URL parameters, trying {@code databasename} first and falling
+   * back to {@code database}. This is used by URL-based parsers ({@link #applyCommonParams}) and
+   * by parsers that handle params separately (e.g., {@code JtdsUrlParser}).
+   *
+   * @param params the URL parameter map
+   */
+  public void applyDatabaseNameParam(Map<String, String> params) {
+    String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
+    if (databaseName != null && !databaseName.isEmpty()) {
+      this.databaseName = databaseName;
+    }
+  }
+
+  /**
    * Apply common parameters from URL parameters to the context.
    *
    * <p>Extracts the same properties as {@link #applyDataSourceProperties()} but using lowercase
@@ -190,13 +207,7 @@ public final class ParseContext {
     if (port != null) {
       this.port = port;
     }
-    String databaseName = params.get("databasename");
-    if (databaseName == null || databaseName.isEmpty()) {
-      databaseName = params.get("database");
-    }
-    if (databaseName != null && !databaseName.isEmpty()) {
-      this.databaseName = databaseName;
-    }
+    applyDatabaseNameParam(params);
     if (params.containsKey("user")) {
       this.user = params.get("user");
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -191,6 +191,9 @@ public final class ParseContext {
       this.port = port;
     }
     String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
     if (databaseName != null && !databaseName.isEmpty()) {
       this.databaseName = databaseName;
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -168,8 +168,8 @@ public final class ParseContext {
 
   /**
    * Resolve the database name from URL parameters, trying {@code databasename} first and falling
-   * back to {@code database}. Used by URL-based parsers ({@link #applyCommonParams}) and by
-   * parsers that handle params separately (e.g., {@code JtdsUrlParser}).
+   * back to {@code database}. Used by URL-based parsers ({@link #applyCommonParams}) and by parsers
+   * that handle params separately (e.g., {@code JtdsUrlParser}).
    *
    * @param params the URL parameter map
    */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -279,6 +279,22 @@ public final class UrlParsingUtils {
   }
 
   /**
+   * Resolve the database name from URL parameters, trying {@code databasename} first and falling
+   * back to {@code database}. Returns {@code null} if neither key has a non-empty value.
+   *
+   * @param params the URL parameter map (keys must be lowercase)
+   * @return the resolved database name, or {@code null}
+   */
+  @Nullable
+  public static String getDatabaseNameParam(Map<String, String> params) {
+    String databaseName = params.get("databasename");
+    if (databaseName == null || databaseName.isEmpty()) {
+      databaseName = params.get("database");
+    }
+    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
+  }
+
+  /**
    * Lightweight wrapper for URL parameters that provides cleaner access patterns.
    *
    * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -279,22 +279,6 @@ public final class UrlParsingUtils {
   }
 
   /**
-   * Resolve the database name from URL parameters, trying {@code databasename} first and falling
-   * back to {@code database}. Returns {@code null} if neither key has a non-empty value.
-   *
-   * @param params the URL parameter map (keys must be lowercase)
-   * @return the resolved database name, or {@code null}
-   */
-  @Nullable
-  public static String getDatabaseNameParam(Map<String, String> params) {
-    String databaseName = params.get("databasename");
-    if (databaseName == null || databaseName.isEmpty()) {
-      databaseName = params.get("database");
-    }
-    return databaseName == null || databaseName.isEmpty() ? null : databaseName;
-  }
-
-  /**
    * Lightweight wrapper for URL parameters that provides cleaner access patterns.
    *
    * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -557,6 +557,25 @@ class JdbcConnectionUrlParserTest {
             .setPort(1433)
             .setName("ssdb")
             .build(),
+        // database= alias (shorthand for databaseName)
+        arg("jdbc:sqlserver://ss.host;database=ssdb;")
+            .setShortUrl("sqlserver://ss.host:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setName("ssdb")
+            .build(),
+        arg("jdbc:sqlserver://ss.host\\ssinstance:44;database=ssdb;user=ssuser")
+            .setShortUrl("sqlserver://ss.host:44")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setUser("ssuser")
+            .setHost("ss.host")
+            .setPort(44)
+            .setNamespace("ssinstance|ssdb")
+            .setName("ssinstance")
+            .build(),
         arg("jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;")
             .setShortUrl("microsoft:sqlserver://ss.host:44")
             .setSystem("microsoft.sql_server")
@@ -657,6 +676,27 @@ class JdbcConnectionUrlParserTest {
             .setHost("ss.host")
             .setPort(1433)
             .setNamespace("ssinstance")
+            .setName("ssinstance")
+            .build(),
+        // database= alias (shorthand for databaseName) in jTDS URLs
+        arg("jdbc:jtds:sqlserver://ss.host/ssdb;instance=ssinstance;database=otherdb")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setSubtype("sqlserver")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setNamespace("ssinstance|ssdb")
+            .setName("ssinstance")
+            .build(),
+        // database= param provides database name when there's no URL path
+        arg("jdbc:jtds:sqlserver://ss.host;instance=ssinstance;database=ssdb")
+            .setShortUrl("jtds:sqlserver://ss.host:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host")
+            .setPort(1433)
+            .setNamespace("ssinstance|ssdb")
             .setName("ssinstance")
             .build(),
         arg("jdbc:jtds:sqlserver://ss.host:1444/urldb")

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -694,6 +694,7 @@ class JdbcConnectionUrlParserTest {
             .setShortUrl("jtds:sqlserver://ss.host:1433")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
+            .setSubtype("sqlserver")
             .setHost("ss.host")
             .setPort(1433)
             .setNamespace("ssinstance|ssdb")


### PR DESCRIPTION
For this issue [The Java agent did not detect the database name](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19024), I want to create a pr.


The Microsoft SQL Server JDBC driver supports both 'databaseName' and 'database' as connection property names for specifying the database name. However, the URL parser only checked for 'databasename' (after lowercasing), causing jdbc:sqlserver://...;database=xxx URLs to not extract the db.name attribute.

This commit adds 'database' as a fallback key in:
- ParseContext.applyCommonParams() - used by MssqlUrlParser
- JtdsUrlParser.parse() - used by jTDS driver

Additional test cases cover the 'database=' parameter for both sqlserver and jtds URL formats.