### PR TITLE
Make `ConfigPropertiesBackedDeclarativeConfigProperties` package-private

### DIFF
--- a/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigProperties.java
+++ b/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/ConfigPropertiesBackedDeclarativeConfigProperties.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  * <p>It tracks the navigation path and only resolves to system properties at the leaf node when a
  * value is actually requested.
  */
-public final class ConfigPropertiesBackedDeclarativeConfigProperties
+final class ConfigPropertiesBackedDeclarativeConfigProperties
     implements DeclarativeConfigProperties {
 
   private static final String JAVA_COMMON_SERVICE_PEER_MAPPING = "java.common.service_peer_mapping";
@@ -95,7 +95,7 @@ public final class ConfigPropertiesBackedDeclarativeConfigProperties
   private final ConfigProperties configProperties;
   private final List<String> path;
 
-  public static DeclarativeConfigProperties createInstrumentationConfig(
+  static DeclarativeConfigProperties createInstrumentationConfig(
       ConfigProperties configProperties) {
     return new ConfigPropertiesBackedDeclarativeConfigProperties(configProperties, emptyList());
   }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/DeclarativeConfigValidationTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.docs;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedDeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.config.bridge.ConfigPropertiesBackedConfigProvider;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
 import io.opentelemetry.instrumentation.docs.internal.DeclarativeSchema;
@@ -118,8 +118,7 @@ class DeclarativeConfigValidationTest {
     DefaultConfigProperties configProperties = DefaultConfigProperties.createFromMap(properties);
 
     DeclarativeConfigProperties declarativeConfig =
-        ConfigPropertiesBackedDeclarativeConfigProperties.createInstrumentationConfig(
-            configProperties);
+        ConfigPropertiesBackedConfigProvider.create(configProperties).getInstrumentationConfig();
 
     Object retrievedValue =
         navigateAndGetValue(declarativeConfig, declarativePath, type, structuredList);


### PR DESCRIPTION
`ConfigPropertiesBackedConfigProvider` is the intended public entry point.