### PR TITLE
Handle explicit empty database batches

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -94,7 +94,10 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       boolean captureQueryParameters) {
     Long batchSize = getter.getDbOperationBatchSize(request);
-    boolean isBatch = batchSize != null && batchSize > 1;
+    // db.operation.batch.size is captured for every batch execution (including an empty batch with
+    // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
+    boolean emitBatchSize = batchSize != null && batchSize != 1;
+    boolean isBatch = emitBatchSize;
 
     if (emitStableDatabaseSemconv()) {
       attributes.put(
@@ -104,7 +107,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       attributes.put(DB_QUERY_TEXT, getter.getDbQueryText(request));
       attributes.put(DB_OPERATION_NAME, getter.getDbOperationName(request));
       attributes.put(DB_QUERY_SUMMARY, getter.getDbQuerySummary(request));
-      if (isBatch) {
+      if (emitBatchSize) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -96,8 +96,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
     Long batchSize = getter.getDbOperationBatchSize(request);
     // db.operation.batch.size is captured for every batch execution (including an empty batch with
     // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
-    boolean emitBatchSize = batchSize != null && batchSize != 1;
-    boolean isBatch = emitBatchSize;
+    boolean isBatch = batchSize != null && batchSize != 1;
 
     if (emitStableDatabaseSemconv()) {
       attributes.put(
@@ -107,7 +106,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
       attributes.put(DB_QUERY_TEXT, getter.getDbQueryText(request));
       attributes.put(DB_OPERATION_NAME, getter.getDbOperationName(request));
       attributes.put(DB_QUERY_SUMMARY, getter.getDbQuerySummary(request));
-      if (emitBatchSize) {
+      if (isBatch) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -243,6 +243,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     private boolean isBatch(REQUEST request) {
       Long batchSize = getter.getDbOperationBatchSize(request);
+      // Empty batches with size 0 are batches; single-statement batches are reported as non-batch.
       return batchSize != null && batchSize != 1;
     }
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -193,6 +193,9 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
       if (rawQueryTexts.isEmpty()) {
         if (emitStableDatabaseSemconv()) {
+          if (isBatch(request)) {
+            return "BATCH";
+          }
           return computeSpanNameStable(getter, request, null, null, null);
         }
         String dbName = getter.getDbName(request);
@@ -240,7 +243,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     private boolean isBatch(REQUEST request) {
       Long batchSize = getter.getDbOperationBatchSize(request);
-      return batchSize != null && batchSize > 1;
+      return batchSize != null && batchSize != 1;
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -17,9 +17,7 @@ class MultiQuery {
   @Nullable private final String querySummary;
 
   private MultiQuery(
-      @Nullable String storedProcedureName,
-      Set<String> queryTexts,
-      @Nullable String querySummary) {
+      @Nullable String storedProcedureName, Set<String> queryTexts, @Nullable String querySummary) {
     this.storedProcedureName = storedProcedureName;
     this.queryTexts = queryTexts;
     this.querySummary = querySummary;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -15,20 +15,14 @@ class MultiQuery {
   @Nullable private final String storedProcedureName;
   private final Set<String> queryTexts;
   @Nullable private final String querySummary;
-  @Nullable private final String operationName;
-  @Nullable private final String collectionName;
 
   private MultiQuery(
       @Nullable String storedProcedureName,
       Set<String> queryTexts,
-      @Nullable String querySummary,
-      @Nullable String operationName,
-      @Nullable String collectionName) {
+      @Nullable String querySummary) {
     this.storedProcedureName = storedProcedureName;
     this.queryTexts = queryTexts;
     this.querySummary = querySummary;
-    this.operationName = operationName;
-    this.collectionName = collectionName;
   }
 
   static MultiQuery analyzeWithSummary(Collection<String> rawQueryTexts, SqlDialect dialect) {
@@ -55,16 +49,6 @@ class MultiQuery {
     return querySummary;
   }
 
-  @Nullable
-  public String getOperationName() {
-    return operationName;
-  }
-
-  @Nullable
-  public String getCollectionName() {
-    return collectionName;
-  }
-
   public Set<String> getQueryTexts() {
     return queryTexts;
   }
@@ -73,28 +57,19 @@ class MultiQuery {
     private final UniqueValue uniqueStoredProcedureName = new UniqueValue();
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
-    private final UniqueValue uniqueOperationName = new UniqueValue();
-    private final UniqueValue uniqueCollectionName = new UniqueValue();
 
-    @SuppressWarnings(
-        "deprecation") // getOperationName()/getCollectionName() package-private in 3.0
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
-      uniqueOperationName.set(analyzedQuery.getOperationName());
-      uniqueCollectionName.set(analyzedQuery.getCollectionName());
     }
 
     MultiQuery build() {
       String querySummary = uniqueQuerySummary.getValue();
-      String operationName = uniqueOperationName.getValue();
       return new MultiQuery(
           uniqueStoredProcedureName.getValue(),
           uniqueQueryTexts,
-          querySummary == null ? "BATCH" : "BATCH " + querySummary,
-          operationName == null ? "BATCH" : "BATCH " + operationName,
-          uniqueCollectionName.getValue());
+          querySummary == null ? "BATCH" : "BATCH " + querySummary);
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -15,12 +15,20 @@ class MultiQuery {
   @Nullable private final String storedProcedureName;
   private final Set<String> queryTexts;
   @Nullable private final String querySummary;
+  @Nullable private final String operationName;
+  @Nullable private final String collectionName;
 
   private MultiQuery(
-      @Nullable String storedProcedureName, Set<String> queryTexts, @Nullable String querySummary) {
+      @Nullable String storedProcedureName,
+      Set<String> queryTexts,
+      @Nullable String querySummary,
+      @Nullable String operationName,
+      @Nullable String collectionName) {
     this.storedProcedureName = storedProcedureName;
     this.queryTexts = queryTexts;
     this.querySummary = querySummary;
+    this.operationName = operationName;
+    this.collectionName = collectionName;
   }
 
   static MultiQuery analyzeWithSummary(Collection<String> rawQueryTexts, SqlDialect dialect) {
@@ -47,6 +55,16 @@ class MultiQuery {
     return querySummary;
   }
 
+  @Nullable
+  public String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  public String getCollectionName() {
+    return collectionName;
+  }
+
   public Set<String> getQueryTexts() {
     return queryTexts;
   }
@@ -55,19 +73,28 @@ class MultiQuery {
     private final UniqueValue uniqueStoredProcedureName = new UniqueValue();
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
+    private final UniqueValue uniqueOperationName = new UniqueValue();
+    private final UniqueValue uniqueCollectionName = new UniqueValue();
 
+    @SuppressWarnings(
+        "deprecation") // getOperationName()/getCollectionName() package-private in 3.0
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
+      uniqueOperationName.set(analyzedQuery.getOperationName());
+      uniqueCollectionName.set(analyzedQuery.getCollectionName());
     }
 
     MultiQuery build() {
       String querySummary = uniqueQuerySummary.getValue();
+      String operationName = uniqueOperationName.getValue();
       return new MultiQuery(
           uniqueStoredProcedureName.getValue(),
           uniqueQueryTexts,
-          querySummary == null ? "BATCH" : "BATCH " + querySummary);
+          querySummary == null ? "BATCH" : "BATCH " + querySummary,
+          operationName == null ? "BATCH" : "BATCH " + operationName,
+          uniqueCollectionName.getValue());
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -101,7 +101,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     SqlDialect dialect = getter.getSqlDialect(request);
 
     Long batchSize = getter.getDbOperationBatchSize(request);
-    boolean isBatch = batchSize != null && batchSize > 1;
+    // db.operation.batch.size is captured for every batch execution (including an empty batch with
+    // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
+    boolean emitBatchSize = batchSize != null && batchSize != 1;
+    boolean isBatch = emitBatchSize;
 
     if (emitOldDatabaseSemconv()) {
       if (rawQueryTexts.size() == 1) { // for backcompat(?)
@@ -118,7 +121,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     }
 
     if (emitStableDatabaseSemconv()) {
-      if (isBatch) {
+      if (emitBatchSize) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
       if (rawQueryTexts.size() == 1) {
@@ -149,6 +152,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         MultiQuery multiQuery = builder.build();
         attributes.put(DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         attributes.put(DB_QUERY_SUMMARY, multiQuery.getQuerySummary());
+        if (singleOperationAndCollection) {
+          attributes.put(DB_OPERATION_NAME, multiQuery.getOperationName());
+          attributes.put(DB_COLLECTION_NAME, multiQuery.getCollectionName());
+        }
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -151,10 +151,6 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         MultiQuery multiQuery = builder.build();
         attributes.put(DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         attributes.put(DB_QUERY_SUMMARY, multiQuery.getQuerySummary());
-        if (singleOperationAndCollection) {
-          attributes.put(DB_OPERATION_NAME, multiQuery.getOperationName());
-          attributes.put(DB_COLLECTION_NAME, multiQuery.getCollectionName());
-        }
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -103,8 +103,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     Long batchSize = getter.getDbOperationBatchSize(request);
     // db.operation.batch.size is captured for every batch execution (including an empty batch with
     // size 0); it is only omitted for a single-statement batch, which is reported as a non-batch
-    boolean emitBatchSize = batchSize != null && batchSize != 1;
-    boolean isBatch = emitBatchSize;
+    boolean isBatch = batchSize != null && batchSize != 1;
 
     if (emitOldDatabaseSemconv()) {
       if (rawQueryTexts.size() == 1) { // for backcompat(?)
@@ -121,7 +120,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     }
 
     if (emitStableDatabaseSemconv()) {
-      if (emitBatchSize) {
+      if (isBatch) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }
       if (rawQueryTexts.size() == 1) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -35,6 +35,7 @@ class DbClientSpanNameExtractorTest {
     lenient()
         .when(sqlAttributesGetter.getSqlDialect(any()))
         .thenReturn(DOUBLE_QUOTES_ARE_STRING_LITERALS);
+    lenient().when(sqlAttributesGetter.getDbOperationBatchSize(any())).thenReturn(null);
   }
 
   @Test
@@ -267,6 +268,30 @@ class DbClientSpanNameExtractorTest {
   }
 
   @Test
+  void shouldExtractFullSpanNameForSingleQueryEmptyBatch() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest))
+        .thenReturn(singleton("INSERT INTO table VALUES(?)"));
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("database");
+    }
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+
+    SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName)
+        .isEqualTo(emitStableDatabaseSemconv() ? "BATCH INSERT table" : "INSERT database.table");
+  }
+
+  @Test
   void shouldFallBackToNamespaceForEmptySqlQuery() {
     // given
     DbRequest dbRequest = new DbRequest();
@@ -286,6 +311,28 @@ class DbClientSpanNameExtractorTest {
 
     // then
     assertThat(spanName).isEqualTo("mydb");
+  }
+
+  @Test
+  void shouldExtractBatchSpanNameForEmptySqlQueryBatch() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest)).thenReturn(emptyList());
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("mydb");
+    }
+
+    SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName).isEqualTo(emitStableDatabaseSemconv() ? "BATCH" : "mydb");
   }
 
   @Test
@@ -333,6 +380,30 @@ class DbClientSpanNameExtractorTest {
 
     // then
     assertThat(spanName).isEqualTo("mydb");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // testing deprecated method
+  void shouldExtractBatchSpanNameForEmptySqlQueryBatchInMigration() {
+    // given
+    DbRequest dbRequest = new DbRequest();
+
+    when(sqlAttributesGetter.getRawQueryTexts(dbRequest)).thenReturn(emptyList());
+    if (emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbOperationBatchSize(dbRequest)).thenReturn(0L);
+    }
+    if (emitOldDatabaseSemconv() && !emitStableDatabaseSemconv()) {
+      when(sqlAttributesGetter.getDbName(dbRequest)).thenReturn("mydb");
+    }
+
+    SpanNameExtractor<DbRequest> underTest =
+        DbClientSpanNameExtractor.createWithGenericOldSpanName(sqlAttributesGetter);
+
+    // when
+    String spanName = underTest.extract(dbRequest);
+
+    // then
+    assertThat(spanName).isEqualTo(emitStableDatabaseSemconv() ? "BATCH" : "mydb");
   }
 
   static class DbRequest {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -9,8 +9,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDiale
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -319,6 +321,57 @@ class SqlClientAttributesExtractorTest {
   }
 
   @Test
+  void shouldExtractSingleQueryEmptyBatchAttributes() {
+    // given
+    Map<String, Object> request = new HashMap<>();
+    request.put("db.namespace", "potatoes");
+    request.put("db.query.texts", singleton("INSERT INTO potato VALUES(?)"));
+    request.put(DB_OPERATION_BATCH_SIZE.getKey(), 0L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.create(new TestMultiAttributesGetter());
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    underTest.onStart(startAttributes, context, request);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    underTest.onEnd(endAttributes, context, request, null, null);
+
+    // then
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    } else if (emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"));
+    } else if (emitStableDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    }
+
+    assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
   void shouldExtractMultiQueryBatchAttributes() {
     // given
     Map<String, Object> request = new HashMap<>();
@@ -410,6 +463,66 @@ class SqlClientAttributesExtractorTest {
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
+    // given
+    Map<String, Object> sameOperation = new HashMap<>();
+    sameOperation.put("db.namespace", "potatoes");
+    sameOperation.put(
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
+    sameOperation.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedOperations = new HashMap<>();
+    mixedOperations.put("db.namespace", "potatoes");
+    mixedOperations.put(
+        "db.query.texts",
+        asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
+    mixedOperations.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedCollections = new HashMap<>();
+    mixedCollections.put("db.namespace", "potatoes");
+    mixedCollections.put(
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
+    mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
+            .setSingleOperationAndCollection(true)
+            .build();
+
+    // when
+    AttributesBuilder sameOperationAttributes = Attributes.builder();
+    underTest.onStart(sameOperationAttributes, context, sameOperation);
+
+    AttributesBuilder mixedOperationsAttributes = Attributes.builder();
+    underTest.onStart(mixedOperationsAttributes, context, mixedOperations);
+
+    AttributesBuilder mixedCollectionsAttributes = Attributes.builder();
+    underTest.onStart(mixedCollectionsAttributes, context, mixedCollections);
+
+    // then
+    if (emitStableDatabaseSemconv()) {
+      assertThat(sameOperationAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
+      assertThat(mixedOperationsAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH");
+      // different collections -> db.collection.name is omitted, db.operation.name is BATCH INSERT
+      assertThat(mixedCollectionsAttributes.build())
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .doesNotContainKey(DB_COLLECTION_NAME);
+    } else {
+      assertThat(sameOperationAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedOperationsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedCollectionsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+    }
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -9,10 +9,8 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDiale
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
-import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -463,66 +461,6 @@ class SqlClientAttributesExtractorTest {
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
-  }
-
-  @Test
-  void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
-    // given
-    Map<String, Object> sameOperation = new HashMap<>();
-    sameOperation.put("db.namespace", "potatoes");
-    sameOperation.put(
-        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
-    sameOperation.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
-
-    Map<String, Object> mixedOperations = new HashMap<>();
-    mixedOperations.put("db.namespace", "potatoes");
-    mixedOperations.put(
-        "db.query.texts",
-        asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
-    mixedOperations.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
-
-    Map<String, Object> mixedCollections = new HashMap<>();
-    mixedCollections.put("db.namespace", "potatoes");
-    mixedCollections.put(
-        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
-    mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
-
-    Context context = Context.root();
-
-    AttributesExtractor<Map<String, Object>, Void> underTest =
-        SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
-            .setSingleOperationAndCollection(true)
-            .build();
-
-    // when
-    AttributesBuilder sameOperationAttributes = Attributes.builder();
-    underTest.onStart(sameOperationAttributes, context, sameOperation);
-
-    AttributesBuilder mixedOperationsAttributes = Attributes.builder();
-    underTest.onStart(mixedOperationsAttributes, context, mixedOperations);
-
-    AttributesBuilder mixedCollectionsAttributes = Attributes.builder();
-    underTest.onStart(mixedCollectionsAttributes, context, mixedCollections);
-
-    // then
-    if (emitStableDatabaseSemconv()) {
-      assertThat(sameOperationAttributes.build())
-          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
-          .containsEntry(DB_COLLECTION_NAME, "potato")
-          .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
-      assertThat(mixedOperationsAttributes.build())
-          .containsEntry(DB_OPERATION_NAME, "BATCH")
-          .containsEntry(DB_COLLECTION_NAME, "potato")
-          .containsEntry(DB_QUERY_SUMMARY, "BATCH");
-      // different collections -> db.collection.name is omitted, db.operation.name is BATCH INSERT
-      assertThat(mixedCollectionsAttributes.build())
-          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
-          .doesNotContainKey(DB_COLLECTION_NAME);
-    } else {
-      assertThat(sameOperationAttributes.build().get(DB_OPERATION_NAME)).isNull();
-      assertThat(mixedOperationsAttributes.build().get(DB_OPERATION_NAME)).isNull();
-      assertThat(mixedCollectionsAttributes.build().get(DB_OPERATION_NAME)).isNull();
-    }
   }
 
   @Test

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -390,8 +390,6 @@ class CassandraClientTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
-                .operationName("BATCH INSERT")
-                .collectionName("batch_test.records")
                 .build()),
         Arguments.argumentSet(
             "twoDifferentOperations",
@@ -412,8 +410,6 @@ class CassandraClientTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
-                .operationName("BATCH")
-                .collectionName("batch_test.records")
                 .build()));
   }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -337,8 +337,16 @@ class CassandraClientTest {
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? scenario.querySummary : null),
-                            equalTo(maybeStable(DB_OPERATION), scenario.operationName),
-                            equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.collectionName))));
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.operationName
+                                    : scenario.oldOperationName()),
+                            equalTo(
+                                maybeStable(DB_CASSANDRA_TABLE),
+                                emitStableDatabaseSemconv()
+                                    ? scenario.collectionName
+                                    : scenario.oldCollectionName()))));
   }
 
   private static Stream<Arguments> batchScenarios() {
@@ -347,8 +355,9 @@ class CassandraClientTest {
             "empty",
             BatchScenario.builder()
                 .buildBatch(session -> new BatchStatement())
-                .spanName("cassandra")
+                .spanName("BATCH")
                 .oldSpanName("DB Query")
+                .batchSize(0)
                 .build()),
         Arguments.argumentSet(
             "single",
@@ -381,6 +390,8 @@ class CassandraClientTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
+                .operationName("BATCH INSERT")
+                .collectionName("batch_test.records")
                 .build()),
         Arguments.argumentSet(
             "twoDifferentOperations",
@@ -401,6 +412,8 @@ class CassandraClientTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
+                .operationName("BATCH")
+                .collectionName("batch_test.records")
                 .build()));
   }
 
@@ -561,6 +574,14 @@ class CassandraClientTest {
 
     static Builder builder() {
       return new Builder();
+    }
+
+    String oldOperationName() {
+      return batchSize == null ? operationName : null;
+    }
+
+    String oldCollectionName() {
+      return batchSize == null ? collectionName : null;
     }
 
     static class Builder {

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -258,6 +258,7 @@ public abstract class AbstractCassandraTest {
                 .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
                 .spanName("cassandra")
                 .oldSpanName("DB Query")
+                .batchSize(0)
                 .build()),
         Arguments.argumentSet(
             "single",
@@ -291,6 +292,8 @@ public abstract class AbstractCassandraTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
+                .operationName("INSERT")
+                .collectionName("batch_test.records")
                 .build()),
         Arguments.argumentSet(
             "twoDifferentOperations",
@@ -311,6 +314,8 @@ public abstract class AbstractCassandraTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
+                .operationName("BATCH")
+                .collectionName("batch_test.records")
                 .build()));
   }
 

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -300,8 +300,6 @@ public abstract class AbstractCassandraTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
-                .operationName("BATCH INSERT")
-                .collectionName("batch_test.records")
                 .build()),
         Arguments.argumentSet(
             "twoDifferentOperations",
@@ -322,8 +320,6 @@ public abstract class AbstractCassandraTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
-                .operationName("BATCH")
-                .collectionName("batch_test.records")
                 .build()));
   }
 

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -264,7 +264,7 @@ public abstract class AbstractCassandraTest {
             "empty",
             BatchScenario.builder()
                 .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
-                .spanName("cassandra")
+                .spanName("BATCH")
                 .oldSpanName("DB Query")
                 .batchSize(0)
                 .build()),
@@ -300,7 +300,7 @@ public abstract class AbstractCassandraTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
-                .operationName("INSERT")
+                .operationName("BATCH INSERT")
                 .collectionName("batch_test.records")
                 .build()),
         Arguments.argumentSet(

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -235,8 +235,16 @@ public abstract class AbstractCassandraTest {
                                 equalTo(
                                     DB_QUERY_SUMMARY,
                                     emitStableDatabaseSemconv() ? scenario.querySummary : null),
-                                equalTo(maybeStable(DB_OPERATION), scenario.operationName),
-                                equalTo(maybeStable(DB_CASSANDRA_TABLE), scenario.collectionName),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.operationName
+                                        : scenario.oldOperationName()),
+                                equalTo(
+                                    maybeStable(DB_CASSANDRA_TABLE),
+                                    emitStableDatabaseSemconv()
+                                        ? scenario.collectionName
+                                        : scenario.oldCollectionName()),
                                 equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
                                 equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
                                 satisfies(
@@ -600,6 +608,14 @@ public abstract class AbstractCassandraTest {
 
     static Builder builder() {
       return new Builder();
+    }
+
+    String oldOperationName() {
+      return batchSize == null ? operationName : null;
+    }
+
+    String oldCollectionName() {
+      return batchSize == null ? collectionName : null;
     }
 
     static class Builder {

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1884,8 +1884,9 @@ public abstract class AbstractJdbcInstrumentationTest {
         Arguments.argumentSet(
             "empty",
             BatchScenario.builder()
-                .spanName(DATABASE_NAME_LOWER)
+                .spanName("BATCH")
                 .oldSpanName(DATABASE_NAME_LOWER)
+                .batchSize(0)
                 .build()),
         Arguments.argumentSet(
             "single",

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -250,7 +250,7 @@ class RediscalaClientTest {
 
   private def transactionScenarios(): Stream[Arguments] =
     Stream.of(
-      Arguments.argumentSet("empty", BatchScenario(operationName = "MULTI")),
+      Arguments.argumentSet("empty", BatchScenario(operationName = "MULTI", batchSize = 0L)),
       Arguments.argumentSet(
         "single",
         BatchScenario(

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -250,7 +250,10 @@ class RediscalaClientTest {
 
   private def transactionScenarios(): Stream[Arguments] =
     Stream.of(
-      Arguments.argumentSet("empty", BatchScenario(operationName = "MULTI", batchSize = 0L)),
+      Arguments.argumentSet(
+        "empty",
+        BatchScenario(operationName = "MULTI", batchSize = 0L)
+      ),
       Arguments.argumentSet(
         "single",
         BatchScenario(


### PR DESCRIPTION
Treat explicit empty database batches as batches in the shared database semconv helpers. This makes `db.operation.batch.size = 0` drive stable batch span naming and query summaries while continuing to omit the batch-size attribute for single-statement batches, and adds extractor tests covering the empty-batch paths.