### PR TITLE
Improve Redisson batch coverage

### DIFF
--- a/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.EndOperationListener;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.PromiseWrapper;
+import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonBatchSpanManager;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonRequest;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
@@ -38,14 +39,30 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
   public static class SendAdvice {
 
     public static class AdviceScope {
-      private final RedissonRequest request;
-      private final Context context;
-      private final Scope scope;
+      private final RedisConnection connection;
+      @Nullable private final RedissonRequest request;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean multiSpan;
+      private final boolean suppressedSpan;
 
-      private AdviceScope(RedissonRequest request, Context context, Scope scope) {
+      private AdviceScope(
+          RedisConnection connection,
+          @Nullable RedissonRequest request,
+          @Nullable Context context,
+          @Nullable Scope scope,
+          boolean multiSpan,
+          boolean suppressedSpan) {
+        this.connection = connection;
         this.request = request;
         this.context = context;
         this.scope = scope;
+        this.multiSpan = multiSpan;
+        this.suppressedSpan = suppressedSpan;
+      }
+
+      private static AdviceScope suppressed(RedisConnection connection) {
+        return new AdviceScope(connection, null, null, null, false, true);
       }
 
       @Nullable
@@ -57,6 +74,9 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         if (promise == null) {
           return null;
         }
+        if (RedissonBatchSpanManager.suppressSpanOrEndMultiSpan(connection, request, promise)) {
+          return suppressed(connection);
+        }
         Context parentContext = currentContext();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
@@ -65,16 +85,26 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         Context context = instrumenter().start(parentContext, request);
         Scope scope = context.makeCurrent();
 
+        if (request.isMultiBatch()) {
+          RedissonBatchSpanManager.startMultiSpan(connection, instrumenter(), context, request);
+          return new AdviceScope(connection, request, context, scope, true, false);
+        }
         promise.setEndOperationListener(
             new EndOperationListener<>(instrumenter(), context, request));
-        return new AdviceScope(request, context, scope);
+        return new AdviceScope(connection, request, context, scope, false, false);
       }
 
       public void end(@Nullable Throwable throwable) {
-        scope.close();
+        if (scope != null) {
+          scope.close();
+        }
 
         if (throwable != null) {
-          instrumenter().end(context, request, null, throwable);
+          if (multiSpan || suppressedSpan) {
+            RedissonBatchSpanManager.endMultiSpan(connection, throwable);
+          } else if (context != null && request != null) {
+            instrumenter().end(context, request, null, throwable);
+          }
         }
         // span ended in EndOperationListener
       }

--- a/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.EndOperationListener;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.PromiseWrapper;
+import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonBatchSpanManager;
 import io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0.RedissonRequest;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
@@ -38,14 +39,30 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
   public static class SendAdvice {
 
     public static class AdviceScope {
-      private final RedissonRequest request;
-      private final Context context;
-      private final Scope scope;
+      private final RedisConnection connection;
+      @Nullable private final RedissonRequest request;
+      @Nullable private final Context context;
+      @Nullable private final Scope scope;
+      private final boolean multiSpan;
+      private final boolean suppressedSpan;
 
-      private AdviceScope(RedissonRequest request, Context context, Scope scope) {
+      private AdviceScope(
+          RedisConnection connection,
+          @Nullable RedissonRequest request,
+          @Nullable Context context,
+          @Nullable Scope scope,
+          boolean multiSpan,
+          boolean suppressedSpan) {
+        this.connection = connection;
         this.request = request;
         this.context = context;
         this.scope = scope;
+        this.multiSpan = multiSpan;
+        this.suppressedSpan = suppressedSpan;
+      }
+
+      private static AdviceScope suppressed(RedisConnection connection) {
+        return new AdviceScope(connection, null, null, null, false, true);
       }
 
       @Nullable
@@ -58,6 +75,9 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         if (promise == null) {
           return null;
         }
+        if (RedissonBatchSpanManager.suppressSpanOrEndMultiSpan(connection, request, promise)) {
+          return suppressed(connection);
+        }
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
         }
@@ -65,15 +85,25 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         Context context = instrumenter().start(parentContext, request);
         Scope scope = context.makeCurrent();
 
+        if (request.isMultiBatch()) {
+          RedissonBatchSpanManager.startMultiSpan(connection, instrumenter(), context, request);
+          return new AdviceScope(connection, request, context, scope, true, false);
+        }
         promise.setEndOperationListener(
             new EndOperationListener<>(instrumenter(), context, request));
-        return new AdviceScope(request, context, scope);
+        return new AdviceScope(connection, request, context, scope, false, false);
       }
 
       public void end(@Nullable Throwable throwable) {
-        scope.close();
+        if (scope != null) {
+          scope.close();
+        }
         if (throwable != null) {
-          instrumenter().end(context, request, null, throwable);
+          if (multiSpan || suppressedSpan) {
+            RedissonBatchSpanManager.endMultiSpan(connection, throwable);
+          } else if (context != null && request != null) {
+            instrumenter().end(context, request, null, throwable);
+          }
         }
         // span ended in EndOperationListener
       }

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonBatchSpanManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.redisson.common.v3_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.annotation.Nullable;
+
+public final class RedissonBatchSpanManager {
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<String> DB_STATEMENT = AttributeKey.stringKey("db.statement");
+
+  private static final Map<Object, ActiveSpan> activeMultiSpans =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  public static void startMultiSpan(
+      Object connection,
+      Instrumenter<RedissonRequest, Void> instrumenter,
+      Context context,
+      RedissonRequest request) {
+    activeMultiSpans.put(connection, new ActiveSpan(instrumenter, context, request));
+  }
+
+  public static boolean suppressSpanOrEndMultiSpan(
+      Object connection, RedissonRequest request, PromiseWrapper<?> promise) {
+    ActiveSpan activeSpan = activeMultiSpans.get(connection);
+    if (activeSpan == null) {
+      return false;
+    }
+
+    activeSpan.request.addCommandsFrom(request);
+    activeSpan.updateAttributes();
+    setEndOperationListener(connection, promise, activeSpan, request.isExecCommand());
+    return true;
+  }
+
+  public static void endMultiSpan(Object connection, @Nullable Throwable error) {
+    ActiveSpan activeSpan = activeMultiSpans.remove(connection);
+    if (activeSpan != null) {
+      activeSpan.end(error);
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"}) // promise value type is irrelevant to span ending
+  private static void setEndOperationListener(
+      Object connection, PromiseWrapper<?> promise, ActiveSpan activeSpan, boolean endOnSuccess) {
+    ((PromiseWrapper) promise)
+        .setEndOperationListener(
+            new EndOperationListener(
+                activeSpan.instrumenter, activeSpan.context, activeSpan.request) {
+              @Override
+              public void accept(@Nullable Object unused, @Nullable Throwable error) {
+                if (endOnSuccess || error != null) {
+                  endMultiSpan(connection, error);
+                }
+              }
+            });
+  }
+
+  private RedissonBatchSpanManager() {}
+
+  private static final class ActiveSpan {
+    private final Instrumenter<RedissonRequest, Void> instrumenter;
+    private final Context context;
+    private final RedissonRequest request;
+
+    private ActiveSpan(
+        Instrumenter<RedissonRequest, Void> instrumenter,
+        Context context,
+        RedissonRequest request) {
+      this.instrumenter = instrumenter;
+      this.context = context;
+      this.request = request;
+    }
+
+    private void end(@Nullable Throwable error) {
+      instrumenter.end(context, request, null, error);
+    }
+
+    private void updateAttributes() {
+      Span span = Span.fromContext(context);
+      if (emitStableDatabaseSemconv()) {
+        String operationName = request.getOperationName();
+        if (operationName != null) {
+          span.updateName(operationName);
+        }
+        span.setAttribute(DB_OPERATION_NAME, operationName);
+        span.setAttribute(DB_QUERY_TEXT, request.getQueryText());
+        Long batchSize = request.getOperationBatchSize();
+        if (batchSize != null) {
+          span.setAttribute(DB_OPERATION_BATCH_SIZE, batchSize);
+        }
+      }
+      if (emitOldDatabaseSemconv()) {
+        span.setAttribute(DB_STATEMENT, request.getQueryText());
+      }
+    }
+  }
+}

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -43,6 +43,8 @@ public abstract class RedissonRequest {
   // note that RedisCommandSanitizer already limits the size of sanitized commands
   private static final int LIMIT = 32 * 1024;
 
+  private final List<CommandData<?, ?>> additionalCommands = new ArrayList<>();
+
   @Nullable
   private static final MethodHandle COMMAND_DATA_GET_PROMISE =
       findGetPromiseMethod(CommandData.class);
@@ -83,14 +85,37 @@ public abstract class RedissonRequest {
 
   public abstract Object getCommand();
 
+  void addCommandsFrom(RedissonRequest request) {
+    if (!isMultiBatch()) {
+      return;
+    }
+    Object command = request.getCommand();
+    if (command == getCommand()) {
+      return;
+    }
+    if (command instanceof CommandData) {
+      addCommand((CommandData<?, ?>) command);
+    } else if (command instanceof CommandsData) {
+      for (CommandData<?, ?> singleCommand : ((CommandsData) command).getCommands()) {
+        addCommand(singleCommand);
+      }
+    }
+  }
+
+  private void addCommand(CommandData<?, ?> command) {
+    String commandName = command.getCommand().getName();
+    if (!commandName.equals(MULTI) && !commandName.equals("EXEC")) {
+      additionalCommands.add(command);
+    }
+  }
+
   @Nullable
   public String getOperationName() {
     Object command = getCommand();
     if (command instanceof CommandData) {
       return ((CommandData<?, ?>) command).getCommand().getName();
     } else if (command instanceof CommandsData) {
-      CommandsData commandsData = (CommandsData) command;
-      List<CommandData<?, ?>> commands = commandsData.getCommands();
+      List<CommandData<?, ?>> commands = getCommands();
       if (commands.size() == 1) {
         return commands.get(0).getCommand().getName();
       }
@@ -99,13 +124,37 @@ public abstract class RedissonRequest {
     return null;
   }
 
+  public boolean isMultiBatch() {
+    Object command = getCommand();
+    if (!(command instanceof CommandsData)) {
+      return false;
+    }
+    List<CommandData<?, ?>> commands = getCommands();
+    return !commands.isEmpty() && commands.get(0).getCommand().getName().equals(MULTI);
+  }
+
+  public boolean isExecCommand() {
+    Object command = getCommand();
+    if (command instanceof CommandData) {
+      return ((CommandData<?, ?>) command).getCommand().getName().equals("EXEC");
+    }
+    if (command instanceof CommandsData) {
+      for (CommandData<?, ?> singleCommand : getCommands()) {
+        if (singleCommand.getCommand().getName().equals("EXEC")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   @Nullable
   public Long getOperationBatchSize() {
     Object command = getCommand();
     if (!(command instanceof CommandsData)) {
       return null;
     }
-    List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+    List<CommandData<?, ?>> commands = getCommands();
     if (commands.isEmpty()) {
       return null;
     }
@@ -151,7 +200,7 @@ public abstract class RedissonRequest {
     // get command
     if (command instanceof CommandsData) {
       int length = 0;
-      List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+      List<CommandData<?, ?>> commands = getCommands();
       List<String> normalizedCommands = new ArrayList<>(commands.size());
       for (CommandData<?, ?> singleCommand : commands) {
         String s = normalizeSingleCommand(singleCommand);
@@ -207,6 +256,18 @@ public abstract class RedissonRequest {
       }
     }
     return sanitizer.sanitize(command.getCommand().getName(), args);
+  }
+
+  private List<CommandData<?, ?>> getCommands() {
+    List<CommandData<?, ?>> commands = ((CommandsData) getCommand()).getCommands();
+    if (additionalCommands.isEmpty()) {
+      return commands;
+    }
+    List<CommandData<?, ?>> combinedCommands =
+        new ArrayList<>(commands.size() + additionalCommands.size());
+    combinedCommands.addAll(commands);
+    combinedCommands.addAll(additionalCommands);
+    return combinedCommands;
   }
 
   @Nullable

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -125,6 +126,7 @@ public abstract class AbstractRedissonAsyncClientTest {
   void cleanup() {
     if (redisson != null) {
       redisson.shutdown();
+      testing.clearData();
     }
   }
 
@@ -241,7 +243,7 @@ public abstract class AbstractRedissonAsyncClientTest {
     assertThat(result.toCompletableFuture()).succeedsWithin(TIMEOUT);
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("parent", "SADD", "callback"),
+        orderByRootSpanName("parent", "DB Query", "callback"),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
@@ -256,32 +258,9 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
-                            // db.operation.batch.size is not emitted because MULTI transaction
-                            // telemetry is split across wrapper and command spans, so this span
-                            // does not represent the full logical batch.
-                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("SET")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(maybeStable(DB_OPERATION), "SET"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("EXEC")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
-                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?;SET batch2 ?"))
                         .hasParent(trace.getSpan(0)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -52,6 +53,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.RAtomicLong;
@@ -142,6 +146,7 @@ public abstract class AbstractRedissonClientTest {
   void cleanup() {
     if (redisson != null) {
       redisson.shutdown();
+      testing.clearData();
     }
   }
 
@@ -246,20 +251,34 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
-  @Test
-  void batchCommand() throws ReflectiveOperationException {
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchCommand(BatchScenario scenario) {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch2").setAsync("v2");
+    scenario.commands.accept(batch);
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
+    try {
+      invokeExecute(batch);
+    } catch (ReflectiveOperationException ignored) {
+      // an empty batch fails to execute
+    }
+
+    if (scenario.empty) {
+      // an empty batch produces no span
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? scenario.operationName
+                                : scenario.oldSpanName)
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
@@ -267,42 +286,61 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(
-                                DB_OPERATION_NAME,
-                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.operationName
+                                    : scenario.oldOperation),
+                            equalTo(maybeStable(DB_STATEMENT), scenario.queryText))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+        // an empty batch fails to execute and produces no span
+        Arguments.argumentSet(
+            "empty", BatchScenario.builder().commands(batch -> {}).empty().build()),
+        // a single-command batch is reported as a normal command, not a pipeline
+        Arguments.argumentSet(
+            "single",
+            BatchScenario.builder()
+                .commands(batch -> batch.getBucket("batch1").setAsync("v1"))
+                .operationName("SET")
+                .oldSpanName("SET")
+                .oldOperation("SET")
+                .queryText("SET batch1 ?")
+                .build()),
+        Arguments.argumentSet(
+            "twoSameOperation",
+            BatchScenario.builder()
+                .commands(
+                    batch -> {
+                      batch.getBucket("batch1").setAsync("v1");
+                      batch.getBucket("batch2").setAsync("v2");
+                    })
+                .operationName("PIPELINE SET")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .queryText("SET batch1 ?;SET batch2 ?")
+                .build()),
+        Arguments.argumentSet(
+            "twoDifferentOperations",
+            BatchScenario.builder()
+                .commands(
+                    batch -> {
+                      batch.getBucket("batch1").setAsync("v1");
+                      batch.getBucket("batch1").getAsync();
+                    })
+                .operationName("PIPELINE")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .queryText("SET batch1 ?;GET batch1")
+                .build()));
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {
     batch.getClass().getMethod("execute").invoke(batch);
-  }
-
-  @Test
-  void mixedBatchCommand() throws ReflectiveOperationException {
-    RBatch batch = createBatch(redisson);
-    assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch1").getAsync();
-    // Adapt different method signature:
-    // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE" : "DB Query")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(
-                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
   }
 
   @Test
@@ -361,8 +399,7 @@ public abstract class AbstractRedissonClientTest {
           batch.getBucket("batch2").setAsync("v2");
           batch.execute();
         });
-    testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("MULTI SET", "DB Query", "SET", "EXEC"),
+    testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasKind(INTERNAL),
@@ -377,32 +414,48 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
-                            // db.operation.batch.size is not emitted because MULTI transaction
-                            // telemetry is split across wrapper and command spans, so this span
-                            // does not represent the full logical batch.
-                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?"))
-                        .hasParent(trace.getSpan(0)),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?;SET batch2 ?"))
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void atomicBatchCommandWithDifferentOperations() {
+    try {
+      // available since 3.7.2
+      Class.forName("org.redisson.api.BatchOptions$ExecutionMode");
+    } catch (ClassNotFoundException ignored) {
+      Assumptions.abort();
+    }
+
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          BatchOptions batchOptions =
+              BatchOptions.defaults().executionMode(BatchOptions.ExecutionMode.REDIS_WRITE_ATOMIC);
+          RBatch batch = redisson.createBatch(batchOptions);
+          batch.getBucket("batch1").setAsync("v1");
+          batch.getBucket("batch1").getAsync();
+          batch.execute();
+        });
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasNoParent().hasKind(INTERNAL),
                 span ->
-                    span.hasName("SET")
+                    span.hasName(emitStableDatabaseSemconv() ? "MULTI" : "DB Query")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
                             equalTo(NETWORK_PEER_ADDRESS, ip),
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
-                            equalTo(maybeStable(DB_OPERATION), "SET"))
-                        .hasParent(trace.getSpan(0)),
-                span ->
-                    span.hasName("EXEC")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(maybeStable(DB_STATEMENT), "EXEC"),
-                            equalTo(maybeStable(DB_OPERATION), "EXEC"))
+                            equalTo(
+                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "MULTI" : null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
+                            equalTo(maybeStable(DB_STATEMENT), "MULTI;SET batch1 ?;GET batch1"))
                         .hasParent(trace.getSpan(0))));
   }
 
@@ -606,5 +659,78 @@ public abstract class AbstractRedissonClientTest {
 
   protected RBatch createBatch(RedissonClient redisson) {
     return redisson.createBatch(BatchOptions.defaults());
+  }
+
+  private static final class BatchScenario {
+    final Consumer<RBatch> commands;
+    final String operationName;
+    final String oldSpanName;
+    final Long batchSize;
+    final String oldOperation;
+    final String queryText;
+    final boolean empty;
+
+    BatchScenario(Builder builder) {
+      this.commands = builder.commands;
+      this.operationName = builder.operationName;
+      this.oldSpanName = builder.oldSpanName;
+      this.batchSize = builder.batchSize;
+      this.oldOperation = builder.oldOperation;
+      this.queryText = builder.queryText;
+      this.empty = builder.empty;
+    }
+
+    static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+      private Consumer<RBatch> commands;
+      private String operationName;
+      private String oldSpanName;
+      private Long batchSize;
+      private String oldOperation;
+      private String queryText;
+      private boolean empty;
+
+      Builder commands(Consumer<RBatch> commands) {
+        this.commands = commands;
+        return this;
+      }
+
+      Builder operationName(String operationName) {
+        this.operationName = operationName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+      }
+
+      Builder empty() {
+        this.empty = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }


### PR DESCRIPTION
Improve Redisson batch and transaction coverage so active batch spans can be updated when additional queued commands are observed. The change adds a Redisson batch span manager and expands batch and transaction tests, including stable DB semconv `db.operation.batch.size` expectations.