### PR TITLE
Add JFR metrics for virtual thread pinning and submit failures

### DIFF
--- a/instrumentation/runtime-telemetry/library/README.md
+++ b/instrumentation/runtime-telemetry/library/README.md
@@ -149,6 +149,13 @@ These metrics are collected via JMX on all Java versions:
 | `jvm.network.io`         | Network I/O bytes      |
 | `jvm.network.time`       | Network I/O time       |
 
+#### JFR-based (Java 19+ only)
+
+| Metric                             | Description                                                        |
+| ---------------------------------- | ------------------------------------------------------------------ |
+| `jvm.thread.virtual.pinned`        | Duration of virtual thread pinning (histogram, seconds)            |
+| `jvm.thread.virtual.submit_failed` | Number of times a virtual thread failed to submit to its scheduler |
+
 #### JFR-based (Overlap with JMX)
 
 When `experimental.prefer-jfr=true`, the following metrics are sourced from JFR instead of JMX

--- a/instrumentation/runtime-telemetry/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry/library/build.gradle.kts
@@ -18,6 +18,11 @@ sourceSets {
       setSrcDirs(listOf("src/testJava17/java"))
     }
   }
+  create("testJava21") {
+    java {
+      setSrcDirs(listOf("src/testJava21/java"))
+    }
+  }
 }
 
 for (version in mrJarVersions) {
@@ -60,12 +65,23 @@ configurations {
   named("testJava17RuntimeOnly") {
     extendsFrom(configurations["testRuntimeOnly"])
   }
+  named("testJava21Implementation") {
+    extendsFrom(configurations["testImplementation"])
+  }
+  named("testJava21RuntimeOnly") {
+    extendsFrom(configurations["testRuntimeOnly"])
+  }
 }
 
 dependencies {
   add("testJava17Implementation", sourceSets.test.get().output)
   add("testJava17Implementation", sourceSets["java17"].output)
   add("testJava17Implementation", sourceSets.main.get().output)
+
+  add("testJava21Implementation", sourceSets.test.get().output)
+  add("testJava21Implementation", sourceSets["java17"].output)
+  add("testJava21Implementation", sourceSets["testJava17"].output)
+  add("testJava21Implementation", sourceSets.main.get().output)
 }
 
 tasks {
@@ -79,6 +95,14 @@ tasks {
     sourceCompatibility = "17"
     targetCompatibility = "17"
     options.release.set(17)
+  }
+
+  // Configure testJava21 compilation for Java 21
+  named<JavaCompile>("compileTestJava21Java") {
+    dependsOn("compileJava17Java", "compileTestJava17Java")
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
   }
 
   withType(Jar::class) {
@@ -154,6 +178,14 @@ tasks {
     // Java 8 tests only
   }
 
+  // Run Java 21+ tests (virtual threads)
+  val testJava21 = register<Test>("testJava21") {
+    dependsOn("compileTestJava21Java")
+    testClassesDirs = sourceSets["testJava21"].output.classesDirs
+    classpath = sourceSets["testJava21"].runtimeClasspath
+    systemProperty("metadataConfig", "Java21")
+  }
+
   val testJavaVersion = otelProps.testJavaVersion ?: JavaVersion.current()
   if (!testJavaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
     named("testG1", Test::class).configure {
@@ -169,8 +201,13 @@ tasks {
       enabled = false
     }
   }
+  if (!testJavaVersion.isCompatibleWith(JavaVersion.VERSION_21)) {
+    named("testJava21", Test::class).configure {
+      enabled = false
+    }
+  }
 
   check {
-    dependsOn(testJava17, testG1, testPS, testSerial)
+    dependsOn(testJava17, testJava21, testG1, testPS, testSerial)
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/HandlerRegistry.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/HandlerRegistry.java
@@ -24,6 +24,8 @@ import io.opentelemetry.instrumentation.runtimetelemetry.internal.memory.Paralle
 import io.opentelemetry.instrumentation.runtimetelemetry.internal.network.NetworkReadHandler;
 import io.opentelemetry.instrumentation.runtimetelemetry.internal.network.NetworkWriteHandler;
 import io.opentelemetry.instrumentation.runtimetelemetry.internal.threads.ThreadCountHandler;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.threads.VirtualThreadPinnedHandler;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.threads.VirtualThreadSubmitFailedHandler;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -72,6 +74,8 @@ final class HandlerRegistry {
             new ContainerConfigurationHandler(meter, useLegacyCpuCountMetric),
             new LongLockHandler(meter),
             new ThreadCountHandler(meter),
+            new VirtualThreadPinnedHandler(meter),
+            new VirtualThreadSubmitFailedHandler(meter),
             new ClassesLoadedHandler(meter),
             new MetaspaceSummaryHandler(meter),
             new CodeCacheConfigurationHandler(meter),

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/JfrFeature.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/JfrFeature.java
@@ -27,6 +27,7 @@ public enum JfrFeature {
   MEMORY_POOL_METRICS(/* overlapsWithJmx= */ true, /* experimental= */ false),
   NETWORK_IO_METRICS(/* overlapsWithJmx= */ false, /* experimental= */ true),
   THREAD_METRICS(/* overlapsWithJmx= */ true, /* experimental= */ false),
+  VIRTUAL_THREAD_METRICS(/* overlapsWithJmx= */ false, /* experimental= */ true),
   ;
 
   private final boolean overlapsWithJmx;

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadPinnedHandler.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadPinnedHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimetelemetry.internal.threads;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Constants;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.DurationUtil;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.JfrFeature;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class VirtualThreadPinnedHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "jvm.thread.virtual.pinned";
+  private static final String METRIC_DESCRIPTION = "Duration of virtual thread pinning";
+  private static final String EVENT_NAME = "jdk.VirtualThreadPinned";
+
+  private final DoubleHistogram histogram;
+  private final Attributes attributes;
+
+  public VirtualThreadPinnedHandler(Meter meter) {
+    histogram =
+        meter
+            .histogramBuilder(METRIC_NAME)
+            .setDescription(METRIC_DESCRIPTION)
+            .setUnit(Constants.SECONDS)
+            .build();
+
+    attributes = Attributes.empty();
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public JfrFeature getFeature() {
+    return JfrFeature.VIRTUAL_THREAD_METRICS;
+  }
+
+  @Override
+  public void accept(RecordedEvent recordedEvent) {
+    histogram.record(DurationUtil.toSeconds(recordedEvent.getDuration()), attributes);
+  }
+
+  @Override
+  public Optional<Duration> getThreshold() {
+    return Optional.empty();
+  }
+}

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadPinnedHandler.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadPinnedHandler.java
@@ -22,7 +22,7 @@ import jdk.jfr.consumer.RecordedEvent;
  */
 public final class VirtualThreadPinnedHandler implements RecordedEventHandler {
   private static final String METRIC_NAME = "jvm.thread.virtual.pinned";
-  private static final String METRIC_DESCRIPTION = "Duration of virtual thread pinning";
+  private static final String METRIC_DESCRIPTION = "Duration of virtual thread pinning.";
   private static final String EVENT_NAME = "jdk.VirtualThreadPinned";
 
   private final DoubleHistogram histogram;

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadSubmitFailedHandler.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadSubmitFailedHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimetelemetry.internal.threads;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.JfrFeature;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class VirtualThreadSubmitFailedHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "jvm.thread.virtual.submit_failed";
+  private static final String METRIC_DESCRIPTION =
+      "Number of times a virtual thread failed to be submitted to its scheduler";
+  private static final String EVENT_NAME = "jdk.VirtualThreadSubmitFailed";
+
+  private final LongCounter counter;
+  private final Attributes attributes;
+
+  public VirtualThreadSubmitFailedHandler(Meter meter) {
+    counter = meter.counterBuilder(METRIC_NAME).setDescription(METRIC_DESCRIPTION).build();
+
+    attributes = Attributes.empty();
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public JfrFeature getFeature() {
+    return JfrFeature.VIRTUAL_THREAD_METRICS;
+  }
+
+  @Override
+  public void accept(RecordedEvent recordedEvent) {
+    counter.add(1, attributes);
+  }
+
+  @Override
+  public Optional<Duration> getThreshold() {
+    return Optional.empty();
+  }
+}

--- a/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadSubmitFailedHandler.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java17/io/opentelemetry/instrumentation/runtimetelemetry/internal/threads/VirtualThreadSubmitFailedHandler.java
@@ -21,7 +21,7 @@ import jdk.jfr.consumer.RecordedEvent;
 public final class VirtualThreadSubmitFailedHandler implements RecordedEventHandler {
   private static final String METRIC_NAME = "jvm.thread.virtual.submit_failed";
   private static final String METRIC_DESCRIPTION =
-      "Number of times a virtual thread failed to be submitted to its scheduler";
+      "Number of times a virtual thread failed to be submitted to its scheduler.";
   private static final String EVENT_NAME = "jdk.VirtualThreadSubmitFailed";
 
   private final LongCounter counter;

--- a/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
+++ b/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimetelemetry;
+
+import static io.opentelemetry.instrumentation.runtimetelemetry.internal.Constants.SECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.JfrFeature;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class JfrVirtualThreadPinnedTest {
+
+  @RegisterExtension
+  JfrExtension jfrExtension =
+      new JfrExtension(
+          jfrConfig -> {
+            jfrConfig.disableAllFeatures();
+            jfrConfig.enableFeature(JfrFeature.VIRTUAL_THREAD_METRICS);
+          });
+
+  @Test
+  void shouldHaveVirtualThreadPinnedEvents() throws InterruptedException {
+    // Thread.ofVirtual() is GA in Java 21; synchronized pinning was removed in Java 24 (JEP 491)
+    int feature = Runtime.version().feature();
+    Assumptions.assumeTrue(feature >= 21 && feature < 24, "Requires Java 21-23");
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    // Run a synchronized block inside a virtual thread to trigger pinning
+    Object lock = new Object();
+    Thread vt =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  synchronized (lock) {
+                    // Parking inside a synchronized block pins the virtual thread
+                    LockSupport.parkNanos(100_000_000L); // 100ms
+                  }
+                  latch.countDown();
+                });
+
+    assertThat(latch.await(10, SECONDS)).isTrue();
+    vt.join(5000);
+
+    jfrExtension.waitAndAssertMetrics(
+        metric ->
+            metric
+                .hasName("jvm.thread.virtual.pinned")
+                .hasUnit(SECONDS)
+                .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(point -> {})));
+  }
+}

--- a/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
+++ b/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
@@ -12,8 +12,9 @@ import io.opentelemetry.instrumentation.runtimetelemetry.internal.Constants;
 import io.opentelemetry.instrumentation.runtimetelemetry.internal.JfrFeature;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.LockSupport;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class JfrVirtualThreadPinnedTest {
@@ -26,12 +27,10 @@ class JfrVirtualThreadPinnedTest {
             jfrConfig.enableFeature(JfrFeature.VIRTUAL_THREAD_METRICS);
           });
 
+  // synchronized pinning was removed in Java 24 (JEP 491)
   @Test
+  @EnabledForJreRange(min = JRE.JAVA_21, max = JRE.JAVA_23)
   void shouldHaveVirtualThreadPinnedEvents() throws InterruptedException {
-    // Thread.ofVirtual() is GA in Java 21; synchronized pinning was removed in Java 24 (JEP 491)
-    int feature = Runtime.version().feature();
-    Assumptions.assumeTrue(feature >= 21 && feature < 24, "Requires Java 21-23");
-
     CountDownLatch latch = new CountDownLatch(1);
 
     // Run a synchronized block inside a virtual thread to trigger pinning

--- a/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
+++ b/instrumentation/runtime-telemetry/library/src/testJava21/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrVirtualThreadPinnedTest.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.instrumentation.runtimetelemetry;
 
-import static io.opentelemetry.instrumentation.runtimetelemetry.internal.Constants.SECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Constants;
 import io.opentelemetry.instrumentation.runtimetelemetry.internal.JfrFeature;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.LockSupport;
@@ -54,7 +54,7 @@ class JfrVirtualThreadPinnedTest {
         metric ->
             metric
                 .hasName("jvm.thread.virtual.pinned")
-                .hasUnit(SECONDS)
+                .hasUnit(Constants.SECONDS)
                 .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(point -> {})));
   }
 }


### PR DESCRIPTION
- Add VirtualThreadPinnedHandler to collect `jdk.VirtualThreadPinned` as `jvm.thread.virtual.pinned` histogram (seconds)
- Add VirtualThreadSubmitFailedHandler to collect `jdk.VirtualThreadSubmitFailed` as `jvm.thread.virtual.submit_failed` counter
- Add `VIRTUAL_THREAD_METRICS` feature to JfrFeature (experimental, disabled by default) - Add testJava21 source set for tests requiring Java 21+ APIs

Both events exist since Java 19. The implementation lives in the java17 source set since only the event name strings depend on JVM version.

No test for `VirtualThreadSubmitFailed`, as I couldn't come up with a reliable way to trigger it.

`VirtualThreadPinned` threshold defaults to 20 ms, which may be worth making configurable. Other handlers such as LongLockHandler also rely on the JFR default threshold, so I've kept the same approach here.

Related: #14949