### PR TITLE
Expand Redisson batch test coverage

### DIFF
--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -258,11 +258,7 @@ public abstract class AbstractRedissonClientTest {
     scenario.commands.forEach(addCommand -> addCommand.accept(batch));
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
-    try {
-      invokeExecute(batch);
-    } catch (ReflectiveOperationException ignored) {
-      // an empty batch fails to execute
-    }
+    invokeExecute(batch);
 
     if (scenario.empty) {
       // an empty batch produces no span

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testL
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -22,7 +22,6 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
@@ -42,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -52,6 +52,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.BatchOptions;
 import org.redisson.api.RAtomicLong;
@@ -246,20 +249,34 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
 
-  @Test
-  void batchCommand() throws ReflectiveOperationException {
+  @ParameterizedTest
+  @MethodSource("batchScenarios")
+  void batchCommand(BatchScenario scenario) throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch2").setAsync("v2");
+    scenario.commands.forEach(addCommand -> addCommand.accept(batch));
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
+    try {
+      invokeExecute(batch);
+    } catch (ReflectiveOperationException e) {
+      // an empty batch fails to execute
+    }
+
+    if (scenario.empty) {
+      // an empty batch produces no span
+      assertThat(testing.spans()).isEmpty();
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE SET" : "DB Query")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? scenario.operationName
+                                : scenario.oldSpanName)
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
@@ -267,42 +284,53 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(NETWORK_PEER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(
-                                DB_OPERATION_NAME,
-                                emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.operationName
+                                    : scenario.oldOperation),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;SET batch2 ?"))));
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? scenario.batchSize : null),
+                            equalTo(maybeStable(DB_STATEMENT), scenario.queryText))));
+  }
+
+  private static Stream<Arguments> batchScenarios() {
+    return Stream.of(
+        // an empty batch fails to execute and produces no span
+        Arguments.argumentSet("empty", BatchScenario.builder().empty().build()),
+        Arguments.argumentSet(
+            "single",
+            BatchScenario.builder()
+                .addCommand(batch -> batch.getBucket("batch1").setAsync("v1"))
+                .operationName("SET")
+                .oldSpanName("SET")
+                .oldOperation("SET")
+                .queryText("SET batch1 ?")
+                .build()),
+        Arguments.argumentSet(
+            "twoSameOperation",
+            BatchScenario.builder()
+                .addCommand(batch -> batch.getBucket("batch1").setAsync("v1"))
+                .addCommand(batch -> batch.getBucket("batch2").setAsync("v2"))
+                .operationName("PIPELINE SET")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .queryText("SET batch1 ?;SET batch2 ?")
+                .build()),
+        Arguments.argumentSet(
+            "twoDifferentOperations",
+            BatchScenario.builder()
+                .addCommand(batch -> batch.getBucket("batch1").setAsync("v1"))
+                .addCommand(batch -> batch.getBucket("batch1").getAsync())
+                .operationName("PIPELINE")
+                .oldSpanName("DB Query")
+                .batchSize(2)
+                .queryText("SET batch1 ?;GET batch1")
+                .build()));
   }
 
   private static void invokeExecute(RBatch batch) throws ReflectiveOperationException {
     batch.getClass().getMethod("execute").invoke(batch);
-  }
-
-  @Test
-  void mixedBatchCommand() throws ReflectiveOperationException {
-    RBatch batch = createBatch(redisson);
-    assertThat(batch).isNotNull();
-    batch.getBucket("batch1").setAsync("v1");
-    batch.getBucket("batch1").getAsync();
-    // Adapt different method signature:
-    // `BatchResult<?> execute()` and `List<?> execute()`
-    invokeExecute(batch);
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(emitStableDatabaseSemconv() ? "PIPELINE" : "DB Query")
-                        .hasKind(CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(
-                                DB_OPERATION_NAME, emitStableDatabaseSemconv() ? "PIPELINE" : null),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null),
-                            equalTo(maybeStable(DB_STATEMENT), "SET batch1 ?;GET batch1"))));
   }
 
   @Test
@@ -606,5 +634,78 @@ public abstract class AbstractRedissonClientTest {
 
   protected RBatch createBatch(RedissonClient redisson) {
     return redisson.createBatch(BatchOptions.defaults());
+  }
+
+  private static final class BatchScenario {
+    final List<Consumer<RBatch>> commands;
+    final String operationName;
+    final String oldSpanName;
+    final Long batchSize;
+    final String oldOperation;
+    final String queryText;
+    final boolean empty;
+
+    BatchScenario(Builder builder) {
+      this.commands = builder.commands;
+      this.operationName = builder.operationName;
+      this.oldSpanName = builder.oldSpanName;
+      this.batchSize = builder.batchSize;
+      this.oldOperation = builder.oldOperation;
+      this.queryText = builder.queryText;
+      this.empty = builder.empty;
+    }
+
+    static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+      private final List<Consumer<RBatch>> commands = new ArrayList<>();
+      private String operationName;
+      private String oldSpanName;
+      private Long batchSize;
+      private String oldOperation;
+      private String queryText;
+      private boolean empty;
+
+      Builder addCommand(Consumer<RBatch> addCommand) {
+        this.commands.add(addCommand);
+        return this;
+      }
+
+      Builder operationName(String operationName) {
+        this.operationName = operationName;
+        return this;
+      }
+
+      Builder oldSpanName(String oldSpanName) {
+        this.oldSpanName = oldSpanName;
+        return this;
+      }
+
+      Builder batchSize(long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+      }
+
+      Builder oldOperation(String oldOperation) {
+        this.oldOperation = oldOperation;
+        return this;
+      }
+
+      Builder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+      }
+
+      Builder empty() {
+        this.empty = true;
+        return this;
+      }
+
+      BatchScenario build() {
+        return new BatchScenario(this);
+      }
+    }
   }
 }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -260,7 +260,7 @@ public abstract class AbstractRedissonClientTest {
     // `BatchResult<?> execute()` and `List<?> execute()`
     try {
       invokeExecute(batch);
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException ignored) {
       // an empty batch fails to execute
     }
 


### PR DESCRIPTION
Adds focused current-behavior test coverage for Redisson non-atomic `RBatch` telemetry.
