### PR TITLE
[jmx-metrics] fix instrument type for jvm.classes.* metrics

### DIFF
--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/jvm.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/jvm.yaml
@@ -45,20 +45,22 @@ rules:
 
   - bean: java.lang:type=ClassLoading
     prefix: jvm.class.
-    type: updowncounter
     unit: "{class}"
     mapping:
       # jvm.class.loaded
       TotalLoadedClassCount:
         metric: loaded
+        type: counter
         desc: Number of classes loaded since JVM start.
       # jvm.class.unloaded
       UnloadedClassCount:
         metric: unloaded
+        type: counter
         desc: Number of classes unloaded since JVM start.
       # jvm.class.count
       LoadedClassCount:
         metric: count
+        type: updowncounter
         desc: Number of classes currently loaded.
 
   - bean: java.lang:type=OperatingSystem

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/JvmTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/JvmTest.java
@@ -119,7 +119,7 @@ class JvmTest extends TargetSystemTest {
                     metric
                         .hasDescription("Number of classes loaded since JVM start.")
                         .hasUnit("{class}")
-                        .isUpDownCounter()
+                        .isCounter()
                         .hasDataPointsWithoutAttributes())
             .add(
                 "jvm.class.unloaded",
@@ -127,7 +127,7 @@ class JvmTest extends TargetSystemTest {
                     metric
                         .hasDescription("Number of classes unloaded since JVM start.")
                         .hasUnit("{class}")
-                        .isUpDownCounter()
+                        .isCounter()
                         .hasDataPointsWithoutAttributes())
             .add(
                 "jvm.class.count",


### PR DESCRIPTION
In the `jvm.yaml` metrics definitions that is included in instrumentation and reused in [jmx-scraper](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/jmx-scraper), there is an error on the instrument type used to capture the following metrics:

- `jvm.class.loaded`
- `jvm.class.unloaded`

For both, the instrument type is `updowncounter` whereas it should have been `counter` to align with [related JVM semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclassloaded).

This does not affect the `jvm.*` metrics that are reported by the Java agent, as it is using a separate implementation to capture those metrics.

This was discovered while working on #19139.