### PR TITLE
Add Instrumenter operation listener propagation test

### DIFF
--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
@@ -36,6 +37,7 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -474,40 +476,54 @@ class InstrumenterTest {
 
   @Test
   void operationListenersCanPropagateToDifferentInstrumenterEnd() {
-    AtomicReference<Boolean> startContext = new AtomicReference<>();
-    AtomicReference<Boolean> endContext = new AtomicReference<>();
+    AtomicBoolean startingListenerStarted = new AtomicBoolean();
+    AtomicBoolean startingListenerEnded = new AtomicBoolean();
+    AtomicBoolean endingListenerEnded = new AtomicBoolean();
 
-    OperationListener operationListener =
+    OperationListener startingListener =
         new OperationListener() {
           @Override
           public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            startContext.set(true);
+            startingListenerStarted.set(true);
             return context;
           }
 
           @Override
           public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            endContext.set(true);
+            startingListenerEnded.set(true);
+          }
+        };
+    OperationListener endingListener =
+        new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            return context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            endingListenerEnded.set(true);
           }
         };
 
-    InstrumenterBuilder<Map<String, String>, Map<String, String>> builder =
-        Instrumenter.<Map<String, String>, Map<String, String>>builder(
-                otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addOperationListener(operationListener);
-    builder.propagateOperationListenersToOnEnd = true;
     Instrumenter<Map<String, String>, Map<String, String>> startingInstrumenter =
-        builder.buildServerInstrumenter(new MapGetter());
+        InstrumenterUtil.propagateOperationListenersToOnEnd(
+                Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                        otelTesting.getOpenTelemetry(), "test", unused -> "span")
+                    .addOperationListener(startingListener))
+            .buildServerInstrumenter(new MapGetter());
     Instrumenter<Map<String, String>, Map<String, String>> endingInstrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(endingListener)
             .buildServerInstrumenter(new MapGetter());
 
     Context context = startingInstrumenter.start(Context.root(), REQUEST);
     endingInstrumenter.end(context, REQUEST, RESPONSE, null);
 
-    assertThat(startContext.get()).isTrue();
-    assertThat(endContext.get()).isTrue();
+    assertThat(startingListenerStarted).isTrue();
+    assertThat(startingListenerEnded).isTrue();
+    assertThat(endingListenerEnded).isFalse();
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -473,6 +473,104 @@ class InstrumenterTest {
   }
 
   @Test
