### PR TITLE
Add Rediscala transaction span aggregation

### DIFF
--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/OnCompleteHandler.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/OnCompleteHandler.java
@@ -9,15 +9,14 @@ import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.Rediscal
 
 import io.opentelemetry.context.Context;
 import javax.annotation.Nullable;
-import redis.RedisCommand;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
 class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void> {
   private final Context context;
-  private final RedisCommand<?, ?> request;
+  private final RediscalaRequest request;
 
-  OnCompleteHandler(Context context, RedisCommand<?, ?> request) {
+  OnCompleteHandler(Context context, RediscalaRequest request) {
     this.context = context;
     this.request = request;
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -7,32 +7,35 @@ package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
-import java.util.Locale;
 import javax.annotation.Nullable;
-import redis.RedisCommand;
 
-final class RediscalaAttributesGetter
-    implements DbClientAttributesGetter<RedisCommand<?, ?>, Void> {
+final class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
 
   @Override
-  public String getDbSystemName(RedisCommand<?, ?> redisCommand) {
+  public String getDbSystemName(RediscalaRequest request) {
     return DbSystemNameIncubatingValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String getDbNamespace(RedisCommand<?, ?> redisCommand) {
+  public String getDbNamespace(RediscalaRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String getDbQueryText(RedisCommand<?, ?> redisCommand) {
+  public String getDbQueryText(RediscalaRequest request) {
     return null;
   }
 
   @Override
-  public String getDbOperationName(RedisCommand<?, ?> redisCommand) {
-    return redisCommand.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+  public String getDbOperationName(RediscalaRequest request) {
+    return request.getOperationName();
+  }
+
+  @Override
+  @Nullable
+  public Long getDbOperationBatchSize(RediscalaRequest request) {
+    return request.getBatchSize();
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -21,6 +21,6 @@ public class RediscalaInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new RequestInstrumentation());
+    return asList(new RequestInstrumentation(), new TransactionInstrumentation());
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+import java.util.Locale;
+import javax.annotation.Nullable;
+import redis.Operation;
+import redis.RedisCommand;
+import scala.collection.Iterator;
+import scala.collection.immutable.Queue;
+
+class RediscalaRequest {
+  private final String operationName;
+  @Nullable private final Long batchSize;
+
+  static RediscalaRequest create(RedisCommand<?, ?> command) {
+    return new RediscalaRequest(operationName(command), null);
+  }
+
+  static RediscalaRequest createTransaction(Queue<Operation<?, ?>> operations) {
+    return new RediscalaRequest(transactionOperationName(operations), batchSize(operations));
+  }
+
+  private RediscalaRequest(String operationName, @Nullable Long batchSize) {
+    this.operationName = operationName;
+    this.batchSize = batchSize;
+  }
+
+  String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  Long getBatchSize() {
+    return batchSize;
+  }
+
+  private static String transactionOperationName(Queue<Operation<?, ?>> operations) {
+    if (operations.isEmpty()) {
+      return "MULTI";
+    }
+
+    Iterator<Operation<?, ?>> iterator = operations.iterator();
+    String operationName = operationName(iterator.next().redisCommand());
+    while (iterator.hasNext()) {
+      if (!operationName.equals(operationName(iterator.next().redisCommand()))) {
+        return "MULTI";
+      }
+    }
+    return "MULTI " + operationName;
+  }
+
+  @Nullable
+  private static Long batchSize(Queue<Operation<?, ?>> operations) {
+    int size = operations.size();
+    return size != 1 ? (long) size : null;
+  }
+
+  private static String operationName(RedisCommand<?, ?> command) {
+    return command.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -14,19 +14,18 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import redis.RedisCommand;
 
 public class RediscalaSingletons {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rediscala-1.8";
 
-  private static final Instrumenter<RedisCommand<?, ?>, Void> instrumenter;
+  private static final Instrumenter<RediscalaRequest, Void> instrumenter;
 
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();
 
-    InstrumenterBuilder<RedisCommand<?, ?>, Void> builder =
-        Instrumenter.<RedisCommand<?, ?>, Void>builder(
+    InstrumenterBuilder<RediscalaRequest, Void> builder =
+        Instrumenter.<RediscalaRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
@@ -37,7 +36,7 @@ public class RediscalaSingletons {
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
-  public static Instrumenter<RedisCommand<?, ?>, Void> instrumenter() {
+  public static Instrumenter<RediscalaRequest, Void> instrumenter() {
     return instrumenter;
   }
 

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
@@ -62,28 +62,33 @@ class RequestInstrumentation implements TypeInstrumentation {
     public static class AdviceScope {
       private final Context context;
       private final Scope scope;
+      private final RediscalaRequest request;
 
-      private AdviceScope(Context context, Scope scope) {
+      private AdviceScope(Context context, Scope scope, RediscalaRequest request) {
         this.context = context;
         this.scope = scope;
+        this.request = request;
       }
 
       @Nullable
-      public static AdviceScope start(RedisCommand<?, ?> cmd) {
-        Context parentContext = Context.current();
-        if (!instrumenter().shouldStart(parentContext, cmd)) {
+      public static AdviceScope start(Object action, RedisCommand<?, ?> cmd) {
+        if (action instanceof BufferedRequest) {
+          // TransactionInstrumentation records the span when exec() sends the batch.
           return null;
         }
 
-        Context context = instrumenter().start(parentContext, cmd);
-        return new AdviceScope(context, context.makeCurrent());
+        RediscalaRequest request = RediscalaRequest.create(cmd);
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(context, context.makeCurrent(), request);
       }
 
       public void end(
-          Object action,
-          RedisCommand<?, ?> cmd,
-          @Nullable Future<Object> responseFuture,
-          @Nullable Throwable throwable) {
+          Object action, @Nullable Future<Object> responseFuture, @Nullable Throwable throwable) {
         scope.close();
 
         ExecutionContext ctx = null;
@@ -98,17 +103,18 @@ class RequestInstrumentation implements TypeInstrumentation {
         }
 
         if (throwable != null || responseFuture == null) {
-          instrumenter().end(context, cmd, null, throwable);
+          instrumenter().end(context, request, null, throwable);
         } else {
-          responseFuture.onComplete(new OnCompleteHandler(context, cmd), ctx);
+          responseFuture.onComplete(new OnCompleteHandler(context, request), ctx);
         }
       }
     }
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static AdviceScope onEnter(@Advice.Argument(0) RedisCommand<?, ?> cmd) {
-      return AdviceScope.start(cmd);
+    public static AdviceScope onEnter(
+        @Advice.This Object action, @Advice.Argument(0) RedisCommand<?, ?> cmd) {
+      return AdviceScope.start(action, cmd);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -119,7 +125,7 @@ class RequestInstrumentation implements TypeInstrumentation {
         @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Return @Nullable Future<Object> responseFuture) {
       if (adviceScope != null) {
-        adviceScope.end(action, cmd, responseFuture, throwable);
+        adviceScope.end(action, responseFuture, throwable);
       }
     }
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import redis.Operation;
+import redis.commands.TransactionBuilder;
+import scala.collection.immutable.Queue;
+import scala.concurrent.Future;
+
+class TransactionInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("redis.commands.TransactionBuilder");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("exec").and(returns(named("scala.concurrent.Future"))),
+        getClass().getName() + "$ExecAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ExecAdvice {
+    public static class AdviceScope {
+      private final Context context;
+      private final Scope scope;
+      private final RediscalaRequest request;
+
+      private AdviceScope(Context context, Scope scope, RediscalaRequest request) {
+        this.context = context;
+        this.scope = scope;
+        this.request = request;
+      }
+
+      @Nullable
+      public static AdviceScope start(TransactionBuilder transactionBuilder) {
+        Queue<Operation<?, ?>> operations = transactionBuilder.operations().result();
+        RediscalaRequest request = RediscalaRequest.createTransaction(operations);
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(context, context.makeCurrent(), request);
+      }
+
+      public void end(
+          TransactionBuilder transactionBuilder,
+          @Nullable Future<Object> responseFuture,
+          @Nullable Throwable throwable) {
+        scope.close();
+        if (throwable != null || responseFuture == null) {
+          instrumenter().end(context, request, null, throwable);
+        } else {
+          responseFuture.onComplete(
+              new OnCompleteHandler(context, request), transactionBuilder.executionContext());
+        }
+      }
+    }
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static AdviceScope onEnter(@Advice.This TransactionBuilder transactionBuilder) {
+      return AdviceScope.start(transactionBuilder);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This TransactionBuilder transactionBuilder,
+        @Advice.Enter @Nullable AdviceScope adviceScope,
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Return @Nullable Future<Object> responseFuture) {
+      if (adviceScope != null) {
+        adviceScope.end(transactionBuilder, responseFuture, throwable);
+      }
+    }
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -6,12 +6,14 @@
 package rediscala
 
 import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv
 import io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.assertj.{SpanDataAssert, TraceAssert}
+import io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS
@@ -19,10 +21,15 @@ import io.opentelemetry.semconv.DbAttributes.{DB_OPERATION_NAME, DB_SYSTEM_NAME}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterAll, BeforeAll, Test, TestInstance}
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 import org.testcontainers.containers.GenericContainer
+import redis.commands.TransactionBuilder
 import redis.{RedisClient, RedisDispatcher}
 
+import java.lang.{Long => JLong}
 import java.util.function.Consumer
+import java.util.stream.Stream
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
@@ -195,4 +202,89 @@ class RediscalaClientTest {
         )
     })
   }
+
+  @ParameterizedTest
+  @MethodSource(Array("transactionScenarios"))
+  def testTransaction(scenario: BatchScenario): Unit = {
+    val result = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] = {
+          val transaction = redisClient.multi()
+          scenario.commands.foreach(_(transaction))
+          transaction.exec()
+        }
+      }
+    )
+
+    Await.result(result, Duration("3 second"))
+
+    testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+      override def accept(trace: TraceAssert): Unit =
+        trace.hasSpansSatisfyingExactly(
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span.hasName("parent").hasNoParent
+            }
+          },
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span
+                .hasName(scenario.operationName)
+                .hasKind(CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                  equalTo(maybeStable(DB_OPERATION), scenario.operationName),
+                  equalTo(
+                    DB_OPERATION_BATCH_SIZE,
+                    if (emitStableDatabaseSemconv()) scenario.batchSize
+                    else null
+                  )
+                )
+            }
+          }
+        )
+    })
+  }
+
+  private def transactionScenarios(): Stream[Arguments] =
+    Stream.of(
+      Arguments.argumentSet("empty", BatchScenario(operationName = "MULTI")),
+      Arguments.argumentSet(
+        "single",
+        BatchScenario(
+          commands = Seq(_.set("transaction-single", "value")),
+          operationName = "MULTI SET"
+        )
+      ),
+      Arguments.argumentSet(
+        "twoSameOperation",
+        BatchScenario(
+          commands = Seq(
+            _.set("transaction-same-1", "value"),
+            _.set("transaction-same-2", "value")
+          ),
+          operationName = "MULTI SET",
+          batchSize = 2L
+        )
+      ),
+      Arguments.argumentSet(
+        "twoDifferentOperations",
+        BatchScenario(
+          commands = Seq(
+            _.set("transaction-different", "value"),
+            _.get[String]("transaction-different")
+          ),
+          operationName = "MULTI",
+          batchSize = 2L
+        )
+      )
+    )
+
+  private case class BatchScenario(
+      commands: Seq[TransactionBuilder => Unit] = Seq.empty,
+      operationName: String = null,
+      batchSize: JLong = null
+  )
 }


### PR DESCRIPTION
Implements Rediscala transaction span aggregation as a module-scoped slice from the Redis batch work.

Summary:
- instrument transaction exec to emit one aggregate client span
- derive aggregate operation names for same-operation and mixed-operation transactions
- add multi/exec coverage in Rediscala tests

Validation:
- ./gradlew.bat --no-daemon :instrumentation:rediscala-1.8:javaagent:test :instrumentation:rediscala-1.8:javaagent:spotlessCheck