### PR TITLE
[jdbc] Capture custom object types in prepared statement parameter instrumentation

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -21,13 +21,8 @@ import io.opentelemetry.instrumentation.jdbc.internal.JdbcData;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.net.URL;
-import java.sql.Date;
 import java.sql.PreparedStatement;
-import java.sql.RowId;
 import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Calendar;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -168,22 +163,8 @@ class PreparedStatementInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      String str = null;
-
-      if (value instanceof Boolean
-          // Byte, Short, Int, Long, Float, Double, BigDecimal
-          || value instanceof Number
-          || value instanceof String
-          || value instanceof Date
-          || value instanceof Time
-          || value instanceof Timestamp
-          || value instanceof URL
-          || value instanceof RowId) {
-        str = value.toString();
-      }
-
-      if (str != null) {
-        JdbcData.addParameter(statement, Integer.toString(index - 1), str);
+      if (value != null) {
+        JdbcData.addParameter(statement, Integer.toString(index - 1), value.toString());
       }
     }
   }
@@ -207,22 +188,8 @@ class PreparedStatementInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      String str = null;
-
-      if (value instanceof Boolean
-          // Byte, Short, Int, Long, Float, Double, BigDecimal
-          || value instanceof Number
-          || value instanceof String
-          || value instanceof Date
-          || value instanceof Time
-          || value instanceof Timestamp
-          || value instanceof URL
-          || value instanceof RowId) {
-        str = value.toString();
-      }
-
-      if (str != null) {
-        JdbcData.addParameter(statement, Integer.toString(index - 1), str);
+      if (value != null) {
+        JdbcData.addParameter(statement, Integer.toString(index - 1), value.toString());
       }
     }
   }
@@ -246,14 +213,8 @@ class PreparedStatementInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      String str = null;
-
-      if (value instanceof Date || value instanceof Time || value instanceof Timestamp) {
-        str = value.toString();
-      }
-
-      if (str != null) {
-        JdbcData.addParameter(statement, Integer.toString(index - 1), str);
+      if (value != null) {
+        JdbcData.addParameter(statement, Integer.toString(index - 1), value.toString());
       }
     }
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -68,7 +68,11 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
 
   private void putParameter(int index, Object value) {
     if (this.captureQueryParameters && value != null) {
-      parameters.put(Integer.toString(index - 1), value.toString());
+      try {
+        parameters.put(Integer.toString(index - 1), value.toString());
+      } catch (Throwable ignored) {
+        // ignore
+      }
     }
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -72,28 +72,6 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
     }
   }
 
