### PR TITLE
Add CI fix skill

### DIFF
--- a/.github/scripts/pr-triage/fix_ci.py
+++ b/.github/scripts/pr-triage/fix_ci.py
@@ -14,6 +14,7 @@ from common import (
     changed_files,
     commit_all_tracked,
     detect_repo,
+    display_path,
     diff_check,
     download_actions_job_log,
     extract_job_id,
@@ -35,6 +36,11 @@ AGGREGATE_CHECK_SUFFIX = "required-status-check"
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int, help="pull request number")
+    parser.add_argument(
+        "--download-only",
+        action="store_true",
+        help="only check out the PR and download failing CI logs into a retained bundle; implies --keep-temp and does not invoke Copilot, commit, or push",
+    )
     parser.add_argument("--no-push", action="store_true", help="commit locally but do not push to the PR")
     parser.add_argument("--keep-temp", action="store_true", help="reuse and retain the temp bundle directory")
     parser.add_argument(
@@ -182,8 +188,13 @@ def main() -> int:
             summary.outcome = "no failing checks found"
             return 0
 
-        bundle_dir = make_temp_dir("otel-ci-fix", args.pr, args.keep_temp)
+        bundle_dir = make_temp_dir("otel-ci-fix", args.pr, args.keep_temp or args.download_only)
         bundle_checks = write_ci_bundle(args.pr, checks, bundle_dir, summary)
+        summary.notes.append(f"CI failure bundle: {display_path(str(bundle_dir))}")
+
+        if args.download_only:
+            summary.outcome = "CI logs downloaded"
+            return 0
 
         commit_message_path = bundle_dir / "commit-message.txt"
         prompt_improvement_path = bundle_dir / "prompt-improvement.md"
@@ -215,7 +226,7 @@ def main() -> int:
         summary.outcome = "CI fix committed"
         return 0
 
-    return run_pr_workflow(args.pr, body, push_required=not args.no_push)
+    return run_pr_workflow(args.pr, body, push_required=not args.no_push and not args.download_only)
 
 
 if __name__ == "__main__":

--- a/.github/skills/fix-ci/SKILL.md
+++ b/.github/skills/fix-ci/SKILL.md
@@ -24,6 +24,7 @@ The first source of truth is always the deterministic CI bundle produced by [.gi
    ```
 
    The script checks out the PR, discovers failed non-aggregate checks, downloads one representative log for each failed job family into `build/pr-triage/otel-ci-fix-<pr-number>/logs/`, writes `summary.json`, and restores the original branch.
+
 3. Read `build/pr-triage/otel-ci-fix-<pr-number>/summary.json` and the referenced log files. Treat them as the source of truth for what failed.
 4. Check out the PR branch again if the script restored you to another branch:
 

--- a/.github/skills/fix-ci/SKILL.md
+++ b/.github/skills/fix-ci/SKILL.md
@@ -24,7 +24,6 @@ The first source of truth is always the deterministic CI bundle produced by [.gi
    ```
 
    The script checks out the PR, discovers failed non-aggregate checks, downloads one representative log for each failed job family into `build/pr-triage/otel-ci-fix-<pr-number>/logs/`, writes `summary.json`, and restores the original branch.
-
 3. Read `build/pr-triage/otel-ci-fix-<pr-number>/summary.json` and the referenced log files. Treat them as the source of truth for what failed.
 4. Check out the PR branch again if the script restored you to another branch:
 

--- a/.github/skills/fix-ci/SKILL.md
+++ b/.github/skills/fix-ci/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fix-ci
+description: "Use when: fixing failing GitHub Actions CI, failed checks, test failures, Spotless, FOSSA, Gradle, or build failures on an opentelemetry-java-instrumentation PR branch. Downloads CI logs deterministically before debugging."
+argument-hint: "PR number, for example: 12345"
+---
+
+# Fix CI
+
+Use this skill to fix failing CI on an `opentelemetry-java-instrumentation` pull request branch.
+
+The first source of truth is always the deterministic CI bundle produced by [.github/scripts/pr-triage/fix_ci.py](../../scripts/pr-triage/fix_ci.py). Do not start by manually browsing GitHub Actions logs or guessing from check names. If the bundle is incomplete, improve or rerun the script before relying on ad hoc log collection.
+
+## Required Input
+
+- Pull request number.
+
+## Workflow
+
+1. Confirm the worktree is clean. If it is dirty, stop and ask the user how to handle the existing changes.
+2. Download the failing CI logs with the deterministic script:
+
+   ```bash
+   python .github/scripts/pr-triage/fix_ci.py <pr-number> --download-only
+   ```
+
+   The script checks out the PR, discovers failed non-aggregate checks, downloads one representative log for each failed job family into `build/pr-triage/otel-ci-fix-<pr-number>/logs/`, writes `summary.json`, and restores the original branch.
+3. Read `build/pr-triage/otel-ci-fix-<pr-number>/summary.json` and the referenced log files. Treat them as the source of truth for what failed.
+4. Check out the PR branch again if the script restored you to another branch:
+
+   ```bash
+   gh pr checkout <pr-number>
+   ```
+
+5. Diagnose the root cause from the downloaded logs and make the smallest appropriate fix on the PR branch.
+6. For deterministic generated-file or formatting failures, run the repository task instead of editing generated output by hand. Common examples:
+
+   ```bash
+   ./gradlew spotlessApply
+   ./gradlew generateFossaConfiguration
+   ```
+
+7. Validate with the narrowest command that covers the failure. For Gradle, follow repository rules: do not use `--rerun-tasks`, and do not pipe Gradle output through `tail`, `head`, or `grep`.
+8. Show the changed files, validation run, and the remaining status to the user. Commit or push only when the user has asked for that.
+
+## Boundaries
+
+- Do not switch away from the PR branch after edits unless cleanup requires restoring the user's original branch.
+- Do not invent a code change for flaky or infrastructure-only failures. Leave the tree clean and explain the evidence from the logs.
+- Do not broaden the fix to unrelated checks or unrelated files.
+- If CI failed because logs are unavailable, authentication is missing, or GitHub returned incomplete check metadata, report that blocker and the exact command that failed.
+
+## Optional Full Automation
+
+The same script also supports an all-in-one automation mode, which invokes Copilot CLI, commits, and pushes unless `--no-push` is supplied:
+
+```bash
+python .github/scripts/pr-triage/fix_ci.py <pr-number>
+```
+
+Prefer the `--download-only` workflow for this skill so the current VS Code agent reads the deterministic, retained bundle directly and keeps commit or push decisions explicit.

--- a/.github/skills/fix-ci/SKILL.md
+++ b/.github/skills/fix-ci/SKILL.md
@@ -17,13 +17,11 @@ The first source of truth is always the deterministic CI bundle produced by [.gi
 ## Workflow
 
 1. Confirm the worktree is clean. If it is dirty, stop and ask the user how to handle the existing changes.
-2. Download the failing CI logs with the deterministic script:
+2. Download the failing CI logs with the deterministic script, which checks out the PR, discovers failed non-aggregate checks, downloads one representative log for each failed job family into `build/pr-triage/otel-ci-fix-<pr-number>/logs/`, writes `summary.json`, and restores the original branch:
 
    ```bash
    python .github/scripts/pr-triage/fix_ci.py <pr-number> --download-only
    ```
-
-   The script checks out the PR, discovers failed non-aggregate checks, downloads one representative log for each failed job family into `build/pr-triage/otel-ci-fix-<pr-number>/logs/`, writes `summary.json`, and restores the original branch.
 
 3. Read `build/pr-triage/otel-ci-fix-<pr-number>/summary.json` and the referenced log files. Treat them as the source of truth for what failed.
 4. Check out the PR branch again if the script restored you to another branch:


### PR DESCRIPTION
Adds a workspace Copilot skill for fixing CI failures on PR branches. The skill starts by running the deterministic PR triage script in download-only mode so agents inspect a retained CI log bundle before debugging.