### PR TITLE
Prune docker images/volumes in free-disk-space script

### DIFF
--- a/.github/scripts/gha-free-disk-space.sh
+++ b/.github/scripts/gha-free-disk-space.sh
@@ -9,4 +9,7 @@ sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/local/julia*
 sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/local/.ghcup
+# test suites pull many testcontainers images (elasticsearch, kafka connect, etc.) over the
+# course of a single job; prune whatever shipped with the runner image first to make room.
+docker system prune -af --volumes
 df -h

--- a/.github/scripts/gha-free-disk-space.sh
+++ b/.github/scripts/gha-free-disk-space.sh
@@ -11,5 +11,14 @@ sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/local/.ghcup
 # test suites pull many testcontainers images (elasticsearch, kafka connect, etc.) over the
 # course of a single job; prune whatever shipped with the runner image first to make room.
-docker system prune -af --volumes
+# The reclaimable amount is runner-image dependent; GitHub-hosted jobs start on a fresh runner, so
+# this cannot reclaim Docker data from a previous workflow run.
+# On Windows, the Docker service can be stopped at this point; skip pruning in that case so the
+# workflow can start the service in the following step. Once the daemon is available, keep prune
+# failures fatal so that real cleanup errors are not hidden.
+if docker info >/dev/null 2>&1; then
+  docker system prune -af --volumes
+else
+  echo "Docker daemon is unavailable; skipping Docker prune." >&2
+fi
 df -h

--- a/.github/scripts/gha-free-disk-space.sh
+++ b/.github/scripts/gha-free-disk-space.sh
@@ -9,13 +9,11 @@ sudo rm -rf /usr/share/dotnet
 sudo rm -rf /usr/local/julia*
 sudo rm -rf /usr/share/swift
 sudo rm -rf /usr/local/.ghcup
-# test suites pull many testcontainers images (elasticsearch, kafka connect, etc.) over the
-# course of a single job; prune whatever shipped with the runner image first to make room.
-# The reclaimable amount is runner-image dependent; GitHub-hosted jobs start on a fresh runner, so
-# this cannot reclaim Docker data from a previous workflow run.
-# On Windows, the Docker service can be stopped at this point; skip pruning in that case so the
-# workflow can start the service in the following step. Once the daemon is available, keep prune
-# failures fatal so that real cleanup errors are not hidden.
+# GitHub-hosted runners can include about 1.9 GB of unused GitHub and Dependabot images. Remove
+# them before Testcontainers starts pulling test images. Each job gets a fresh runner, so this
+# does not clean up Docker data from an earlier workflow run.
+# Docker may not be running yet on Windows. Skip pruning in that case, but fail the job if a
+# running daemon cannot be pruned.
 if docker info >/dev/null 2>&1; then
   docker system prune -af --volumes
 else


### PR DESCRIPTION
## Summary
- Test suites pull many testcontainers images over the course of a single CI job (elasticsearch, kafka connect, etc.), which can exhaust runner disk space mid-run — saw this cause a spurious CI failure on #19183 (docs-only PR, `No space left on device` on a `test3` matrix job, disk went from 39GB free to 0 during the test run).
- Adds `docker system prune -af --volumes` to `.github/scripts/gha-free-disk-space.sh`, removing unused Docker content already present on the runner before tests begin.
- GitHub-hosted jobs start on a fresh runner VM, so this is **not** intended to clean Docker data from a prior workflow run. It targets unused content present on the fresh runner image or created during job setup.

Caveat: this only frees space *before* tests start, matching the existing script's approach — it does not address images pulled during the job, so it may reduce but not eliminate this failure mode.

## Observed evidence
- The 16 Ubuntu smoke jobs in [run 29429470350](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/29429470350) and [run 29580716222](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/29580716222) each reported **1.851 GB reclaimed** by Docker pruning.
- The overall filesystem cleanup increased available space by roughly 25–26 GB in those jobs; that larger number includes the script's non-Docker cleanup and should not be attributed to Docker alone.
- Both runs completed successfully. This is evidence of additional capacity, not a controlled measurement of failure prevention or total runtime improvement.

## Test plan
- [x] CI passes
