### PR TITLE
Align RpcMetricsAdvice old-semconv constant with repo convention

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcMetricsAdvice.java
@@ -25,7 +25,7 @@ final class RpcMetricsAdvice {
       AttributeKey.stringKey("rpc.response.status_code");
 
   // copied from RpcIncubatingAttributes
-  @Deprecated // use RPC_RESPONSE_STATUS_CODE for stable semconv
+  // use RPC_RESPONSE_STATUS_CODE for stable semconv
   private static final AttributeKey<Long> RPC_GRPC_STATUS_CODE =
       AttributeKey.longKey("rpc.grpc.status_code");
 
@@ -34,7 +34,6 @@ final class RpcMetricsAdvice {
   private static final List<AttributeKey<?>> RPC_METRICS_STABLE_ATTRIBUTE_KEYS =
       buildAttributeKeysList(true);
 
-  @SuppressWarnings("deprecation") // until old rpc semconv are dropped
   private static List<AttributeKey<?>> buildAttributeKeysList(boolean stable) {
     List<AttributeKey<?>> keys = new ArrayList<>();
 


### PR DESCRIPTION
Aligns `RpcMetricsAdvice.RPC_GRPC_STATUS_CODE` with the repo convention for locally-copied old-semconv attribute keys.

These "copied from `…IncubatingAttributes`" constants are written as plain `private static final` keys with a `// use … for stable semconv` comment and **no** `@Deprecated` annotation — for example its sibling `RpcCommonAttributesExtractor.RPC_SYSTEM` (paired with `RPC_SYSTEM_NAME`) and the DB analog `SqlClientAttributesExtractor`.

`RPC_GRPC_STATUS_CODE` was the only such constant carrying a stray `@Deprecated`, which was also the sole reason `buildAttributeKeysList` needed `@SuppressWarnings("deprecation")`. This drops both; the constant still gets removed together with the other old-RPC-semconv keys when old semconv is dropped in 3.0.

Internal-only change (private field, alpha module); no API impact.