### PR TITLE
Add Ktor 3.0 client span accessors and bridge them under the agent

### DIFF
--- a/instrumentation/ktor/ktor-3.0/javaagent/README.md
+++ b/instrumentation/ktor/ktor-3.0/javaagent/README.md
@@ -1,0 +1,53 @@
+# Auto-instrumentation for Ktor version 3.0 and higher
+
+Provides OpenTelemetry auto-instrumentation for [Ktor](https://ktor.io/) server and client.
+
+The agent installs the same `KtorServerTelemetry` / `KtorClientTelemetry` plugins as the
+[library instrumentation](../library/README.md), so no code changes are required. See the library
+README for configuration details.
+
+## Setting attributes on the client span
+
+There are two ways to reach the client span inside the `execute { }` block under the agent.
+
+### Ambient context
+
+The agent instruments `HttpStatement.execute` so the client span is the ambient OpenTelemetry `Context`
+inside the block. This needs only `opentelemetry-api` (plus `opentelemetry-extension-kotlin` for the
+coroutine form below) — no instrumentation library dependency. In coroutine code, read it from the
+current coroutine context:
+
+```kotlin
+import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
+
+client.prepareGet("https://example.com").execute { response ->
+  Span.fromContext(currentCoroutineContext().getOpenTelemetryContext())
+    .setAttribute("example.attribute", "value")
+  // ...
+}
+```
+
+The ambient form is unique to the agent — it is unavailable with the library instrumentation.
+
+### Library helper
+
+If you also depend on the `opentelemetry-ktor-3.0` library artifact (for example so the same code
+runs with either the agent or the library), you can use `HttpClientCall.withClientSpan { }`
+instead. The agent bridges the context it stores on the call, so this works identically under the
+agent:
+
+```kotlin
+import io.opentelemetry.instrumentation.ktor.v3_0.withClientSpan
+
+client.prepareGet("https://example.com").execute { response ->
+  response.call.withClientSpan {
+    setAttribute("example.attribute", "value")
+  }
+  // ...
+}
+```
+
+This is the same API documented in the
+[library README](../library/README.md#setting-attributes-on-the-client-span); it reads the span
+straight from the call, with no thread-local or coroutine context dependency. It does require the
+library artifact on the classpath, which a pure-agent setup would not otherwise need.

--- a/instrumentation/ktor/ktor-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/ktor/ktor-3.0/javaagent/build.gradle.kts
@@ -12,6 +12,11 @@ muzzle {
     versions.set("[3.0.0,)")
     assertInverse.set(true)
     excludeInstrumentationName("ktor-server")
+    // the client span context bridging in KtorClientExtensionsInstrumentation pulls in the
+    // opentelemetry-api instrumentation, which needs the api on the classpath and its own module
+    // excluded from this module's muzzle check
+    extraDependency("io.opentelemetry:opentelemetry-api:1.0.0")
+    excludeInstrumentationName("opentelemetry-api")
   }
   pass {
     group.set("io.ktor")
@@ -19,6 +24,8 @@ muzzle {
     versions.set("[3.0.0,)")
     assertInverse.set(true)
     excludeInstrumentationName("ktor-client")
+    extraDependency("io.opentelemetry:opentelemetry-api:1.0.0")
+    excludeInstrumentationName("opentelemetry-api")
   }
 }
 
@@ -29,6 +36,12 @@ dependencies {
   library("io.ktor:ktor-server-core:$ktorVersion")
 
   implementation(project(":instrumentation:ktor:ktor-3.0:library"))
+
+  // needed for bridging the shaded Context stored on the call back to the application context in
+  // KtorClientExtensionsInstrumentation
+  implementation(project(":instrumentation:opentelemetry-api:opentelemetry-api-1.0:javaagent"))
+  // see the comment in opentelemetry-api-1.0.gradle for more details
+  compileOnly(project(":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
 
   compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 

--- a/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/HttpStatementInstrumentation.java
+++ b/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/HttpStatementInstrumentation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.ktor.v3_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.instrumentation.ktor.common.v2_0.internal.KtorClientTelemetryUtil;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class HttpStatementInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("io.ktor.client.statement.HttpStatement");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("execute").and(takesArgument(0, named("kotlin.jvm.functions.Function2"))),
+        getClass().getName() + "$ExecuteAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ExecuteAdvice {
+
+    @AssignReturned.ToArguments(@ToArgument(0))
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static Object onEnter(@Advice.Argument(0) Object block) {
+      return KtorClientTelemetryUtil.wrapWithClientSpanContext(block);
+    }
+  }
+}

--- a/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/KtorClientExtensionsInstrumentation.java
+++ b/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/KtorClientExtensionsInstrumentation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.ktor.v3_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.ktor.client.call.HttpClientCall;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.ktor.common.v2_0.internal.KtorClientTelemetryUtil;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.opentelemetryapi.v1_0.context.AgentContextStorage;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Bridges the library extension {@code HttpClientCall.getOpenTelemetryContext()} so it works under
+ * the agent. The library stores an agent-shaded {@code Context} on the call; the application-side
+ * method body reads it as an application {@code Context}, which fails with a {@code
+ * ClassCastException}. This advice reads the shaded context via the agent-shaded util, converts it
+ * to an application context, and skips the original body.
+ */
+class KtorClientExtensionsInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    // the "application." prefix targets the application's (unshaded) class; without it the agent
+    // remaps the matcher to the shaded helper copy, which is never loaded as an application class
+    return named("application.io.opentelemetry.instrumentation.ktor.v3_0.KtorClientExtensionsKt");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getOpenTelemetryContext")
+            .and(takesArgument(0, named("io.ktor.client.call.HttpClientCall"))),
+        getClass().getName() + "$GetOpenTelemetryContextAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class GetOpenTelemetryContextAdvice {
+
+    @Nullable
+    @Advice.OnMethodEnter(
+        skipOn = Advice.OnNonDefaultValue.class,
+        suppress = Throwable.class,
+        inline = false)
+    public static application.io.opentelemetry.context.Context enter(
+        @Advice.Argument(0) HttpClientCall call) {
+      Context agentContext = KtorClientTelemetryUtil.getOpenTelemetryContext(call);
+      if (agentContext == null) {
+        return null;
+      }
+      return AgentContextStorage.toApplicationContext(agentContext);
+    }
+
+    @Nullable
+    @AssignReturned.ToReturned
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static application.io.opentelemetry.context.Context onExit(
+        @Advice.Return application.io.opentelemetry.context.Context originalResult,
+        @Advice.Enter @Nullable application.io.opentelemetry.context.Context context) {
+      return context != null ? context : originalResult;
+    }
+  }
+}

--- a/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/KtorClientInstrumentationModule.java
+++ b/instrumentation/ktor/ktor-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v3_0/KtorClientInstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.ktor.v3_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -35,6 +35,9 @@ public class KtorClientInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new HttpClientInstrumentation());
+    return asList(
+        new HttpClientInstrumentation(),
+        new HttpStatementInstrumentation(),
+        new KtorClientExtensionsInstrumentation());
   }
 }

