### PR TITLE
Fix ambiguous IPv6 address in db.connection_string for MySQL/MariaDB

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -127,7 +127,13 @@ public final class UrlParsingUtils {
     }
     if (host != null) {
       url.append("//");
-      url.append(host);
+      if (host.contains(":") && !host.startsWith("[")) {
+        url.append('[');
+        url.append(host);
+        url.append(']');
+      } else {
+        url.append(host);
+      }
       if (port != null) {
         url.append(':');
         url.append(port);

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -194,7 +194,7 @@ class JdbcConnectionUrlParserTest {
             .setPort(3306)
             .build(),
         arg("jdbc:mysql:failover://[::1]:3306") // IPv6 without slash
-            .setShortUrl("mysql:failover://::1:3306")
+            .setShortUrl("mysql:failover://[::1]:3306")
             .setSystem(MYSQL)
             .setSubtype("failover")
             .setHost("::1")
@@ -419,7 +419,7 @@ class JdbcConnectionUrlParserTest {
             .setName("mdbdb")
             .build(),
         arg("jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb")
-            .setShortUrl("mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33")
+            .setShortUrl("mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33")
             .setSystem(MARIADB)
             .setSubtype("loadbalance")
             .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
@@ -449,7 +449,7 @@ class JdbcConnectionUrlParserTest {
             .setPort(3306)
             .build(),
         arg("jdbc:mariadb:failover://[::1]:3306") // IPv6 without slash
-            .setShortUrl("mariadb:failover://::1:3306")
+            .setShortUrl("mariadb:failover://[::1]:3306")
             .setSystem(MARIADB)
             .setSubtype("failover")
             .setHost("::1")


### PR DESCRIPTION
Fixes #1421

## Problem

When a JDBC URL contains a bracketed IPv6 host — for example:

```
jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb
```

the `db.connection_string` attribute was produced without brackets around the address:

```
mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33
```

This makes it impossible to tell where the IPv6 address ends and the port begins — which is explicitly disallowed by [RFC 5952 §6.6](https://tools.ietf.org/html/rfc5952#page-11) and [RFC 3986 §3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2). Both RFCs require IPv6 literals inside URL authority components to be enclosed in square brackets.

The same problem affected the compressed form (`::1`) used in MySQL/MariaDB failover URLs:

```
mysql:failover://::1:3306     ← ambiguous
mariadb:failover://::1:3306   ← ambiguous
```

## Fix

The root cause is in `UrlParsingUtils.buildShortUrl`. The MySQL/MariaDB parser strips brackets when storing the host (keeping just the raw IPv6 literal), but `buildShortUrl` appended it verbatim without re-adding brackets.

The fix adds a check: if the host string contains a colon and does not already start with `[`, it is wrapped in square brackets before being appended to the URL:

```java
if (host.contains(":") && !host.startsWith("[")) {
    url.append('[');
    url.append(host);
    url.append(']');
} else {
    url.append(host);
}
```

Hosts that already carry brackets (e.g. SQL Server, which routes through `extractHostPort` and preserves them) are left untouched.

## After the fix

| Input URL | Before | After |
|-----------|--------|-------|
| `jdbc:mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host/mdbdb` | `mariadb:loadbalance://2001:0660:7401:0200:0000:0000:0edf:bdd7:33` | `mariadb:loadbalance://[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33` |
| `jdbc:mysql:failover://[::1]:3306` | `mysql:failover://::1:3306` | `mysql:failover://[::1]:3306` |
| `jdbc:mariadb:failover://[::1]:3306` | `mariadb:failover://::1:3306` | `mariadb:failover://[::1]:3306` |

## Changes

- `UrlParsingUtils.java` — wrap bare IPv6 literals in brackets inside `buildShortUrl`
- `JdbcConnectionUrlParserTest.java` — update three test expectations to match the corrected (RFC-compliant) output