+  void operationListenersCanPropagateToDifferentInstrumenterEnd() {
+    AtomicReference<Boolean> startContext = new AtomicReference<>();
+    AtomicReference<Boolean> endContext = new AtomicReference<>();
+
+    OperationListener operationListener =
+        new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            startContext.set(true);
+            return context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            endContext.set(true);
+          }
+        };
+
+    InstrumenterBuilder<Map<String, String>, Map<String, String>> builder =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(operationListener);
+    builder.propagateOperationListenersToOnEnd = true;
+    Instrumenter<Map<String, String>, Map<String, String>> startingInstrumenter =
+        builder.buildServerInstrumenter(new MapGetter());
+    Instrumenter<Map<String, String>, Map<String, String>> endingInstrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .buildServerInstrumenter(new MapGetter());
+
+    Context context = startingInstrumenter.start(Context.root(), REQUEST);
+    endingInstrumenter.end(context, REQUEST, RESPONSE, null);
+
+    assertThat(startContext.get()).isTrue();
+    assertThat(endContext.get()).isTrue();
+  }
+
+  @Test
+  void operationListenersFromNestedInstrumenterPropagateToDifferentInstrumenterEnd() {
+    AtomicReference<Boolean> parentEndContext = new AtomicReference<>();
+    AtomicReference<Boolean> childStartContext = new AtomicReference<>();
+    AtomicReference<Boolean> childEndContext = new AtomicReference<>();
+
+    OperationListener parentOperationListener =
+        new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            return context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            parentEndContext.set(true);
+          }
+        };
+    OperationListener childOperationListener =
+        new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            childStartContext.set(true);
+            return context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            childEndContext.set(true);
+          }
+        };
+
+    InstrumenterBuilder<Map<String, String>, Map<String, String>> parentBuilder =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(parentOperationListener);
+    parentBuilder.propagateOperationListenersToOnEnd = true;
+    Instrumenter<Map<String, String>, Map<String, String>> parentInstrumenter =
+        parentBuilder.buildServerInstrumenter(new MapGetter());
+    Instrumenter<Map<String, String>, Map<String, String>> childStartingInstrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(childOperationListener)
+            .buildServerInstrumenter(new MapGetter());
+    Instrumenter<Map<String, String>, Map<String, String>> childEndingInstrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .buildServerInstrumenter(new MapGetter());
+
+    Context parentContext = parentInstrumenter.start(Context.root(), REQUEST);
+    Context childContext = childStartingInstrumenter.start(parentContext, REQUEST);
+    childEndingInstrumenter.end(childContext, REQUEST, RESPONSE, null);
+
+    assertThat(childStartContext.get()).isTrue();
+    assertThat(childEndContext.get()).isTrue();
+    assertThat(parentEndContext.get()).isNull();
+
+    parentInstrumenter.end(parentContext, REQUEST, RESPONSE, null);
+  }
+
+  @Test
   void operationMetrics() {
     AtomicReference<Context> startContext = new AtomicReference<>();
     AtomicReference<Context> endContext = new AtomicReference<>();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -528,9 +528,9 @@ class InstrumenterTest {
 
   @Test
   void operationListenersFromNestedInstrumenterPropagateToDifferentInstrumenterEnd() {
-    AtomicReference<Boolean> parentEndContext = new AtomicReference<>();
-    AtomicReference<Boolean> childStartContext = new AtomicReference<>();
-    AtomicReference<Boolean> childEndContext = new AtomicReference<>();
+    AtomicBoolean parentListenerEnded = new AtomicBoolean();
+    AtomicBoolean childListenerStarted = new AtomicBoolean();
+    AtomicBoolean childListenerEnded = new AtomicBoolean();
 
     OperationListener parentOperationListener =
         new OperationListener() {
@@ -541,30 +541,29 @@ class InstrumenterTest {
 
           @Override
           public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            parentEndContext.set(true);
+            parentListenerEnded.set(true);
           }
         };
     OperationListener childOperationListener =
         new OperationListener() {
           @Override
           public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            childStartContext.set(true);
+            childListenerStarted.set(true);
             return context;
           }
 
           @Override
           public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            childEndContext.set(true);
+            childListenerEnded.set(true);
           }
         };
 
-    InstrumenterBuilder<Map<String, String>, Map<String, String>> parentBuilder =
-        Instrumenter.<Map<String, String>, Map<String, String>>builder(
-                otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addOperationListener(parentOperationListener);
-    parentBuilder.propagateOperationListenersToOnEnd = true;
     Instrumenter<Map<String, String>, Map<String, String>> parentInstrumenter =
-        parentBuilder.buildServerInstrumenter(new MapGetter());
+        InstrumenterUtil.propagateOperationListenersToOnEnd(
+                Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                        otelTesting.getOpenTelemetry(), "test", unused -> "span")
+                    .addOperationListener(parentOperationListener))
+            .buildServerInstrumenter(new MapGetter());
     Instrumenter<Map<String, String>, Map<String, String>> childStartingInstrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
@@ -579,11 +578,12 @@ class InstrumenterTest {
     Context childContext = childStartingInstrumenter.start(parentContext, REQUEST);
     childEndingInstrumenter.end(childContext, REQUEST, RESPONSE, null);
 
-    assertThat(childStartContext.get()).isTrue();
-    assertThat(childEndContext.get()).isTrue();
-    assertThat(parentEndContext.get()).isNull();
+    assertThat(childListenerStarted).isTrue();
+    assertThat(childListenerEnded).isTrue();
+    assertThat(parentListenerEnded).isFalse();
 
     parentInstrumenter.end(parentContext, REQUEST, RESPONSE, null);
+    assertThat(parentListenerEnded).isTrue();
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -168,6 +168,23 @@ class InstrumenterTest {
     }
   }
 
+  static class RecordingOperationListener implements OperationListener {
+
+    final AtomicBoolean started = new AtomicBoolean();
+    final AtomicBoolean ended = new AtomicBoolean();
+
+    @Override
+    public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+      started.set(true);
+      return context;
+    }
+
+    @Override
+    public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+      ended.set(true);
+    }
+  }
+
   @RegisterExtension
   static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