--- a/instrumentation/ktor/ktor-3.0/javaagent/src/test/java/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-3.0/javaagent/src/test/java/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
@@ -6,17 +6,66 @@
 package io.opentelemetry.instrumentation.ktor.v3_0
 
 import io.ktor.client.*
+import io.ktor.client.statement.*
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension
+import kotlinx.coroutines.currentCoroutineContext
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.UUID
 
 class KtorHttpClientTest : AbstractKtorHttpClientTest() {
 
   companion object {
     @JvmStatic
     @RegisterExtension
-    private val testing = HttpClientInstrumentationExtension.forAgent()
+    private val testingExtension = HttpClientInstrumentationExtension.forAgent()
   }
 
   override fun HttpClientConfig<*>.installTracing() {
+  }
+
+  // The agent wraps HttpStatement.execute so the client span is active as the ambient context
+  // inside the execute block, reachable via Span.current() and the coroutine context. The library
+  // cannot do this; it exposes the span via HttpClientCall instead (see the library test).
+  @Test
+  fun spanAmbientInExecuteBlock() {
+    val spanCurrentAttributeKey = AttributeKey.stringKey("Span.current()")
+    val spanCurrentAttributeValue = UUID.randomUUID().toString()
+
+    val coroutineContextAttributeKey = AttributeKey.stringKey("currentCoroutineContext()")
+    val coroutineContextAttributeValue = UUID.randomUUID().toString()
+
+    // The agent bridges the shaded Context stored on the call, so the library's HttpClientCall
+    // accessor also works under the agent (see KtorClientExtensionsInstrumentation).
+    val clientCallAttributeKey = AttributeKey.stringKey("HttpClientCall.withClientSpan")
+    val clientCallAttributeValue = UUID.randomUUID().toString()
+
+    val uri = resolveAddress("/success")
+    val request = buildRequest("GET", uri, mutableMapOf())
+
+    sendStreamingRequest(request) { response ->
+      response.bodyAsText()
+      Span.current().setAttribute(spanCurrentAttributeKey, spanCurrentAttributeValue)
+      Span.fromContext(currentCoroutineContext().getOpenTelemetryContext()).setAttribute(coroutineContextAttributeKey, coroutineContextAttributeValue)
+      response.call.withClientSpan { setAttribute(clientCallAttributeKey, clientCallAttributeValue) }
+    }
+
+    testing.waitAndAssertTraces(
+      { trace ->
+        trace.hasSpansSatisfyingExactly(
+          { span ->
+            span.hasName("GET").hasKind(SpanKind.CLIENT).hasNoParent()
+              .hasAttribute(spanCurrentAttributeKey, spanCurrentAttributeValue)
+              .hasAttribute(coroutineContextAttributeKey, coroutineContextAttributeValue)
+              .hasAttribute(clientCallAttributeKey, clientCallAttributeValue)
+          },
+          { span -> assertServerSpan(span).hasParent(trace.getSpan(0)) },
+        )
+      }
+    )
   }
 }

