### PR TITLE
Capture Vert.x Redis spans for empty batches

### DIFF
--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.vertx.core.Future;
 import io.vertx.core.net.NetSocket;
+import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.impl.RedisStandaloneConnection;
@@ -118,14 +119,36 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class BatchAdvice {
     public static class BatchAdviceScope {
+      private static final boolean VERTX_4_0_X = isVertx40x();
+
       private final VertxRedisClientRequest otelRequest;
       private final Context context;
       private final Scope scope;
+      private final boolean emptyBatch;
 
-      private BatchAdviceScope(VertxRedisClientRequest otelRequest, Context context, Scope scope) {
+      private BatchAdviceScope(
+          VertxRedisClientRequest otelRequest, Context context, Scope scope, boolean emptyBatch) {
         this.otelRequest = otelRequest;
         this.context = context;
         this.scope = scope;
+        this.emptyBatch = emptyBatch;
+      }
+
+      // Vert.x Redis 4.0.0 through 4.0.3 create a promise for an empty batch but never process a
+      // response that could complete it. Version 4.1.0.Beta1 added explicit empty-batch completion.
+      // The same 4.1.0.Beta1 update replaced the connection provider API, so init(RedisConnection)
+      // is a reliable marker for the affected 4.0.x line.
+      private static boolean isVertx40x() {
+        try {
+          return Class.forName(
+                      "io.vertx.redis.client.impl.RedisConnectionManager$RedisConnectionProvider",
+                      false,
+                      RedisStandaloneConnection.class.getClassLoader())
+                  .getDeclaredMethod("init", RedisConnection.class)
+              != null;
+        } catch (ReflectiveOperationException ignored) {
+          return false;
+        }
       }
 
       @Nullable
@@ -134,8 +157,7 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
           @Nullable List<Request> requests,
           NetSocket netSocket) {
 
-        // Vert.x sends no command and never completes the returned future for an empty batch.
-        if (requests == null || requests.isEmpty()) {
+        if (requests == null) {
           return null;
         }
 
@@ -148,7 +170,8 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
           return null;
         }
         Context context = instrumenter().start(parentContext, otelRequest);
-        return new BatchAdviceScope(otelRequest, context, context.makeCurrent());
+        return new BatchAdviceScope(
+            otelRequest, context, context.makeCurrent(), requests.isEmpty());
       }
 
       @Nullable
@@ -157,6 +180,12 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
         scope.close();
         if (throwable != null) {
           instrumenter().end(context, otelRequest, null, throwable);
+        } else if (emptyBatch
+            && VERTX_4_0_X
+            && responseFuture != null
+            && !responseFuture.isComplete()) {
+          // Vert.x 4.0.x never completes the promise returned for an empty batch.
+          instrumenter().end(context, otelRequest, null, null);
         } else {
           responseFuture =
               VertxRedisClientSingletons.wrapEndSpan(responseFuture, context, otelRequest);

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/RedisStandaloneConnectionInstrumentation.java
@@ -134,7 +134,8 @@ class RedisStandaloneConnectionInstrumentation implements TypeInstrumentation {
           @Nullable List<Request> requests,
           NetSocket netSocket) {
 
-        if (requests == null) {
+        // Vert.x sends no command and never completes the returned future for an empty batch.
+        if (requests == null || requests.isEmpty()) {
           return null;
         }
 

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -228,6 +228,7 @@ class VertxRedisClientTest {
 
     assertThat(future.isComplete()).isFalse();
     assertThat(future).isInstanceOf(Promise.class);
+    assertThat(future).isInstanceOf(FutureInternal.class);
     assertThat(((FutureInternal<?>) future).context()).isNotNull();
 
     // Complete the otherwise permanently pending Vert.x promise only to clean up the test.

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -24,6 +24,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
@@ -35,12 +36,16 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.future.FutureInternal;
 import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -211,6 +216,24 @@ class VertxRedisClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             redisSpanAttributes("RANDOMKEY", "RANDOMKEY"))));
+  }
+
+  @Test
+  void emptyBatchDoesNotStartSpan() {
+    // Vert.x never completes the future returned by batch(emptyList()), so this test cannot wait
+    // for completion like the regular batch tests. Starting a span would replace the pending future
+    // with a span-ending wrapper, but the span would never end or become exportable. The original
+    // Vert.x promise retains its event-loop context, while the wrapper does not.
+    Future<List<Response>> future = connection.batch(emptyList());
+
+    assertThat(future.isComplete()).isFalse();
+    assertThat(future).isInstanceOf(Promise.class);
+    assertThat(((FutureInternal<?>) future).context()).isNotNull();
+
+    // Complete the otherwise permanently pending Vert.x promise only to clean up the test.
+    Promise<?> promise = (Promise<?>) future;
+    assertThat(promise.tryComplete(null)).isTrue();
+    assertThat(testing.spans()).isEmpty();
   }
 
   @ParameterizedTest

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -37,9 +37,7 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.future.FutureInternal;
 import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
@@ -219,22 +217,42 @@ class VertxRedisClientTest {
   }
 
   @Test
-  void emptyBatchDoesNotStartSpan() {
-    // Vert.x never completes the future returned by batch(emptyList()), so this test cannot wait
-    // for completion like the regular batch tests. Starting a span would replace the pending future
-    // with a span-ending wrapper, but the span would never end or become exportable. The original
-    // Vert.x promise retains its event-loop context, while the wrapper does not.
+  void emptyBatch() throws Exception {
     Future<List<Response>> future = connection.batch(emptyList());
 
-    assertThat(future.isComplete()).isFalse();
-    assertThat(future).isInstanceOf(Promise.class);
-    assertThat(future).isInstanceOf(FutureInternal.class);
-    assertThat(((FutureInternal<?>) future).context()).isNotNull();
+    if (isVertx40x() && !future.isComplete()) {
+      // Vert.x 4.0.x never completes an empty batch. Complete it only to clean up the test.
+      assertThat(
+              future
+                  .getClass()
+                  .getMethod("tryComplete", Object.class)
+                  .invoke(future, (Object) null))
+          .isEqualTo(true);
+    } else {
+      assertThat(future.toCompletionStage().toCompletableFuture().get(30, SECONDS)).isEmpty();
+    }
 
-    // Complete the otherwise permanently pending Vert.x promise only to clean up the test.
-    Promise<?> promise = (Promise<?>) future;
-    assertThat(promise.tryComplete(null)).isTrue();
-    assertThat(testing.spans()).isEmpty();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "PIPELINE " + host + ":" + port
+                                : "PIPELINE")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(redisSpanAttributes("PIPELINE", "", 0L))));
+  }
+
+  private static boolean isVertx40x() {
+    try {
+      return Class.forName(
+                  "io.vertx.redis.client.impl.RedisConnectionManager$RedisConnectionProvider")
+              .getDeclaredMethod("init", RedisConnection.class)
+          != null;
+    } catch (ReflectiveOperationException ignored) {
+      return false;
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Capture Vert.x Redis empty batches as PIPELINE spans instead of skipping them. Vert.x Redis 4.0.0 through 4.0.3 never complete the future returned for an empty batch, so end those spans synchronously; starting with 4.1.0.Beta1, retain normal asynchronous completion by wrapping the returned future. Remove internal FutureInternal usage so latest-dependencies tests remain compatible.