### PR TITLE
Set jms destination to null when it can't be extracted

### DIFF
--- a/instrumentation/jms/jms-common-1.1/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestinationTest.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestinationTest.java
@@ -33,7 +33,7 @@ class MessageWithDestinationTest {
     MessageWithDestination result = MessageWithDestination.create(message, null);
 
     // then
-    assertMessage("unknown", /* expectedTemporary= */ false, result);
+    assertMessage(null, /* expectedTemporary= */ false, result);
   }
 
   @Test
@@ -45,7 +45,7 @@ class MessageWithDestinationTest {
     MessageWithDestination result = MessageWithDestination.create(message, destination);
 
     // then
-    assertMessage("unknown", /* expectedTemporary= */ false, result);
+    assertMessage(null, /* expectedTemporary= */ false, result);
   }
 
   @ParameterizedTest
@@ -105,7 +105,7 @@ class MessageWithDestinationTest {
   private static Stream<Arguments> destinations() {
     return Stream.of(
         Arguments.of("destination", false, "destination", false),
-        Arguments.of(null, false, "unknown", false),
+        Arguments.of(null, false, null, false),
         Arguments.of(TIBCO_TMP_PREFIX + "dest", false, TIBCO_TMP_PREFIX + "dest", true),
         Arguments.of("destination", true, "destination", true));
   }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsMessageAttributesGetter.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsMessageAttributesGetter.java
@@ -23,6 +23,7 @@ final class JmsMessageAttributesGetter
     return "jms";
   }
 
+  @Nullable
   @Override
   public String getDestination(MessageWithDestination messageWithDestination) {
     return messageWithDestination.destinationName();

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestination.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestination.java
@@ -53,7 +53,8 @@ public abstract class MessageWithDestination {
       MessageAdapter message, DestinationAdapter queue) {
 
     String queueName = getDestinationName(queue, DestinationAdapter::getQueueName);
-    boolean temporary = queue.isTemporaryQueue() || queueName.startsWith(TIBCO_TMP_PREFIX);
+    boolean temporary =
+        queue.isTemporaryQueue() || (queueName != null && queueName.startsWith(TIBCO_TMP_PREFIX));
 
     return new AutoValue_MessageWithDestination(message, queueName, temporary);
   }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestination.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageWithDestination.java
@@ -21,6 +21,7 @@ public abstract class MessageWithDestination {
 
   public abstract MessageAdapter message();
 
+  @Nullable
   public abstract String destinationName();
 
   public abstract boolean isTemporaryDestination();
@@ -45,8 +46,7 @@ public abstract class MessageWithDestination {
         return createMessageWithTopic(message, jmsDestination);
       }
     }
-    return new AutoValue_MessageWithDestination(
-        message, "unknown", /* isTemporaryDestination= */ false);
+    return new AutoValue_MessageWithDestination(message, null, /* isTemporaryDestination= */ false);
   }
 
   private static MessageWithDestination createMessageWithQueue(
@@ -62,17 +62,19 @@ public abstract class MessageWithDestination {
       MessageAdapter message, DestinationAdapter topic) {
 
     String topicName = getDestinationName(topic, DestinationAdapter::getTopicName);
-    boolean temporary = topic.isTemporaryTopic() || topicName.startsWith(TIBCO_TMP_PREFIX);
+    boolean temporary =
+        topic.isTemporaryTopic() || (topicName != null && topicName.startsWith(TIBCO_TMP_PREFIX));
 
     return new AutoValue_MessageWithDestination(message, topicName, temporary);
   }
 
+  @Nullable
   private static String getDestinationName(DestinationAdapter destination, NameGetter nameGetter) {
     try {
       return nameGetter.getName(destination);
     } catch (Exception e) {
       logger.log(FINE, "Failure getting JMS destination name", e);
-      return "unknown";
+      return null;
     }
   }
 


### PR DESCRIPTION
If some value is missing we should just not set it instead of using `unknown`. `MessagingSpanNameExtractor` already replaces `null` destination with `unknown`.