--- a/instrumentation/ktor/ktor-3.0/library/README.md
+++ b/instrumentation/ktor/ktor-3.0/library/README.md
@@ -61,3 +61,35 @@ val client = HttpClient {
   }
 }
 ```
+
+### Setting attributes on the client span
+
+The client span is stored on the `HttpClientCall` and can be reached from a response. This is the
+supported way to enrich the client span with the library instrumentation, from inside a
+`HttpStatement.execute { }` block, where the client span is not the ambient `Context`:
+
+```kotlin
+import io.opentelemetry.instrumentation.ktor.v3_0.withClientSpan
+
+client.prepareGet("https://example.com").execute { response ->
+  response.call.withClientSpan {
+    setAttribute("example.attribute", "value")
+  }
+  // ...
+}
+```
+
+`HttpClientCall.getOpenTelemetryContext()` is also available if you need the raw `Context` (for
+example to make it current via `asContextElement()`). Both return `null`/no-op if no span was
+created. e.g. if instrumentation is disabled, or the client span was suppressed because a client
+span was already active.
+
+The client span ends when the call completes, so mutate it while the call is still in progress
+(within the `execute` block); attribute changes after the span has ended are no-ops.
+
+> [!NOTE]
+> This `HttpClientCall` approach also works under the OpenTelemetry Java agent (the agent bridges
+> the context it stores on the call). Under the agent the client span is additionally available as
+> the ambient `Context` inside the `execute` block, so `Span.current()` works there too — see the
+> [javaagent README](../javaagent/README.md#setting-attributes-on-the-client-span). Prefer this
+> `HttpClientCall` approach if your code must run in both modes.

--- a/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorClientExtensions.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorClientExtensions.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ktor.v3_0
+
+import io.ktor.client.call.*
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.ktor.common.v2_0.internal.KtorClientTelemetryUtil
+
+/**
+ * Returns the OpenTelemetry [Context] carrying the client span created for this call, or `null` if
+ * no span was created (for example if instrumentation is disabled, or the client span was
+ * suppressed because a client span was already active).
+ *
+ * Intended for use inside the `HttpStatement.execute { }` block, where the client span is still
+ * active. The client span ends when the call completes, after which mutations to it are silently
+ * dropped.
+ */
+fun HttpClientCall.getOpenTelemetryContext(): Context? = KtorClientTelemetryUtil.getOpenTelemetryContext(this)
+
+/**
+ * Runs [block] with the client [Span] created for this call as the receiver. Does nothing if no
+ * span was created (see [getOpenTelemetryContext]).
+ *
+ * Intended for use inside the `HttpStatement.execute { }` block, where the client span is still
+ * active. The client span ends when the call completes, after which mutations to it are silently
+ * dropped.
+ */
+inline fun HttpClientCall.withClientSpan(block: Span.() -> Unit) {
+  val context = getOpenTelemetryContext() ?: return
+  Span.fromContext(context).block()
+}

--- a/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
@@ -6,8 +6,13 @@
 package io.opentelemetry.instrumentation.ktor.v3_0
 
 import io.ktor.client.*
+import io.ktor.client.statement.*
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.UUID
 
 class KtorHttpClientTest : AbstractKtorHttpClientTest() {
 
@@ -23,5 +28,35 @@ class KtorHttpClientTest : AbstractKtorHttpClientTest() {
       capturedRequestHeaders(TEST_REQUEST_HEADER)
       capturedResponseHeaders(TEST_RESPONSE_HEADER)
     }
+  }
+
+  // The library cannot make the client span the ambient context inside the execute block (that
+  // needs bytecode instrumentation of HttpStatement.execute, which only the agent has). Instead it
+  // exposes the span via the HttpClientCall of the response, using the same span stored on the
+  // call attributes that the agent bridge reads.
+  @Test
+  fun spanAccessibleViaClientCallInExecuteBlock() {
+    val attributeKey = AttributeKey.stringKey("HttpClientCall.withClientSpan")
+    val attributeValue = UUID.randomUUID().toString()
+
+    val uri = resolveAddress("/success")
+    val request = buildRequest("GET", uri, mutableMapOf())
+
+    sendStreamingRequest(request) { response ->
+      response.bodyAsText()
+      response.call.withClientSpan { setAttribute(attributeKey, attributeValue) }
+    }
+
+    testing.waitAndAssertTraces(
+      { trace ->
+        trace.hasSpansSatisfyingExactly(
+          { span ->
+            span.hasName("GET").hasKind(SpanKind.CLIENT).hasNoParent()
+              .hasAttribute(attributeKey, attributeValue)
+          },
+          { span -> assertServerSpan(span).hasParent(trace.getSpan(0)) },
+        )
+      }
+    )
   }
 }

--- a/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-3.0/testing/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/AbstractKtorHttpClientTest.kt
@@ -66,13 +66,12 @@ abstract class AbstractKtorHttpClientTest : AbstractHttpClientTest<HttpRequestBu
     client.request(request).status.value
   }
 
-  fun sendStreamingRequest(request: HttpRequestBuilder) = runBlocking {
+  fun sendStreamingRequest(request: HttpRequestBuilder, executeBlock: suspend (HttpResponse) -> Unit) = runBlocking {
     // withTimeout ensures requests complete before the HttpTimeout fires. The bug this guards
     // against caused the instrumentation to prevent timely completion of streaming requests.
     withTimeout(5.seconds) {
       client.prepareRequest(request).execute { response ->
-        response.bodyAsText()
-        response.status.value
+        executeBlock(response)
       }
     }
   }
@@ -82,7 +81,9 @@ abstract class AbstractKtorHttpClientTest : AbstractHttpClientTest<HttpRequestBu
     val uri = resolveAddress("/success")
     val request = buildRequest("GET", uri, mutableMapOf())
 
-    sendStreamingRequest(request)
+    sendStreamingRequest(request) { response ->
+      response.bodyAsText()
+    }
 
     testing.waitAndAssertTraces(
       { trace ->

--- a/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorClientTelemetryUtil.kt
+++ b/instrumentation/ktor/ktor-common-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/common/v2_0/internal/KtorClientTelemetryUtil.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.ktor.common.v2_0.internal
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.util.*
@@ -24,6 +25,26 @@ import kotlinx.coroutines.withContext
 object KtorClientTelemetryUtil {
   private val OPEN_TELEMETRY_CONTEXT_KEY = AttributeKey<Context>("OpenTelemetry")
   private val OPEN_TELEMETRY_PARENT_CONTEXT_KEY = AttributeKey<Context>("OpenTelemetryParent")
+
+  /** Returns the OpenTelemetry [Context] holding the client span for [call], or null if absent. */
+  @JvmStatic
+  fun getOpenTelemetryContext(call: HttpClientCall): Context? = call.attributes.getOrNull(OPEN_TELEMETRY_CONTEXT_KEY)
+
+  @JvmStatic
+  @Suppress("UNCHECKED_CAST")
+  fun wrapWithClientSpanContext(block: Any?): Any? {
+    block ?: return null
+    val original = block as suspend (HttpResponse) -> Any?
+    val wrapped: suspend (HttpResponse) -> Any? = { response ->
+      val otelContext = response.call.attributes.getOrNull(OPEN_TELEMETRY_CONTEXT_KEY)
+      if (otelContext != null) {
+        withContext(otelContext.asContextElement()) { original(response) }
+      } else {
+        original(response)
+      }
+    }
+    return wrapped
+  }
 
   fun install(plugin: AbstractKtorClientTelemetry, scope: HttpClient) {
     installSpanCreation(plugin, scope)


### PR DESCRIPTION
Ktor client instrumentation improvement to first-class support adding attributes to client spans, e.g. setting data from the parsed response.

New public library APIs (`io.opentelemetry.instrumentation.ktor.v3_0`):
- `HttpClientCall.getOpenTelemetryContext(): Context?`: null if no span was created (disabled, or suppressed by an already-active client span).
- `HttpClientCall.withClientSpan { }`: runs a block with the client Span as receiver; no-op when absent.

Bridged under the agent (new): reading the stored `Context` from application code previously threw ClassCastException due to being shaded under the agent.
`KtorClientExtensionsInstrumentation` instruments the app-side accessor and converts the shaded `Context` to the application `Context`, so `getOpenTelemetryContext` / `withClientSpan` now behave identically with the agent.

Ambient access (`Span.current()`, coroutine context) now works as expected out of the box inside the `execute { }` block.