### PR TITLE
ci: upload metadata telemetry artifacts

### DIFF
--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -51,6 +51,15 @@ jobs:
           DEBUG_LOGGING: ${{ inputs.debug_logging || 'false' }}
         run: ./.github/scripts/metadata-ci-collect.sh
 
+      - name: Upload telemetry metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemetry-metadata
+          path: instrumentation/**/.telemetry/*.yaml
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: true
+
       - name: Run documentation analyzer
         run: ./gradlew :instrumentation-docs:runAnalysis
 


### PR DESCRIPTION
## Summary

Upload generated `.telemetry` YAML files from the metadata update workflow so future generated documentation diffs can be diagnosed from the exact telemetry inputs.

## Details

- Adds a pinned `actions/upload-artifact` step after metadata collection.
- Includes hidden `.telemetry` directories in the upload.
- Retains the artifact for 7 days.

## Validation

- Parsed `.github/workflows/metadata-update.yml` with Python YAML parser.