### PR TITLE
Add messaging metrics to Kafka client instrumentation

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -8,10 +8,12 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
@@ -62,6 +64,32 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
                     span.hasName("producer callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+
+    assertThat(testing.metrics())
+        .filteredOn(
+            metric ->
+                metric.getName().equals("messaging.publish.duration")
+                    || metric.getName().equals("messaging.receive.duration")
+                    || metric.getName().equals("messaging.receive.messages"))
+        .satisfiesExactlyInAnyOrder(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.publish.duration")
+                    .hasUnit("s")
+                    .hasDescription("Measures the duration of publish operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSumGreaterThan(0.0)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                                            equalTo(MESSAGING_OPERATION, "publish"),
+                                            satisfies(
+                                                MESSAGING_DESTINATION_PARTITION_ID,
+                                                AbstractStringAssert::isNotEmpty)))));
   }
 
   static List<AttributeAssertion> sendAttributes(boolean testHeaders, boolean testExperimental) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -13,11 +13,11 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -147,7 +147,7 @@ class WrapperTest extends AbstractWrapperTest {
                             sum.hasPointsSatisfying(
                                 point ->
                                     point
-                                        .hasValueGreaterThan(0)
+                                        .hasValue(1)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(MESSAGING_SYSTEM, "kafka"),
                                             equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -96,6 +96,62 @@ class WrapperTest extends AbstractWrapperTest {
                     span.hasName("process child")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(1))));
+
+    assertThat(testing.metrics())
+        .filteredOn(
+            metric ->
+                metric.getName().equals("messaging.publish.duration")
+                    || metric.getName().equals("messaging.receive.duration")
+                    || metric.getName().equals("messaging.receive.messages"))
+        .satisfiesExactlyInAnyOrder(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.publish.duration")
+                    .hasUnit("s")
+                    .hasDescription("Measures the duration of publish operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSumGreaterThan(0.0)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                                            equalTo(MESSAGING_OPERATION, "publish"),
+                                            satisfies(
+                                                MESSAGING_DESTINATION_PARTITION_ID,
+                                                AbstractStringAssert::isNotEmpty)))),
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.receive.duration")
+                    .hasUnit("s")
+                    .hasDescription("Measures the duration of receive operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSumGreaterThan(0.0)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                                            equalTo(MESSAGING_OPERATION, "receive")))),
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.receive.messages")
+                    .hasUnit("{message}")
+                    .hasDescription("Measures the number of received messages.")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValueGreaterThan(0)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_SYSTEM, "kafka"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                                            equalTo(MESSAGING_OPERATION, "receive")))));
   }
 
   protected static List<AttributeAssertion> sendAttributes(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -15,6 +15,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
@@ -90,6 +92,7 @@ public final class KafkaInstrumenterFactory {
                 buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
             .addAttributesExtractors(extractors)
             .addAttributesExtractor(new KafkaProducerAttributesExtractor())
+            .addOperationMetrics(MessagingProducerMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
     if (captureExperimentalSpanAttributes) {
       builder.addAttributesExtractor(new KafkaProducerExperimentalAttributesExtractor());
@@ -116,6 +119,7 @@ public final class KafkaInstrumenterFactory {
                 buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
             .addAttributesExtractor(new KafkaReceiveAttributesExtractor())
             .addAttributesExtractors(extractors)
+            .addOperationMetrics(MessagingConsumerMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor)
             .setEnabled(messagingReceiveInstrumentationEnabled);
     setMessagingReceiveExceptionEventExtractor(builder);
@@ -172,6 +176,7 @@ public final class KafkaInstrumenterFactory {
             .addSpanLinksExtractor(
                 new KafkaBatchProcessSpanLinksExtractor(
                     openTelemetry.getPropagators().getTextMapPropagator()))
+            .addOperationMetrics(MessagingConsumerMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());


### PR DESCRIPTION
Fixes #19094

The Kafka client instrumentation emitted spans but never registered the semconv messaging metrics (`messaging.publish.duration`, `messaging.receive.duration`, `messaging.receive.messages`). `KafkaInstrumenterFactory` had no `addOperationMetrics(...)` calls on any of its instrumenters.

This mirrors the Pulsar instrumentation: `MessagingProducerMetrics` is registered on the producer instrumenter and `MessagingConsumerMetrics` on the consumer receive and batch process instrumenters. Because all Kafka variants (javaagent, `kafka-clients-2.6` library, `KafkaTelemetry`, spring-kafka) share this factory, one change covers all of them. The receive metrics remain gated on `messagingReceiveInstrumentationEnabled`, consistent with the existing span behaviour.