### PR TITLE
Merge attributes in generated telemetry

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.docs.parsers.TelemetryParser.norm
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import java.io.IOException;
@@ -17,8 +18,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -112,7 +115,18 @@ public class EmittedMetricsParser {
         Map<String, EmittedMetrics.Metric> metricMap = metricsByScopeName.get(scope);
 
         for (EmittedMetrics.Metric metric : scopeEntry.getMetrics()) {
-          metricMap.put(metric.getName(), metric); // deduplicate by name
+          EmittedMetrics.Metric existing = metricMap.get(metric.getName());
+          if (existing == null) {
+            metricMap.put(metric.getName(), metric);
+          } else {
+            // The same metric can be captured by multiple tests with differing attribute sets
+            // (e.g. jvm.thread.count is emitted by both the JMX and JFR code paths, only one of
+            // which carries jvm.thread.state). Union the attributes rather than letting the last
+            // file win, otherwise the generated docs depend on non-deterministic file iteration
+            // order.
+            existing.setAttributes(
+                mergeAttributes(existing.getAttributes(), metric.getAttributes()));
+          }
         }
       }
 
@@ -126,6 +140,23 @@ public class EmittedMetricsParser {
       result.put(when, new EmittedMetrics(when, mergedScopes));
     }
     return result;
+  }
+
+  /**
+   * Returns the union of two attribute lists, deduplicating by name and type. {@link
+   * TelemetryAttribute} defines equality on name and type, so a {@link LinkedHashSet} both
+   * deduplicates and preserves a stable insertion order.
+   */
+  private static List<TelemetryAttribute> mergeAttributes(
+      List<TelemetryAttribute> existing, List<TelemetryAttribute> additional) {
+    Set<TelemetryAttribute> merged = new LinkedHashSet<>();
+    if (existing != null) {
+      merged.addAll(existing);
+    }
+    if (additional != null) {
+      merged.addAll(additional);
+    }
+    return new ArrayList<>(merged);
   }
 
   /**

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -115,6 +116,70 @@ class EmittedMetricsParserTest {
       List<String> metricNames =
           metrics.getMetrics().stream().map(EmittedMetrics.Metric::getName).sorted().toList();
       assertThat(metricNames).containsExactly("metric1", "metric2");
+    }
+  }
+
+  @Test
+  void getMetricsFromFilesUnionsAttributesForSameMetric(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    String withState =
+        """
+    when: Java17
+    metrics_by_scope:
+      - scope: io.opentelemetry.runtime-telemetry
+        metrics:
+          - name: jvm.thread.count
+            type: LONG_SUM
+            attributes:
+              - name: jvm.thread.daemon
+                type: BOOLEAN
+              - name: jvm.thread.state
+                type: STRING
+    """;
+
+    String withoutState =
+        """
+    when: Java17
+    metrics_by_scope:
+      - scope: io.opentelemetry.runtime-telemetry
+        metrics:
+          - name: jvm.thread.count
+            type: LONG_SUM
+            attributes:
+              - name: jvm.thread.daemon
+                type: BOOLEAN
+    """;
+
+    Files.writeString(telemetryDir.resolve("metrics-1.yaml"), withState);
+    Files.writeString(telemetryDir.resolve("metrics-2.yaml"), withoutState);
+
+    try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
+      fileManagerMock
+          .when(
+              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml").toString()))
+          .thenReturn(withState);
+      fileManagerMock
+          .when(
+              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml").toString()))
+          .thenReturn(withoutState);
+
+      Map<String, EmittedMetrics> result =
+          EmittedMetricsParser.getMetricsFromFiles(tempDir.toString(), "");
+
+      EmittedMetrics.MetricsByScope metrics =
+          result.get("Java17").getMetricsByScope().stream()
+              .filter(scope -> scope.getScope().equals("io.opentelemetry.runtime-telemetry"))
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(metrics.getMetrics()).hasSize(1);
+      List<String> attributeNames =
+          metrics.getMetrics().get(0).getAttributes().stream()
+              .map(TelemetryAttribute::getName)
+              .sorted()
+              .toList();
+      assertThat(attributeNames).containsExactly("jvm.thread.daemon", "jvm.thread.state");
     }
   }
 


### PR DESCRIPTION
This should resolve https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19061/changes#r3450266426

Merges attributes for metrics of the same name instead of taking the last written

I ran it on my fork and it resulted no diff (the expected outcome instead of trying to remove the `jvm.thread.state` attribute:

https://github.com/jaydeluca/opentelemetry-java-instrumentation/actions/runs/28131879537/job/83309816234