### PR TITLE
Fix Vert.x SQL empty batch size telemetry

### DIFF
--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
@@ -101,7 +101,7 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            batchSize = size == 1 ? null : (long) size;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -364,8 +364,9 @@ class VertxSqlClientTest {
             BatchScenario.builder()
                 .preparedQuery("insert into batch_test values ($1, $2) returning *")
                 .tuples(emptyList())
-                .stableSpanName("insert batch_test")
-                .querySummary("insert batch_test")
+                .stableSpanName("BATCH insert batch_test")
+                .querySummary("BATCH insert batch_test")
+                .batchSize(0)
                 .errorType("io.vertx.core.impl.NoStackTraceThrowable")
                 .build()),
         argumentSet(

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
@@ -100,7 +100,7 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            batchSize = size == 1 ? null : (long) size;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -365,8 +365,9 @@ class VertxSqlClientTest {
             BatchScenario.builder()
                 .preparedQuery("insert into batch_test values ($1, $2) returning *")
                 .tuples(emptyList())
-                .stableSpanName("insert batch_test")
-                .querySummary("insert batch_test")
+                .stableSpanName("BATCH insert batch_test")
+                .querySummary("BATCH insert batch_test")
+                .batchSize(0)
                 .errorType("io.vertx.core.VertxException")
                 .build()),
         argumentSet(


### PR DESCRIPTION
Preserve Vert.x SQL empty prepared batch executions as batch operations with db.operation.batch.size=0 under stable database semantic conventions. Empty batch spans now keep the prepared-query summary explicit with the BATCH prefix while retaining the existing error.type assertions for Vert.x SQL 4.0 and 5.0.