### PR TITLE
Report db.operation.batch.size=0 for explicit empty batches in R2DBC and Vert.x SQL

### DIFF
--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -14,6 +14,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
@@ -110,7 +111,14 @@ public final class DbExecution {
                     R2dbcSqlCommenterUtil.getOriginalQuery(queryInfo.getConnectionInfo(), query))
             .collect(toList());
     int queryInfoBatchSize = queryInfo.getBatchSize();
-    this.batchSize = queryInfoBatchSize > 1 ? (long) queryInfoBatchSize : null;
+    // An explicit empty batch (ExecutionType.BATCH with size 0) is still a batch and reports
+    // db.operation.batch.size=0; a single-statement batch (size 1) is reported as a non-batch; a
+    // plain (non-batch) statement execution reports null. Gating on ExecutionType is required
+    // because r2dbc-proxy also reports batchSize=0 for plain statement executions.
+    this.batchSize =
+        queryInfo.getType() == ExecutionType.BATCH && queryInfoBatchSize != 1
+            ? (long) queryInfoBatchSize
+            : null;
     this.parameterizedQuery =
         queryInfo.getQueries().stream()
             .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.proxy.test.MockConnectionInfo;
@@ -60,6 +61,7 @@ class DbExecutionTest {
         MockQueryExecutionInfo.builder()
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
+            .type(ExecutionType.BATCH)
             .batchSize(2)
             .connectionInfo(MockConnectionInfo.builder().build())
             .build();
@@ -74,10 +76,29 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionWithEmptyBatch() {
+    QueryExecutionInfo queryExecutionInfo =
+        MockQueryExecutionInfo.builder()
+            .type(ExecutionType.BATCH)
+            .batchSize(0)
+            .connectionInfo(MockConnectionInfo.builder().build())
+            .build();
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
+
+    // an explicit empty batch is still a batch and reports db.operation.batch.size=0
+    assertThat(dbExecution.getRawQueryTexts()).isEmpty();
+    assertThat(dbExecution.getBatchSize()).isEqualTo(0);
+  }
+
+  @Test
   void dbExecutionWithBatchSizeOne() {
     QueryExecutionInfo queryExecutionInfo =
         MockQueryExecutionInfo.builder()
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
+            .type(ExecutionType.BATCH)
             .batchSize(1)
             .connectionInfo(MockConnectionInfo.builder().build())
             .build();

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.R2dbcSqlAttributesGetter;
+import io.r2dbc.proxy.core.ExecutionType;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.proxy.test.MockConnectionInfo;
@@ -45,6 +46,7 @@ class R2dbcSqlAttributesGetterTest {
         MockQueryExecutionInfo.builder()
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(1)"))
             .queryInfo(new QueryInfo("INSERT INTO person VALUES(2)"))
+            .type(ExecutionType.BATCH)
             .batchSize(2)
             .connectionInfo(MockConnectionInfo.builder().build())
             .build();

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -362,7 +362,7 @@ public abstract class AbstractR2dbcStatementTest {
                   trace.hasSpansSatisfyingExactly(
                       span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                       span ->
-                          span.hasName(DB)
+                          span.hasName(emitStableDatabaseSemconv() ? "BATCH" : DB)
                               .hasKind(SpanKind.CLIENT)
                               .hasParent(trace.getSpan(0))
                               .hasAttributesSatisfyingExactly(
@@ -375,7 +375,9 @@ public abstract class AbstractR2dbcStatementTest {
                                   equalTo(
                                       maybeStable(DB_STATEMENT),
                                       emitStableDatabaseSemconv() ? null : ""),
-                                  equalTo(DB_OPERATION_BATCH_SIZE, null),
+                                  equalTo(
+                                      DB_OPERATION_BATCH_SIZE,
+                                      emitStableDatabaseSemconv() ? 0L : null),
                                   equalTo(maybeStablePeerService(), "test-peer-service"),
                                   equalTo(SERVER_ADDRESS, container.getHost()),
                                   equalTo(SERVER_PORT, port),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/QueryExecutorInstrumentation.java
@@ -101,7 +101,9 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            // an explicit empty batch (size 0) is still a batch; only a single-item batch is
+            // reported as a non-batch operation
+            batchSize = size != 1 ? (long) size : null;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientTest.java
@@ -364,8 +364,9 @@ class VertxSqlClientTest {
             BatchScenario.builder()
                 .preparedQuery("insert into batch_test values ($1, $2) returning *")
                 .tuples(emptyList())
-                .stableSpanName("insert batch_test")
-                .querySummary("insert batch_test")
+                .stableSpanName("BATCH insert batch_test")
+                .querySummary("BATCH insert batch_test")
+                .batchSize(0)
                 .errorType("io.vertx.core.impl.NoStackTraceThrowable")
                 .build()),
         argumentSet(

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
@@ -100,7 +100,9 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
           }
           if (methodName.equals("executeBatchQuery") && argument instanceof Collection) {
             int size = ((Collection<?>) argument).size();
-            batchSize = size > 1 ? (long) size : null;
+            // an explicit empty batch (size 0) is still a batch; only a single-item batch is
+            // reported as a non-batch operation
+            batchSize = size != 1 ? (long) size : null;
           }
         }
         if (sql == null || promiseInternal == null) {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -365,8 +365,9 @@ class VertxSqlClientTest {
             BatchScenario.builder()
                 .preparedQuery("insert into batch_test values ($1, $2) returning *")
                 .tuples(emptyList())
-                .stableSpanName("insert batch_test")
-                .querySummary("insert batch_test")
+                .stableSpanName("BATCH insert batch_test")
+                .querySummary("BATCH insert batch_test")
+                .batchSize(0)
                 .errorType("io.vertx.core.VertxException")
                 .build()),
         argumentSet(


### PR DESCRIPTION
Follow-up to #19143, which taught the shared extractors to treat an explicit empty batch (size 0) as a batch but did not update the R2DBC or Vert.x SQL getters. Both still reported `db.operation.batch.size = null` for an empty batch, deviating from the [database semantic conventions](https://opentelemetry.io/docs/specs/semconv/database/database-spans/) (note [12]): "A request to execute a batch operation with no operations SHOULD also be treated as a batch operation, and `db.operation.batch.size` SHOULD be set to `0`."

- R2DBC: `DbExecution` collapsed size 0 and 1 to `null`. Since r2dbc-proxy reports `batchSize = 0` for plain (non-batch) `Statement` executions too, the batch size is now gated on `ExecutionType.BATCH`: size 0 -> `0`, size 1 -> `null` (single-item batch is a non-batch), size >= 2 -> size, plain statement -> `null`.
- Vert.x SQL 4.0 and 5.0: the `executeBatchQuery` branch already knows it is a batch, so `size > 1 ? size : null` becomes `size != 1 ? size : null`.

As a result, an empty R2DBC batch now emits `db.operation.batch.size = 0` with span name `BATCH`, and an empty Vert.x batch emits `db.operation.batch.size = 0` with span name/summary `BATCH insert batch_test` (derived from the prepared query template), matching JDBC and Cassandra.