### PR TITLE
Deprecate DeclarativeConfigPropertiesBridgeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🚫 Deprecations
+
+- Deprecate `DeclarativeConfigPropertiesBridgeBuilder` for removal in 3.0. Use
+  `DeclarativeConfigProperties` directly when reading declarative component configuration.
+
 ### 📈 Enhancements
 
 - Add Cassandra JMX metrics target system.

--- a/declarative-config-bridge/README.md
+++ b/declarative-config-bridge/README.md
@@ -1,5 +1,11 @@
 # Declarative Config Bridge
 
+> [!WARNING]
+> `DeclarativeConfigPropertiesBridgeBuilder` is deprecated and will be removed in 3.0. Read
+> declarative component configuration through `DeclarativeConfigProperties` directly. To expose
+> `ConfigProperties` through the declarative configuration API, use
+> `ConfigPropertiesBackedConfigProvider`.
+
 Declarative Config Bridge allows instrumentation authors to access configuration in a uniform way,
 regardless of the configuration source.
 

--- a/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeBuilder.java
+++ b/declarative-config-bridge/src/main/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeBuilder.java
@@ -22,7 +22,13 @@ import javax.annotation.Nullable;
 /**
  * A builder for {@link DeclarativeConfigPropertiesBridge} that allows adding translations and fixed
  * values for properties.
+ *
+ * @deprecated Use {@link DeclarativeConfigProperties} directly when reading declarative component
+ *     configuration, or use {@link ConfigPropertiesBackedConfigProvider} when exposing a {@link
+ *     io.opentelemetry.api.incubator.config.ConfigProvider} backed by {@link ConfigProperties}.
+ *     This class will be removed in 3.0.
  */
+@Deprecated // will be removed in 3.0
 public class DeclarativeConfigPropertiesBridgeBuilder {
   /**
    * order is important here, so we use LinkedHashMap - see {@link #addMapping(String, String)} for

--- a/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeBuilderTest.java
+++ b/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeBuilderTest.java
@@ -20,7 +20,7 @@ import io.opentelemetry.sdk.internal.ExtendedOpenTelemetrySdk;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-@SuppressWarnings("DoNotMockAutoValue")
+@SuppressWarnings({"DoNotMockAutoValue", "deprecation"}) // testing deprecated bridge
 class DeclarativeConfigPropertiesBridgeBuilderTest {
   @Test
   void shouldUseConfigPropertiesForAutoConfiguration() {

--- a/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeTest.java
+++ b/declarative-config-bridge/src/test/java/io/opentelemetry/instrumentation/config/bridge/DeclarativeConfigPropertiesBridgeTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // testing deprecated bridge
 class DeclarativeConfigPropertiesBridgeTest {
 
   private ConfigProperties bridge;


### PR DESCRIPTION
<!--
CHANGELOG.md is generated from merged pull requests. Do not add an entry unless this PR introduces
a deprecation or breaking change.
-->
Deprecate `DeclarativeConfigPropertiesBridgeBuilder` for removal in 3.0 because declarative components should read `DeclarativeConfigProperties` directly instead of adapting back to `ConfigProperties`. Code that needs to expose legacy `ConfigProperties` through the declarative configuration API should use `ConfigPropertiesBackedConfigProvider`; the README and changelog now document these migration paths.