### PR TITLE
Remove SpEL from SpringConfigProperties.getMap()

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigProperties.java
@@ -19,8 +19,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.springframework.core.env.Environment;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -29,7 +27,6 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 public class SpringConfigProperties implements ConfigProperties {
   private final CachedPropertyResolver environment;
 
-  private final ExpressionParser parser;
   private final OtlpExporterProperties otlpExporterProperties;
   private final OtelResourceProperties resourceProperties;
   private final ConfigProperties otelSdkProperties;
@@ -47,23 +44,16 @@ public class SpringConfigProperties implements ConfigProperties {
       OtelSpringProperties otelSpringProperties,
       ConfigProperties fallback) {
     return new SpringConfigProperties(
-        env,
-        new SpelExpressionParser(),
-        otlpExporterProperties,
-        resourceProperties,
-        otelSpringProperties,
-        fallback);
+        env, otlpExporterProperties, resourceProperties, otelSpringProperties, fallback);
   }
 
   public SpringConfigProperties(
       Environment environment,
-      ExpressionParser parser,
       OtlpExporterProperties otlpExporterProperties,
       OtelResourceProperties resourceProperties,
       OtelSpringProperties otelSpringProperties,
       ConfigProperties otelSdkProperties) {
     this.environment = new CachedPropertyResolver(environment);
-    this.parser = parser;
     this.otlpExporterProperties = otlpExporterProperties;
     this.resourceProperties = resourceProperties;
     this.otelSdkProperties = otelSdkProperties;
@@ -225,7 +215,6 @@ public class SpringConfigProperties implements ConfigProperties {
     return DefaultConfigProperties.createFromMap(singletonMap(name, value)).getDuration(name);
   }
 
-  @SuppressWarnings("unchecked") // reading map loses generic type
   @Override
   public Map<String, String> getMap(String name) {
     Map<String, String> otelSdkMap = otelSdkProperties.getMap(name);
@@ -241,7 +230,7 @@ public class SpringConfigProperties implements ConfigProperties {
     if (value == null) {
       return otelSdkMap;
     }
-    return (Map<String, String>) parser.parseExpression(value).getValue();
+    return DefaultConfigProperties.createFromMap(singletonMap(name, value)).getMap(name);
   }
 
   @Nullable

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigPropertiesTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/properties/SpringConfigPropertiesTest.java
@@ -36,7 +36,6 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.env.Environment;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 class SpringConfigPropertiesTest {
   private final ApplicationContextRunner contextRunner =
@@ -228,7 +227,6 @@ class SpringConfigPropertiesTest {
               SpringConfigProperties config =
                   new SpringConfigProperties(
                       spyEnvironment,
-                      new SpelExpressionParser(),
                       context.getBean(OtlpExporterProperties.class),
                       context.getBean(OtelResourceProperties.class),
                       context.getBean(OtelSpringProperties.class),
@@ -247,7 +245,7 @@ class SpringConfigPropertiesTest {
   void mapPropertyCaching() {
     this.contextRunner
         .withSystemProperties(
-            "otel.instrumentation.common.peer-service-mapping={'host1':'serviceA','host2':'serviceB'}")
+            "otel.instrumentation.common.peer-service-mapping=host1=serviceA,host2=serviceB")
         .run(
             context -> {
               Environment realEnvironment = context.getBean("environment", Environment.class);
@@ -256,7 +254,6 @@ class SpringConfigPropertiesTest {
               SpringConfigProperties config =
                   new SpringConfigProperties(
                       spyEnvironment,
-                      new SpelExpressionParser(),
                       context.getBean(OtlpExporterProperties.class),
                       context.getBean(OtelResourceProperties.class),
                       context.getBean(OtelSpringProperties.class),
@@ -286,7 +283,6 @@ class SpringConfigPropertiesTest {
       AssertableApplicationContext context, Map<String, String> fallback) {
     return new SpringConfigProperties(
         context.getBean("environment", Environment.class),
-        new SpelExpressionParser(),
         context.getBean(OtlpExporterProperties.class),
         context.getBean(OtelResourceProperties.class),
         context.getBean(OtelSpringProperties.class),


### PR DESCRIPTION
## Summary
- `SpringConfigProperties.getMap()` fell back to evaluating environment-sourced values as SpEL expressions (default `StandardEvaluationContext`) for any map-typed property not covered by the special-cased headers/attributes keys.
- Removes SpEL entirely from this path; non-special-cased map properties now parse as comma-delimited `key=value` pairs, reusing `DefaultConfigProperties`'s existing safe parsing — the same pattern `getMap()`'s sibling `getDuration()` already delegates to.

## Test plan
- [x] `SpringConfigPropertiesTest` updated (constructor no longer takes an `ExpressionParser`; map-property test uses `key=value` syntax instead of SpEL map-literal syntax) and passes locally (32/32).
- [x] Repo-wide audit found no other usage of `SpelExpressionParser`/`StandardEvaluationContext`/other expression or scripting engines.