### PR TITLE
Add Rediscala server endpoint attributes

### DIFF
--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
-import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 final class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
@@ -43,14 +42,12 @@ final class RediscalaAttributesGetter implements DbClientAttributesGetter<Redisc
   @Nullable
   @Override
   public String getServerAddress(RediscalaRequest request) {
-    InetSocketAddress address = request.getAddress();
-    return address != null ? address.getHostString() : null;
+    return request.getHost();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(RediscalaRequest request) {
-    InetSocketAddress address = request.getAddress();
-    return address != null ? address.getPort() : null;
+    return request.getPort();
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 final class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
@@ -37,5 +38,19 @@ final class RediscalaAttributesGetter implements DbClientAttributesGetter<Redisc
   @Nullable
   public Long getDbOperationBatchSize(RediscalaRequest request) {
     return request.getBatchSize();
+  }
+
+  @Nullable
+  @Override
+  public String getServerAddress(RediscalaRequest request) {
+    InetSocketAddress address = request.getAddress();
+    return address != null ? address.getHostString() : null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getServerPort(RediscalaRequest request) {
+    InetSocketAddress address = request.getAddress();
+    return address != null ? address.getPort() : null;
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaInstrumentationModule.java
@@ -21,6 +21,9 @@ public class RediscalaInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new RequestInstrumentation(), new TransactionInstrumentation());
+    return asList(
+        new RequestInstrumentation(),
+        new TransactionBuilderInstrumentation(),
+        new TransactionInstrumentation());
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import java.net.InetSocketAddress;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import redis.Operation;
@@ -16,23 +15,29 @@ import scala.collection.immutable.Queue;
 class RediscalaRequest {
   private final String operationName;
   @Nullable private final Long batchSize;
-  @Nullable private final InetSocketAddress address;
+  @Nullable private final String host;
+  @Nullable private final Integer port;
 
-  static RediscalaRequest create(RedisCommand<?, ?> command, @Nullable InetSocketAddress address) {
-    return new RediscalaRequest(operationName(command), null, address);
+  static RediscalaRequest create(
+      RedisCommand<?, ?> command, @Nullable String host, @Nullable Integer port) {
+    return new RediscalaRequest(operationName(command), null, host, port);
   }
 
   static RediscalaRequest createTransaction(
-      Queue<Operation<?, ?>> operations, @Nullable InetSocketAddress address) {
+      Queue<Operation<?, ?>> operations, @Nullable String host, @Nullable Integer port) {
     return new RediscalaRequest(
-        transactionOperationName(operations), batchSize(operations), address);
+        transactionOperationName(operations), batchSize(operations), host, port);
   }
 
   private RediscalaRequest(
-      String operationName, @Nullable Long batchSize, @Nullable InetSocketAddress address) {
+      String operationName,
+      @Nullable Long batchSize,
+      @Nullable String host,
+      @Nullable Integer port) {
     this.operationName = operationName;
     this.batchSize = batchSize;
-    this.address = address;
+    this.host = host;
+    this.port = port;
   }
 
   String getOperationName() {
@@ -45,8 +50,13 @@ class RediscalaRequest {
   }
 
   @Nullable
-  InetSocketAddress getAddress() {
-    return address;
+  String getHost() {
+    return host;
+  }
+
+  @Nullable
+  Integer getPort() {
+    return port;
   }
 
   private static String transactionOperationName(Queue<Operation<?, ?>> operations) {

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
+import java.net.InetSocketAddress;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import redis.Operation;
@@ -15,18 +16,23 @@ import scala.collection.immutable.Queue;
 class RediscalaRequest {
   private final String operationName;
   @Nullable private final Long batchSize;
+  @Nullable private final InetSocketAddress address;
 
-  static RediscalaRequest create(RedisCommand<?, ?> command) {
-    return new RediscalaRequest(operationName(command), null);
+  static RediscalaRequest create(RedisCommand<?, ?> command, @Nullable InetSocketAddress address) {
+    return new RediscalaRequest(operationName(command), null, address);
   }
 
-  static RediscalaRequest createTransaction(Queue<Operation<?, ?>> operations) {
-    return new RediscalaRequest(transactionOperationName(operations), batchSize(operations));
+  static RediscalaRequest createTransaction(
+      Queue<Operation<?, ?>> operations, @Nullable InetSocketAddress address) {
+    return new RediscalaRequest(
+        transactionOperationName(operations), batchSize(operations), address);
   }
 
-  private RediscalaRequest(String operationName, @Nullable Long batchSize) {
+  private RediscalaRequest(
+      String operationName, @Nullable Long batchSize, @Nullable InetSocketAddress address) {
     this.operationName = operationName;
     this.batchSize = batchSize;
+    this.address = address;
   }
 
   String getOperationName() {
@@ -36,6 +42,11 @@ class RediscalaRequest {
   @Nullable
   Long getBatchSize() {
     return batchSize;
+  }
+
+  @Nullable
+  InetSocketAddress getAddress() {
+    return address;
   }
 
   private static String transactionOperationName(Queue<Operation<?, ?>> operations) {

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -14,12 +14,18 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.net.InetSocketAddress;
+import redis.commands.TransactionBuilder;
 
 public class RediscalaSingletons {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rediscala-1.8";
 
   private static final Instrumenter<RediscalaRequest, Void> instrumenter;
+
+  public static final VirtualField<TransactionBuilder, InetSocketAddress> TRANSACTION_ADDRESS =
+      VirtualField.find(TransactionBuilder.class, InetSocketAddress.class);
 
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -15,7 +15,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
-import java.net.InetSocketAddress;
 import redis.commands.TransactionBuilder;
 
 public class RediscalaSingletons {
@@ -24,8 +23,8 @@ public class RediscalaSingletons {
 
   private static final Instrumenter<RediscalaRequest, Void> instrumenter;
 
-  public static final VirtualField<TransactionBuilder, InetSocketAddress> TRANSACTION_ADDRESS =
-      VirtualField.find(TransactionBuilder.class, InetSocketAddress.class);
+  public static final VirtualField<TransactionBuilder, ServerEndpoint> TRANSACTION_ENDPOINT =
+      VirtualField.find(TransactionBuilder.class, ServerEndpoint.class);
 
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
@@ -18,12 +18,14 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import redis.ActorRequest;
 import redis.BufferedRequest;
+import redis.RedisClientActorLike;
 import redis.RedisCommand;
 import redis.Request;
 import redis.RoundRobinPoolRequest;
@@ -77,7 +79,12 @@ class RequestInstrumentation implements TypeInstrumentation {
           return null;
         }
 
-        RediscalaRequest request = RediscalaRequest.create(cmd);
+        InetSocketAddress address = null;
+        if (action instanceof RedisClientActorLike) {
+          RedisClientActorLike client = (RedisClientActorLike) action;
+          address = InetSocketAddress.createUnresolved(client.host(), client.port());
+        }
+        RediscalaRequest request = RediscalaRequest.create(cmd, address);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
@@ -18,7 +18,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -79,12 +78,14 @@ class RequestInstrumentation implements TypeInstrumentation {
           return null;
         }
 
-        InetSocketAddress address = null;
+        String host = null;
+        Integer port = null;
         if (action instanceof RedisClientActorLike) {
           RedisClientActorLike client = (RedisClientActorLike) action;
-          address = InetSocketAddress.createUnresolved(client.host(), client.port());
+          host = client.host();
+          port = client.port();
         }
-        RediscalaRequest request = RediscalaRequest.create(cmd, address);
+        RediscalaRequest request = RediscalaRequest.create(cmd, host, port);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+public class ServerEndpoint {
+  private final String host;
+  private final int port;
+
+  public ServerEndpoint(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  String getHost() {
+    return host;
+  }
+
+  int getPort() {
+    return port;
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
+
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ADDRESS;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.net.InetSocketAddress;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import redis.RedisClientActorLike;
+import redis.commands.TransactionBuilder;
+
+class TransactionBuilderInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("redis.RedisClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        namedOneOf("multi", "transaction", "watch")
+            .and(returns(named("redis.commands.TransactionBuilder"))),
+        getClass().getName() + "$CreateAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class CreateAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This RedisClientActorLike client,
+        @Advice.Return TransactionBuilder transactionBuilder) {
+      if (transactionBuilder != null) {
+        TRANSACTION_ADDRESS.set(
+            transactionBuilder, InetSocketAddress.createUnresolved(client.host(), client.port()));
+      }
+    }
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ADDRESS;
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ENDPOINT;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.net.InetSocketAddress;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -42,8 +41,8 @@ class TransactionBuilderInstrumentation implements TypeInstrumentation {
         @Advice.This RedisClientActorLike client,
         @Advice.Return TransactionBuilder transactionBuilder) {
       if (transactionBuilder != null) {
-        TRANSACTION_ADDRESS.set(
-            transactionBuilder, InetSocketAddress.createUnresolved(client.host(), client.port()));
+        TRANSACTION_ENDPOINT.set(
+            transactionBuilder, new ServerEndpoint(client.host(), client.port()));
       }
     }
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ADDRESS;
 import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -51,7 +52,9 @@ class TransactionInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope start(TransactionBuilder transactionBuilder) {
         Queue<Operation<?, ?>> operations = transactionBuilder.operations().result();
-        RediscalaRequest request = RediscalaRequest.createTransaction(operations);
+        RediscalaRequest request =
+            RediscalaRequest.createTransaction(
+                operations, TRANSACTION_ADDRESS.get(transactionBuilder));
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ADDRESS;
+import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.TRANSACTION_ENDPOINT;
 import static io.opentelemetry.javaagent.instrumentation.rediscala.v1_8.RediscalaSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -52,9 +52,12 @@ class TransactionInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope start(TransactionBuilder transactionBuilder) {
         Queue<Operation<?, ?>> operations = transactionBuilder.operations().result();
+        ServerEndpoint endpoint = TRANSACTION_ENDPOINT.get(transactionBuilder);
         RediscalaRequest request =
             RediscalaRequest.createTransaction(
-                operations, TRANSACTION_ADDRESS.get(transactionBuilder));
+                operations,
+                endpoint != null ? endpoint.getHost() : null,
+                endpoint != null ? endpoint.getPort() : null);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -18,6 +18,7 @@ import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS
 import io.opentelemetry.semconv.DbAttributes.{DB_OPERATION_NAME, DB_SYSTEM_NAME}
+import io.opentelemetry.semconv.ServerAttributes.{SERVER_ADDRESS, SERVER_PORT}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterAll, BeforeAll, Test, TestInstance}
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -41,6 +42,8 @@ class RediscalaClientTest {
   var system: Object = null
   var redisServer: GenericContainer[_] = null
   var redisClient: RedisClient = null
+  var host: String = null
+  var port: JLong = null
 
   @BeforeAll
   def setUp(): Unit = {
@@ -48,8 +51,8 @@ class RediscalaClientTest {
       new GenericContainer("redis:6.2.3-alpine").withExposedPorts(6379)
     redisServer.start()
 
-    val host: String = redisServer.getHost
-    val port: Integer = redisServer.getMappedPort(6379)
+    host = redisServer.getHost
+    port = redisServer.getMappedPort(6379).longValue()
 
     try {
       val clazz = Class.forName("akka.actor.ActorSystem")
@@ -67,7 +70,7 @@ class RediscalaClientTest {
         .getConstructors()(0)
         .newInstance(
           host,
-          port,
+          Integer.valueOf(port.intValue()),
           Option.apply(null),
           Option.apply(null),
           Option.apply(null),
@@ -83,7 +86,7 @@ class RediscalaClientTest {
           .getConstructors()(0)
           .newInstance(
             host,
-            port,
+            Integer.valueOf(port.intValue()),
             Option.apply(null),
             Option.apply(null),
             "RedisClient",
@@ -125,12 +128,14 @@ class RediscalaClientTest {
           new Consumer[SpanDataAssert] {
             override def accept(span: SpanDataAssert): Unit = {
               span
-                .hasName("SET")
+                .hasName(spanName("SET"))
                 .hasKind(CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
-                  equalTo(maybeStable(DB_OPERATION), "SET")
+                  equalTo(maybeStable(DB_OPERATION), "SET"),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port)
                 )
             }
           }
@@ -141,7 +146,9 @@ class RediscalaClientTest {
       testing,
       "io.opentelemetry.rediscala-1.8",
       DB_SYSTEM_NAME,
-      DB_OPERATION_NAME
+      DB_OPERATION_NAME,
+      SERVER_ADDRESS,
+      SERVER_PORT
     )
   }
 
@@ -178,24 +185,28 @@ class RediscalaClientTest {
           new Consumer[SpanDataAssert] {
             override def accept(span: SpanDataAssert): Unit = {
               span
-                .hasName("SET")
+                .hasName(spanName("SET"))
                 .hasKind(CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
-                  equalTo(maybeStable(DB_OPERATION), "SET")
+                  equalTo(maybeStable(DB_OPERATION), "SET"),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port)
                 )
             }
           },
           new Consumer[SpanDataAssert] {
             override def accept(span: SpanDataAssert): Unit = {
               span
-                .hasName("GET")
+                .hasName(spanName("GET"))
                 .hasKind(CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
-                  equalTo(maybeStable(DB_OPERATION), "GET")
+                  equalTo(maybeStable(DB_OPERATION), "GET"),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port)
                 )
             }
           }
@@ -230,12 +241,14 @@ class RediscalaClientTest {
           new Consumer[SpanDataAssert] {
             override def accept(span: SpanDataAssert): Unit = {
               span
-                .hasName(scenario.operationName)
+                .hasName(spanName(scenario.operationName))
                 .hasKind(CLIENT)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), scenario.operationName),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port),
                   equalTo(
                     DB_OPERATION_BATCH_SIZE,
                     if (emitStableDatabaseSemconv()) scenario.batchSize
@@ -247,6 +260,9 @@ class RediscalaClientTest {
         )
     })
   }
+
+  private def spanName(operation: String): String =
+    if (emitStableDatabaseSemconv()) s"$operation $host:$port" else operation
 
   private def transactionScenarios(): Stream[Arguments] =
     Stream.of(


### PR DESCRIPTION
Propagate the Redis client endpoint to Rediscala command and transaction spans without depending on Akka- or Pekko-specific actor types. This records `server.address` and `server.port`, and gives stable database spans endpoint-targeted names while preserving legacy span names.