### PR TITLE
Clean up 3.0 removal markers

### DIFF
--- a/instrumentation/oshi-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/MetricsRegistration.java
+++ b/instrumentation/oshi-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/v5_0/MetricsRegistration.java
@@ -30,9 +30,7 @@ public class MetricsRegistration {
 
   private static final AtomicBoolean registered = new AtomicBoolean();
 
-  // deprecated registerObservers(Meter) overloads exist solely so we can keep emitting the legacy
-  // io.opentelemetry.oshi scope by default; both go away in 3.0 once v3-preview becomes default
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // deprecated overloads keep the legacy scope by default
   public static void register() {
     if (registered.compareAndSet(false, true)) {
       Meter meter = buildMeter();

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
@@ -43,10 +43,7 @@ public class TomcatConnectionPoolMetrics {
     dataSourceMetrics.computeIfAbsent(dataSource, TomcatConnectionPoolMetrics::createInstruments);
   }
 
-  // deprecated DbConnectionPoolMetrics.create(Meter, String) overload exists solely so we can keep
-  // emitting the legacy io.opentelemetry.tomcat-jdbc scope by default; goes away in 3.0 once
-  // v3-preview becomes default
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // deprecated overload keeps the legacy scope by default
   private static BatchCallback createInstruments(DataSourceProxy dataSource) {
     DbConnectionPoolMetrics metrics =
         DbConnectionPoolMetrics.create(meter, dataSource.getPoolName());

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/code/SemconvCodeStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/code/SemconvCodeStabilityUtil.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 
-// until old code semconv are dropped in 3.0
+// supports asserting on old code semconv, to be removed in 3.0
 public class SemconvCodeStabilityUtil {
 
   public static List<AttributeAssertion> codeFunctionAssertions(Class<?> type, String methodName) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/SemconvStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/db/SemconvStabilityUtil.java
@@ -37,7 +37,7 @@ import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import java.util.HashMap;
 import java.util.Map;
 
-// until old database semconv are dropped in 3.0
+// supports asserting on old database semconv, to be removed in 3.0
 public class SemconvStabilityUtil {
 
   private static final Map<AttributeKey<?>, AttributeKey<?>> oldToNewMap = buildMap();

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/message/MessageHeaderUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/message/MessageHeaderUtil.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.v3P
 import io.opentelemetry.api.common.AttributeKey;
 import java.util.List;
 
-// until message header normalization is dropped in 3.0
+// message header normalization, to be removed in 3.0
 public class MessageHeaderUtil {
 
   public static AttributeKey<List<String>> headerAttributeKey(String headerName) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/rpc/SemconvRpcStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/rpc/SemconvRpcStabilityUtil.java
@@ -12,7 +12,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import java.util.HashMap;
 import java.util.Map;
 
-// until old rpc semconv are dropped in 3.0
 @SuppressWarnings("deprecation") // using deprecated semconv
 public class SemconvRpcStabilityUtil {
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/service/SemconvServiceStabilityUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/service/SemconvServiceStabilityUtil.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes.SE
 
 import io.opentelemetry.api.common.AttributeKey;
 
-// until old peer.service attribute is dropped in 3.0
 @SuppressWarnings("deprecation") // using deprecated semconv
 public class SemconvServiceStabilityUtil {
 


### PR DESCRIPTION
Cleans up 3.0-removal markers so they're accurate and match the wording #18903's audit greps for.

- Normalize the semconv-stability test utils (code, database, messaging) to `to be removed in 3.0`.
- Drop redundant markers from the oshi / tomcat-jdbc call sites — the deprecated APIs they call are already tagged for 3.0 at their definitions — leaving a one-line `@SuppressWarnings` reason.
- Drop the 3.0 claim from the rpc and service.peer stability utils, whose migrations aren't gated on v3-preview and have no scheduled 3.0 removal.

Comment-only; no behavior change.