### PR TITLE
Fix R2DBC empty batch size telemetry

### DIFF
--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -110,7 +110,10 @@ public final class DbExecution {
                     R2dbcSqlCommenterUtil.getOriginalQuery(queryInfo.getConnectionInfo(), query))
             .collect(toList());
     int queryInfoBatchSize = queryInfo.getBatchSize();
-    this.batchSize = queryInfoBatchSize > 1 ? (long) queryInfoBatchSize : null;
+    // r2dbc-proxy reports 0 as the default size for ordinary non-batch executions. Those still
+    // have a query text; an empty Batch.execute() is represented with no query texts.
+    boolean emptyBatch = rawQueryTexts.isEmpty();
+    this.batchSize = queryInfoBatchSize > 1 || emptyBatch ? (long) queryInfoBatchSize : null;
     this.parameterizedQuery =
         queryInfo.getQueries().stream()
             .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -362,7 +362,7 @@ public abstract class AbstractR2dbcStatementTest {
                   trace.hasSpansSatisfyingExactly(
                       span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                       span ->
-                          span.hasName(DB)
+                          span.hasName(emitStableDatabaseSemconv() ? "BATCH" : DB)
                               .hasKind(SpanKind.CLIENT)
                               .hasParent(trace.getSpan(0))
                               .hasAttributesSatisfyingExactly(
@@ -375,7 +375,9 @@ public abstract class AbstractR2dbcStatementTest {
                                   equalTo(
                                       maybeStable(DB_STATEMENT),
                                       emitStableDatabaseSemconv() ? null : ""),
-                                  equalTo(DB_OPERATION_BATCH_SIZE, null),
+                                  equalTo(
+                                      DB_OPERATION_BATCH_SIZE,
+                                      emitStableDatabaseSemconv() ? 0L : null),
                                   equalTo(maybeStablePeerService(), "test-peer-service"),
                                   equalTo(SERVER_ADDRESS, container.getHost()),
                                   equalTo(SERVER_PORT, port),


### PR DESCRIPTION
Preserve R2DBC empty batch executions as batch operations with db.operation.batch.size=0 under stable database semantic conventions. Empty batch spans now use the stable BATCH span name while retaining the existing error.type behavior for the failed execution.