### PR TITLE
Clarify when to add changelog entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+<!--
+CHANGELOG.md is generated from merged pull requests. Do not add an entry unless this PR introduces
+a deprecation or breaking change.
+-->

--- a/.github/workflows/pr-automation-comments.yml
+++ b/.github/workflows/pr-automation-comments.yml
@@ -94,7 +94,7 @@ jobs:
                 "",
                 "### 📋 Checklist",
                 "- Deprecation details added to the PR description",
-                "- Deprecation is documented in the changelog entry for the next release",
+                "- Deprecation is documented in the \"Unreleased\" section of the [Changelog](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md), preferably as part of this PR.",
                 "- Consider adding deprecation warnings in code/documentation",
                 "",
                 "Your deprecation notes will be included in the release notes to help users prepare for future changes.",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,19 @@ Before submitting new features or changes to current functionality, it is recomm
 [open an issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/new)
 and discuss your ideas or propose the changes you wish to make.
 
+## Changelog
+
+The changelog is generated from merged pull requests. Do not add a changelog entry for normal
+changes. Add an entry only for a deprecation or breaking change, where the hand-written entry is
+useful for double-checking the generated changelog.
+
 ## Breaking Changes
 
 When your PR introduces a breaking change:
 
 - Add the `breaking change` label to your PR
   - If you can't add labels directly, post a comment containing only `/breaking-change` and the label will be added automatically
+- Add an entry to the `Unreleased` section of `CHANGELOG.md`
 - Provide migration notes in the PR description:
   - What is changing and why
   - How users should update their code/configuration
@@ -30,6 +37,7 @@ When your PR deprecates functionality:
 
 - Add the `deprecation` label to your PR
   - If you can't add labels directly, post a comment containing only `/deprecation` and the label will be added automatically
+- Add an entry to the `Unreleased` section of `CHANGELOG.md`
 - Provide deprecation details in the PR description:
   - What is being deprecated and why
   - What should be used instead (if applicable)


### PR DESCRIPTION
Document that `CHANGELOG.md` is generated and contributors should only add hand-written entries for deprecations and breaking changes. Add an author-facing pull request reminder and align the deprecation automation with the existing breaking-change guidance.