### PR TITLE
Extract multi-query batch operation attributes

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -15,12 +15,20 @@ class MultiQuery {
   @Nullable private final String storedProcedureName;
   private final Set<String> queryTexts;
   @Nullable private final String querySummary;
+  @Nullable private final String operationName;
+  @Nullable private final String collectionName;
 
   private MultiQuery(
-      @Nullable String storedProcedureName, Set<String> queryTexts, @Nullable String querySummary) {
+      @Nullable String storedProcedureName,
+      Set<String> queryTexts,
+      @Nullable String querySummary,
+      @Nullable String operationName,
+      @Nullable String collectionName) {
     this.storedProcedureName = storedProcedureName;
     this.queryTexts = queryTexts;
     this.querySummary = querySummary;
+    this.operationName = operationName;
+    this.collectionName = collectionName;
   }
 
   static MultiQuery analyzeWithSummary(Collection<String> rawQueryTexts, SqlDialect dialect) {
@@ -47,6 +55,16 @@ class MultiQuery {
     return querySummary;
   }
 
+  @Nullable
+  public String getOperationName() {
+    return operationName;
+  }
+
+  @Nullable
+  public String getCollectionName() {
+    return collectionName;
+  }
+
   public Set<String> getQueryTexts() {
     return queryTexts;
   }
@@ -55,19 +73,28 @@ class MultiQuery {
     private final UniqueValue uniqueStoredProcedureName = new UniqueValue();
     private final Set<String> uniqueQueryTexts = new LinkedHashSet<>();
     private final UniqueValue uniqueQuerySummary = new UniqueValue();
+    private final UniqueValue uniqueOperationName = new UniqueValue();
+    private final UniqueValue uniqueCollectionName = new UniqueValue();
 
+    @SuppressWarnings(
+        "deprecation") // getOperationName()/getCollectionName() package-private in 3.0
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);
       uniqueQuerySummary.set(analyzedQuery.getQuerySummary());
+      uniqueOperationName.set(analyzedQuery.getOperationName());
+      uniqueCollectionName.set(analyzedQuery.getCollectionName());
     }
 
     MultiQuery build() {
       String querySummary = uniqueQuerySummary.getValue();
+      String operationName = uniqueOperationName.getValue();
       return new MultiQuery(
           uniqueStoredProcedureName.getValue(),
           uniqueQueryTexts,
-          querySummary == null ? "BATCH" : "BATCH " + querySummary);
+          querySummary == null ? "BATCH" : "BATCH " + querySummary,
+          operationName == null ? "BATCH" : "BATCH " + operationName,
+          uniqueCollectionName.getValue());
     }
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -76,8 +76,9 @@ class MultiQuery {
     private final UniqueValue uniqueOperationName = new UniqueValue();
     private final UniqueValue uniqueCollectionName = new UniqueValue();
 
-    @SuppressWarnings(
-        "deprecation") // getOperationName()/getCollectionName() package-private in 3.0
+    // getOperationName()/getCollectionName() are deprecated because they will become
+    // package-private in 3.0. This helper is in the same package, so it can still use them.
+    @SuppressWarnings("deprecation")
     void add(SqlQuery analyzedQuery, @Nullable String queryText) {
       uniqueStoredProcedureName.set(analyzedQuery.getStoredProcedureName());
       uniqueQueryTexts.add(queryText);

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -151,6 +151,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         MultiQuery multiQuery = builder.build();
         attributes.put(DB_QUERY_TEXT, join("; ", multiQuery.getQueryTexts()));
         attributes.put(DB_QUERY_SUMMARY, multiQuery.getQuerySummary());
+        if (singleOperationAndCollection) {
+          attributes.put(DB_OPERATION_NAME, multiQuery.getOperationName());
+          attributes.put(DB_COLLECTION_NAME, multiQuery.getCollectionName());
+        }
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
       }
     }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -9,8 +9,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDiale
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
@@ -462,6 +464,66 @@ class SqlClientAttributesExtractorTest {
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
   }
