### PR TITLE
Clarify Redis batch query truncation

### DIFF
--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -342,9 +342,9 @@ public abstract class AbstractRedissonClientTest {
     }
     String bucketName = bucketNameBuilder.toString();
     int batchSize = 4;
-    int queryTextCommandCount = 2;
-    for (int commandIndex = 0; commandIndex < batchSize; commandIndex++) {
-      batch.getBucket(bucketName).setAsync("v" + commandIndex);
+    int truncatedQueryTextCommandCount = 2;
+    for (int i = 0; i < batchSize; i++) {
+      batch.getBucket(bucketName).setAsync("v" + i);
     }
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
@@ -370,7 +370,9 @@ public abstract class AbstractRedissonClientTest {
                                 maybeStable(DB_STATEMENT),
                                 String.join(
                                     ";",
-                                  nCopies(queryTextCommandCount, "SET " + bucketName + " ?"))))));
+                                    nCopies(
+                                        truncatedQueryTextCommandCount,
+                                        "SET " + bucketName + " ?"))))));
   }
 
   @Test

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -333,7 +333,7 @@ public abstract class AbstractRedissonClientTest {
   }
 
   @Test
-  void largeBatchCommandTruncatesQueryText() throws ReflectiveOperationException {
+  void batchCommandTruncatesQueryText() throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
     StringBuilder bucketNameBuilder = new StringBuilder("bucket");

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -365,7 +365,7 @@ public abstract class AbstractRedissonClientTest {
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
-                                emitStableDatabaseSemconv() ? (long) batchSize : null),
+                                emitStableDatabaseSemconv() ? Long.valueOf(batchSize) : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 String.join(

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -365,7 +365,7 @@ public abstract class AbstractRedissonClientTest {
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
-                                emitStableDatabaseSemconv() ? Long.valueOf(batchSize) : null),
+                                emitStableDatabaseSemconv() ? (long) batchSize : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 String.join(

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -27,6 +27,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.util.Collections.nCopies;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -332,7 +333,7 @@ public abstract class AbstractRedissonClientTest {
   }
 
   @Test
-  void largeBatchCommand() throws ReflectiveOperationException {
+  void largeBatchCommandTruncatesQueryText() throws ReflectiveOperationException {
     RBatch batch = createBatch(redisson);
     assertThat(batch).isNotNull();
     StringBuilder bucketNameBuilder = new StringBuilder("bucket");
@@ -340,9 +341,10 @@ public abstract class AbstractRedissonClientTest {
       bucketNameBuilder.append("a");
     }
     String bucketName = bucketNameBuilder.toString();
-    // run 4 command but only 2 will be added to the query text because of the max length limit
-    for (int i = 0; i < 4; i++) {
-      batch.getBucket(bucketName).setAsync("v" + i);
+    int batchSize = 4;
+    int queryTextCommandCount = 2;
+    for (int commandIndex = 0; commandIndex < batchSize; commandIndex++) {
+      batch.getBucket(bucketName).setAsync("v" + commandIndex);
     }
     // Adapt different method signature:
     // `BatchResult<?> execute()` and `List<?> execute()`
@@ -362,10 +364,13 @@ public abstract class AbstractRedissonClientTest {
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
                             equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 4L : null),
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? (long) batchSize : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
-                                "SET " + bucketName + " ?;SET " + bucketName + " ?"))));
+                                String.join(
+                                    ";",
+                                  nCopies(queryTextCommandCount, "SET " + bucketName + " ?"))))));
   }
 
   @Test

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -236,6 +236,8 @@ class VertxRedisClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     String longBatchKey = String.join("", nCopies(1020, "x"));
+    int largeBatchSize = 33;
+    int largeQueryTextCommandCount = 31;
     // No empty scenario: Vert.x Redis never completes client.batch(emptyList()),
     // and times out before asserting instrumentation.
     return Stream.of(
@@ -265,15 +267,16 @@ class VertxRedisClientTest {
                 .batchSize(2)
                 .build()),
         argumentSet(
-            "large",
+              "largeTruncatedQueryText",
             BatchScenario.builder()
                 .requests(
                     Stream.generate(() -> Request.cmd(Command.GET).arg(longBatchKey))
-                        .limit(33)
+                    .limit(largeBatchSize)
                         .collect(toList()))
                 .operationName("PIPELINE GET")
-                .queryText(String.join(";", nCopies(31, "GET " + longBatchKey)))
-                .batchSize(33)
+                .queryText(
+                  String.join(";", nCopies(largeQueryTextCommandCount, "GET " + longBatchKey)))
+                .batchSize(largeBatchSize)
                 .build()));
   }
 

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -236,7 +236,7 @@ class VertxRedisClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     String longBatchKey = String.join("", nCopies(1020, "x"));
-    int truncatingBatchSize = 33;
+    int batchSize = 33;
     int truncatedQueryTextCommandCount = 31;
     // No empty scenario: Vert.x Redis never completes client.batch(emptyList()),
     // and times out before asserting instrumentation.
@@ -271,13 +271,13 @@ class VertxRedisClientTest {
             BatchScenario.builder()
                 .requests(
                     Stream.generate(() -> Request.cmd(Command.GET).arg(longBatchKey))
-                        .limit(truncatingBatchSize)
+                        .limit(batchSize)
                         .collect(toList()))
                 .operationName("PIPELINE GET")
                 .queryText(
                     String.join(
                         ";", nCopies(truncatedQueryTextCommandCount, "GET " + longBatchKey)))
-                .batchSize(truncatingBatchSize)
+                .batchSize(batchSize)
                 .build()));
   }
 

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -236,8 +236,8 @@ class VertxRedisClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     String longBatchKey = String.join("", nCopies(1020, "x"));
-    int largeBatchSize = 33;
-    int largeQueryTextCommandCount = 31;
+    int truncatingBatchSize = 33;
+    int truncatedQueryTextCommandCount = 31;
     // No empty scenario: Vert.x Redis never completes client.batch(emptyList()),
     // and times out before asserting instrumentation.
     return Stream.of(
@@ -267,16 +267,17 @@ class VertxRedisClientTest {
                 .batchSize(2)
                 .build()),
         argumentSet(
-              "largeTruncatedQueryText",
+            "truncatedQueryText",
             BatchScenario.builder()
                 .requests(
                     Stream.generate(() -> Request.cmd(Command.GET).arg(longBatchKey))
-                    .limit(largeBatchSize)
+                        .limit(truncatingBatchSize)
                         .collect(toList()))
                 .operationName("PIPELINE GET")
                 .queryText(
-                  String.join(";", nCopies(largeQueryTextCommandCount, "GET " + longBatchKey)))
-                .batchSize(largeBatchSize)
+                    String.join(
+                        ";", nCopies(truncatedQueryTextCommandCount, "GET " + longBatchKey)))
+                .batchSize(truncatingBatchSize)
                 .build()));
   }
 


### PR DESCRIPTION
Make Redis batch tests explicit that db.query.text can be truncated independently from db.operation.batch.size. Redisson and Vert.x Redis keep the existing query text caps, while tests now name the truncation behavior and use constants for total batch size versus commands represented in query text.