-  private void putParameterIfRecognizedType(int index, Object value) {
-    if (this.captureQueryParameters && value != null) {
-      String str = null;
-
-      if (value instanceof Boolean
-          // Byte, Short, Int, Long, Float, Double, BigDecimal
-          || value instanceof Number
-          || value instanceof String
-          || value instanceof Date
-          || value instanceof Time
-          || value instanceof Timestamp
-          || value instanceof URL
-          || value instanceof RowId) {
-        str = value.toString();
-      }
-
-      if (str != null) {
-        parameters.put(Integer.toString(index - 1), str);
-      }
-    }
-  }
-
   @Override
   public ResultSet executeQuery() throws SQLException {
     return OpenTelemetryResultSet.wrap(wrapCall(query, delegate::executeQuery), this);
@@ -267,14 +245,14 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
   @Override
   public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
     delegate.setObject(parameterIndex, x, targetSqlType);
-    putParameterIfRecognizedType(parameterIndex, x);
+    putParameter(parameterIndex, x);
   }
 
   @SuppressWarnings("UngroupedOverloads")
   @Override
   public void setObject(int parameterIndex, Object x) throws SQLException {
     delegate.setObject(parameterIndex, x);
-    putParameterIfRecognizedType(parameterIndex, x);
+    putParameter(parameterIndex, x);
   }
 
   @Override

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SQL_
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_USER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -387,6 +388,10 @@ public abstract class AbstractPreparedStatementParametersTest {
       String url,
       String table)
       throws SQLException {
+    // only H2 and SQLite accept setObject() with an unknown custom type; other drivers reject it at execute time
+    Assumptions.assumeFalse(system.equalsIgnoreCase("derby"));
+    Assumptions.assumeFalse(system.equalsIgnoreCase("hsqldb"));
+
     test(
         system,
         connection,

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
@@ -376,6 +377,31 @@ public abstract class AbstractPreparedStatementParametersTest {
 
   @ParameterizedTest
   @MethodSource("preparedStatementStream")
+  void testCustomObjectPreparedStatementParameter(
+      String system,
+      Connection connection,
+      String username,
+      String query,
+      String sanitizedQuery,
+      String spanName,
+      String url,
+      String table)
+      throws SQLException {
+    test(
+        system,
+        connection,
+        username,
+        query,
+        sanitizedQuery,
+        spanName,
+        url,
+        table,
+        statement -> statement.setObject(1, new IdType()),
+        "id");
+  }
+
+  @ParameterizedTest
+  @MethodSource("preparedStatementStream")
   void testObjectWithTypePreparedStatementParameter(
       String system,
       Connection connection,
@@ -656,6 +682,13 @@ public abstract class AbstractPreparedStatementParametersTest {
                                 equalTo(
                                     DB_QUERY_PARAMETER.getAttributeKey("0"),
                                     expectedParameterValue))));
+  }
+
+  private static class IdType implements Serializable {
+    @Override
+    public String toString() {
+      return "id";
+    }
   }
 
   private interface ThrowingConsumer<T, E extends Throwable> {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractPreparedStatementParametersTest.java
@@ -388,7 +388,7 @@ public abstract class AbstractPreparedStatementParametersTest {
       String url,
       String table)
       throws SQLException {
-    // only H2 and SQLite accept setObject() with an unknown custom type; other drivers reject it at execute time
+    // Derby and HSQLDB reject setObject() with an unknown custom type at execution time
     Assumptions.assumeFalse(system.equalsIgnoreCase("derby"));
     Assumptions.assumeFalse(system.equalsIgnoreCase("hsqldb"));
 


### PR DESCRIPTION
## Summary

The JDBC prepared statement parameter capture feature (opt-in via `CAPTURE_QUERY_PARAMETERS`) previously only recorded parameters whose runtime type matched a hardcoded whitelist:

```
Boolean, Number, String, Date, Time, Timestamp, URL, RowId
```

Any value passed via `setObject()` with a custom type — for example, an ORM-managed ID class — was silently dropped. The resulting span contained no attribute for that parameter position, which is indistinguishable from a parameter that was never set. This defeats the purpose of opting into parameter capture.

This PR replaces the instanceof whitelist with a simple null check and calls `toString()` on any non-null value, matching the same contract the JDBC driver itself must satisfy.

## Risk assessment

**Low.** Three considerations were weighed:

1. **The feature is opt-in.** Users who enable parameter capture have explicitly accepted that parameter values appear in telemetry. There is no new exposure for users who have not opted in.

2. **The JDBC driver already requires serializability.** Any object passed to `setObject()` must be something the driver can handle — a type the driver cannot use would have thrown before reaching the instrumentation. If the driver accepts it, calling `toString()` on it is safe.

3. **Worst case for unknown types is noise, not harm.** For raw `byte[]` or other types without a meaningful `toString()`, the captured value will be something like `[B@7b23ec81` — useless but harmless, and still more informative than a missing attribute (it at least reveals the parameter's Java type). A completely missing parameter attribute is actively misleading when debugging a query.

The one theoretical risk — a custom `toString()` that materialises a large blob — exists, but requires an unusual implementation choice by the application and is bounded by the same constraints as any other span attribute.

## Test

Added `testCustomObjectPreparedStatementParameter` to `AbstractPreparedStatementParametersTest`, which passes a custom `IdType` (implementing `Serializable` for H2 compatibility) via `setObject()` and asserts that its `toString()` value `"id"` is captured as the parameter attribute.

Fixes the case reported in #7413 for ORM frameworks that pass custom ID types through `setObject()`.