@@ -476,35 +493,8 @@ class InstrumenterTest {
 
   @Test
   void operationListenersCanPropagateToDifferentInstrumenterEnd() {
-    AtomicBoolean startingListenerStarted = new AtomicBoolean();
-    AtomicBoolean startingListenerEnded = new AtomicBoolean();
-    AtomicBoolean endingListenerEnded = new AtomicBoolean();
-
-    OperationListener startingListener =
-        new OperationListener() {
-          @Override
-          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            startingListenerStarted.set(true);
-            return context;
-          }
-
-          @Override
-          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            startingListenerEnded.set(true);
-          }
-        };
-    OperationListener endingListener =
-        new OperationListener() {
-          @Override
-          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            return context;
-          }
-
-          @Override
-          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            endingListenerEnded.set(true);
-          }
-        };
+    RecordingOperationListener startingListener = new RecordingOperationListener();
+    RecordingOperationListener endingListener = new RecordingOperationListener();
 
     Instrumenter<Map<String, String>, Map<String, String>> startingInstrumenter =
         InstrumenterUtil.propagateOperationListenersToOnEnd(
@@ -521,53 +511,28 @@ class InstrumenterTest {
     Context context = startingInstrumenter.start(Context.root(), REQUEST);
     endingInstrumenter.end(context, REQUEST, RESPONSE, null);
 
-    assertThat(startingListenerStarted).isTrue();
-    assertThat(startingListenerEnded).isTrue();
-    assertThat(endingListenerEnded).isFalse();
+    assertThat(startingListener.started).isTrue();
+    assertThat(startingListener.ended).isTrue();
+    assertThat(endingListener.ended).isFalse();
   }
 
   @Test
-  void operationListenersFromNestedInstrumenterPropagateToDifferentInstrumenterEnd() {
-    AtomicBoolean parentListenerEnded = new AtomicBoolean();
-    AtomicBoolean childListenerStarted = new AtomicBoolean();
-    AtomicBoolean childListenerEnded = new AtomicBoolean();
-
-    OperationListener parentOperationListener =
-        new OperationListener() {
-          @Override
-          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            return context;
-          }
-
-          @Override
-          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            parentListenerEnded.set(true);
-          }
-        };
-    OperationListener childOperationListener =
-        new OperationListener() {
-          @Override
-          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-            childListenerStarted.set(true);
-            return context;
-          }
-
-          @Override
-          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-            childListenerEnded.set(true);
-          }
-        };
+  void nestedInstrumenterOverridesPropagatedOperationListeners() {
+    RecordingOperationListener parentListener = new RecordingOperationListener();
+    RecordingOperationListener childListener = new RecordingOperationListener();
 
     Instrumenter<Map<String, String>, Map<String, String>> parentInstrumenter =
         InstrumenterUtil.propagateOperationListenersToOnEnd(
                 Instrumenter.<Map<String, String>, Map<String, String>>builder(
                         otelTesting.getOpenTelemetry(), "test", unused -> "span")
-                    .addOperationListener(parentOperationListener))
+                    .addOperationListener(parentListener))
             .buildServerInstrumenter(new MapGetter());
+    // The child does not enable propagation itself. It replaces the propagated parent listener
+    // because its parent context already carries operation listeners.
     Instrumenter<Map<String, String>, Map<String, String>> childStartingInstrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addOperationListener(childOperationListener)
+            .addOperationListener(childListener)
             .buildServerInstrumenter(new MapGetter());
     Instrumenter<Map<String, String>, Map<String, String>> childEndingInstrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
@@ -578,12 +543,12 @@ class InstrumenterTest {
     Context childContext = childStartingInstrumenter.start(parentContext, REQUEST);
     childEndingInstrumenter.end(childContext, REQUEST, RESPONSE, null);
 
-    assertThat(childListenerStarted).isTrue();
-    assertThat(childListenerEnded).isTrue();
-    assertThat(parentListenerEnded).isFalse();
+    assertThat(childListener.started).isTrue();
+    assertThat(childListener.ended).isTrue();
+    assertThat(parentListener.ended).isFalse();
 
     parentInstrumenter.end(parentContext, REQUEST, RESPONSE, null);
-    assertThat(parentListenerEnded).isTrue();
+    assertThat(parentListener.ended).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Hi,

I added focused tests for listener state that is carried from start to end through the context. They cover both the simple cross-instrumenter end path and the nested case where the child listener should end without also ending the parent listener.

Impact on coverage:

* Covers operation-listener propagation when start and end happen through different instrumenters, including the nested-context case around [Instrumenter.java:232-239](https://github.com/amirdeljouyi/opentelemetry-java-instrumentation/blob/c15bd4244b3f3dd8a62de65c87c435eefdbe0b34/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java#L232-L239) and [Instrumenter.java:271-274](https://github.com/amirdeljouyi/opentelemetry-java-instrumentation/blob/c15bd4244b3f3dd8a62de65c87c435eefdbe0b34/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java#L271-L274).
* Branch coverage for `Instrumenter` increases by about 9%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir