### PR TITLE
Ignore deprecated config aliases in v3 preview

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
-import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -98,6 +97,7 @@ public final class CommonConfig {
     loggingTraceIdKey =
         getConfig(
             logging,
+            v3Preview,
             "trace_id_key",
             "trace_id",
             "otel.instrumentation.common.logging.trace-id-key",
@@ -106,6 +106,7 @@ public final class CommonConfig {
     loggingSpanIdKey =
         getConfig(
             logging,
+            v3Preview,
             "span_id_key",
             "span_id",
             "otel.instrumentation.common.logging.span-id-key",
@@ -114,6 +115,7 @@ public final class CommonConfig {
     loggingTraceFlagsKey =
         getConfig(
             logging,
+            v3Preview,
             "trace_flags_key",
             "trace_flags",
             "otel.instrumentation.common.logging.trace-flags-key",
@@ -123,6 +125,7 @@ public final class CommonConfig {
 
   private static String getConfig(
       DeclarativeConfigProperties config,
+      boolean v3Preview,
       String newDeclarativeKey,
       String oldDeclarativeKey,
       String newProperty,
@@ -132,7 +135,7 @@ public final class CommonConfig {
     if (value != null) {
       return value;
     }
-    if (!SemconvStability.v3Preview()) {
+    if (!v3Preview) {
       value = config.getString(oldDeclarativeKey);
       if (value != null) {
         if (warnedDeprecatedProperties.add(oldProperty)) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -131,18 +132,20 @@ public final class CommonConfig {
     if (value != null) {
       return value;
     }
-    value = config.getString(oldDeclarativeKey);
-    if (value != null) {
-      if (warnedDeprecatedProperties.add(oldProperty)) {
-        logger.warning(
-            "The "
-                + oldProperty
-                + " setting and the equivalent declarative configuration property"
-                + " are deprecated and will be removed in 3.0. Use "
-                + newProperty
-                + " or equivalent declarative configuration instead.");
+    if (!SemconvStability.v3Preview()) {
+      value = config.getString(oldDeclarativeKey);
+      if (value != null) {
+        if (warnedDeprecatedProperties.add(oldProperty)) {
+          logger.warning(
+              "The "
+                  + oldProperty
+                  + " setting and the equivalent declarative configuration property"
+                  + " are deprecated and will be removed in 3.0. Use "
+                  + newProperty
+                  + " or equivalent declarative configuration instead.");
+        }
+        return value;
       }
-      return value;
     }
     return defaultValue;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
@@ -75,15 +75,17 @@ public final class DbConfig {
       return value;
     }
 
-    // this variant was never a regular (non-declarative) configuration property name
-    Boolean deprecatedValue =
-        commonConfig.get("database").get("sqlcommenter/development").getBoolean("enabled");
-    if (deprecatedValue != null) {
-      warnIfDeprecatedDeclarativeConfigurationUsed(
-          "instrumentation/development: java: common: database:"
-              + " sqlcommenter/development: enabled",
-          "instrumentation/development: java: common: db: sqlcommenter/development: enabled");
-      return deprecatedValue;
+    if (!SemconvStability.v3Preview()) {
+      // this variant was never a regular (non-declarative) configuration property name
+      Boolean deprecatedValue =
+          commonConfig.get("database").get("sqlcommenter/development").getBoolean("enabled");
+      if (deprecatedValue != null) {
+        warnIfDeprecatedDeclarativeConfigurationUsed(
+            "instrumentation/development: java: common: database:"
+                + " sqlcommenter/development: enabled",
+            "instrumentation/development: java: common: db: sqlcommenter/development: enabled");
+        return deprecatedValue;
+      }
     }
 
     return null;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java
@@ -75,7 +75,7 @@ public final class DbConfig {
       return value;
     }
 
-    if (!SemconvStability.v3Preview()) {
+    if (!SemconvStability.v3Preview(openTelemetry)) {
       // this variant was never a regular (non-declarative) configuration property name
       Boolean deprecatedValue =
           commonConfig.get("database").get("sqlcommenter/development").getBoolean("enabled");
@@ -101,7 +101,7 @@ public final class DbConfig {
       return value;
     }
 
-    if (!SemconvStability.v3Preview()) {
+    if (!SemconvStability.v3Preview(openTelemetry)) {
       // this variant was never a regular (non-declarative) configuration property name
       Boolean deprecatedStatementSanitizerValue =
           commonConfig.get("database").get("statement_sanitizer").getBoolean("enabled");

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfigTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.config.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class CommonConfigTest {
+
+  @Test
+  void deprecatedLoggingKeyIgnoredInV3Preview() {
+    ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
+    DeclarativeConfigProperties commonConfig =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(openTelemetry.getGeneralInstrumentationConfig())
+        .thenReturn(DeclarativeConfigProperties.empty());
+    when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
+    when(commonConfig.getBoolean("v3_preview", false)).thenReturn(true);
+    when(commonConfig.get("http").getScalarList(eq("known_methods"), eq(String.class), anyList()))
+        .thenReturn(new ArrayList<>());
+    when(commonConfig.get("logging").getString("trace_id")).thenReturn("deprecated_trace_id");
+
+    CommonConfig config = new CommonConfig(openTelemetry);
+
+    assertThat(config.getTraceIdKey()).isEqualTo(LoggingContextConstants.TRACE_ID);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfigTest.java
@@ -31,7 +31,7 @@ class CommonConfigTest {
     when(commonConfig.getBoolean("v3_preview", false)).thenReturn(true);
     when(commonConfig.get("http").getScalarList(eq("known_methods"), eq(String.class), anyList()))
         .thenReturn(new ArrayList<>());
-    when(commonConfig.get("logging").getString("trace_id")).thenReturn("deprecated_trace_id");
+    when(commonConfig.get("logging").getString("trace_id")).thenReturn("custom_trace_id");
 
     CommonConfig config = new CommonConfig(openTelemetry);
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfigTest.java
@@ -60,6 +60,41 @@ class DbConfigTest {
   }
 
   @Test
+  void deprecatedCommonStatementSanitizerConfigIgnoredInV3Preview() {
+    ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
+    DeclarativeConfigProperties commonConfig =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
+    when(commonConfig.getBoolean("v3_preview")).thenReturn(true);
+    when(commonConfig.get("db").get("query_sanitization").getBoolean("enabled")).thenReturn(null);
+    when(commonConfig.get("database").get("statement_sanitizer").getBoolean("enabled"))
+        .thenReturn(false);
+    when(commonConfig.get("db_statement_sanitizer").getBoolean("enabled")).thenReturn(null);
+
+    assertThat(DbConfig.isCommonQuerySanitizationEnabled(openTelemetry)).isTrue();
+  }
+
+  @Test
+  void deprecatedCommonSqlCommenterConfigIgnoredInV3Preview() {
+    ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
+    DeclarativeConfigProperties commonConfig =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    DeclarativeConfigProperties instrumentationConfig =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
+    when(openTelemetry.getInstrumentationConfig("jdbc")).thenReturn(instrumentationConfig);
+    when(commonConfig.getBoolean("v3_preview")).thenReturn(true);
+    when(instrumentationConfig.get("sqlcommenter/development").getBoolean("enabled"))
+        .thenReturn(null);
+    when(commonConfig.get("db").get("sqlcommenter/development").getBoolean("enabled"))
+        .thenReturn(null);
+    when(commonConfig.get("database").get("sqlcommenter/development").getBoolean("enabled"))
+        .thenReturn(true);
+
+    assertThat(DbConfig.isSqlCommenterEnabled(openTelemetry, "jdbc")).isFalse();
+  }
+
+  @Test
   void deprecatedCommonSqlCommenterConfigWarningUsesFutureVersionMessage() throws Exception {
     ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
     DeclarativeConfigProperties commonConfig =

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -40,7 +40,7 @@ public final class SemconvStability {
   static {
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.getOrNoop();
     DeclarativeConfigProperties generalConfig = getGeneralInstrumentationConfig(openTelemetry);
-    v3Preview = resolveV3Preview(openTelemetry);
+    v3Preview = v3Preview(openTelemetry);
     SemconvSelectionResolver semconvSelection =
         new SemconvSelectionResolver(openTelemetry, generalConfig, v3Preview);
 
@@ -66,7 +66,7 @@ public final class SemconvStability {
   }
 
   @SuppressWarnings("deprecation") // using deprecated config property fallback
-  private static boolean resolveV3Preview(OpenTelemetry openTelemetry) {
+  public static boolean v3Preview(OpenTelemetry openTelemetry) {
     Boolean value = getInstrumentationConfig(openTelemetry, "common").getBoolean("v3_preview");
     if (value != null) {
       return value;

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v12_0.GraphQLTelemetry;
 import java.util.logging.Logger;
@@ -58,7 +59,9 @@ public class GraphqlSingletons {
       this.captureQuery = config.getBoolean("capture_query", true);
       this.querySanitizationEnabled = getQuerySanitizationEnabled(config);
       Boolean deprecatedAddOperationNameToSpanName =
-          config.get("add_operation_name_to_span_name").getBoolean("enabled");
+          SemconvStability.v3Preview()
+              ? null
+              : config.get("add_operation_name_to_span_name").getBoolean("enabled");
       if (deprecatedAddOperationNameToSpanName != null) {
         // Support the deprecated config key until 3.0.
         logger.warning(
@@ -82,16 +85,18 @@ public class GraphqlSingletons {
         return querySanitizationEnabled;
       }
 
-      Boolean deprecatedQuerySanitizationEnabled =
-          config.get("query_sanitizer").getBoolean("enabled");
-      if (deprecatedQuerySanitizationEnabled != null) {
-        logger.warning(
-            "The otel.instrumentation.graphql.query-sanitizer.enabled setting or equivalent"
-                + " declarative configuration is deprecated and will be"
-                + " removed in 3.0. Use "
-                + "otel.instrumentation.graphql.query-sanitization.enabled"
-                + " or equivalent declarative configuration instead.");
-        return deprecatedQuerySanitizationEnabled;
+      if (!SemconvStability.v3Preview()) {
+        Boolean deprecatedQuerySanitizationEnabled =
+            config.get("query_sanitizer").getBoolean("enabled");
+        if (deprecatedQuerySanitizationEnabled != null) {
+          logger.warning(
+              "The otel.instrumentation.graphql.query-sanitizer.enabled setting or equivalent"
+                  + " declarative configuration is deprecated and will be"
+                  + " removed in 3.0. Use "
+                  + "otel.instrumentation.graphql.query-sanitization.enabled"
+                  + " or equivalent declarative configuration instead.");
+          return deprecatedQuerySanitizationEnabled;
+        }
       }
 
       return true;

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v20_0.GraphQLTelemetry;
 import java.util.logging.Logger;
@@ -69,7 +70,9 @@ public class GraphqlSingletons {
       this.trivialDataFetcherEnabled =
           config.get("trivial_data_fetcher").getBoolean("enabled", false);
       Boolean deprecatedAddOperationNameToSpanName =
-          config.get("add_operation_name_to_span_name").getBoolean("enabled");
+          SemconvStability.v3Preview()
+              ? null
+              : config.get("add_operation_name_to_span_name").getBoolean("enabled");
       if (deprecatedAddOperationNameToSpanName != null) {
         // Support the deprecated config key until 3.0.
         logger.warning(
@@ -93,16 +96,18 @@ public class GraphqlSingletons {
         return querySanitizationEnabled;
       }
 
-      Boolean deprecatedQuerySanitizationEnabled =
-          config.get("query_sanitizer").getBoolean("enabled");
-      if (deprecatedQuerySanitizationEnabled != null) {
-        logger.warning(
-            "The otel.instrumentation.graphql.query-sanitizer.enabled setting or equivalent"
-                + " declarative configuration is deprecated and will be"
-                + " removed in 3.0. Use "
-                + "otel.instrumentation.graphql.query-sanitization.enabled"
-                + " or equivalent declarative configuration instead.");
-        return deprecatedQuerySanitizationEnabled;
+      if (!SemconvStability.v3Preview()) {
+        Boolean deprecatedQuerySanitizationEnabled =
+            config.get("query_sanitizer").getBoolean("enabled");
+        if (deprecatedQuerySanitizationEnabled != null) {
+          logger.warning(
+              "The otel.instrumentation.graphql.query-sanitizer.enabled setting or equivalent"
+                  + " declarative configuration is deprecated and will be"
+                  + " removed in 3.0. Use "
+                  + "otel.instrumentation.graphql.query-sanitization.enabled"
+                  + " or equivalent declarative configuration instead.");
+          return deprecatedQuerySanitizationEnabled;
+        }
       }
 
       return true;

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -68,32 +69,37 @@ public final class ContextDataKeys {
     if (value != null) {
       return value;
     }
-    value = config.getString(oldDeclarativeKey);
-    if (value != null) {
-      logDeprecationWarning(
-          oldProperty,
-          "The "
-              + oldProperty
-              + " setting and the equivalent declarative configuration property"
-              + " are deprecated and will be removed in 3.0. Use "
-              + newProperty
-              + " or equivalent declarative configuration instead.");
-      return value;
+    boolean v3Preview = SemconvStability.v3Preview();
+    if (!v3Preview) {
+      value = config.getString(oldDeclarativeKey);
+      if (value != null) {
+        logDeprecationWarning(
+            oldProperty,
+            "The "
+                + oldProperty
+                + " setting and the equivalent declarative configuration property"
+                + " are deprecated and will be removed in 3.0. Use "
+                + newProperty
+                + " or equivalent declarative configuration instead.");
+        return value;
+      }
     }
     value = ConfigPropertiesUtil.getString(newProperty);
     if (value != null) {
       return value;
     }
-    value = ConfigPropertiesUtil.getString(oldProperty);
-    if (value != null) {
-      logDeprecationWarning(
-          oldProperty,
-          "The '"
-              + oldProperty
-              + "' system property is deprecated and will be removed in 3.0. Use '"
-              + newProperty
-              + "' instead.");
-      return value;
+    if (!v3Preview) {
+      value = ConfigPropertiesUtil.getString(oldProperty);
+      if (value != null) {
+        logDeprecationWarning(
+            oldProperty,
+            "The '"
+                + oldProperty
+                + "' system property is deprecated and will be removed in 3.0. Use '"
+                + newProperty
+                + "' instead.");
+        return value;
+      }
     }
     return defaultValue;
   }

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java
@@ -30,9 +30,11 @@ public final class ContextDataKeys {
   public static ContextDataKeys create(OpenTelemetry openTelemetry) {
     DeclarativeConfigProperties logging =
         DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "common").get("logging");
+    boolean v3Preview = SemconvStability.v3Preview(openTelemetry);
     String traceIdKey =
         getConfig(
             logging,
+            v3Preview,
             "trace_id_key",
             "trace_id",
             "otel.instrumentation.common.logging.trace-id-key",
@@ -41,6 +43,7 @@ public final class ContextDataKeys {
     String spanIdKey =
         getConfig(
             logging,
+            v3Preview,
             "span_id_key",
             "span_id",
             "otel.instrumentation.common.logging.span-id-key",
@@ -49,6 +52,7 @@ public final class ContextDataKeys {
     String traceFlagsKey =
         getConfig(
             logging,
+            v3Preview,
             "trace_flags_key",
             "trace_flags",
             "otel.instrumentation.common.logging.trace-flags-key",
@@ -60,6 +64,7 @@ public final class ContextDataKeys {
   @SuppressWarnings("deprecation") // using deprecated ConfigPropertiesUtil
   private static String getConfig(
       DeclarativeConfigProperties config,
+      boolean v3Preview,
       String newDeclarativeKey,
       String oldDeclarativeKey,
       String newProperty,
@@ -69,7 +74,6 @@ public final class ContextDataKeys {
     if (value != null) {
       return value;
     }
-    boolean v3Preview = SemconvStability.v3Preview();
     if (!v3Preview) {
       value = config.getString(oldDeclarativeKey);
       if (value != null) {

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeysTest.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeysTest.java
@@ -24,7 +24,7 @@ class ContextDataKeysTest {
         mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
     when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
     when(commonConfig.getBoolean("v3_preview")).thenReturn(true);
-    when(commonConfig.get("logging").getString("trace_id")).thenReturn("deprecated_trace_id");
+    when(commonConfig.get("logging").getString("trace_id")).thenReturn("custom_trace_id");
 
     ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeysTest.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeysTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.contextdata.v2_17.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.incubator.log.LoggingContextConstants;
+import org.junit.jupiter.api.Test;
+
+class ContextDataKeysTest {
+
+  @Test
+  void deprecatedLoggingKeyIgnoredInV3Preview() {
+    ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
+    DeclarativeConfigProperties commonConfig =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
+    when(commonConfig.getBoolean("v3_preview")).thenReturn(true);
+    when(commonConfig.get("logging").getString("trace_id")).thenReturn("deprecated_trace_id");
+
+    ContextDataKeys contextDataKeys = ContextDataKeys.create(openTelemetry);
+
+    assertThat(contextDataKeys.getTraceIdKey()).isEqualTo(LoggingContextConstants.TRACE_ID);
+  }
+}


### PR DESCRIPTION
## Overview

Ignore configuration aliases scheduled for removal in 3.0 when `otel.instrumentation.common.v3-preview` is enabled.

This covers:
- deprecated common logging context key aliases
- deprecated common database/sqlcommenter aliases
- deprecated GraphQL query sanitizer and operation-name aliases
- deprecated Log4j context-data key aliases, including their old system-property forms