### PR TITLE
Limit LocalRootSpan usage to http.route and span name

### DIFF
--- a/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
@@ -56,6 +56,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
   }
 
   check {

--- a/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/apache-shenyu-2.4/javaagent/build.gradle.kts
@@ -38,17 +38,29 @@ if (otelProps.testLatestDeps) {
   }
 }
 
-tasks.test {
-  jvmArgs("-Dotel.instrumentation.apache-shenyu.experimental-span-attributes=true")
+tasks {
+  withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.apache-shenyu.experimental-span-attributes=true")
 
-  systemProperty("metadataConfig", "otel.instrumentation.apache-shenyu.experimental-span-attributes=true")
-  systemProperty("collectMetadata", otelProps.collectMetadata)
+    systemProperty("metadataConfig", "otel.instrumentation.apache-shenyu.experimental-span-attributes=true")
+    systemProperty("collectMetadata", otelProps.collectMetadata)
 
-  // required on jdk17
-  jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
-  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+    // required on jdk17
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 
-  systemProperty("testLatestDeps", otelProps.testLatestDeps)
+    systemProperty("testLatestDeps", otelProps.testLatestDeps)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
+  }
 }
 
 // spring 6 (spring boot 3) uses slf4j 2.0

--- a/instrumentation/apache-shenyu-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheshenyu/v2_4/MetaDataHelper.java
+++ b/instrumentation/apache-shenyu-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheshenyu/v2_4/MetaDataHelper.java
@@ -72,7 +72,7 @@ public class MetaDataHelper {
       return;
     }
     Span serverSpan =
-        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
+        v3Preview() ? Span.fromContextOrNull(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }

--- a/instrumentation/apache-shenyu-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheshenyu/v2_4/MetaDataHelper.java
+++ b/instrumentation/apache-shenyu-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheshenyu/v2_4/MetaDataHelper.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.apacheshenyu.v2_4;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.v3Preview;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -69,7 +71,8 @@ public class MetaDataHelper {
     if (!CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       return;
     }
-    Span serverSpan = LocalRootSpan.fromContextOrNull(context);
+    Span serverSpan =
+        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }

--- a/instrumentation/servlet/servlet-3.0/javaagent-testing/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/javaagent-testing/build.gradle.kts
@@ -23,12 +23,23 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+    jvmArgs("-Dotel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled=true")
     // required on jdk17
     jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
     systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
@@ -143,7 +143,8 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
     if (!AppServerBridge.captureServletAttributes(context)) {
       return;
     }
-    Span serverSpan = LocalRootSpan.fromContextOrNull(context);
+    Span serverSpan =
+        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
@@ -144,7 +144,7 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
       return;
     }
     Span serverSpan =
-        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
+        v3Preview() ? Span.fromContextOrNull(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/build.gradle.kts
@@ -29,9 +29,21 @@ dependencies {
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:4.0.+") // related dependency
 }
 
-tasks.test {
-  jvmArgs("-Dotel.instrumentation.spring-cloud-gateway.experimental-span-attributes=true")
-  jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+tasks {
+  withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.spring-cloud-gateway.experimental-span-attributes=true")
+    jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
+  }
 }
 
 // spring 7 requires java 17

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/gateway/webmvc/v4_3/ServerRequestHelper.java
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/gateway/webmvc/v4_3/ServerRequestHelper.java
@@ -45,7 +45,7 @@ public class ServerRequestHelper {
     }
 
     Span serverSpan =
-        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
+        v3Preview() ? Span.fromContextOrNull(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }

--- a/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/gateway/webmvc/v4_3/ServerRequestHelper.java
+++ b/instrumentation/spring/spring-cloud-gateway/spring-cloud-gateway-webmvc-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/gateway/webmvc/v4_3/ServerRequestHelper.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.cloud.gateway.webmvc.v4_3;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.v3Preview;
 import static io.opentelemetry.javaagent.instrumentation.spring.cloud.gateway.common.GatewayRouteHelper.ROUTE_ID_ATTRIBUTE;
 import static io.opentelemetry.javaagent.instrumentation.spring.cloud.gateway.common.GatewayRouteHelper.ROUTE_URI_ATTRIBUTE;
 
@@ -43,7 +44,8 @@ public class ServerRequestHelper {
       return;
     }
 
-    Span serverSpan = LocalRootSpan.fromContextOrNull(context);
+    Span serverSpan =
+        v3Preview() ? Span.fromContext(context) : LocalRootSpan.fromContextOrNull(context);
     if (serverSpan == null) {
       return;
     }


### PR DESCRIPTION
Limit LocalRootSpan usage.

LocalRootSpan isn't blessed by the OpenTelemetry Specification, and there's no semantic conventions around it.

These usages don't seem to require it anyways.