### PR TITLE
Try to improve Spotless speed

### DIFF
--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import com.diffplug.spotless.LineEnding
 import io.opentelemetry.instrumentation.gradle.StaticImportFormatter
 
 plugins {
@@ -5,6 +6,9 @@ plugins {
 }
 
 spotless {
+  // Match .gitattributes without probing source files during configuration.
+  lineEndings = LineEnding.UNIX
+
   java {
     custom("staticImports", StaticImportFormatter())
     googleJavaFormat()

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
@@ -43,7 +43,8 @@ val inputClasspath = (sourceSet.output.resourcesDir?.let { codegen.plus(project.
 URLConnection.setDefaultUseCaches("jar", false)
 
 val languageTasks = LANGUAGES.map { language ->
-  if (fileTree("src/${sourceSet.name}/${language}").isEmpty) {
+  // Inspecting source contents here invalidates the configuration cache after every source edit.
+  if (!file("src/${sourceSet.name}/${language}").isDirectory) {
     return@map null
   }
   val compileTaskName = sourceSet.getCompileTaskName(language)


### PR DESCRIPTION
Avoid invalidating Gradle configuration cache on source edits by checking only for Muzzle source directories and configuring Spotless LF handling explicitly. This keeps formatting output aligned with `.gitattributes` while allowing targeted and repository-wide Spotless invocations to reuse cached configuration.