### PR TITLE
Remove isIndyModule method

### DIFF
--- a/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
+++ b/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
@@ -36,11 +36,6 @@ public class TestInstrumentationModule extends InstrumentationModule {
         "test-resources/test-resource.txt", "test-resources/test-resource-2.txt");
   }
 
-  @Override
-  public boolean isIndyModule() {
-    return false;
-  }
-
   private static class TestTypeInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -116,20 +116,6 @@ public abstract class InstrumentationModule implements Ordered {
     return false;
   }
 
-  /**
-   * Note this is an experimental feature until phase 1 of <a
-   * href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8999">
-   * implementing the invokedynamic based instrumentation mechanism</a> is complete. Instrumentation
-   * modules that override this to true (recommended) must use the inline=false Invoke Dynamic style
-   * of Byte Buddy advices which calls out to helper classes in their own classloader, thus enabling
-   * better isolation, best practice code development, avoids shading and enables standard debugging
-   * techniques. The non-inlining of advice will be enforced by muzzle (TODO)
-   */
-  @Deprecated // to be removed in next release
-  public boolean isIndyModule() {
-    return false;
-  }
-
   /** Register resource names to inject into the user's class loader. */
   public void registerHelperResources(HelperResourceBuilder helperResourceBuilder) {}
 


### PR DESCRIPTION
There are still references to in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/writing-instrumentation-module.md these should get removed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19076