### PR TITLE
Clarify Redis empty batch no-op tests

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -503,6 +503,7 @@ class LettuceAsyncClientTest {
     }
 
     if (scenario.isEmpty()) {
+      // Empty flush writes no Redis commands, so there is no database client request to report.
       assertThat(testing.spans()).isEmpty();
       return;
     }
@@ -526,7 +527,7 @@ class LettuceAsyncClientTest {
 
   private static Stream<Arguments> deferredFlushScenarios() {
     return Stream.of(
-        // empty batch doesn't produce any span
+        // Empty flush writes no Redis commands.
         argumentSet("empty", BatchScenario.builder().build()),
         argumentSet(
             "single",

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -512,6 +512,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
     }
 
     if (scenario.isEmpty()) {
+      // Empty flush writes no Redis commands, so there is no database client request to report.
       assertThat(testing.spans()).isEmpty();
       return;
     }
@@ -536,7 +537,7 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
 
   private static Stream<Arguments> deferredFlushScenarios() {
     return Stream.of(
-        // empty batch doesn't produce any span
+        // Empty flush writes no Redis commands.
         argumentSet("empty", BatchScenario.builder().build()),
         argumentSet(
             "single",

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -262,7 +262,8 @@ public abstract class AbstractRedissonClientTest {
     invokeExecute(batch);
 
     if (scenario.empty) {
-      // an empty batch produces no span
+      // An empty batch fails before Redisson sends a Redis command, so there is no database client
+      // request to report.
       assertThat(testing.spans()).isEmpty();
       return;
     }
@@ -294,7 +295,7 @@ public abstract class AbstractRedissonClientTest {
 
   private static Stream<Arguments> batchScenarios() {
     return Stream.of(
-        // an empty batch fails to execute and produces no span
+        // An empty batch fails to execute before any Redis command is sent.
         argumentSet("empty", BatchScenario.builder().empty().build()),
         argumentSet(
             "single",


### PR DESCRIPTION
Clarify Redis empty batch test comments for Redisson and Lettuce. Empty Redisson batches fail before sending Redis commands, and empty Lettuce flushes write no Redis commands, so these cases continue to assert that no database client span is reported.