### PR TITLE
Consolidate markdown formatting onto rumdl/flint, drop spotless prettier

### DIFF
--- a/.github/config/.rumdl.toml
+++ b/.github/config/.rumdl.toml
@@ -3,6 +3,11 @@
 [global]
 # disable link text should be descriptive check
 disable = ["MD059", "line-length", "no-inline-html", "MD041", "MD022", "ul-style", "fenced-code-language"]
+# MD060 (table-cell-alignment) is off by default in rumdl; enable it explicitly
+# so misaligned table columns are caught (previously only caught by spotless's
+# prettier markdown formatting). Use extend-enable, NOT enable — `enable` is an
+# allowlist ("only these rules") and would silently disable everything else.
+extend-enable = ["MD060"]
 
 [per-file-ignores]
 ".github/workflows/*.md" = ["MD046"]

--- a/.github/config/.rumdl.toml
+++ b/.github/config/.rumdl.toml
@@ -3,10 +3,7 @@
 [global]
 # disable link text should be descriptive check
 disable = ["MD059", "line-length", "no-inline-html", "MD041", "MD022", "ul-style", "fenced-code-language"]
-# MD060 (table-cell-alignment) is off by default in rumdl; enable it explicitly
-# so misaligned table columns are caught (previously only caught by spotless's
-# prettier markdown formatting). Use extend-enable, NOT enable — `enable` is an
-# allowlist ("only these rules") and would silently disable everything else.
+# MD060 (table-cell-alignment)
 extend-enable = ["MD060"]
 
 [per-file-ignores]

--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -27,7 +27,5 @@ exclude = [
   '^http://www.slf4j.org.*',
   '^https://logback.qos.ch/.*',
   '^https://vaadin.com/$',
-  '^https://camel.apache.org/$',
-  # SSL certificate expired.
-  '^https://www.gwtproject.org/$'
+  '^https://camel.apache.org/$'
 ]

--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -27,5 +27,7 @@ exclude = [
   '^http://www.slf4j.org.*',
   '^https://logback.qos.ch/.*',
   '^https://vaadin.com/$',
-  '^https://camel.apache.org/$'
+  '^https://camel.apache.org/$',
+  # SSL certificate expired.
+  '^https://www.gwtproject.org/$'
 ]

--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -78,20 +78,6 @@ spotless {
 
 if (project == rootProject) {
   spotless {
-    format("markdown") {
-      target("**/*.md")
-      targetExclude(
-        "**/build/**",
-        "licenses/**"
-      )
-      prettier("3.6.2").config(
-        mapOf(
-          "proseWrap" to "preserve",
-          "embeddedLanguageFormatting" to "off"
-        )
-      )
-    }
-
     format("misc") {
       target(
         ".gitignore",

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -19,11 +19,14 @@ In addition to Google Java Style formatting, spotless applies
 [custom static importing rules](../../conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt)
 (e.g. rewriting `Objects.requireNonNull` to a static import).
 
-Markdown files are formatted and linted separately through flint:
+Markdown files are formatted and linted separately through
+[flint](https://github.com/grafana/flint), run via [mise](https://mise.jdx.dev/):
 
 ```bash
 mise run lint:fix
 ```
+
+flint also checks that links in markdown files resolve.
 
 #### Pre-commit hook
 

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -19,6 +19,12 @@ In addition to Google Java Style formatting, spotless applies
 [custom static importing rules](../../conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/StaticImportFormatter.kt)
 (e.g. rewriting `Objects.requireNonNull` to a static import).
 
+Markdown files are formatted and linted separately through flint:
+
+```bash
+mise run lint:fix
+```
+
 #### Pre-commit hook
 
 To completely delegate code style formatting to the machine,

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Linters
-"aqua:grafana/flint" = "0.22.8"
+"aqua:grafana/flint" = "0.22.9"
 lychee = "0.24.2"
 rumdl = "0.2.32"
 


### PR DESCRIPTION
## Summary
1. Enables rumdl's `MD060` (`table-cell-alignment`) via `extend-enable` — off by default in rumdl, and the specific gap that motivated #18952 (a misaligned table nobody caught: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18926#discussion_r3380990427). Uses `extend-enable`, not `enable` — `enable` is an allowlist ("only these rules") and would have silently disabled every other rumdl rule.
2. Reverts the `format("markdown")` spotless block added in #18952, which used prettier for the same purpose.

Rationale:
- `flint`/`rumdl` already runs in CI on every PR (`build / lint / lint-check`), so this consolidates onto a toolchain already enforced rather than introducing a new one.
- The full markdown corpus (207 files, excluding `CHANGELOG.md` which `flint.toml` already excludes from all lint checks) passes cleanly under rumdl/flint with `MD060` enabled and the existing `.rumdl.toml` disable list otherwise unchanged — no cleanup backlog.
- `rumdl --fix` produces output byte-identical to prettier's canonical formatting for the motivating misaligned-table case.
- The other 7 rules currently disabled in `.rumdl.toml` (line-length, no-inline-html, etc.) are unrelated stylistic opt-outs (intentional long prose lines, intentional `<details>` blocks, etc.) — not things prettier was silently covering for.

Does **not** revert the markdown *content* changes from #18952 (the ~60 files it reformatted) — those stay, since they already satisfy rumdl/flint's rules and reverting them would just reintroduce inconsistent formatting with no corresponding tooling change.

Net effect: drops the Node/prettier dependency from the Gradle build in favor of the single flint/rumdl toolchain already enforced in CI.

## Test plan
- [x] `flint run` on the full repo — 0 violations
- [x] `rumdl check --fix` on a known-misaligned table — output matches prettier's canonical form exactly
- [x] `./gradlew spotlessCheck` — passes (no markdown target left to fail)
- [x] `./gradlew tasks --all` — confirms `spotlessMarkdown*` tasks are gone, `spotlessMisc*` unaffected