### PR TITLE
docs(webflux): document when Reactor hook is needed

### DIFF
--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
@@ -83,6 +83,15 @@ public class WebClientConfig {
 }
 ```
 
+### Reactor context propagation hook
+
+Spring WebFlux runs on Project Reactor, which can switch threads across a reactive pipeline.
+OTel context is stored in a `ThreadLocal` and will not survive these switches without the Reactor context propagation hook.
+
+**When you need the hook:**
+Use `createWebFilterAndRegisterReactorHook()` or `addFilterAndRegisterReactorHook()` when application code or downstream instrumentation needs the current OpenTelemetry context to be available inside Reactor callbacks and the OpenTelemetry Reactor hook has not already been registered.
+Otherwise, use `createWebFilter()` or `addFilter()`.
+
 ## Starter Guide
 
 Check

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/README.md
@@ -86,7 +86,7 @@ public class WebClientConfig {
 ### Reactor context propagation hook
 
 Spring WebFlux runs on Project Reactor, which can switch threads across a reactive pipeline.
-OTel context is stored in a `ThreadLocal` and will not survive these switches without the Reactor context propagation hook.
+OpenTelemetry context is stored in a `ThreadLocal` and will not survive these switches without the Reactor context propagation hook.
 
 **When you need the hook:**
 Use `createWebFilterAndRegisterReactorHook()` or `addFilterAndRegisterReactorHook()` when application code or downstream instrumentation needs the current OpenTelemetry context to be available inside Reactor callbacks and the OpenTelemetry Reactor hook has not already been registered.


### PR DESCRIPTION
 Fixes #17858
Improves the README to clarify when the Reactor context propagation hook 
is needed and when it is not.