### PR TITLE
Deprecate config parameters in javaagent extension SPIs

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -94,7 +94,7 @@ public abstract class InstrumentationModule implements Ordered {
    * Allows instrumentation modules to disable themselves by default, or to additionally disable
    * themselves on some other condition.
    *
-   * @deprecated Use {@link #defaultEnabled()} instead.
+   * @deprecated Use {@link #defaultEnabled()} instead. Will be removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public boolean defaultEnabled(ConfigProperties config) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentExtension.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentExtension.java
@@ -26,7 +26,21 @@ public interface AgentExtension extends Ordered {
    * @return The customized agent. Note that this method MUST return a non-null {@link AgentBuilder}
    *     instance that contains all customizations defined in this extension.
    */
-  AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config);
+  default AgentBuilder extend(AgentBuilder agentBuilder) {
+    return agentBuilder;
+  }
+
+  /**
+   * Extend the passed {@code agentBuilder} with custom logic (e.g. instrumentation).
+   *
+   * @return The customized agent. Note that this method MUST return a non-null {@link AgentBuilder}
+   *     instance that contains all customizations defined in this extension.
+   * @deprecated Use {@link #extend(AgentBuilder)} instead. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
+  default AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
+    return extend(agentBuilder);
+  }
 
   /**
    * Returns the name of the extension. It does not have to be unique, but it should be

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -105,6 +105,8 @@ public class AgentInstaller {
     }
   }
 
+  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
+  @SuppressWarnings("deprecation")
   private static void installBytebuddyAgent(
       Instrumentation inst,
       ClassLoader extensionClassLoader,
@@ -153,8 +155,7 @@ public class AgentInstaller {
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
         installOpenTelemetrySdk(extensionClassLoader);
-
-    ConfigProperties sdkConfig = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    ConfigProperties sdkConfig = getConfig(autoConfiguredSdk);
 
     setBootstrapPackages(sdkConfig, extensionClassLoader);
     ConfiguredResourceAttributesHolder.initialize(
@@ -212,6 +213,11 @@ public class AgentInstaller {
     runAfterAgentListeners(agentListeners, autoConfiguredSdk);
   }
 
+  private static ConfigProperties getConfig(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
+    ConfigProperties config = AutoConfigureUtil.getConfig(autoConfiguredSdk);
+    return config == null ? EmptyConfigProperties.INSTANCE : config;
+  }
+
   private static AgentBuilder newAgentBuilder(ByteBuddy byteBuddy) {
     // AgentBuilder.Default constructor triggers sun.misc.Unsafe::objectFieldOffset called warning
     // AgentBuilder$Default.<init>
@@ -267,6 +273,8 @@ public class AgentInstaller {
     agentBuilder.installOn(instrumentation);
   }
 
+  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
+  @SuppressWarnings("deprecation")
   private static void setBootstrapPackages(
       ConfigProperties config, ClassLoader extensionClassLoader) {
     BootstrapPackagesBuilderImpl builder = new BootstrapPackagesBuilderImpl();
@@ -281,14 +289,14 @@ public class AgentInstaller {
     DefineClassHelper.internalSetHandler(DefineClassHandler.INSTANCE);
   }
 
-  // Need to call deprecated API for backward compatibility with extensions that haven't migrated
+  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
   @SuppressWarnings("deprecation")
   private static AgentBuilder configureIgnoredTypes(
       ConfigProperties config, ClassLoader extensionClassLoader, AgentBuilder agentBuilder) {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
     for (IgnoredTypesConfigurer configurer :
         loadOrdered(IgnoredTypesConfigurer.class, extensionClassLoader)) {
-      configurer.configure(builder, config != null ? config : EmptyConfigProperties.INSTANCE);
+      configurer.configure(builder, config);
     }
 
     Trie<Boolean> ignoredTasksTrie = builder.buildIgnoredTasksTrie();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bootstrap/BootstrapPackagesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bootstrap/BootstrapPackagesConfigurer.java
@@ -24,5 +24,16 @@ public interface BootstrapPackagesConfigurer {
    * Configure the passed {@code builder} and define which classes should always be loaded by the
    * bootstrap class loader.
    */
-  void configure(BootstrapPackagesBuilder builder, ConfigProperties config);
+  default void configure(BootstrapPackagesBuilder builder) {}
+
+  /**
+   * Configure the passed {@code builder} and define which classes should always be loaded by the
+   * bootstrap class loader.
+   *
+   * @deprecated Use {@link #configure(BootstrapPackagesBuilder)} instead. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
+  default void configure(BootstrapPackagesBuilder builder, ConfigProperties config) {
+    configure(builder);
+  }
 }

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentExtension.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentExtension.java
@@ -7,14 +7,13 @@ package io.opentelemetry.javaagent.testing.bytebuddy;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.AgentExtension;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
 @AutoService(AgentExtension.class)
 public class TestAgentExtension implements AgentExtension {
 
   @Override
-  public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
+  public AgentBuilder extend(AgentBuilder agentBuilder) {
     return agentBuilder.with(TestAgentListener.INSTANCE);
   }
 


### PR DESCRIPTION
Add no-config overloads for javaagent extension and bootstrap package SPIs, and deprecate their ConfigProperties-taking methods for removal in 3.0. Existing install paths continue to call the deprecated overloads so current custom extensions keep working while migrated implementations can override the new no-config methods.

For open question, see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/15798#issuecomment-4920353687

