### PR TITLE
Remove deprecated query-related APIs

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
@@ -96,31 +96,19 @@ public interface SqlClientAttributesGetter<REQUEST, RESPONSE>
   Collection<String> getRawQueryTexts(REQUEST request);
 
   /**
-   * Returns whether the query is parameterized. Prepared statements are always considered
-   * parameterized even if no parameters are bound. By using a parameterized query the user is
-   * giving a strong signal that any sensitive data will be passed as parameter values, and so the
-   * query does not need to be sanitized. See <a
+   * Returns whether the query at {@code queryIndex} in {@link #getRawQueryTexts(Object)} is
+   * parameterized. Prepared statements are always considered parameterized even if no parameters
+   * are bound. By using a parameterized query the user is giving a strong signal that any sensitive
+   * data will be passed as parameter values, and so the query does not need to be sanitized. See <a
    * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sanitization-of-dbquerytext">sanitization
    * of db.query.text</a>.
-   *
-   * @deprecated use {@link #isParameterizedQuery(Object, int)} instead
-   */
-  @Deprecated
-  default boolean isParameterizedQuery(REQUEST request) {
-    return false;
-  }
-
-  /**
-   * Returns whether the query at {@code queryIndex} in {@link #getRawQueryTexts(Object)} is
-   * parameterized.
    *
    * <p>The {@code queryIndex} is zero-based and follows the iteration order of {@link
    * #getRawQueryTexts(Object)}. This supports batch operations where individual entries may have
    * different parameterization.
    */
   // TODO: make this required to implement
-  @SuppressWarnings("deprecation")
   default boolean isParameterizedQuery(REQUEST request, int queryIndex) {
-    return isParameterizedQuery(request);
+    return false;
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/Experimental.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.internal;
 
-import static java.util.Collections.emptySet;
-
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
@@ -45,17 +43,6 @@ public final class Experimental {
       exceptionEventExtractorSetter;
 
   private Experimental() {}
-
-  /**
-   * @deprecated Use {@link #setSensitiveQueryParameters(HttpClientAttributesExtractorBuilder, Set)}
-   *     instead.
-   */
-  @Deprecated
-  public static void setRedactQueryParameters(
-      HttpClientAttributesExtractorBuilder<?, ?> builder, boolean redactQueryParameters) {
-    setSensitiveQueryParameters(
-        builder, redactQueryParameters ? HttpConstants.SENSITIVE_QUERY_PARAMETERS : emptySet());
-  }
 
   public static void setSensitiveQueryParameters(
       HttpClientAttributesExtractorBuilder<?, ?> builder, Set<String> sensitiveQueryParameters) {

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraAttributesExtractor.java
@@ -110,8 +110,6 @@ final class CassandraAttributesExtractor
 
     Statement<?> statement = (Statement<?>) executionInfo.getRequest();
     String consistencyLevel;
-    // getSession() is deprecated only because its visibility will be reduced in the future.
-    @SuppressWarnings("deprecation")
     DriverExecutionProfile config =
         request.getSession().getContext().getConfig().getDefaultProfile();
     if (statement.getConsistencyLevel() != null) {

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraRequest.java
@@ -22,12 +22,6 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class CassandraRequest {
 
-  @Deprecated
-  public static CassandraRequest create(
-      Session session, String queryText, boolean parameterizedQuery) {
-    return create(session, singleton(queryText), parameterizedQuery, null, null);
-  }
-
   static CassandraRequest create(Session session, String queryText) {
     return create(session, singleton(queryText), false, null, null);
   }
@@ -110,42 +104,14 @@ public abstract class CassandraRequest {
     return false;
   }
 
-  /**
-   * @deprecated this method will be reduced to package-private visibility
-   */
-  @Deprecated
-  public abstract Session getSession();
+  abstract Session getSession();
 
   abstract Collection<String> getQueryTexts();
-
-  /**
-   * Returns the raw query text.
-   *
-   * @deprecated use {@link #getQueryTexts()} instead
-   */
-  @Deprecated
-  public String getQueryText() {
-    if (getBatchSize() != null) {
-      // Preserve previous public API behavior: BatchStatement query text was not captured.
-      return "";
-    }
-    return getQueryTexts().iterator().next();
-  }
 
   abstract boolean allQueriesParameterized();
 
   @Nullable
   abstract List<Boolean> mixedParameterizedQueries();
-
-  /**
-   * Returns whether all queries in this request are parameterized.
-   *
-   * @deprecated use {@link #isParameterizedQuery(int)} instead
-   */
-  @Deprecated
-  public boolean isParameterizedQuery() {
-    return allQueriesParameterized();
-  }
 
   boolean isParameterizedQuery(int queryIndex) {
     List<Boolean> mixedParameterizedQueries = mixedParameterizedQueries();

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraSqlAttributesGetter.java
@@ -35,8 +35,6 @@ final class CassandraSqlAttributesGetter
     return DOUBLE_QUOTES_ARE_IDENTIFIERS;
   }
 
-  // getSession() is deprecated only because its visibility will be reduced in the future.
-  @SuppressWarnings("deprecation")
   @Override
   @Nullable
   public String getDbNamespace(CassandraRequest request) {


### PR DESCRIPTION
Removes deprecated query-related APIs flagged during pre-3.0 cleanup. All are in non-stable (alpha) modules or in an `.internal` package (both excluded from the japicmp API-compatibility gate):

- `SqlClientAttributesGetter.isParameterizedQuery(REQUEST)` (incubator, deprecated in 2.29.0) — use `isParameterizedQuery(Object, int)`. The sanitization guidance from its Javadoc was folded into the two-arg method.
- `Experimental.setRedactQueryParameters(...)` (`instrumentation-api` `.internal`, deprecated in 2.26.0) — use `setSensitiveQueryParameters(...)`.
- `CassandraRequest.create(Session, String, boolean)`, `getQueryText()`, and `isParameterizedQuery()` (cassandra-4.4 library, deprecated in 2.29.0) — use the batch-aware replacements.
- `CassandraRequest.getSession()` is reduced to package-private (its deprecation note stated its visibility would be reduced; it is still used in-package).