### PR TITLE
Revert "Add prettier to spotless" (#18952)

### DIFF
--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -78,20 +78,6 @@ spotless {
 
 if (project == rootProject) {
   spotless {
-    format("markdown") {
-      target("**/*.md")
-      targetExclude(
-        "**/build/**",
-        "licenses/**"
-      )
-      prettier("3.6.2").config(
-        mapOf(
-          "proseWrap" to "preserve",
-          "embeddedLanguageFormatting" to "off"
-        )
-      )
-    }
-
     format("misc") {
       target(
         ".gitignore",


### PR DESCRIPTION
## Summary
Removes the `format("markdown")` block added in #18952, which used prettier via spotless to catch/fix markdown formatting (motivated by a misaligned table: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18926#discussion_r3380990427).

**Depends on #19181** (enable rumdl `MD060`) — that PR closes the specific gap this one was covering. Should merge after #19181, not before.

Rationale (full investigation in #19181):
- `flint`/`rumdl` already runs in CI on every PR (`build / lint / lint-check`), so this isn't introducing a new enforcement gap — it's consolidating onto the toolchain already enforced.
- The full markdown corpus (207 files, excluding `CHANGELOG.md` which `flint.toml` already excludes from all lint checks) passes cleanly under rumdl/flint with `MD060` enabled and the existing `.rumdl.toml` disable list otherwise unchanged.
- `rumdl --fix` produces output byte-identical to prettier's canonical formatting for the motivating misaligned-table case.
- The other 7 rules currently disabled in `.rumdl.toml` (line-length, no-inline-html, etc.) are unrelated stylistic opt-outs, not things prettier was silently covering for — verified each doesn't overlap with prettier's actual formatting behavior.

Does **not** revert the markdown *content* changes from #18952 (the ~60 files it reformatted) — those stay as-is, since they already satisfy rumdl/flint's rules and reverting them would just reintroduce inconsistent formatting with no corresponding tooling change.

Net effect: drops the Node/prettier dependency from the Gradle build.

## Test plan
- [x] `./gradlew spotlessCheck` — passes (no markdown target left to fail)
- [x] `./gradlew tasks --all` — confirms `spotlessMarkdown*` tasks are gone, `spotlessMisc*` unaffected
- [x] See #19181 for the `flint run` / rumdl-coverage verification this depends on