### PR TITLE
Enable rumdl MD060 (table-cell-alignment)

### DIFF
--- a/.github/config/.rumdl.toml
+++ b/.github/config/.rumdl.toml
@@ -3,6 +3,11 @@
 [global]
 # disable link text should be descriptive check
 disable = ["MD059", "line-length", "no-inline-html", "MD041", "MD022", "ul-style", "fenced-code-language"]
+# MD060 (table-cell-alignment) is off by default in rumdl; enable it explicitly
+# so misaligned table columns are caught (previously only caught by spotless's
+# prettier markdown formatting). Use extend-enable, NOT enable — `enable` is an
+# allowlist ("only these rules") and would silently disable everything else.
+extend-enable = ["MD060"]
 
 [per-file-ignores]
 ".github/workflows/*.md" = ["MD046"]


### PR DESCRIPTION
## Summary
- `MD060` (`table-cell-alignment`, catches misaligned markdown table columns) exists in rumdl but is off by default. Enables it via `extend-enable` (not `enable`, which is an allowlist and would have silently disabled every other rule).
- Verified against the full repo (`flint run`, matching the `build / lint / lint-check` CI job exactly): 0 violations. The current tree, already formatted by spotless's prettier markdown block (#18952), already satisfies MD060 — no cleanup needed.
- Verified `rumdl --fix` output for a misaligned table matches prettier's canonical formatting byte-for-byte.
- Precursor to #<revert-PR> (reverting #18952) — this closes the specific gap (table alignment) that prettier was covering, so rumdl/flint alone is sufficient going forward.

## Test plan
- [x] `flint run` on the full repo — 0 violations
- [x] `rumdl check --fix` on a known-misaligned table — output matches prettier's canonical form exactly