### PR TITLE
Add structured property support for declarative config metadata

### DIFF
--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -9,12 +9,62 @@
 
 Each configuration entry includes:
 
-- `name`: Flat system property (e.g., `otel.instrumentation.grpc.emit-message-events`)
+- `name`: Flat system property (e.g., `otel.instrumentation.grpc.emit-message-events`). Optional
+  only for declarative-only configs that have no flat property (see Structured Lists); such entries
+  MUST have a `declarative_name`.
 - `declarative_name`: YAML key path (e.g., `java.grpc.emit_message_events`)
-- `type`: `boolean`, `string`, `list`, `integer`
+- `type`: `boolean`, `string`, `list`, `integer`, `map`. Describes the **flat** form.
 - `description`: Human-readable explanation
 - `default`: Default value
 - `examples` (optional): Only for module-specific configs with non-obvious format
+- `declarative_type` (optional): Overrides the declarative-form shape when it differs from the flat
+  `type`. Currently only `structured_list` (see Structured Lists).
+- `declarative_schema` (optional): Per-item object schema, required when
+  `declarative_type: structured_list` (see Structured Lists).
+
+## Structured Lists
+
+Some declarative configs are **lists of objects** even though their flat form is a scalar/map. The
+flat `type` describes the flat system property; `declarative_type: structured_list` plus a
+`declarative_schema` describe the per-item object shape for the declarative builder. The schema
+mirrors the JSON-schema style used by opentelemetry-configuration: `type: object`, a `required`
+list, and named `properties` (each with `type`, optional `description`, optional `default`). The
+`required` keys must be a subset of `properties`.
+
+`service_peer_mapping` — flat form is a `host=service` map, declarative form is a list of
+`{peer, service_name}`:
+
+```yaml
+- name: otel.instrumentation.common.peer-service-mapping
+  declarative_name: java.common.service_peer_mapping
+  description: Used to specify a mapping from host names or IP addresses to peer services.
+  type: map
+  default: ""
+  declarative_type: structured_list
+  declarative_schema:
+    type: object
+    required: [peer, service_name]
+    properties:
+      peer: { type: string, description: Host name or IP address to match against. }
+      service_name: { type: string, description: Peer service name to record for matching peers. }
+```
+
+`url_template_rules` is **declarative-only** (no flat property) — it omits `name`:
+
+```yaml
+- declarative_name: java.common.http.client.url_template_rules/development
+  description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
+  type: list
+  default: ""
+  declarative_type: structured_list
+  declarative_schema:
+    type: object
+    required: [pattern, template]
+    properties:
+      pattern: { type: string }
+      template: { type: string }
+      override: { type: boolean, default: false }
+```
 
 ## Special Mappings
 

