### PR TITLE
Simplify pulsar instrumentation

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -63,7 +64,7 @@ final class PulsarMessagingAttributesGetter
   @Nullable
   @Override
   public String getMessageId(PulsarRequest request, @Nullable Void response) {
-    return request.getMessageId();
+    return Objects.toString(request.getMessage().getMessageId(), null);
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -11,11 +11,9 @@ import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.ProducerData;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
 
 public class PulsarRequest extends BasePulsarRequest {
   private final Message<?> message;
-  private final String messageId;
 
   public static PulsarRequest create(Message<?> message) {
     return new PulsarRequest(message, message.getTopicName(), null);
@@ -36,22 +34,9 @@ public class PulsarRequest extends BasePulsarRequest {
   private PulsarRequest(Message<?> message, String destination, @Nullable UrlData urlData) {
     super(destination, urlData);
     this.message = message;
-    // for producer spans message id is not available when the PulsarRequest is created, so we will
-    // try to get it later when it's available
-    MessageId id = message.getMessageId();
-    this.messageId = id != null ? id.toString() : null;
   }
 
   public Message<?> getMessage() {
     return message;
-  }
-
-  @Nullable
-  public String getMessageId() {
-    if (messageId != null) {
-      return messageId;
-    }
-    MessageId id = message.getMessageId();
-    return id != null ? id.toString() : null;
   }
 }


### PR DESCRIPTION
Reverts https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18803 I believe that the `null` message id issue has been sorted out and this shouldn't be necessary.