### PR TITLE
Fix OtelInternalJavadoc diagnostic message

### DIFF
--- a/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/OtelInternalJavadoc.java
+++ b/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/OtelInternalJavadoc.java
@@ -23,7 +23,7 @@ import javax.lang.model.element.Modifier;
 @AutoService(BugChecker.class)
 @BugPattern(
     summary =
-        "This public internal class doesn't end with any of the applicable javadoc disclaimers: \""
+        "This public internal class doesn't contain any of the applicable javadoc disclaimers: \""
             + OtelInternalJavadoc.EXPECTED_INTERNAL_COMMENT_V1
             + "\", or \""
             + OtelInternalJavadoc.EXPECTED_INTERNAL_COMMENT_V2

--- a/custom-checks/src/test/java/io/opentelemetry/javaagent/customchecks/OtelInternalJavadocTest.java
+++ b/custom-checks/src/test/java/io/opentelemetry/javaagent/customchecks/OtelInternalJavadocTest.java
@@ -17,14 +17,14 @@ class OtelInternalJavadocTest {
 """
 package io.opentelemetry.javaagent.customchecks.internal;
 
-// BUG: Diagnostic contains: doesn't end with any of the applicable javadoc disclaimers
+// BUG: Diagnostic contains: doesn't contain any of the applicable javadoc disclaimers
 public class InternalJavadocPositiveCases {
 
-  // BUG: Diagnostic contains: doesn't end with any of the applicable javadoc disclaimers
+  // BUG: Diagnostic contains: doesn't contain any of the applicable javadoc disclaimers
   public static class One {}
 
   /** Doesn't have the disclaimer. */
-  // BUG: Diagnostic contains: doesn't end with any of the applicable javadoc disclaimers
+  // BUG: Diagnostic contains: doesn't contain any of the applicable javadoc disclaimers
   public static class Two {}
 }
 """);


### PR DESCRIPTION
Update `OtelInternalJavadoc` diagnostic wording from "doesn't end with" to "doesn't contain" so it matches the checker's accepted disclaimer placement. Ports open-telemetry/opentelemetry-java#8590.