--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -52,7 +52,7 @@ list, and named `properties` (each with `type`, optional `description`, optional
 `url_template_rules` is **declarative-only** (no flat property) — it omits `name`:
 
 ```yaml
-- declarative_name: java.common.http.client.url_template_rules/development
+- declarative_name: java.common.http.client.url_template_rules
   description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
   type: list
   default: ""

--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -13,7 +13,7 @@ Each configuration entry includes:
   only for declarative-only configs that have no flat property (see Structured Lists); such entries
   MUST have a `declarative_name`.
 - `declarative_name`: YAML key path (e.g., `java.grpc.emit_message_events`)
-- `type`: `boolean`, `string`, `list`, `integer`, `map`. Describes the **flat** form.
+- `type`: `boolean`, `string`, `list`, `int`, `map`. Describes the **flat** form.
 - `description`: Human-readable explanation
 - `default`: Default value
 - `examples` (optional): Only for module-specific configs with non-obvious format

--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -276,7 +276,7 @@ and is identified solely by its `declarative_name`, for example `url_template_ru
 
 ```yaml
 configurations:
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
     type: list
     default: ""

--- a/docs/contributing/documenting-instrumentation.md
+++ b/docs/contributing/documenting-instrumentation.md
@@ -223,13 +223,79 @@ If an instrumentation module has configuration options, they should be documente
 Each configuration should include:
 
 - `name`: The full configuration property name, for example `otel.instrumentation.common.db.query-sanitization.enabled`.
+  Optional only for declarative-only configs that have no flat property (see Structured Lists below);
+  such entries must instead provide a `declarative_name`.
+- `declarative_name` (optional): The declarative configuration YAML key path, for example
+  `java.common.db.query_sanitization.enabled`.
 - `description`: A brief description of what the configuration does.
-- `type`: The data type of the configuration value. Supported types are: `boolean`, `string`, `list`, and `map`.
+- `type`: The data type of the configuration value. Supported types are: `boolean`, `string`, `list`,
+  and `map`. This describes the **flat** (system property) form.
 - `default`: The default value for the configuration.
 
 If a configuration enables experimental attributes, list them, for example:
 
 > Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`.
+
+#### Structured Lists
+
+Some configurations are **lists of objects** in declarative configuration even though their flat
+system-property form is a scalar or map. For these, keep `type` describing the flat form and add:
+
+- `declarative_type`: set to `structured_list`.
+- `declarative_schema`: the per-item object schema, mirroring the JSON-schema style used by
+  [opentelemetry-configuration](https://github.com/open-telemetry/opentelemetry-configuration). It
+  consists of `type: object`, a `required` list, and named `properties` (each with `type`, an
+  optional `description`, and an optional `default`). The `required` keys must be a subset of
+  `properties`.
+
+For example, `service_peer_mapping` is a `host=service` map as a flat property but a list of
+`{peer, service_name}` objects in declarative configuration:
+
+```yaml
+configurations:
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer services.
+    type: map
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required: [peer, service_name]
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+```
+
+A configuration that exists only in declarative configuration (no flat system property) omits `name`
+and is identified solely by its `declarative_name`, for example `url_template_rules`:
+
+```yaml
+configurations:
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required: [pattern, template]
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
+```
 
 ### Classification (optional)
 

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -211,7 +211,7 @@ configurations:
       - "false"
   # Structured-list config: a list of objects in declarative config. `name` may be omitted for
   # declarative-only settings (identified solely by `declarative_name`).
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
     type: list
     default: ""

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -170,6 +170,8 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 - configuration settings
   - List of settings that are available for the instrumentation module
   - Each setting has a name (flat property format), optional declarative_name (YAML path format), description, type, default value, and optional examples
+  - `name` is optional for declarative-only settings that have no flat property (they must provide a `declarative_name`)
+  - Structured-list settings additionally carry `declarative_type: structured_list` and a `declarative_schema` describing the per-item object shape
 - metrics
   - List of metrics that the instrumentation module collects, including the metric name, description, type, and attributes.
   - Separate lists for the metrics emitted by default vs via configuration options.
@@ -202,11 +204,32 @@ configurations:
   - name: otel.instrumentation.common.db.query-sanitization.enabled
     declarative_name: java.common.db.query_sanitization.enabled    # Optional: YAML config path
     description: Enables query sanitization for database queries.
-    type: boolean               # boolean | string | list | map
+    type: boolean               # boolean | string | list | map (the flat form)
     default: true
     examples:                   # Optional: Example values for this configuration
       - "true"
       - "false"
+  # Structured-list config: a list of objects in declarative config. `name` may be omitted for
+  # declarative-only settings (identified solely by `declarative_name`).
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: Rules for deriving low-cardinality URL templates from HTTP client request URLs.
+    type: list
+    default: ""
+    declarative_type: structured_list      # Optional: overrides the declarative-form shape
+    declarative_schema:                     # Required when declarative_type is structured_list
+      type: object
+      required: [pattern, template]
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
 override_telemetry: false                         # Set to true to ignore auto-generated .telemetry files
 additional_telemetry:                             # Manually document telemetry metadata
   - when: "default"

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -16,26 +16,47 @@ import javax.annotation.Nullable;
  * hence not for public use. Its APIs are unstable and can change at any time.
  */
 public record ConfigurationOption(
-    String name,
+    @Nullable String name,
     @JsonProperty("declarative_name") @Nullable String declarativeName,
     String description,
     @JsonProperty("default") String defaultValue,
     ConfigurationType type,
-    @Nullable List<String> examples) {
+    @Nullable List<String> examples,
+    @JsonProperty("declarative_type") @Nullable ConfigurationType declarativeType,
+    @JsonProperty("declarative_schema") @Nullable DeclarativeSchema declarativeSchema) {
 
   public ConfigurationOption {
-    requireNonNull(name, "name");
     requireNonNull(description, "description");
     requireNonNull(defaultValue, "defaultValue");
     requireNonNull(type, "type");
 
-    if (name.isBlank() || description.isBlank()) {
+    // Most configs are backed by a flat system property (name). Declarative-only configs (such as
+    // the url_template_rules structured list) have no flat property and rely on declarative_name.
+    if (name == null && declarativeName == null) {
+      throw new IllegalArgumentException(
+          "ConfigurationOption must have a name or a declarative_name");
+    }
+    if ((name != null && name.isBlank()) || description.isBlank()) {
       throw new IllegalArgumentException("ConfigurationOption name/description cannot be blank");
+    }
+
+    if (declarativeType == ConfigurationType.STRUCTURED_LIST) {
+      if (declarativeSchema == null
+          || declarativeSchema.properties() == null
+          || declarativeSchema.properties().isEmpty()) {
+        throw new IllegalArgumentException(
+            "structured_list configuration must define a declarative_schema with properties");
+      }
+      if (declarativeSchema.required() != null
+          && !declarativeSchema.properties().keySet().containsAll(declarativeSchema.required())) {
+        throw new IllegalArgumentException(
+            "declarative_schema required keys must be a subset of its properties");
+      }
     }
   }
 
   public ConfigurationOption(
       String name, String description, String defaultValue, ConfigurationType type) {
-    this(name, null, description, defaultValue, type, null);
+    this(name, null, description, defaultValue, type, null, null, null);
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/DeclarativeSchema.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/DeclarativeSchema.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.internal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Describes the per-item object schema of a {@code structured_list} declarative configuration. The
+ * shape mirrors the JSON-schema style used by opentelemetry-configuration (and consumed by the
+ * ecosystem explorer): an {@code object} with named {@code properties} and a list of {@code
+ * required} keys.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public record DeclarativeSchema(
+    String type, @Nullable List<String> required, Map<String, Property> properties) {
+
+  /**
+   * A single property within a {@link DeclarativeSchema}. This class is internal and is hence not
+   * for public use. Its APIs are unstable and can change at any time.
+   */
+  public record Property(
+      String type,
+      @Nullable String description,
+      @JsonProperty("default") @Nullable Object defaultValue) {}
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
+import io.opentelemetry.instrumentation.docs.internal.DeclarativeSchema;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedScope;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
@@ -252,7 +253,10 @@ public class YamlHelper {
 
   private static Map<String, Object> configurationToMap(ConfigurationOption configuration) {
     Map<String, Object> conf = new LinkedHashMap<>();
-    conf.put("name", configuration.name());
+    // Declarative-only configs (e.g. url_template_rules) have no flat system property name.
+    if (configuration.name() != null) {
+      conf.put("name", configuration.name());
+    }
     if (configuration.declarativeName() != null) {
       conf.put("declarative_name", configuration.declarativeName());
     }
@@ -268,7 +272,38 @@ public class YamlHelper {
     if (configuration.examples() != null && !configuration.examples().isEmpty()) {
       conf.put("examples", configuration.examples());
     }
+    if (configuration.declarativeType() != null) {
+      conf.put("declarative_type", configuration.declarativeType().toString());
+    }
+    if (configuration.declarativeSchema() != null) {
+      conf.put("declarative_schema", declarativeSchemaToMap(configuration.declarativeSchema()));
+    }
     return conf;
+  }
+
+  private static Map<String, Object> declarativeSchemaToMap(DeclarativeSchema schema) {
+    Map<String, Object> schemaMap = new LinkedHashMap<>();
+    schemaMap.put("type", schema.type());
+    if (schema.required() != null && !schema.required().isEmpty()) {
+      schemaMap.put("required", schema.required());
+    }
+    Map<String, Object> properties = new LinkedHashMap<>();
+    schema
+        .properties()
+        .forEach(
+            (key, property) -> {
+              Map<String, Object> propertyMap = new LinkedHashMap<>();
+              propertyMap.put("type", property.type());
+              if (property.description() != null) {
+                propertyMap.put("description", property.description());
+              }
+              if (property.defaultValue() != null) {
+                propertyMap.put("default", property.defaultValue());
+              }
+              properties.put(key, propertyMap);
+            });
+    schemaMap.put("properties", properties);
+    return schemaMap;
   }
 
   private static List<Map<String, Object>> getSortedAttributeMaps(

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedDeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
+import io.opentelemetry.instrumentation.docs.internal.DeclarativeSchema;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
@@ -55,7 +56,16 @@ class DeclarativeConfigValidationTest {
           InstrumentationMetadata metadata = YamlHelper.metaDataParser(content);
 
           for (ConfigurationOption config : metadata.getConfigurations()) {
-            if (config.declarativeName() != null && !config.declarativeName().isBlank()) {
+            // Structured-list schemas are validated structurally, even for declarative-only configs
+            // (those without a flat property name, such as url_template_rules).
+            validateStructuredListSchema(metadataFile, config, errors);
+
+            // The flat -> declarative round-trip needs a flat system property to drive the bridge.
+            // Declarative-only configs (no name) are skipped here.
+            if (config.name() != null
+                && !config.name().isBlank()
+                && config.declarativeName() != null
+                && !config.declarativeName().isBlank()) {
               ValidationResult result = validateConfig(metadataFile, config);
               results.add(result);
               if (!result.valid) {
@@ -93,8 +103,15 @@ class DeclarativeConfigValidationTest {
     String declarativePath = config.declarativeName();
     ConfigurationType type = config.type();
 
+    // The declarative form is a structured list when either the flat type is structured_list
+    // (legacy) or the dedicated declarative_type marks it as such. service_peer_mapping uses
+    // type: map (the flat host=service form) + declarative_type: structured_list.
+    boolean structuredList =
+        type == ConfigurationType.STRUCTURED_LIST
+            || config.declarativeType() == ConfigurationType.STRUCTURED_LIST;
+
     // Create test value appropriate for the type
-    TestValue testValue = createTestValue(type);
+    TestValue testValue = structuredList ? structuredListTestValue() : createTestValue(type);
 
     Map<String, String> properties = new HashMap<>();
     properties.put(flatProperty, testValue.propertyValue);
@@ -104,7 +121,8 @@ class DeclarativeConfigValidationTest {
         ConfigPropertiesBackedDeclarativeConfigProperties.createInstrumentationConfig(
             configProperties);
 
-    Object retrievedValue = navigateAndGetValue(declarativeConfig, declarativePath, type);
+    Object retrievedValue =
+        navigateAndGetValue(declarativeConfig, declarativePath, type, structuredList);
 
     boolean valid = Objects.equals(testValue.expectedValue, retrievedValue);
 
@@ -124,15 +142,19 @@ class DeclarativeConfigValidationTest {
       case STRING -> new TestValue("test-validation-value", "test-validation-value");
       case INT -> new TestValue("42", 42);
       case LIST -> new TestValue("item1,item2,item3", List.of("item1", "item2", "item3"));
-      case MAP -> new TestValue("key1=value1,key2=value2", "key1=value1,key2=value2");
-      // The only structured_list config is the common peer-service-mapping. Its flat form is a
-      // host=service map, which the bridge turns into a list of {peer, service_name} entries.
-      // readPeerServiceMappingAsMap below rebuilds the host->service map from those entries, so the
-      // comparison exercises getStructuredList (what the consumer uses) rather than a string
-      // lookup.
-      case STRUCTURED_LIST ->
-          new TestValue("host1=svc1,host2=svc2", Map.of("host1", "svc1", "host2", "svc2"));
+      case MAP, STRUCTURED_LIST ->
+          new TestValue("key1=value1,key2=value2", "key1=value1,key2=value2");
     };
+  }
+
+  // The only structured_list config with a flat property is the common peer-service-mapping. Its
+  // flat form is a host=service map, which the bridge turns into a list of {peer, service_name}
+  // entries. readPeerServiceMappingAsMap below rebuilds the host->service map from those entries,
+  // so
+  // the comparison exercises getStructuredList (what the consumer uses) rather than a string
+  // lookup.
+  private static TestValue structuredListTestValue() {
+    return new TestValue("host1=svc1,host2=svc2", Map.of("host1", "svc1", "host2", "svc2"));
   }
 
   private record TestValue(String propertyValue, Object expectedValue) {}
@@ -144,7 +166,10 @@ class DeclarativeConfigValidationTest {
    * "java.logback_appender.capture_code_attributes/development".
    */
   private static Object navigateAndGetValue(
-      DeclarativeConfigProperties config, String path, ConfigurationType type) {
+      DeclarativeConfigProperties config,
+      String path,
+      ConfigurationType type,
+      boolean structuredList) {
     String[] segments = path.split("\\.");
 
     DeclarativeConfigProperties current = config;
@@ -158,13 +183,15 @@ class DeclarativeConfigValidationTest {
     }
 
     String lastSegment = segments[segments.length - 1];
+    if (structuredList) {
+      return readPeerServiceMappingAsMap(current, lastSegment);
+    }
     return switch (type) {
       case BOOLEAN -> current.getBoolean(lastSegment);
       case STRING -> current.getString(lastSegment);
       case INT -> current.getInt(lastSegment);
       case LIST -> current.getScalarList(lastSegment, String.class);
-      case MAP -> current.getString(lastSegment);
-      case STRUCTURED_LIST -> readPeerServiceMappingAsMap(current, lastSegment);
+      case MAP, STRUCTURED_LIST -> current.getString(lastSegment);
     };
   }
 
@@ -186,6 +213,34 @@ class DeclarativeConfigValidationTest {
       mapping.put(entry.getString("peer"), entry.getString("service_name"));
     }
     return mapping;
+  }
+
+  /**
+   * Validates the structure of a {@code declarative_schema} on a {@code structured_list} config.
+   * Applies to every structured-list config, including declarative-only ones (no flat property)
+   * such as {@code url_template_rules}, which the round-trip check above cannot exercise.
+   */
+  private static void validateStructuredListSchema(
+      Path metadataFile, ConfigurationOption config, List<String> errors) {
+    if (config.declarativeType() != ConfigurationType.STRUCTURED_LIST) {
+      return;
+    }
+    String label = metadataFile + " (" + config.declarativeName() + ")";
+    DeclarativeSchema schema = config.declarativeSchema();
+    if (schema == null) {
+      errors.add(label + ": structured_list config is missing a declarative_schema");
+      return;
+    }
+    if (!"object".equals(schema.type())) {
+      errors.add(label + ": declarative_schema type must be 'object'");
+    }
+    if (schema.properties() == null || schema.properties().isEmpty()) {
+      errors.add(label + ": declarative_schema must define at least one property");
+      return;
+    }
+    if (schema.required() != null && !schema.properties().keySet().containsAll(schema.required())) {
+      errors.add(label + ": declarative_schema required keys must be a subset of its properties");
+    }
   }
 
   private record ValidationResult(

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -32,8 +32,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -42,6 +55,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -55,7 +55,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/apache-dubbo-2.7/metadata.yaml
+++ b/instrumentation/apache-dubbo-2.7/metadata.yaml
@@ -12,5 +12,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -31,8 +31,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -41,6 +54,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -54,7 +54,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/http-url-connection/metadata.yaml
+++ b/instrumentation/http-url-connection/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/http-url-connection/metadata.yaml
+++ b/instrumentation/http-url-connection/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/java-http-client/metadata.yaml
+++ b/instrumentation/java-http-client/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/java-http-client/metadata.yaml
+++ b/instrumentation/java-http-client/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/java-http-server/metadata.yaml
+++ b/instrumentation/java-http-server/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.server.emit-experimental-telemetry
     declarative_name: java.common.http.server.emit_experimental_telemetry/development
     description: >

--- a/instrumentation/jdbc/metadata.yaml
+++ b/instrumentation/jdbc/metadata.yaml
@@ -38,8 +38,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.jdbc.experimental.capture-query-parameters
     declarative_name: java.jdbc.capture_query_parameters/development
     description: >

--- a/instrumentation/jedis/jedis-1.4/metadata.yaml
+++ b/instrumentation/jedis/jedis-1.4/metadata.yaml
@@ -13,5 +13,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/jedis/jedis-3.0/metadata.yaml
+++ b/instrumentation/jedis/jedis-3.0/metadata.yaml
@@ -13,5 +13,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/jodd-http-4.2/metadata.yaml
+++ b/instrumentation/jodd-http-4.2/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/jodd-http-4.2/metadata.yaml
+++ b/instrumentation/jodd-http-4.2/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/ktor/ktor-2.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-2.0/metadata.yaml
@@ -72,7 +72,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/ktor/ktor-2.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-2.0/metadata.yaml
@@ -49,8 +49,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -59,6 +72,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/ktor/ktor-3.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-3.0/metadata.yaml
@@ -72,7 +72,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/ktor/ktor-3.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-3.0/metadata.yaml
@@ -49,8 +49,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -59,6 +72,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/kubernetes-client-7.0/metadata.yaml
+++ b/instrumentation/kubernetes-client-7.0/metadata.yaml
@@ -32,8 +32,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -42,6 +55,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/kubernetes-client-7.0/metadata.yaml
+++ b/instrumentation/kubernetes-client-7.0/metadata.yaml
@@ -55,7 +55,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/lettuce/lettuce-4.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-4.0/metadata.yaml
@@ -20,5 +20,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/lettuce/lettuce-5.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-5.0/metadata.yaml
@@ -27,5 +27,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/netty/netty-3.8/metadata.yaml
+++ b/instrumentation/netty/netty-3.8/metadata.yaml
@@ -29,8 +29,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -39,6 +52,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/netty/netty-3.8/metadata.yaml
+++ b/instrumentation/netty/netty-3.8/metadata.yaml
@@ -52,7 +52,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/netty/netty-4.0/metadata.yaml
+++ b/instrumentation/netty/netty-4.0/metadata.yaml
@@ -29,8 +29,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -39,6 +52,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/netty/netty-4.0/metadata.yaml
+++ b/instrumentation/netty/netty-4.0/metadata.yaml
@@ -52,7 +52,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/netty/netty-4.1/metadata.yaml
+++ b/instrumentation/netty/netty-4.1/metadata.yaml
@@ -29,8 +29,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -39,6 +52,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/netty/netty-4.1/metadata.yaml
+++ b/instrumentation/netty/netty-4.1/metadata.yaml
@@ -52,7 +52,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/okhttp/okhttp-2.2/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-2.2/metadata.yaml
@@ -24,8 +24,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -34,6 +47,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/okhttp/okhttp-2.2/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-2.2/metadata.yaml
@@ -47,7 +47,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/okhttp/okhttp-3.0/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-3.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/okhttp/okhttp-3.0/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-3.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/pekko/pekko-http-1.0/metadata.yaml
+++ b/instrumentation/pekko/pekko-http-1.0/metadata.yaml
@@ -32,8 +32,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -42,6 +55,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.http.server.capture-request-headers
     declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.

--- a/instrumentation/pekko/pekko-http-1.0/metadata.yaml
+++ b/instrumentation/pekko/pekko-http-1.0/metadata.yaml
@@ -55,7 +55,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/r2dbc-1.0/metadata.yaml
+++ b/instrumentation/r2dbc-1.0/metadata.yaml
@@ -31,5 +31,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/ratpack/ratpack-1.7/metadata.yaml
+++ b/instrumentation/ratpack/ratpack-1.7/metadata.yaml
@@ -56,8 +56,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -66,6 +79,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/ratpack/ratpack-1.7/metadata.yaml
+++ b/instrumentation/ratpack/ratpack-1.7/metadata.yaml
@@ -79,7 +79,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.reactor-netty.connection-telemetry.enabled
     declarative_name: java.reactor_netty.connection_telemetry.enabled
     description: Enables the creation of Connect and DNS spans.

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/sofa-rpc-5.4/metadata.yaml
+++ b/instrumentation/sofa-rpc-5.4/metadata.yaml
@@ -12,5 +12,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.

--- a/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
@@ -13,3 +13,26 @@ configurations:
       as the span name.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.

--- a/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
@@ -13,7 +13,7 @@ configurations:
       as the span name.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
@@ -27,8 +27,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -37,6 +50,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
@@ -50,7 +50,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
@@ -25,8 +25,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -35,6 +48,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
@@ -48,7 +48,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
@@ -49,7 +49,7 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
-  - declarative_name: java.common.http.client.url_template_rules/development
+  - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
       applied when experimental HTTP client telemetry is enabled.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
@@ -26,8 +26,21 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
@@ -36,6 +49,29 @@ configurations:
       `http.client.response.size` metrics.
     type: boolean
     default: false
+  - declarative_name: java.common.http.client.url_template_rules/development
+    description: >
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
+      applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - pattern
+        - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          default: false
+          description: Whether this rule overrides an already-applied template.
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.

--- a/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
@@ -15,5 +15,18 @@ configurations:
   - name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
+    type: map
     default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.


### PR DESCRIPTION
Related to #18883 and a followup from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18883#discussion_r3346602487

Part of #15728

This adds a way for us to define structured schemas for individual configs that are more complex than a primitive type. I also populated the url_template config for any instrumentations that already were using `emit-experimental-telemetry` since `url_template_rules` only ever takes effect when `emit-experimental-telemetry` is on

We have implemented this structured list approach directly into the ecosystem explorer as a shim when we ingest the data, and it has been working well for us [there](https://explorer.opentelemetry.io/java-agent/configuration/builder):

<img width="1029" height="336" alt="image" src="https://github.com/user-attachments/assets/7d11cdcc-e40b-4f35-aacc-84cabed743e1" />


Right now we are duplicating the config metadata in each metadata.yaml file, but I am planning on doing a followup where I introduce a way to reference common configs instead of duplicating

Tested on fork, instrumentation-list.yaml results can be seen [here](https://github.com/jaydeluca/opentelemetry-java-instrumentation/pull/30/changes#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1)