### PR TITLE
Set db.query.summary to BATCH for explicit empty database batches

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -156,6 +156,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
           attributes.put(DB_COLLECTION_NAME, multiQuery.getCollectionName());
         }
         attributes.put(DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
+      } else if (isBatch) {
+        // an explicit empty batch (no query texts) — summarize as BATCH to match the span name
+        // produced by DbClientSpanNameExtractor
+        attributes.put(DB_QUERY_SUMMARY, "BATCH");
       }
     }
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -372,6 +372,48 @@ class SqlClientAttributesExtractorTest {
   }
 
   @Test
+  void shouldExtractEmptyBatchAttributes() {
+    // given
+    Map<String, Object> request = new HashMap<>();
+    request.put("db.namespace", "potatoes");
+    request.put("db.query.texts", emptySet());
+    request.put(DB_OPERATION_BATCH_SIZE.getKey(), 0L);
+
+    Context context = Context.root();
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.create(new TestMultiAttributesGetter());
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    underTest.onStart(startAttributes, context, request);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    underTest.onEnd(endAttributes, context, request, null, null);
+
+    // then
+    // an explicit empty batch has no query texts, so db.query.summary falls back to "BATCH"
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_SUMMARY, "BATCH"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    } else if (emitOldDatabaseSemconv()) {
+      assertThat(startAttributes.build()).containsOnly(entry(DB_NAME, "potatoes"));
+    } else if (emitStableDatabaseSemconv()) {
+      assertThat(startAttributes.build())
+          .containsOnly(
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_SUMMARY, "BATCH"),
+              entry(DB_OPERATION_BATCH_SIZE, 0L));
+    }
+
+    assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
   void shouldExtractMultiQueryBatchAttributes() {
     // given
     Map<String, Object> request = new HashMap<>();

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -362,6 +362,7 @@ class CassandraClientTest {
                 .buildBatch(session -> new BatchStatement())
                 .spanName("BATCH")
                 .oldSpanName("DB Query")
+                .querySummary("BATCH")
                 .batchSize(0)
                 .build()),
         argumentSet(

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -271,6 +271,7 @@ public abstract class AbstractCassandraTest {
                 .buildBatch(session -> BatchStatement.newInstance(DefaultBatchType.LOGGED))
                 .spanName("BATCH")
                 .oldSpanName("DB Query")
+                .querySummary("BATCH")
                 .batchSize(0)
                 .build()),
         argumentSet(

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1887,6 +1887,7 @@ public abstract class AbstractJdbcInstrumentationTest {
             BatchScenario.builder()
                 .spanName("BATCH")
                 .oldSpanName(DATABASE_NAME_LOWER)
+                .summary("BATCH")
                 .batchSize(0)
                 .build()),
         argumentSet(

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -376,6 +376,9 @@ public abstract class AbstractR2dbcStatementTest {
                                       maybeStable(DB_STATEMENT),
                                       emitStableDatabaseSemconv() ? null : ""),
                                   equalTo(
+                                      DB_QUERY_SUMMARY,
+                                      emitStableDatabaseSemconv() ? "BATCH" : null),
+                                  equalTo(
                                       DB_OPERATION_BATCH_SIZE,
                                       emitStableDatabaseSemconv() ? 0L : null),
                                   equalTo(maybeStablePeerService(), "test-peer-service"),


### PR DESCRIPTION
For an explicit empty batch (`db.operation.batch.size = 0`, no query texts), `SqlClientAttributesExtractor` set the span name to `BATCH` (via `DbClientSpanNameExtractor`) but left `db.query.summary` unset, so the span name and the summary attribute disagreed.

The [database semantic conventions](https://opentelemetry.io/docs/specs/semconv/database/database-spans/) (note [14]) say a batch whose operations have no reducible common summary SHOULD use `BATCH`. An empty batch has no operations to reduce, so `db.query.summary` should be `BATCH`.

This adds an empty-batch branch to the stable-semconv path of `SqlClientAttributesExtractor` that sets `db.query.summary = BATCH`, aligning it with the span name. Affects JDBC statement batches, Cassandra 3.0 / 4.x, and R2DBC; tests updated accordingly, plus a new `SqlClientAttributesExtractorTest` case.