+
+    @Test
+    void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
+    // given
+    Map<String, Object> sameOperation = new HashMap<>();
+    sameOperation.put("db.namespace", "potatoes");
+    sameOperation.put(
+      "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
+    sameOperation.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedOperations = new HashMap<>();
+    mixedOperations.put("db.namespace", "potatoes");
+    mixedOperations.put(
+      "db.query.texts",
+      asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
+    mixedOperations.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Map<String, Object> mixedCollections = new HashMap<>();
+    mixedCollections.put("db.namespace", "potatoes");
+    mixedCollections.put(
+      "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
+    mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+      SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
+        .setSingleOperationAndCollection(true)
+        .build();
+
+    // when
+    AttributesBuilder sameOperationAttributes = Attributes.builder();
+    underTest.onStart(sameOperationAttributes, context, sameOperation);
+
+    AttributesBuilder mixedOperationsAttributes = Attributes.builder();
+    underTest.onStart(mixedOperationsAttributes, context, mixedOperations);
+
+    AttributesBuilder mixedCollectionsAttributes = Attributes.builder();
+    underTest.onStart(mixedCollectionsAttributes, context, mixedCollections);
+
+    // then
+    if (emitStableDatabaseSemconv()) {
+      assertThat(sameOperationAttributes.build())
+        .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+        .containsEntry(DB_COLLECTION_NAME, "potato")
+        .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
+      assertThat(mixedOperationsAttributes.build())
+        .containsEntry(DB_OPERATION_NAME, "BATCH")
+        .containsEntry(DB_COLLECTION_NAME, "potato")
+        .containsEntry(DB_QUERY_SUMMARY, "BATCH");
+      // different collections -> db.collection.name is omitted, db.operation.name is BATCH INSERT
+      assertThat(mixedCollectionsAttributes.build())
+        .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+        .doesNotContainKey(DB_COLLECTION_NAME);
+    } else {
+      assertThat(sameOperationAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedOperationsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+      assertThat(mixedCollectionsAttributes.build().get(DB_OPERATION_NAME)).isNull();
+    }
+    }
 
   @Test
   void shouldIgnoreBatchSizeOne() {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -465,34 +465,34 @@ class SqlClientAttributesExtractorTest {
     assertThat(endAttributes.build().isEmpty()).isTrue();
   }
 
-    @Test
-    void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
+  @Test
+  void shouldExtractMultiQueryBatchOperationNameWhenSingleOperationAndCollection() {
     // given
     Map<String, Object> sameOperation = new HashMap<>();
     sameOperation.put("db.namespace", "potatoes");
     sameOperation.put(
-      "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
     sameOperation.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
 
     Map<String, Object> mixedOperations = new HashMap<>();
     mixedOperations.put("db.namespace", "potatoes");
     mixedOperations.put(
-      "db.query.texts",
-      asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
+        "db.query.texts",
+        asList("INSERT INTO potato VALUES(1)", "UPDATE potato SET name='bob' WHERE id=1"));
     mixedOperations.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
 
     Map<String, Object> mixedCollections = new HashMap<>();
     mixedCollections.put("db.namespace", "potatoes");
     mixedCollections.put(
-      "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO tomato VALUES(2)"));
     mixedCollections.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
 
     Context context = Context.root();
 
     AttributesExtractor<Map<String, Object>, Void> underTest =
-      SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
-        .setSingleOperationAndCollection(true)
-        .build();
+        SqlClientAttributesExtractor.builder(new TestMultiAttributesGetter())
+            .setSingleOperationAndCollection(true)
+            .build();
 
     // when
     AttributesBuilder sameOperationAttributes = Attributes.builder();
@@ -507,23 +507,23 @@ class SqlClientAttributesExtractorTest {
     // then
     if (emitStableDatabaseSemconv()) {
       assertThat(sameOperationAttributes.build())
-        .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
-        .containsEntry(DB_COLLECTION_NAME, "potato")
-        .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH INSERT potato");
       assertThat(mixedOperationsAttributes.build())
-        .containsEntry(DB_OPERATION_NAME, "BATCH")
-        .containsEntry(DB_COLLECTION_NAME, "potato")
-        .containsEntry(DB_QUERY_SUMMARY, "BATCH");
+          .containsEntry(DB_OPERATION_NAME, "BATCH")
+          .containsEntry(DB_COLLECTION_NAME, "potato")
+          .containsEntry(DB_QUERY_SUMMARY, "BATCH");
       // different collections -> db.collection.name is omitted, db.operation.name is BATCH INSERT
       assertThat(mixedCollectionsAttributes.build())
-        .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
-        .doesNotContainKey(DB_COLLECTION_NAME);
+          .containsEntry(DB_OPERATION_NAME, "BATCH INSERT")
+          .doesNotContainKey(DB_COLLECTION_NAME);
     } else {
       assertThat(sameOperationAttributes.build().get(DB_OPERATION_NAME)).isNull();
       assertThat(mixedOperationsAttributes.build().get(DB_OPERATION_NAME)).isNull();
       assertThat(mixedCollectionsAttributes.build().get(DB_OPERATION_NAME)).isNull();
     }
-    }
+  }
 
   @Test
   void shouldIgnoreBatchSizeOne() {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -395,6 +395,8 @@ class CassandraClientTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
+                .operationName("BATCH INSERT")
+                .collectionName("batch_test.records")
                 .build()),
         argumentSet(
             "twoDifferentOperations",
@@ -415,6 +417,8 @@ class CassandraClientTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
+                .operationName("BATCH")
+                .collectionName("batch_test.records")
                 .build()));
   }
 

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -305,6 +305,8 @@ public abstract class AbstractCassandraTest {
                 .queryText("INSERT INTO batch_test.records (id, num) values (?, ?)")
                 .querySummary("BATCH INSERT batch_test.records")
                 .batchSize(2)
+                .operationName("BATCH INSERT")
+                .collectionName("batch_test.records")
                 .build()),
         argumentSet(
             "twoDifferentOperations",
@@ -325,6 +327,8 @@ public abstract class AbstractCassandraTest {
                     "INSERT INTO batch_test.records (id, num) values (4, ?); UPDATE batch_test.records SET num = ? WHERE id = ?")
                 .querySummary("BATCH")
                 .batchSize(2)
+                .operationName("BATCH")
+                .collectionName("batch_test.records")
                 .build()));
   }
 


### PR DESCRIPTION
Emit stable `db.operation.name` and `db.collection.name` for multi-query SQL batches when `singleOperationAndCollection` is enabled. `MultiQuery` now tracks unique operation and collection values independently so mixed-operation batches report `BATCH`, while mixed-collection batches can still preserve the common operation and omit the collection.