### PR TITLE
Fix latest dep update stale checkout

### DIFF
--- a/.github/workflows/update-latest-dep-versions.yml
+++ b/.github/workflows/update-latest-dep-versions.yml
@@ -69,6 +69,18 @@ jobs:
           git add .github/config/latest-dep-versions.json
           git commit -m "$message"
 
+          # Dependency resolution can take long enough for workflow files on main to change after
+          # checkout. GitHub then rejects pushing the stale branch without workflows: write, even
+          # though the generated commit only changes latest-dep-versions.json. Merge instead of
+          # rebase so that commit remains tied to its source snapshot while the pushed branch
+          # contains the current workflow files.
+          git fetch origin main
+          if ! git merge --no-edit origin/main; then
+            echo "::error::Failed to merge the latest origin/main into the generated dependency update."
+            git merge --abort
+            exit 1
+          fi
+
           # If the remote branch already exists, only force-push when its tip
           # was authored by otelbot. This preserves any manual commits that
           # may have pushed on top of an open auto-PR.


### PR DESCRIPTION
Apply the stale-checkout handling from #19222 to the latest-dependency updater. Fetch and merge current `origin/main` into the generated dependency commit before pushing, keeping current workflow files on recreated automation branches without granting otelbot `workflows: write`. Merge conflicts abort explicitly, while the generated commit remains tied to the source snapshot used for dependency resolution.

Fixes #19218